### PR TITLE
Add project board link to local dev guide

### DIFF
--- a/Docs/LOCAL_DEV.md
+++ b/Docs/LOCAL_DEV.md
@@ -44,6 +44,7 @@
 ## Priority workflow (P0-P3)
 - Source of truth: GitHub Issues labeled `P0`, `P1`, `P2`, `P3`.
 - Use a GitHub Project board for "Backlog -> Ready -> In Progress -> Review -> Done".
+  Board: https://github.com/users/ethtri/projects/2
 - Keep repo docs light: `Docs/CURRENT_STATUS.md` is a short, plain-language snapshot.
 - If you keep personal notes, store them locally and do not commit them.
 


### PR DESCRIPTION
## Summary
- Add the Project board link to the local dev guide

## Files changed
- Docs/LOCAL_DEV.md

## Verification
- 
pm ci: not run (doc-only change)
- 
pm run build: not run (doc-only change)
- 
pm test --if-present: not run (doc-only change)
- 
pm run lint --if-present: not run (doc-only change)

## How to test (localhost)
1) Open Docs/LOCAL_DEV.md
2) Confirm the Project board link is present

## Notes / Risks
- None
