### PR TITLE
Docs: finalize status for session closeout

### DIFF
--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -31,6 +31,7 @@
 
 ## Recently completed (post-P0)
 - Plus pricing model by machine count (`$100 per machine/month`) with Stripe quantity-based checkout
+- Supplies UX improvement: typed bulk quantity input for cotton candy sticks ordering
 
 ## Known risks / blockers
 - Product photography availability (Mini may launch as waitlist/coming soon)


### PR DESCRIPTION
## Summary
- Finalize `Docs/CURRENT_STATUS.md` with the latest merged delivery note for sticks bulk quantity UX.
- Keep current status aligned with repo reality at session close.

## Files changed (high level)
- `Docs/CURRENT_STATUS.md`

## Verification commands + results
- `npm ci` -> pass
- `npm run build` -> pass (existing warnings: stale Browserslist data + large chunk warning)
- `npm test --if-present` -> pass (no tests executed)
- `npm run lint --if-present` -> pass with existing `react-refresh/only-export-components` warnings

## How to test
1. Checkout branch `agent/session-closeout`
2. Open `Docs/CURRENT_STATUS.md`
3. Confirm recently completed list includes typed sticks bulk quantity input improvement