### PR TITLE
Document local-only asset access

### DIFF
--- a/Docs/LOCAL_DEV.md
+++ b/Docs/LOCAL_DEV.md
@@ -47,6 +47,13 @@
 - Keep repo docs light: `Docs/CURRENT_STATUS.md` is a short, plain-language snapshot.
 - If you keep personal notes, store them locally and do not commit them.
 
+
+## Asset access (local-only)
+- Create a local folder for photos, e.g. `C:\Repos\Bloomjoy_assets`.
+- Do not place large assets in the Git repo. They should stay local.
+- Agents should keep their own copy of this folder.
+- If an asset is needed in the app, add a small optimized version in `public/` and document it.
+
 ## If/when we add Stripe serverless functions
 Depending on the hosting decision, local dev may require one of:
 - `vercel dev` (for Vercel Functions)


### PR DESCRIPTION
## Summary
- Document local-only asset storage for photos and large files

## Files changed
- Docs/LOCAL_DEV.md

## Verification
- 
pm ci: not run (doc-only change)
- 
pm run build: not run (doc-only change)
- 
pm test --if-present: not run (doc-only change)
- 
pm run lint --if-present: not run (doc-only change)

## How to test (localhost)
1) Open Docs/LOCAL_DEV.md
2) Confirm the Asset access section is present

## Notes / Risks
- None
