### PR TITLE
P0 #5: Environment + config hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,12 @@
-# Client-safe values (these are exposed in the browser)
+# Client-safe values (required by the SPA and exposed in the browser)
 VITE_SUPABASE_URL=
 VITE_SUPABASE_ANON_KEY=
 
-# WARNING: Do not prefix with VITE_. Never expose secrets to client.
+# Server-only values (Supabase Edge Functions / backend only)
+# WARNING: Never prefix these with VITE_.
 STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
 STRIPE_SUGAR_PRICE_ID=
 STRIPE_PLUS_PRICE_ID=
+SUPABASE_URL=
 SUPABASE_SERVICE_ROLE_KEY=

--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -24,6 +24,7 @@
 6) Sugar checkout (Stripe Checkout via Supabase Edge Function + client redirect)
 7) Plus subscription checkout + customer portal (Stripe via Supabase Edge Functions)
 8) Stripe webhook sync (memberships + orders)
+9) Environment + config hardening (`.env.example` coverage + typed client config helper)
 
 ## Known risks / blockers
 - Product photography availability (Mini may launch as waitlist/coming soon)

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,30 @@
+const requiredClientEnvKeys = [
+  'VITE_SUPABASE_URL',
+  'VITE_SUPABASE_ANON_KEY',
+] as const;
+
+type RequiredClientEnvKey = (typeof requiredClientEnvKeys)[number];
+
+const readRequiredClientEnv = (key: RequiredClientEnvKey): string => {
+  const value = import.meta.env[key];
+
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(
+      `Missing required environment variable "${key}". Copy .env.example to .env and set all required values.`
+    );
+  }
+
+  return value;
+};
+
+export interface AppConfig {
+  supabaseUrl: string;
+  supabaseAnonKey: string;
+  isDev: boolean;
+}
+
+export const appConfig: AppConfig = {
+  supabaseUrl: readRequiredClientEnv('VITE_SUPABASE_URL'),
+  supabaseAnonKey: readRequiredClientEnv('VITE_SUPABASE_ANON_KEY'),
+  isDev: import.meta.env.DEV,
+};

--- a/src/lib/stripeCheckout.ts
+++ b/src/lib/stripeCheckout.ts
@@ -7,10 +7,6 @@ interface CheckoutResponse {
 }
 
 export async function startPlusCheckout(email: string | undefined, origin: string) {
-  if (!supabaseClient) {
-    throw new Error('Supabase is not configured.');
-  }
-
   const { data, error } = await supabaseClient.functions.invoke<CheckoutResponse>(
     'stripe-plus-checkout',
     {
@@ -34,10 +30,6 @@ export async function startPlusCheckout(email: string | undefined, origin: strin
 }
 
 export async function openCustomerPortal(email: string, origin: string) {
-  if (!supabaseClient) {
-    throw new Error('Supabase is not configured.');
-  }
-
   const { data, error } = await supabaseClient.functions.invoke<CheckoutResponse>(
     'stripe-customer-portal',
     {
@@ -60,10 +52,6 @@ export async function openCustomerPortal(email: string, origin: string) {
 }
 
 export async function startSugarCheckout(items: CartItem[], origin: string) {
-  if (!supabaseClient) {
-    throw new Error('Supabase is not configured.');
-  }
-
   const { data, error } = await supabaseClient.functions.invoke<CheckoutResponse>(
     'stripe-sugar-checkout',
     {

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,14 +1,13 @@
 import { createClient } from '@supabase/supabase-js';
+import { appConfig } from '@/lib/config';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
-
-export const supabaseClient =
-  supabaseUrl && supabaseAnonKey
-    ? createClient(supabaseUrl, supabaseAnonKey, {
-        auth: {
-          persistSession: true,
-          autoRefreshToken: true,
-        },
-      })
-    : null;
+export const supabaseClient = createClient(
+  appConfig.supabaseUrl,
+  appConfig.supabaseAnonKey,
+  {
+    auth: {
+      persistSession: true,
+      autoRefreshToken: true,
+    },
+  }
+);

--- a/src/lib/trainingRepository.ts
+++ b/src/lib/trainingRepository.ts
@@ -104,10 +104,6 @@ const toTrainingContent = (record: TrainingRecord): TrainingContent => {
 };
 
 export const fetchTrainingLibrary = async (): Promise<TrainingContent[]> => {
-  if (!supabaseClient) {
-    return fallbackTrainingContent;
-  }
-
   const { data, error } = await supabaseClient
     .from('trainings')
     .select(
@@ -151,9 +147,6 @@ export const useTrainingSourceStatus = () =>
   useQuery({
     queryKey: [...TRAINING_QUERY_KEY, 'source'],
     queryFn: async () => {
-      if (!supabaseClient) {
-        return 'local';
-      }
       const { count, error } = await supabaseClient
         .from('trainings')
         .select('*', { count: 'exact', head: true });

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,8 +1,8 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_SUPABASE_URL?: string;
-  readonly VITE_SUPABASE_ANON_KEY?: string;
+  readonly VITE_SUPABASE_URL: string;
+  readonly VITE_SUPABASE_ANON_KEY: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- Add a typed client config helper that validates required `VITE_` env vars with clear startup errors.
- Centralize Supabase env access through the new typed helper and remove nullable Supabase client checks.
- Expand `.env.example` coverage for Supabase Edge Function server-only vars and mark P0 #5 complete in current status.

## Files changed (high level)
- `src/lib/config.ts` (new typed config + env validation)
- `src/lib/supabaseClient.ts` (use typed config)
- `src/lib/stripeCheckout.ts` and `src/lib/trainingRepository.ts` (remove now-redundant null client guards)
- `.env.example` (full client + server-only env placeholders)
- `src/vite-env.d.ts` (required typings for client env vars)
- `Docs/CURRENT_STATUS.md` (record completion of P0 env/config hardening)

## Verification commands + results
- `npm ci` -> pass
- `npm run build` -> pass (existing warnings: browserslist update + large chunk warning)
- `npm test --if-present` -> pass (no tests executed)
- `npm run lint --if-present` -> pass with existing `react-refresh/only-export-components` warnings in generated UI/context files

## How to test
1. Checkout this branch: `agent/env-config-hardening`
2. In `C:\Repos\wt-env-config-hardening`, copy `.env.example` to `.env` and fill values:
   - `VITE_SUPABASE_URL`
   - `VITE_SUPABASE_ANON_KEY`
3. Run `npm ci`
4. Run `npm run dev`
5. Open `http://localhost:8080`
6. Verify app loads with valid env values; verify missing required `VITE_` values now fail fast with explicit error text.

## Notes on overlaps
- This PR touches `Docs/CURRENT_STATUS.md`, which also appears in open PR #31 (`agent/post-merge-smoke`).

Closes #5