### PR TITLE
Add portal auth shell and CI guardrails

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,43 @@
+#!/bin/sh
+set -eu
+
+toplevel=$(git rev-parse --show-toplevel 2>/dev/null || true)
+branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+
+if [ -z "$toplevel" ]; then
+  echo "ERROR: could not determine repo root." >&2
+  exit 1
+fi
+
+case "$toplevel" in
+  *"/wt-"*|*"\\wt-"*)
+    ;;
+  *)
+    echo "ERROR: commits must be made from a wt-* worktree (not the main repo)." >&2
+    exit 1
+    ;;
+esac
+
+if echo "$toplevel" | grep -qi 'Bloomjoy_hub$'; then
+  echo "ERROR: do not commit from C:\\Repos\\Bloomjoy_hub." >&2
+  exit 1
+fi
+
+if [ -z "$branch" ]; then
+  echo "ERROR: detached HEAD. Create or checkout an agent/* branch." >&2
+  exit 1
+fi
+
+case "$branch" in
+  agent/*)
+    ;;
+  *)
+    echo "ERROR: branch must be named agent/*." >&2
+    exit 1
+    ;;
+esac
+
+if [ "$branch" = "main" ]; then
+  echo "ERROR: never commit to main." >&2
+  exit 1
+fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+while read local_ref local_sha remote_ref remote_sha; do
+  case "$remote_ref" in
+    refs/heads/main)
+      echo "ERROR: pushing directly to main is blocked. Open a PR instead." >&2
+      exit 1
+      ;;
+  esac
+done
+
+exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Test
+        run: npm test --if-present
+      - name: Lint
+        run: npm run lint --if-present

--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -7,13 +7,13 @@
 - Write updates in plain language so non-technical readers can follow.
 
 ## Next P0 milestones
-1) Public marketing site shell (Home, Machines, Supplies, Plus, Resources, Contact)
-2) Auth + member portal shell (login, dashboard layout)
-3) Stripe: supplies checkout (one product) + membership checkout (Plus Basic) + customer portal
-4) Training library MVP (gated pages + embeds) + support request forms
+1) Stripe: supplies checkout (one product) + membership checkout (Plus Basic) + customer portal
+2) Training library MVP (gated pages + embeds) + support request forms
 
 ## Completed P0 milestones
 1) POC intake + repo hygiene (build/lint/dev) + document findings in `Docs/POC_NOTES.md`
+2) Public marketing site shell (Home, Machines, Supplies, Plus, Resources, Contact)
+3) Auth + member portal shell (login, dashboard layout)
 
 ## Known risks / blockers
 - Product photography availability (Mini may launch as waitlist/coming soon)

--- a/Docs/LOCAL_DEV.md
+++ b/Docs/LOCAL_DEV.md
@@ -30,6 +30,7 @@
 - Do not copy another person's `.env`; create your own from `.env.example`.
 - Never commit or paste secret keys in PRs, issues, or chat.
 - Keep PRs small and focused; one change set per PR.
+- Enable repo git hooks once per clone: `git config core.hooksPath .githooks`
 - Write notes and docs so non-technical readers can follow.
 - Avoid editing the main repo folder directly; work inside your worktree.
 

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -19,6 +19,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 ## Auth / portal
 - [ ] Login flow works (magic link or configured method)
 - [ ] Demo note: no real email is sent yet; any email should log in locally
+- [ ] Logged-out visit to `/portal` redirects to login
 - [ ] Dashboard loads and shows membership status placeholder
 - [ ] Training catalog visible to logged-in users
 - [ ] Support request forms submit and show success state

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { AuthProvider } from "@/contexts/AuthContext";
+import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 
 import Index from "./pages/Index";
 import Products from "./pages/Products";
@@ -47,12 +48,14 @@ const App = () => (
             <Route path="/resources" element={<Resources />} />
             <Route path="/cart" element={<Cart />} />
             <Route path="/login" element={<Login />} />
-            <Route path="/portal" element={<PortalDashboard />} />
-            <Route path="/portal/training" element={<PortalTraining />} />
-            <Route path="/portal/support" element={<PortalSupport />} />
-            <Route path="/portal/onboarding" element={<PortalOnboarding />} />
-            <Route path="/portal/orders" element={<PortalOrders />} />
-            <Route path="/portal/account" element={<PortalAccount />} />
+            <Route element={<ProtectedRoute />}>
+              <Route path="/portal" element={<PortalDashboard />} />
+              <Route path="/portal/training" element={<PortalTraining />} />
+              <Route path="/portal/support" element={<PortalSupport />} />
+              <Route path="/portal/onboarding" element={<PortalOnboarding />} />
+              <Route path="/portal/orders" element={<PortalOrders />} />
+              <Route path="/portal/account" element={<PortalAccount />} />
+            </Route>
             <Route path="*" element={<NotFound />} />
           </Routes>
         </BrowserRouter>

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -1,0 +1,21 @@
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { useAuth } from '@/contexts/AuthContext';
+
+export function ProtectedRoute() {
+  const { isAuthenticated, loading } = useAuth();
+  const location = useLocation();
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center text-sm text-muted-foreground">
+        Loading...
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  return <Outlet />;
+}

--- a/src/components/portal/PortalLayout.tsx
+++ b/src/components/portal/PortalLayout.tsx
@@ -1,0 +1,46 @@
+import { ReactNode } from 'react';
+import { Layout } from '@/components/layout/Layout';
+import { NavLink } from '@/components/NavLink';
+
+const portalLinks = [
+  { href: '/portal', label: 'Dashboard', end: true },
+  { href: '/portal/training', label: 'Training' },
+  { href: '/portal/onboarding', label: 'Onboarding' },
+  { href: '/portal/support', label: 'Support' },
+  { href: '/portal/orders', label: 'Orders' },
+  { href: '/portal/account', label: 'Account' },
+];
+
+interface PortalLayoutProps {
+  children: ReactNode;
+}
+
+export function PortalLayout({ children }: PortalLayoutProps) {
+  return (
+    <Layout>
+      <div className="border-b border-border bg-muted/30">
+        <div className="container-page py-4">
+          <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+            Member Portal
+          </p>
+          <div className="mt-3 overflow-x-auto pb-2">
+            <nav className="flex min-w-max gap-2">
+              {portalLinks.map((link) => (
+                <NavLink
+                  key={link.href}
+                  to={link.href}
+                  end={link.end}
+                  className="rounded-full border border-transparent bg-background px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  activeClassName="border-primary/20 bg-primary/10 text-primary"
+                >
+                  {link.label}
+                </NavLink>
+              ))}
+            </nav>
+          </div>
+        </div>
+      </div>
+      {children}
+    </Layout>
+  );
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { Mail, ArrowRight, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -13,6 +13,7 @@ export default function LoginPage() {
   const [sent, setSent] = useState(false);
   const { signIn } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -28,7 +29,9 @@ export default function LoginPage() {
 
     // For demo, immediately redirect
     toast.success('Welcome to Bloomjoy Plus!');
-    navigate('/portal');
+    const fromPath =
+      (location.state as { from?: { pathname?: string } })?.from?.pathname || '/portal';
+    navigate(fromPath, { replace: true });
   };
 
   return (

--- a/src/pages/portal/Account.tsx
+++ b/src/pages/portal/Account.tsx
@@ -1,26 +1,14 @@
-import { Link } from 'react-router-dom';
 import { User, MapPin, CreditCard, ExternalLink } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Layout } from '@/components/layout/Layout';
+import { PortalLayout } from '@/components/portal/PortalLayout';
 import { useAuth } from '@/contexts/AuthContext';
 
 export default function AccountPage() {
   const { user } = useAuth();
 
   return (
-    <Layout>
-      {/* Breadcrumb */}
-      <div className="border-b border-border bg-muted/30">
-        <div className="container-page py-3">
-          <nav className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Link to="/portal" className="hover:text-foreground">Portal</Link>
-            <span>/</span>
-            <span className="text-foreground">Account</span>
-          </nav>
-        </div>
-      </div>
-
+    <PortalLayout>
       <section className="section-padding">
         <div className="container-page">
           <h1 className="font-display text-3xl font-bold text-foreground">Account Settings</h1>
@@ -127,6 +115,6 @@ export default function AccountPage() {
           </div>
         </div>
       </section>
-    </Layout>
+    </PortalLayout>
   );
 }

--- a/src/pages/portal/Dashboard.tsx
+++ b/src/pages/portal/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { 
   BookOpen, 
   ShoppingBag, 
@@ -10,7 +10,7 @@ import {
   Package
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Layout } from '@/components/layout/Layout';
+import { PortalLayout } from '@/components/portal/PortalLayout';
 import { useAuth } from '@/contexts/AuthContext';
 import { trackEvent } from '@/lib/analytics';
 
@@ -46,18 +46,11 @@ const quickActions = [
 ];
 
 export default function PortalDashboard() {
-  const { user, isAuthenticated, isMember, signOut } = useAuth();
-  const navigate = useNavigate();
+  const { user, isMember, signOut } = useAuth();
 
   useEffect(() => {
     trackEvent('view_dashboard');
   }, []);
-
-  useEffect(() => {
-    if (!isAuthenticated) {
-      navigate('/login');
-    }
-  }, [isAuthenticated, navigate]);
 
   const handleReorderSugar = () => {
     trackEvent('reorder_sugar_click');
@@ -66,7 +59,7 @@ export default function PortalDashboard() {
   if (!user) return null;
 
   return (
-    <Layout>
+    <PortalLayout>
       <section className="bg-gradient-to-b from-cream to-background section-padding">
         <div className="container-page">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
@@ -176,6 +169,6 @@ export default function PortalDashboard() {
           </div>
         </div>
       </section>
-    </Layout>
+    </PortalLayout>
   );
 }

--- a/src/pages/portal/Onboarding.tsx
+++ b/src/pages/portal/Onboarding.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Check, Circle, ArrowRight } from 'lucide-react';
+import { Check, ArrowRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Layout } from '@/components/layout/Layout';
+import { PortalLayout } from '@/components/portal/PortalLayout';
 import { trackEvent } from '@/lib/analytics';
 import { cn } from '@/lib/utils';
 
@@ -65,18 +65,7 @@ export default function OnboardingPage() {
   };
 
   return (
-    <Layout>
-      {/* Breadcrumb */}
-      <div className="border-b border-border bg-muted/30">
-        <div className="container-page py-3">
-          <nav className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Link to="/portal" className="hover:text-foreground">Portal</Link>
-            <span>/</span>
-            <span className="text-foreground">Onboarding</span>
-          </nav>
-        </div>
-      </div>
-
+    <PortalLayout>
       <section className="section-padding">
         <div className="container-page">
           <div className="mx-auto max-w-2xl">
@@ -151,6 +140,6 @@ export default function OnboardingPage() {
           </div>
         </div>
       </section>
-    </Layout>
+    </PortalLayout>
   );
 }

--- a/src/pages/portal/Orders.tsx
+++ b/src/pages/portal/Orders.tsx
@@ -1,7 +1,6 @@
-import { Link } from 'react-router-dom';
-import { FileText, Download, ExternalLink } from 'lucide-react';
+import { FileText, ExternalLink } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Layout } from '@/components/layout/Layout';
+import { PortalLayout } from '@/components/portal/PortalLayout';
 
 const orders = [
   {
@@ -29,18 +28,7 @@ const orders = [
 
 export default function OrdersPage() {
   return (
-    <Layout>
-      {/* Breadcrumb */}
-      <div className="border-b border-border bg-muted/30">
-        <div className="container-page py-3">
-          <nav className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Link to="/portal" className="hover:text-foreground">Portal</Link>
-            <span>/</span>
-            <span className="text-foreground">Orders</span>
-          </nav>
-        </div>
-      </div>
-
+    <PortalLayout>
       <section className="section-padding">
         <div className="container-page">
           <h1 className="font-display text-3xl font-bold text-foreground">Order History</h1>
@@ -109,6 +97,6 @@ export default function OrdersPage() {
           </div>
         </div>
       </section>
-    </Layout>
+    </PortalLayout>
   );
 }

--- a/src/pages/portal/Support.tsx
+++ b/src/pages/portal/Support.tsx
@@ -1,10 +1,9 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
 import { MessageSquare, Wrench, Package, ArrowRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { Layout } from '@/components/layout/Layout';
+import { PortalLayout } from '@/components/portal/PortalLayout';
 import { trackEvent } from '@/lib/analytics';
 import { toast } from 'sonner';
 
@@ -29,18 +28,7 @@ export default function SupportPage() {
   };
 
   return (
-    <Layout>
-      {/* Breadcrumb */}
-      <div className="border-b border-border bg-muted/30">
-        <div className="container-page py-3">
-          <nav className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Link to="/portal" className="hover:text-foreground">Portal</Link>
-            <span>/</span>
-            <span className="text-foreground">Support</span>
-          </nav>
-        </div>
-      </div>
-
+    <PortalLayout>
       <section className="section-padding">
         <div className="container-page">
           <h1 className="font-display text-3xl font-bold text-foreground">Support</h1>
@@ -232,6 +220,6 @@ export default function SupportPage() {
           )}
         </div>
       </section>
-    </Layout>
+    </PortalLayout>
   );
 }

--- a/src/pages/portal/Training.tsx
+++ b/src/pages/portal/Training.tsx
@@ -1,9 +1,7 @@
 import { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
-import { Play, Clock, Tag, Search, Filter } from 'lucide-react';
-import { Button } from '@/components/ui/button';
+import { Play, Clock, Search } from 'lucide-react';
 import { Input } from '@/components/ui/input';
-import { Layout } from '@/components/layout/Layout';
+import { PortalLayout } from '@/components/portal/PortalLayout';
 import { trackEvent } from '@/lib/analytics';
 
 interface TrainingContent {
@@ -90,18 +88,7 @@ export default function TrainingPage() {
   };
 
   return (
-    <Layout>
-      {/* Breadcrumb */}
-      <div className="border-b border-border bg-muted/30">
-        <div className="container-page py-3">
-          <nav className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Link to="/portal" className="hover:text-foreground">Portal</Link>
-            <span>/</span>
-            <span className="text-foreground">Training Library</span>
-          </nav>
-        </div>
-      </div>
-
+    <PortalLayout>
       <section className="section-padding">
         <div className="container-page">
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
@@ -195,6 +182,6 @@ export default function TrainingPage() {
           )}
         </div>
       </section>
-    </Layout>
+    </PortalLayout>
   );
 }


### PR DESCRIPTION
Summary:
- Add protected portal routes with a shared portal nav layout
- Improve login redirect to return to requested portal page
- Add CI workflow + local git hooks and document hook setup

Files changed:
- Portal auth/layout components and portal pages
- Routing/login behavior
- Docs and CI/hook configuration

Verification:
- npm ci (pass; 7 vulnerabilities reported by npm audit)
- npm run build (pass; Browserslist data warning)
- npm test --if-present (pass; no tests)
- npm run lint --if-present (pass; warnings in generated UI files: react-refresh/only-export-components)

How to test:
- npm ci
- npm run dev
- Visit http://localhost:5173
- Open http://localhost:5173/portal in a new tab; confirm redirect to /login
- Enter any email and submit; confirm redirect back to portal
- Navigate through portal tabs (Training, Onboarding, Support, Orders, Account)
