### PR TITLE
Clarify dev server port and worktree usage

### DIFF
--- a/Docs/LOCAL_DEV.md
+++ b/Docs/LOCAL_DEV.md
@@ -13,10 +13,10 @@
    - If you do not see `.env` in File Explorer, turn on "Hidden items"
 3) Install deps:
    - `npm ci`
-4) Start dev server:
+4) Start dev server (from your worktree folder, e.g. `C:\Repos\wt-<task>`):
    - `npm run dev`
 5) Open the URL printed in the terminal (usually):
-   - http://localhost:5173
+   - http://localhost:8080
 
 ## Testing a PR branch
 1) Checkout the PR branch (or use a worktree)


### PR DESCRIPTION
## Summary
- Clarify dev server port and emphasize running from a worktree

## Files changed
- Local dev documentation

## Verification
- `npm ci`: pass
- `npm run build`: pass (Browserslist warning)
- `npm test --if-present`: no tests
- `npm run lint --if-present`: warnings only (react-refresh/only-export-components in existing UI files)

## How to test (localhost)
1) Open `Docs/LOCAL_DEV.md`
2) Confirm the dev server URL is `http://localhost:8080`
3) Confirm dev server step calls out running from `C:\Repos\wt-<task>`

## Notes / Risks
- Docs-only change
