### PR TITLE
P1 #27: Baseline login access with Plus-gated premium routes

### DIFF
--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -13,7 +13,7 @@
 - Set up Vimeo (Starter/Standard), restrict embeds to approved domains, and add video IDs + hashes into `training_assets`.
 
 ## Upcoming scope clarification (next sprint)
-- Allow non-Plus users to log in and access baseline tasks (e.g., order machines/materials); gate premium features behind Bloomjoy Plus.
+- Plus pricing model by machine count and baseline task boundaries for future portal expansion.
 
 ## Completed P0 milestones
 1) POC intake + repo hygiene (build/lint/dev) + document findings in `Docs/POC_NOTES.md`
@@ -26,6 +26,7 @@
 8) Stripe webhook sync (memberships + orders)
 9) Environment + config hardening (`.env.example` coverage + typed client config helper)
 10) Onboarding checklist with per-user completion tracking in portal
+11) Non-Plus login baseline access with Plus-gated premium portal routes
 
 ## Known risks / blockers
 - Product photography availability (Mini may launch as waitlist/coming soon)

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -22,6 +22,8 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Demo note: no real email is sent yet; any email should log in locally
 - [ ] Logged-out visit to `/portal` redirects to login
 - [ ] Dashboard loads and shows membership status placeholder
+- [ ] Non-Plus login can access baseline pages (`/portal`, `/portal/orders`, `/portal/account`)
+- [ ] Non-Plus login is blocked from premium pages (`/portal/training`, `/portal/onboarding`, `/portal/support`) with clear Plus messaging
 - [ ] Onboarding checklist progress updates when steps are toggled
 - [ ] Onboarding progress persists for the same user after page refresh/re-login
 - [ ] Training catalog visible to logged-in users

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { AuthProvider } from "@/contexts/AuthContext";
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
+import { MemberRoute } from "@/components/auth/MemberRoute";
 
 import Index from "./pages/Index";
 import Products from "./pages/Products";
@@ -61,12 +62,14 @@ const App = () => (
             <Route path="/login" element={<Login />} />
             <Route element={<ProtectedRoute />}>
               <Route path="/portal" element={<PortalDashboard />} />
-              <Route path="/portal/training" element={<PortalTraining />} />
-              <Route path="/portal/training/:id" element={<PortalTrainingDetail />} />
-              <Route path="/portal/support" element={<PortalSupport />} />
-              <Route path="/portal/onboarding" element={<PortalOnboarding />} />
               <Route path="/portal/orders" element={<PortalOrders />} />
               <Route path="/portal/account" element={<PortalAccount />} />
+              <Route element={<MemberRoute />}>
+                <Route path="/portal/training" element={<PortalTraining />} />
+                <Route path="/portal/training/:id" element={<PortalTrainingDetail />} />
+                <Route path="/portal/support" element={<PortalSupport />} />
+                <Route path="/portal/onboarding" element={<PortalOnboarding />} />
+              </Route>
             </Route>
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/components/auth/MemberRoute.tsx
+++ b/src/components/auth/MemberRoute.tsx
@@ -1,0 +1,50 @@
+import { Link, Outlet } from 'react-router-dom';
+import { Lock } from 'lucide-react';
+import { useAuth } from '@/contexts/AuthContext';
+import { PortalLayout } from '@/components/portal/PortalLayout';
+import { Button } from '@/components/ui/button';
+
+export function MemberRoute() {
+  const { loading, isMember } = useAuth();
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center text-sm text-muted-foreground">
+        Loading...
+      </div>
+    );
+  }
+
+  if (isMember) {
+    return <Outlet />;
+  }
+
+  return (
+    <PortalLayout>
+      <section className="section-padding">
+        <div className="container-page">
+          <div className="mx-auto max-w-2xl card-elevated p-8 text-center">
+            <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-primary/10">
+              <Lock className="h-7 w-7 text-primary" />
+            </div>
+            <h1 className="mt-6 font-display text-3xl font-bold text-foreground">
+              Bloomjoy Plus Required
+            </h1>
+            <p className="mt-3 text-muted-foreground">
+              This area is part of Plus membership. Baseline access still includes order history
+              and account basics.
+            </p>
+            <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+              <Button asChild>
+                <Link to="/plus">View Plus Membership</Link>
+              </Button>
+              <Button asChild variant="outline">
+                <Link to="/portal/orders">Go to Order History</Link>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </PortalLayout>
+  );
+}

--- a/src/components/portal/PortalLayout.tsx
+++ b/src/components/portal/PortalLayout.tsx
@@ -1,14 +1,15 @@
 import { ReactNode } from 'react';
 import { Layout } from '@/components/layout/Layout';
 import { NavLink } from '@/components/NavLink';
+import { useAuth } from '@/contexts/AuthContext';
 
 const portalLinks = [
-  { href: '/portal', label: 'Dashboard', end: true },
-  { href: '/portal/training', label: 'Training' },
-  { href: '/portal/onboarding', label: 'Onboarding' },
-  { href: '/portal/support', label: 'Support' },
-  { href: '/portal/orders', label: 'Orders' },
-  { href: '/portal/account', label: 'Account' },
+  { href: '/portal', label: 'Dashboard', end: true, premium: false },
+  { href: '/portal/training', label: 'Training', premium: true },
+  { href: '/portal/onboarding', label: 'Onboarding', premium: true },
+  { href: '/portal/support', label: 'Support', premium: true },
+  { href: '/portal/orders', label: 'Orders', premium: false },
+  { href: '/portal/account', label: 'Account', premium: false },
 ];
 
 interface PortalLayoutProps {
@@ -16,6 +17,8 @@ interface PortalLayoutProps {
 }
 
 export function PortalLayout({ children }: PortalLayoutProps) {
+  const { isMember } = useAuth();
+
   return (
     <Layout>
       <div className="border-b border-border bg-muted/30">
@@ -33,7 +36,12 @@ export function PortalLayout({ children }: PortalLayoutProps) {
                   className="rounded-full border border-transparent bg-background px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                   activeClassName="border-primary/20 bg-primary/10 text-primary"
                 >
-                  {link.label}
+                  <span>{link.label}</span>
+                  {link.premium && !isMember && (
+                    <span className="ml-2 rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-primary">
+                      Plus
+                    </span>
+                  )}
                 </NavLink>
               ))}
             </nav>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,11 +1,12 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { trackEvent, identifyUser } from '@/lib/analytics';
+import { hasPlusAccess, type MembershipStatus } from '@/lib/membership';
 
 // Mock user type - will be replaced with Supabase Auth user
 interface User {
   id: string;
   email: string;
-  membershipStatus?: 'active' | 'inactive' | 'none';
+  membershipStatus?: MembershipStatus;
   membershipPlan?: string;
 }
 
@@ -39,15 +40,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     try {
       // Mock magic link flow - in production, this would call Supabase
       console.log('[Auth] Magic link sent to:', email);
-      
-      // For demo, immediately "sign in"
+
+      // Default to baseline access; Plus access should come from subscription status.
       const mockUser: User = {
         id: crypto.randomUUID(),
         email,
-        membershipStatus: 'active',
-        membershipPlan: 'plus-basic',
+        membershipStatus: 'none',
       };
-      
+
       setUser(mockUser);
       localStorage.setItem('bloomjoy-user', JSON.stringify(mockUser));
       identifyUser(mockUser.id, { email: mockUser.email });
@@ -72,7 +72,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         signIn,
         signOut,
         isAuthenticated: !!user,
-        isMember: user?.membershipStatus === 'active',
+        isMember: hasPlusAccess(user?.membershipStatus),
       }}
     >
       {children}

--- a/src/lib/membership.ts
+++ b/src/lib/membership.ts
@@ -1,0 +1,11 @@
+export type MembershipStatus =
+  | 'active'
+  | 'trialing'
+  | 'past_due'
+  | 'canceled'
+  | 'inactive'
+  | 'none';
+
+// Keep membership checks aligned with subscriptions table policy logic.
+export const hasPlusAccess = (status: MembershipStatus | undefined): boolean =>
+  status === 'active' || status === 'trialing';

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -28,7 +28,7 @@ export default function LoginPage() {
     }
 
     // For demo, immediately redirect
-    toast.success('Welcome to Bloomjoy Plus!');
+    toast.success('Signed in successfully.');
     const fromPath =
       (location.state as { from?: { pathname?: string } })?.from?.pathname || '/portal';
     navigate(fromPath, { replace: true });
@@ -100,7 +100,7 @@ export default function LoginPage() {
               )}
 
               <p className="mt-6 text-center text-sm text-muted-foreground">
-                Don't have a membership?{' '}
+                Need premium training, onboarding, and support?{' '}
                 <a href="/plus" className="font-medium text-primary hover:underline">
                   Learn about Plus
                 </a>

--- a/src/pages/portal/Account.tsx
+++ b/src/pages/portal/Account.tsx
@@ -5,10 +5,12 @@ import { Input } from '@/components/ui/input';
 import { PortalLayout } from '@/components/portal/PortalLayout';
 import { useAuth } from '@/contexts/AuthContext';
 import { openCustomerPortal } from '@/lib/stripeCheckout';
+import { hasPlusAccess } from '@/lib/membership';
 import { toast } from 'sonner';
 
 export default function AccountPage() {
   const { user } = useAuth();
+  const isMember = hasPlusAccess(user?.membershipStatus);
   const [isOpeningPortal, setIsOpeningPortal] = useState(false);
 
   const handleManageBilling = async () => {
@@ -107,16 +109,18 @@ export default function AccountPage() {
                   <h2 className="font-display text-lg font-semibold text-foreground">Billing</h2>
                 </div>
                 <p className="mt-4 text-sm text-muted-foreground">
-                  Manage your subscription and payment methods through the Stripe customer portal.
+                  {isMember
+                    ? 'Manage your subscription and payment methods through the Stripe customer portal.'
+                    : 'Upgrade to Plus to unlock premium training, onboarding, and concierge support.'}
                 </p>
                 <Button
                   variant="outline"
                   className="mt-4 w-full"
                   onClick={handleManageBilling}
-                  disabled={isOpeningPortal || !user?.email}
+                  disabled={isOpeningPortal || !user?.email || !isMember}
                 >
                   <ExternalLink className="mr-2 h-4 w-4" />
-                  {isOpeningPortal ? 'Opening...' : 'Manage Billing'}
+                  {isMember ? (isOpeningPortal ? 'Opening...' : 'Manage Billing') : 'Plus Required'}
                 </Button>
               </div>
 
@@ -124,18 +128,28 @@ export default function AccountPage() {
                 <h3 className="font-semibold text-foreground">Membership</h3>
                 <div className="mt-4 flex items-center justify-between">
                   <span className="text-sm text-muted-foreground">Plan</span>
-                  <span className="font-semibold text-foreground">Plus Basic</span>
-                </div>
-                <div className="mt-2 flex items-center justify-between">
-                  <span className="text-sm text-muted-foreground">Status</span>
-                  <span className="rounded-full bg-sage-light px-2 py-0.5 text-xs font-semibold text-sage">
-                    Active
+                  <span className="font-semibold text-foreground">
+                    {isMember ? 'Plus Basic' : 'Baseline'}
                   </span>
                 </div>
                 <div className="mt-2 flex items-center justify-between">
-                  <span className="text-sm text-muted-foreground">Next billing</span>
-                  <span className="text-sm text-foreground">Feb 11, 2025</span>
+                  <span className="text-sm text-muted-foreground">Status</span>
+                  {isMember ? (
+                    <span className="rounded-full bg-sage-light px-2 py-0.5 text-xs font-semibold text-sage">
+                      Active
+                    </span>
+                  ) : (
+                    <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-semibold text-primary">
+                      Upgrade available
+                    </span>
+                  )}
                 </div>
+                {isMember && (
+                  <div className="mt-2 flex items-center justify-between">
+                    <span className="text-sm text-muted-foreground">Next billing</span>
+                    <span className="text-sm text-foreground">Feb 11, 2025</span>
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/src/pages/portal/Dashboard.tsx
+++ b/src/pages/portal/Dashboard.tsx
@@ -78,6 +78,11 @@ export default function PortalDashboard() {
                   Plus Basic Active
                 </span>
               )}
+              {!isMember && (
+                <span className="rounded-full border border-primary/30 bg-primary/10 px-4 py-2 text-sm font-semibold text-primary">
+                  Baseline Access
+                </span>
+              )}
               <Button variant="outline" size="sm" onClick={() => signOut()}>
                 Sign Out
               </Button>
@@ -90,6 +95,12 @@ export default function PortalDashboard() {
         <div className="container-page">
           {/* Quick Actions */}
           <h2 className="font-display text-xl font-semibold text-foreground">Quick Actions</h2>
+          {!isMember && (
+            <div className="mt-4 rounded-xl border border-primary/20 bg-primary/5 px-4 py-3 text-sm text-muted-foreground">
+              Baseline access includes Orders and Account. Training, onboarding, and support are
+              available with Bloomjoy Plus.
+            </div>
+          )}
           <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
             {quickActions.map((action) => (
               <Link


### PR DESCRIPTION
## Summary
- Split portal access into baseline authenticated routes and Plus-only premium routes.
- Add explicit Plus gate UX when non-members hit premium pages (training, onboarding, support).
- Update auth/member logic and portal messaging so non-Plus users can log in and use baseline tasks.

## Files changed (high level)
- Route and gating: `src/App.tsx`, `src/components/auth/MemberRoute.tsx`
- Membership logic: `src/lib/membership.ts`, `src/contexts/AuthContext.tsx`
- UX updates: `src/components/portal/PortalLayout.tsx`, `src/pages/portal/Dashboard.tsx`, `src/pages/portal/Account.tsx`, `src/pages/Login.tsx`
- Docs: `Docs/QA_SMOKE_TEST_CHECKLIST.md`, `Docs/CURRENT_STATUS.md`

## Verification commands + results
- `npm ci` -> pass
- `npm run build` -> pass (existing warnings: Browserslist data stale, large bundle chunk warning)
- `npm test --if-present` -> pass (no tests executed)
- `npm run lint --if-present` -> pass with existing `react-refresh/only-export-components` warnings

## How to test
1. Checkout branch: `agent/non-plus-access`
2. Run `npm ci`
3. Run `npm run dev`
4. Open `http://localhost:8080/login` and sign in with any email
5. Verify baseline routes are accessible:
   - `http://localhost:8080/portal`
   - `http://localhost:8080/portal/orders`
   - `http://localhost:8080/portal/account`
6. Verify premium routes are gated with clear Plus messaging for non-members:
   - `http://localhost:8080/portal/training`
   - `http://localhost:8080/portal/onboarding`
   - `http://localhost:8080/portal/support`
7. Verify portal nav shows Plus badges on premium tabs for non-members.

## Notes
- Membership access check now aligns with subscription policy semantics (`active` or `trialing` == Plus access).

Closes #27