### PR TITLE
P0 #36: Bulk sugar ordering for 4-color high-volume mixes

### DIFF
--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -27,6 +27,7 @@
 9) Environment + config hardening (`.env.example` coverage + typed client config helper)
 10) Onboarding checklist with per-user completion tracking in portal
 11) Non-Plus login baseline access with Plus-gated premium portal routes
+12) Sugar bulk ordering flow (4 colors + equal split + high-volume quantity inputs)
 
 ## Known risks / blockers
 - Product photography availability (Mini may launch as waitlist/coming soon)

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -12,8 +12,9 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Home loads and key CTAs navigate correctly
 - [ ] Product pages load (Full, Micro, Mini)
   - [ ] Mini shows “Coming soon / Waitlist” when enabled
-- [ ] Sugar page: can start checkout flow (test mode)
-- [ ] Cart checkout blocks non-supply items (remove machines before checkout)
+- [ ] Sugar page supports one-click equal split across white/blue/orange/red and allows custom per-color override
+- [ ] Sugar page handles high-volume setup (e.g., 500KG+) without repetitive click controls
+- [ ] Cart checkout blocks non-sugar items
 - [ ] Plus page: pricing and boundaries are visible and clear
 - [ ] Contact/Quote form submits (and confirmation is shown)
 
@@ -31,7 +32,8 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Support request forms submit and show success state
 
 ## Payments (test mode)
-- [ ] Sugar checkout completes with test card
+- [ ] Sugar checkout completes with test card for high-quantity equal split (e.g., 500KG total)
+- [ ] Sugar checkout completes with test card for unequal split mix (custom per-color quantities)
 - [ ] Plus subscription checkout computes expected monthly amount from selected machine count (e.g., 1x=$100, 3x=$300) and completes with test card
 - [ ] Customer Portal link opens (test mode)
 - [ ] Account page Manage Billing opens Stripe portal (test mode)
@@ -40,3 +42,4 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 ## Regression sanity
 - [ ] `npm run build` passes
 - [ ] `npm run lint` passes (if configured)
+

--- a/src/lib/cart.ts
+++ b/src/lib/cart.ts
@@ -11,7 +11,7 @@ export interface CartItem {
 
 interface CartState {
   items: CartItem[];
-  addItem: (item: Omit<CartItem, 'quantity'>) => void;
+  addItem: (item: Omit<CartItem, 'quantity'>, quantity?: number) => void;
   removeItem: (sku: string) => void;
   updateQuantity: (sku: string, quantity: number) => void;
   clearCart: () => void;
@@ -23,17 +23,18 @@ export const useCart = create<CartState>()(
   persist(
     (set, get) => ({
       items: [],
-      addItem: (item) =>
+      addItem: (item, quantity = 1) =>
         set((state) => {
+          const nextQuantity = Math.max(1, Math.floor(quantity));
           const existingItem = state.items.find((i) => i.sku === item.sku);
           if (existingItem) {
             return {
               items: state.items.map((i) =>
-                i.sku === item.sku ? { ...i, quantity: i.quantity + 1 } : i
+                i.sku === item.sku ? { ...i, quantity: i.quantity + nextQuantity } : i
               ),
             };
           }
-          return { items: [...state.items, { ...item, quantity: 1 }] };
+          return { items: [...state.items, { ...item, quantity: nextQuantity }] };
         }),
       removeItem: (sku) =>
         set((state) => ({

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -68,13 +68,64 @@ export const products: Record<string, Product> = {
     ctaType: 'buy',
     inStock: true,
   },
-  'sugar-1kg': {
-    sku: 'sugar-1kg',
-    name: 'Premium Cotton Candy Sugar',
+  'sugar-white-1kg': {
+    sku: 'sugar-white-1kg',
+    name: 'Premium Cotton Candy Sugar - White (Milk)',
     type: 'supply',
     price: 8,
     description: 'Optimized granularity, dust-free formula for consistent spins. Resealable 1KG bags for freshness and easy storage.',
-    shortDescription: '1KG resealable bag, dust-free, consistent performance',
+    shortDescription: 'White (milk) flavor, 1KG resealable bag',
+    features: [
+      'Optimized granularity for robotic machines',
+      'Dust-free formula',
+      'Consistent spin performance',
+      'Resealable 1KG bags',
+      'Quality controlled production'
+    ],
+    ctaType: 'buy',
+    inStock: true,
+  },
+  'sugar-blue-1kg': {
+    sku: 'sugar-blue-1kg',
+    name: 'Premium Cotton Candy Sugar - Blue (Blueberry)',
+    type: 'supply',
+    price: 8,
+    description: 'Optimized granularity, dust-free formula for consistent spins. Resealable 1KG bags for freshness and easy storage.',
+    shortDescription: 'Blue (blueberry) flavor, 1KG resealable bag',
+    features: [
+      'Optimized granularity for robotic machines',
+      'Dust-free formula',
+      'Consistent spin performance',
+      'Resealable 1KG bags',
+      'Quality controlled production'
+    ],
+    ctaType: 'buy',
+    inStock: true,
+  },
+  'sugar-orange-1kg': {
+    sku: 'sugar-orange-1kg',
+    name: 'Premium Cotton Candy Sugar - Orange',
+    type: 'supply',
+    price: 8,
+    description: 'Optimized granularity, dust-free formula for consistent spins. Resealable 1KG bags for freshness and easy storage.',
+    shortDescription: 'Orange flavor, 1KG resealable bag',
+    features: [
+      'Optimized granularity for robotic machines',
+      'Dust-free formula',
+      'Consistent spin performance',
+      'Resealable 1KG bags',
+      'Quality controlled production'
+    ],
+    ctaType: 'buy',
+    inStock: true,
+  },
+  'sugar-red-1kg': {
+    sku: 'sugar-red-1kg',
+    name: 'Premium Cotton Candy Sugar - Red (Strawberry)',
+    type: 'supply',
+    price: 8,
+    description: 'Optimized granularity, dust-free formula for consistent spins. Resealable 1KG bags for freshness and easy storage.',
+    shortDescription: 'Red (strawberry) flavor, 1KG resealable bag',
     features: [
       'Optimized granularity for robotic machines',
       'Dust-free formula',

--- a/src/lib/sugar.ts
+++ b/src/lib/sugar.ts
@@ -1,0 +1,119 @@
+export const SUGAR_PRICE_PER_KG = 8;
+export const MAX_SUGAR_KG_PER_COLOR = 50000;
+export const MAX_SUGAR_KG_TOTAL = MAX_SUGAR_KG_PER_COLOR * 4;
+export const DEFAULT_BULK_SUGAR_KG = 500;
+export const BULK_SUGAR_PRESETS_KG = [250, 500, 1000] as const;
+
+export const SUGAR_COLOR_OPTIONS = [
+  {
+    sku: 'sugar-white-1kg',
+    color: 'White',
+    flavor: 'Milk',
+    accentClass: 'bg-slate-100 text-slate-700',
+  },
+  {
+    sku: 'sugar-blue-1kg',
+    color: 'Blue',
+    flavor: 'Blueberry',
+    accentClass: 'bg-blue-100 text-blue-700',
+  },
+  {
+    sku: 'sugar-orange-1kg',
+    color: 'Orange',
+    flavor: 'Orange',
+    accentClass: 'bg-orange-100 text-orange-700',
+  },
+  {
+    sku: 'sugar-red-1kg',
+    color: 'Red',
+    flavor: 'Strawberry',
+    accentClass: 'bg-red-100 text-red-700',
+  },
+] as const;
+
+export type SugarSku = (typeof SUGAR_COLOR_OPTIONS)[number]['sku'];
+
+export const LEGACY_SUGAR_SKU = 'sugar-1kg';
+
+export const ALL_SUGAR_SKUS = new Set<string>([
+  ...SUGAR_COLOR_OPTIONS.map((option) => option.sku),
+  LEGACY_SUGAR_SKU,
+]);
+
+export type SugarMix = Record<SugarSku, number>;
+
+export interface SugarLineItemLike {
+  sku: string;
+  quantity: number;
+}
+
+const clampKg = (value: number) => {
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+  return Math.min(MAX_SUGAR_KG_PER_COLOR, Math.floor(value));
+};
+
+const clampTotalKg = (value: number) => {
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+  return Math.min(MAX_SUGAR_KG_TOTAL, Math.floor(value));
+};
+
+const getWhiteSku = () => SUGAR_COLOR_OPTIONS[0].sku;
+
+const resolveSugarSku = (sku: string): SugarSku | null => {
+  if (sku === LEGACY_SUGAR_SKU) {
+    return getWhiteSku();
+  }
+  const matched = SUGAR_COLOR_OPTIONS.find((option) => option.sku === sku);
+  return matched?.sku ?? null;
+};
+
+export const isSugarSku = (sku: string): boolean => ALL_SUGAR_SKUS.has(sku);
+
+export const createEmptySugarMix = (): SugarMix =>
+  Object.fromEntries(
+    SUGAR_COLOR_OPTIONS.map((option) => [option.sku, 0])
+  ) as SugarMix;
+
+export const buildEqualSugarSplit = (totalKg: number): SugarMix => {
+  const normalizedTotalKg = clampTotalKg(totalKg);
+  const mix = createEmptySugarMix();
+  const bucketCount = SUGAR_COLOR_OPTIONS.length;
+  const basePerColor = Math.floor(normalizedTotalKg / bucketCount);
+  const remainder = normalizedTotalKg % bucketCount;
+
+  SUGAR_COLOR_OPTIONS.forEach((option, index) => {
+    mix[option.sku] = basePerColor + (index < remainder ? 1 : 0);
+  });
+
+  return mix;
+};
+
+export const updateSugarMixQuantity = (
+  mix: SugarMix,
+  sku: SugarSku,
+  quantity: number
+): SugarMix => ({
+  ...mix,
+  [sku]: clampKg(quantity),
+});
+
+export const getSugarColorBreakdown = (items: SugarLineItemLike[]): SugarMix => {
+  const mix = createEmptySugarMix();
+
+  items.forEach((item) => {
+    const resolvedSku = resolveSugarSku(item.sku);
+    if (!resolvedSku) {
+      return;
+    }
+    mix[resolvedSku] += clampKg(item.quantity);
+  });
+
+  return mix;
+};
+
+export const getSugarMixTotalKg = (mix: SugarMix): number =>
+  Object.values(mix).reduce((sum, quantity) => sum + quantity, 0);

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -2,15 +2,19 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Trash2, Plus, Minus, ArrowRight, ShoppingBag } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { Layout } from '@/components/layout/Layout';
 import { useCart } from '@/lib/cart';
 import { trackEvent } from '@/lib/analytics';
 import { startSugarCheckout } from '@/lib/stripeCheckout';
+import { SUGAR_COLOR_OPTIONS, SUGAR_PRICE_PER_KG, getSugarColorBreakdown, isSugarSku } from '@/lib/sugar';
 import { toast } from 'sonner';
 
 export default function CartPage() {
   const { items, updateQuantity, removeItem, getTotal, clearCart } = useCart();
   const [isCheckingOut, setIsCheckingOut] = useState(false);
+  const sugarBreakdown = getSugarColorBreakdown(items);
+  const sugarTotalKg = Object.values(sugarBreakdown).reduce((sum, quantity) => sum + quantity, 0);
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -33,12 +37,17 @@ export default function CartPage() {
     trackEvent('start_checkout');
 
     if (items.some((item) => item.type !== 'supply')) {
-      toast.error('Checkout currently supports supplies only. Remove machines to continue.');
+      toast.error('Checkout currently supports sugar only. Remove machines to continue.');
+      return;
+    }
+
+    if (items.some((item) => !isSugarSku(item.sku))) {
+      toast.error('Checkout currently supports sugar only. Remove non-sugar items to continue.');
       return;
     }
 
     if (items.length === 0) {
-      toast.error('Add supplies to your cart to continue.');
+      toast.error('Add sugar to your cart to continue.');
       return;
     }
 
@@ -120,6 +129,19 @@ export default function CartPage() {
                       >
                         <Plus className="h-4 w-4" />
                       </Button>
+                      <Input
+                        type="number"
+                        min={0}
+                        value={item.quantity}
+                        onChange={(event) => {
+                          const value = Number(event.target.value);
+                          updateQuantity(
+                            item.sku,
+                            Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0
+                          );
+                        }}
+                        className="h-8 w-20 text-right"
+                      />
                     </div>
                     <p className="w-20 text-right font-semibold text-foreground">
                       ${(item.price * item.quantity).toFixed(2)}
@@ -143,6 +165,43 @@ export default function CartPage() {
                 <h2 className="font-display text-lg font-semibold text-foreground">
                   Order Summary
                 </h2>
+                {sugarTotalKg > 0 && (
+                  <div className="mt-4 rounded-lg border border-primary/20 bg-primary/5 p-3">
+                    <p className="text-sm font-semibold text-foreground">Sugar Mix</p>
+                    <div className="mt-2 space-y-1 text-sm text-muted-foreground">
+                      {SUGAR_COLOR_OPTIONS.map((option) => {
+                        const quantity = sugarBreakdown[option.sku];
+                        if (quantity <= 0) {
+                          return null;
+                        }
+                        return (
+                          <div key={option.sku} className="flex justify-between">
+                            <span>
+                              {option.color} ({option.flavor})
+                            </span>
+                            <span>{quantity} KG</span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                    <div className="mt-2 border-t border-primary/20 pt-2 text-sm">
+                      <div className="flex justify-between text-foreground">
+                        <span>Total sugar</span>
+                        <span className="font-semibold">{sugarTotalKg} KG</span>
+                      </div>
+                      <div className="mt-1 flex justify-between text-muted-foreground">
+                        <span>1KG bags</span>
+                        <span>{sugarTotalKg} bags</span>
+                      </div>
+                      <div className="mt-1 flex justify-between text-foreground">
+                        <span>Sugar subtotal</span>
+                        <span className="font-semibold">
+                          ${(sugarTotalKg * SUGAR_PRICE_PER_KG).toFixed(2)}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                )}
                 <div className="mt-4 space-y-3 text-sm">
                   <div className="flex justify-between">
                     <span className="text-muted-foreground">Subtotal</span>

--- a/src/pages/Supplies.tsx
+++ b/src/pages/Supplies.tsx
@@ -1,50 +1,130 @@
-import { useEffect } from 'react';
-import { ShoppingCart, Plus, Minus } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { ArrowRight, Minus, Package, Plus, ShoppingCart } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { Layout } from '@/components/layout/Layout';
 import { trackEvent } from '@/lib/analytics';
 import { useCart } from '@/lib/cart';
-import { supplies } from '@/lib/products';
+import {
+  BULK_SUGAR_PRESETS_KG,
+  DEFAULT_BULK_SUGAR_KG,
+  MAX_SUGAR_KG_TOTAL,
+  SUGAR_COLOR_OPTIONS,
+  SUGAR_PRICE_PER_KG,
+  SugarMix,
+  SugarSku,
+  buildEqualSugarSplit,
+  createEmptySugarMix,
+  getSugarColorBreakdown,
+  getSugarMixTotalKg,
+  updateSugarMixQuantity,
+} from '@/lib/sugar';
 import { toast } from 'sonner';
 import sugarProduct from '@/assets/sugar-product.jpg';
 
+const getSugarName = (color: string, flavor: string) =>
+  `Premium Cotton Candy Sugar - ${color} (${flavor}) (1KG)`;
+
 export default function SuppliesPage() {
   const { addItem, items, updateQuantity } = useCart();
+  const [targetTotalKg, setTargetTotalKg] = useState(DEFAULT_BULK_SUGAR_KG);
+  const [sugarMix, setSugarMix] = useState<SugarMix>(() =>
+    buildEqualSugarSplit(DEFAULT_BULK_SUGAR_KG)
+  );
 
   useEffect(() => {
     trackEvent('view_supplies');
   }, []);
 
-  const handleAddToCart = (sku: string, name: string, price: number) => {
-    trackEvent('add_to_cart', { sku, price });
-    addItem({ sku, name, price, type: 'supply' });
-    toast.success(`${name} added to cart!`);
-  };
+  const mixTotalKg = getSugarMixTotalKg(sugarMix);
+  const mixTotalCost = mixTotalKg * SUGAR_PRICE_PER_KG;
+  const cartSugarBreakdown = getSugarColorBreakdown(items);
+  const cartSugarTotalKg = getSugarMixTotalKg(cartSugarBreakdown);
 
   const getItemQuantity = (sku: string) => {
-    const item = items.find((i) => i.sku === sku);
+    const item = items.find((entry) => entry.sku === sku);
     return item?.quantity || 0;
+  };
+
+  const updateColorQuantity = (sku: SugarSku, rawValue: number) => {
+    setSugarMix((currentMix) => updateSugarMixQuantity(currentMix, sku, rawValue));
+  };
+
+  const handleApplyEqualSplit = (totalKg: number) => {
+    setSugarMix(buildEqualSugarSplit(totalKg));
+  };
+
+  const handlePreset = (presetKg: number) => {
+    setTargetTotalKg(presetKg);
+    handleApplyEqualSplit(presetKg);
+  };
+
+  const handleAddSugarMixToCart = () => {
+    if (mixTotalKg <= 0) {
+      toast.error('Set sugar quantities before adding to cart.');
+      return;
+    }
+
+    SUGAR_COLOR_OPTIONS.forEach((option) => {
+      const quantity = sugarMix[option.sku];
+      if (quantity <= 0) {
+        return;
+      }
+      addItem(
+        {
+          sku: option.sku,
+          name: getSugarName(option.color, option.flavor),
+          price: SUGAR_PRICE_PER_KG,
+          type: 'supply',
+        },
+        quantity
+      );
+    });
+
+    trackEvent('add_to_cart', {
+      sku: 'sugar-bulk-mix',
+      quantity: mixTotalKg,
+      sugar_white_kg: sugarMix['sugar-white-1kg'],
+      sugar_blue_kg: sugarMix['sugar-blue-1kg'],
+      sugar_orange_kg: sugarMix['sugar-orange-1kg'],
+      sugar_red_kg: sugarMix['sugar-red-1kg'],
+    });
+
+    toast.success(`Added ${mixTotalKg} KG sugar mix to cart.`);
+  };
+
+  const handleAddSticks = () => {
+    trackEvent('add_to_cart', { sku: 'sticks-plain', price: 12 });
+    addItem(
+      {
+        sku: 'sticks-plain',
+        name: 'Cotton Candy Sticks (100 pack)',
+        price: 12,
+        type: 'supply',
+      },
+      1
+    );
+    toast.success('Cotton Candy Sticks added to cart.');
   };
 
   return (
     <Layout>
-      {/* Hero */}
       <section className="bg-gradient-to-b from-cream to-background section-padding">
         <div className="container-page text-center">
           <h1 className="font-display text-4xl font-bold text-foreground sm:text-5xl">
             Supplies
           </h1>
-          <p className="mx-auto mt-4 max-w-2xl text-lg text-muted-foreground">
-            Premium cotton candy sugar and sticks, optimized for Bloomjoy machines.
+          <p className="mx-auto mt-4 max-w-3xl text-lg text-muted-foreground">
+            Bulk sugar ordering built for operators. Configure white, blue, orange, and red in
+            one flow, including 500KG+ orders.
           </p>
         </div>
       </section>
 
-      {/* Products */}
       <section className="section-padding">
         <div className="container-page">
           <div className="grid gap-8 md:grid-cols-2 lg:gap-12">
-            {/* Sugar */}
             <div className="card-elevated overflow-hidden">
               <div className="aspect-square overflow-hidden bg-muted">
                 <img
@@ -58,58 +138,144 @@ export default function SuppliesPage() {
                   Premium Cotton Candy Sugar
                 </h2>
                 <p className="mt-1 font-display text-2xl font-bold text-primary">
-                  $8 <span className="text-base font-normal text-muted-foreground">/ 1KG bag</span>
+                  ${SUGAR_PRICE_PER_KG}{' '}
+                  <span className="text-base font-normal text-muted-foreground">/ 1KG bag</span>
                 </p>
                 <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
-                  Optimized granularity, dust-free formula for consistent spins. Resealable 1KG bags for freshness and easy storage. Quality controlled production.
+                  Pick your mix across all four core colors and place high-volume orders quickly.
                 </p>
-                <ul className="mt-4 space-y-2">
-                  {[
-                    'Optimized granularity for robotic machines',
-                    'Dust-free formula',
-                    'Consistent spin performance',
-                  ].map((feature) => (
-                    <li key={feature} className="flex items-center gap-2 text-sm text-muted-foreground">
-                      <span className="h-1.5 w-1.5 rounded-full bg-primary" />
-                      {feature}
-                    </li>
-                  ))}
-                </ul>
-                <div className="mt-6">
-                  {getItemQuantity('sugar-1kg') > 0 ? (
-                    <div className="flex items-center gap-4">
-                      <div className="flex items-center gap-2 rounded-lg border border-border p-1">
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-8 w-8"
-                          onClick={() => updateQuantity('sugar-1kg', getItemQuantity('sugar-1kg') - 1)}
-                        >
-                          <Minus className="h-4 w-4" />
-                        </Button>
-                        <span className="w-8 text-center font-semibold">{getItemQuantity('sugar-1kg')}</span>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-8 w-8"
-                          onClick={() => updateQuantity('sugar-1kg', getItemQuantity('sugar-1kg') + 1)}
-                        >
-                          <Plus className="h-4 w-4" />
-                        </Button>
-                      </div>
-                      <span className="text-sm text-muted-foreground">in cart</span>
+
+                <div className="mt-6 rounded-xl border border-border bg-muted/30 p-4">
+                  <p className="text-sm font-semibold text-foreground">Bulk Order Builder</p>
+
+                  <div className="mt-3 flex flex-wrap items-end gap-3">
+                    <div>
+                      <label className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
+                        Total Target (KG)
+                      </label>
+                      <Input
+                        type="number"
+                        min={0}
+                        max={MAX_SUGAR_KG_TOTAL}
+                        value={targetTotalKg}
+                        onChange={(event) => {
+                          const value = Number(event.target.value);
+                          setTargetTotalKg(
+                            Number.isFinite(value)
+                              ? Math.min(MAX_SUGAR_KG_TOTAL, Math.max(0, Math.floor(value)))
+                              : 0
+                          );
+                        }}
+                        className="mt-1 h-9 w-32"
+                      />
                     </div>
-                  ) : (
-                    <Button onClick={() => handleAddToCart('sugar-1kg', 'Premium Cotton Candy Sugar (1KG)', 8)} className="w-full">
-                      <ShoppingCart className="mr-2 h-4 w-4" />
-                      Add to Cart
+
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleApplyEqualSplit(targetTotalKg)}
+                    >
+                      Equal Split (25% each)
                     </Button>
-                  )}
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setSugarMix(createEmptySugarMix())}
+                    >
+                      Clear
+                    </Button>
+                  </div>
+
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {BULK_SUGAR_PRESETS_KG.map((presetKg) => (
+                      <Button
+                        key={presetKg}
+                        type="button"
+                        variant={targetTotalKg === presetKg ? 'default' : 'outline'}
+                        size="sm"
+                        onClick={() => handlePreset(presetKg)}
+                      >
+                        {presetKg} KG
+                      </Button>
+                    ))}
+                  </div>
+
+                  <div className="mt-4 space-y-2">
+                    {SUGAR_COLOR_OPTIONS.map((option) => {
+                      const cartQuantity = cartSugarBreakdown[option.sku];
+                      return (
+                        <div
+                          key={option.sku}
+                          className="grid grid-cols-[1fr_auto] items-center gap-3 rounded-lg border border-border bg-background p-3"
+                        >
+                          <div>
+                            <p className="font-semibold text-foreground">
+                              {option.color}{' '}
+                              <span className="text-sm font-normal text-muted-foreground">
+                                ({option.flavor})
+                              </span>
+                            </p>
+                            <p className="text-xs text-muted-foreground">
+                              In cart: {cartQuantity} KG
+                            </p>
+                          </div>
+                          <Input
+                            type="number"
+                            min={0}
+                            value={sugarMix[option.sku]}
+                            onChange={(event) =>
+                              updateColorQuantity(option.sku, Number(event.target.value))
+                            }
+                            className="h-9 w-24 text-right"
+                          />
+                        </div>
+                      );
+                    })}
+                  </div>
+
+                  <div className="mt-4 rounded-lg border border-primary/20 bg-primary/5 p-3 text-sm">
+                    <div className="flex items-center justify-between text-foreground">
+                      <span>Total sugar</span>
+                      <span className="font-semibold">{mixTotalKg} KG</span>
+                    </div>
+                    <div className="mt-1 flex items-center justify-between text-muted-foreground">
+                      <span>1KG bags</span>
+                      <span>{mixTotalKg} bags</span>
+                    </div>
+                    <div className="mt-1 flex items-center justify-between text-foreground">
+                      <span>Estimated subtotal</span>
+                      <span className="font-semibold">${mixTotalCost.toFixed(2)}</span>
+                    </div>
+                  </div>
+
+                  <div className="mt-4 flex flex-col gap-3 sm:flex-row">
+                    <Button
+                      type="button"
+                      className="w-full"
+                      onClick={handleAddSugarMixToCart}
+                      disabled={mixTotalKg <= 0}
+                    >
+                      <ShoppingCart className="mr-2 h-4 w-4" />
+                      Add Sugar Mix to Cart
+                    </Button>
+                    <Button asChild variant="outline" className="w-full sm:w-auto">
+                      <Link to="/cart">
+                        View Cart
+                        <ArrowRight className="ml-2 h-4 w-4" />
+                      </Link>
+                    </Button>
+                  </div>
                 </div>
+
+                <p className="mt-3 text-xs text-muted-foreground">
+                  Common order pattern: equal split across all four colors, then adjust by color as
+                  needed.
+                </p>
               </div>
             </div>
 
-            {/* Sticks */}
             <div className="card-elevated overflow-hidden">
               <div className="flex aspect-square items-center justify-center bg-muted">
                 <div className="text-center text-muted-foreground">
@@ -127,18 +293,7 @@ export default function SuppliesPage() {
                 <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
                   Plain cotton candy sticks, pack of 100. Compatible with all Bloomjoy machines.
                 </p>
-                <ul className="mt-4 space-y-2">
-                  {[
-                    'Compatible with all Bloomjoy machines',
-                    'Food-grade materials',
-                    '100 sticks per pack',
-                  ].map((feature) => (
-                    <li key={feature} className="flex items-center gap-2 text-sm text-muted-foreground">
-                      <span className="h-1.5 w-1.5 rounded-full bg-primary" />
-                      {feature}
-                    </li>
-                  ))}
-                </ul>
+
                 <div className="mt-6">
                   {getItemQuantity('sticks-plain') > 0 ? (
                     <div className="flex items-center gap-4">
@@ -147,16 +302,22 @@ export default function SuppliesPage() {
                           variant="ghost"
                           size="icon"
                           className="h-8 w-8"
-                          onClick={() => updateQuantity('sticks-plain', getItemQuantity('sticks-plain') - 1)}
+                          onClick={() =>
+                            updateQuantity('sticks-plain', getItemQuantity('sticks-plain') - 1)
+                          }
                         >
                           <Minus className="h-4 w-4" />
                         </Button>
-                        <span className="w-8 text-center font-semibold">{getItemQuantity('sticks-plain')}</span>
+                        <span className="w-8 text-center font-semibold">
+                          {getItemQuantity('sticks-plain')}
+                        </span>
                         <Button
                           variant="ghost"
                           size="icon"
                           className="h-8 w-8"
-                          onClick={() => updateQuantity('sticks-plain', getItemQuantity('sticks-plain') + 1)}
+                          onClick={() =>
+                            updateQuantity('sticks-plain', getItemQuantity('sticks-plain') + 1)
+                          }
                         >
                           <Plus className="h-4 w-4" />
                         </Button>
@@ -164,39 +325,23 @@ export default function SuppliesPage() {
                       <span className="text-sm text-muted-foreground">in cart</span>
                     </div>
                   ) : (
-                    <Button onClick={() => handleAddToCart('sticks-plain', 'Cotton Candy Sticks (100 pack)', 12)} className="w-full">
+                    <Button onClick={handleAddSticks} className="w-full">
                       <ShoppingCart className="mr-2 h-4 w-4" />
                       Add to Cart
                     </Button>
                   )}
                 </div>
+
+                {cartSugarTotalKg > 0 && (
+                  <p className="mt-4 text-sm text-muted-foreground">
+                    Sugar currently in cart: {cartSugarTotalKg} KG
+                  </p>
+                )}
               </div>
             </div>
           </div>
         </div>
       </section>
     </Layout>
-  );
-}
-
-function Package(props: React.SVGProps<SVGSVGElement>) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="24"
-      height="24"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      {...props}
-    >
-      <path d="m7.5 4.27 9 5.15" />
-      <path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z" />
-      <path d="m3.3 7 8.7 5 8.7-5" />
-      <path d="M12 22V12" />
-    </svg>
   );
 }

--- a/supabase/functions/stripe-sugar-checkout/index.ts
+++ b/supabase/functions/stripe-sugar-checkout/index.ts
@@ -8,6 +8,14 @@ export const config = {
 
 const stripeSecretKey = Deno.env.get("STRIPE_SECRET_KEY");
 const sugarPriceId = Deno.env.get("STRIPE_SUGAR_PRICE_ID");
+const maxSugarKgPerCheckout = 200000;
+const allowedSugarSkus = new Set([
+  "sugar-1kg",
+  "sugar-white-1kg",
+  "sugar-blue-1kg",
+  "sugar-orange-1kg",
+  "sugar-red-1kg",
+]);
 
 if (!stripeSecretKey) {
   console.error("Missing STRIPE_SECRET_KEY");
@@ -61,20 +69,41 @@ serve(async (req) => {
       });
     }
 
-    const lineItems: { price: string; quantity: number }[] = [];
+    const sugarBreakdown = {
+      white: 0,
+      blue: 0,
+      orange: 0,
+      red: 0,
+    };
     const invalidSkus: string[] = [];
 
     for (const item of items) {
       const sku = item?.sku;
       const quantity = Number(item?.quantity ?? 0);
-      if (sku !== "sugar-1kg") {
+      if (!allowedSugarSkus.has(String(sku))) {
         invalidSkus.push(String(sku));
         continue;
       }
-      if (!Number.isFinite(quantity) || quantity <= 0) {
+      if (!Number.isInteger(quantity) || quantity <= 0) {
         continue;
       }
-      lineItems.push({ price: sugarPriceId, quantity });
+      const normalizedSku = sku === "sugar-1kg" ? "sugar-white-1kg" : String(sku);
+      switch (normalizedSku) {
+        case "sugar-white-1kg":
+          sugarBreakdown.white += quantity;
+          break;
+        case "sugar-blue-1kg":
+          sugarBreakdown.blue += quantity;
+          break;
+        case "sugar-orange-1kg":
+          sugarBreakdown.orange += quantity;
+          break;
+        case "sugar-red-1kg":
+          sugarBreakdown.red += quantity;
+          break;
+        default:
+          break;
+      }
     }
 
     if (invalidSkus.length) {
@@ -90,7 +119,13 @@ serve(async (req) => {
       );
     }
 
-    if (!lineItems.length) {
+    const totalSugarKg =
+      sugarBreakdown.white +
+      sugarBreakdown.blue +
+      sugarBreakdown.orange +
+      sugarBreakdown.red;
+
+    if (!totalSugarKg) {
       return new Response(
         JSON.stringify({ error: "No valid items in cart." }),
         {
@@ -100,14 +135,31 @@ serve(async (req) => {
       );
     }
 
+    if (totalSugarKg > maxSugarKgPerCheckout) {
+      return new Response(
+        JSON.stringify({ error: `Sugar quantity exceeds max checkout limit (${maxSugarKgPerCheckout} KG).` }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+      );
+    }
+
     const session = await stripe.checkout.sessions.create({
       mode: "payment",
-      line_items: lineItems,
+      line_items: [{ price: sugarPriceId, quantity: totalSugarKg }],
       success_url: successUrl,
       cancel_url: cancelUrl,
       billing_address_collection: "required",
       shipping_address_collection: {
         allowed_countries: ["US"],
+      },
+      metadata: {
+        sugar_total_kg: String(totalSugarKg),
+        sugar_white_kg: String(sugarBreakdown.white),
+        sugar_blue_kg: String(sugarBreakdown.blue),
+        sugar_orange_kg: String(sugarBreakdown.orange),
+        sugar_red_kg: String(sugarBreakdown.red),
       },
     });
 

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -125,6 +125,31 @@ async function upsertOrder(session: Stripe.Checkout.Session) {
     price_id: typeof item.price === "object" && item.price ? item.price.id : null,
   })) ?? [];
 
+  const sugarMixFromMetadata = {
+    white_kg: Number(session.metadata?.sugar_white_kg ?? 0),
+    blue_kg: Number(session.metadata?.sugar_blue_kg ?? 0),
+    orange_kg: Number(session.metadata?.sugar_orange_kg ?? 0),
+    red_kg: Number(session.metadata?.sugar_red_kg ?? 0),
+    total_kg: Number(session.metadata?.sugar_total_kg ?? 0),
+  };
+
+  if (
+    sugarMixFromMetadata.total_kg > 0 ||
+    sugarMixFromMetadata.white_kg > 0 ||
+    sugarMixFromMetadata.blue_kg > 0 ||
+    sugarMixFromMetadata.orange_kg > 0 ||
+    sugarMixFromMetadata.red_kg > 0
+  ) {
+    lineItems.push({
+      description: "Sugar mix breakdown",
+      quantity: sugarMixFromMetadata.total_kg || null,
+      amount_total: null,
+      currency: session.currency,
+      price_id: null,
+      metadata: sugarMixFromMetadata,
+    });
+  }
+
   const resolvedUserId = await resolveUserIdByEmail(
     session.customer_details?.email ?? session.customer_email ?? null
   );


### PR DESCRIPTION
## Summary
- Add a high-volume sugar ordering builder on `/supplies` with four color/flavor options (white, blue, orange, red), one-click equal split, and large-quantity inputs.
- Update cart + checkout flow for sugar-only validation, direct quantity entry, and clear per-color KG math before payment.
- Update Stripe sugar checkout + webhook metadata handling so high-quantity color mixes remain compatible with existing order/subscription sync.

## Files changed (high level)
- UI + cart flow: `src/pages/Supplies.tsx`, `src/pages/Cart.tsx`, `src/lib/cart.ts`, `src/lib/sugar.ts`, `src/lib/products.ts`
- Stripe functions: `supabase/functions/stripe-sugar-checkout/index.ts`, `supabase/functions/stripe-webhook/index.ts`
- Docs: `Docs/CURRENT_STATUS.md`, `Docs/QA_SMOKE_TEST_CHECKLIST.md`

## Verification commands + results
- `npm ci` -> pass
- `npm run build` -> pass (existing warnings: Browserslist stale data + large chunk warning)
- `npm test --if-present` -> pass (no tests executed)
- `npm run lint --if-present` -> pass with existing `react-refresh/only-export-components` warnings

## How to test
1. Checkout branch `agent/sugar-bulk-ordering`
2. Run `npm ci`
3. Run `npm run dev`
4. Open `http://localhost:5173/supplies`
5. In Sugar Bulk Order Builder:
   - Verify white/blue/orange/red are all present
   - Set `500` target and click `Equal Split (25% each)`
   - Confirm per-color KG updates and total shows `500 KG`
6. Override one color manually (unequal split) and confirm totals/math update
7. Click `Add Sugar Mix to Cart`, then open `http://localhost:5173/cart`
8. Confirm cart summary shows per-color KG and total sugar KG clearly
9. Verify checkout blocks non-sugar items and allows sugar-only checkout
10. Complete Stripe test checkout and verify success redirect back to `/cart?checkout=success`

Closes #36