### PR TITLE
Add fetch step to preflight

### DIFF
--- a/Docs/LOCAL_DEV.md
+++ b/Docs/LOCAL_DEV.md
@@ -31,6 +31,7 @@
 - Never commit or paste secret keys in PRs, issues, or chat.
 - Keep PRs small and focused; one change set per PR.
 - Enable repo git hooks once per clone: `git config core.hooksPath .githooks`
+- Fetch before checking recent merges or status: `git fetch origin`
 - Write notes and docs so non-technical readers can follow.
 - Avoid editing the main repo folder directly; work inside your worktree.
 
@@ -39,8 +40,9 @@
 ## Preflight check (1 minute)
 1) Confirm you are in a worktree folder like `C:\Repos\wt-<task>`
 2) Confirm your branch starts with `agent/`
-3) Run `git status -sb` and make sure it looks clean
-4) If you are in `C:\Repos\Bloomjoy_hub`, stop and switch to a worktree
+3) Run `git fetch origin` to update your view of recent merges
+4) Run `git status -sb` and make sure it looks clean
+5) If you are in `C:\Repos\Bloomjoy_hub`, stop and switch to a worktree
 
 ## Priority workflow (P0-P3)
 - Source of truth: GitHub Issues labeled `P0`, `P1`, `P2`, `P3`.


### PR DESCRIPTION
## Summary
- Add a fetch reminder so agents see the latest merges before reading history
- Clarify preflight steps for stale local branches

## Files changed
- Local dev documentation

## Verification
- `npm ci`: pass
- `npm run build`: pass (Browserslist warning)
- `npm test --if-present`: no tests
- `npm run lint --if-present`: warnings only (react-refresh/only-export-components in existing UI files)

## How to test (localhost)
1) Open `Docs/LOCAL_DEV.md`
2) Confirm the new `git fetch origin` step is listed in Preflight
3) Confirm the agent best practices section mentions fetching before checking history

## Notes / Risks
- Docs-only change
