### PR TITLE
P1: add legal/compliance pages and global footer links

### DIFF
--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -21,6 +21,8 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Sticks ordering on `/supplies` allows direct typed quantity input (not only +/- controls)
 - [ ] Cart checkout blocks non-sugar items
 - [ ] Plus page: pricing and boundaries are visible and clear
+- [ ] Footer legal links open `/privacy`, `/terms`, and `/billing-cancellation`
+- [ ] Billing & cancellation page explains Stripe portal cancellation path and end-of-period effect
 - [ ] Contact/Quote form submits (and confirmation is shown)
 - [ ] Contact/Quote submission creates a `lead_submissions` row in Supabase with expected type/email
 - [ ] Mini waitlist submit creates a `mini_waitlist_submissions` row (duplicate email shows friendly already-on-list message)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,9 @@ import Plus from "./pages/Plus";
 import Contact from "./pages/Contact";
 import About from "./pages/About";
 import Resources from "./pages/Resources";
+import Privacy from "./pages/Privacy";
+import Terms from "./pages/Terms";
+import BillingCancellation from "./pages/BillingCancellation";
 import Cart from "./pages/Cart";
 import Login from "./pages/Login";
 import PortalDashboard from "./pages/portal/Dashboard";
@@ -64,6 +67,9 @@ const App = () => (
             <Route path="/contact" element={<Contact />} />
             <Route path="/about" element={<About />} />
             <Route path="/resources" element={<Resources />} />
+            <Route path="/privacy" element={<Privacy />} />
+            <Route path="/terms" element={<Terms />} />
+            <Route path="/billing-cancellation" element={<BillingCancellation />} />
             <Route path="/cart" element={<Cart />} />
             <Route path="/login" element={<Login />} />
             <Route element={<ProtectedRoute />}>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -18,13 +18,18 @@ const footerLinks = {
     { href: '/resources#support-boundaries', label: 'Support Boundaries' },
     { href: '/contact', label: 'Request a Quote' },
   ],
+  legal: [
+    { href: '/privacy', label: 'Privacy Policy' },
+    { href: '/terms', label: 'Terms of Service' },
+    { href: '/billing-cancellation', label: 'Billing & Cancellation' },
+  ],
 };
 
 export function Footer() {
   return (
     <footer className="border-t border-border bg-muted/30">
       <div className="container-page py-12 lg:py-16">
-        <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-4">
+        <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-5">
           {/* Brand */}
           <div className="lg:col-span-1">
             <Link to="/" className="flex items-center gap-2">
@@ -79,6 +84,23 @@ export function Footer() {
             <h4 className="font-display text-sm font-semibold text-foreground">Support</h4>
             <ul className="mt-4 space-y-3">
               {footerLinks.support.map((link) => (
+                <li key={link.href}>
+                  <Link
+                    to={link.href}
+                    className="text-sm text-muted-foreground transition-colors hover:text-primary"
+                  >
+                    {link.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Legal */}
+          <div>
+            <h4 className="font-display text-sm font-semibold text-foreground">Legal</h4>
+            <ul className="mt-4 space-y-3">
+              {footerLinks.legal.map((link) => (
                 <li key={link.href}>
                   <Link
                     to={link.href}

--- a/src/pages/BillingCancellation.tsx
+++ b/src/pages/BillingCancellation.tsx
@@ -1,0 +1,83 @@
+import { Link } from 'react-router-dom';
+import { Layout } from '@/components/layout/Layout';
+import { Button } from '@/components/ui/button';
+
+export default function BillingCancellationPage() {
+  return (
+    <Layout>
+      <section className="bg-gradient-to-b from-cream to-background section-padding">
+        <div className="container-page">
+          <h1 className="font-display text-4xl font-bold text-foreground">
+            Billing and Cancellation
+          </h1>
+          <p className="mt-4 max-w-3xl text-muted-foreground">
+            Last updated: February 23, 2026. This page explains how Bloomjoy Plus subscriptions are
+            billed, renewed, and canceled.
+          </p>
+        </div>
+      </section>
+
+      <section className="section-padding pt-0">
+        <div className="container-page">
+          <div className="card-elevated max-w-4xl space-y-8 p-6 sm:p-8">
+            <section className="space-y-3">
+              <h2 className="font-display text-2xl font-semibold text-foreground">
+                Subscription billing
+              </h2>
+              <p className="text-muted-foreground">
+                Bloomjoy Plus Basic is billed monthly based on machine count at checkout. Charges
+                recur automatically each billing cycle unless canceled.
+              </p>
+            </section>
+
+            <section className="space-y-3">
+              <h2 className="font-display text-2xl font-semibold text-foreground">
+                Managing billing details
+              </h2>
+              <p className="text-muted-foreground">
+                Active subscribers can manage payment methods, invoices, and cancellation through
+                Stripe Customer Portal from their account page.
+              </p>
+              <Button asChild variant="outline">
+                <Link to="/portal/account">Go to account billing</Link>
+              </Button>
+            </section>
+
+            <section className="space-y-3">
+              <h2 className="font-display text-2xl font-semibold text-foreground">
+                How cancellation works
+              </h2>
+              <ul className="list-disc space-y-2 pl-5 text-muted-foreground">
+                <li>Cancel from Stripe Customer Portal via your account billing settings.</li>
+                <li>Cancellation applies at the end of the current paid billing period.</li>
+                <li>
+                  After cancellation, Plus-only features are removed when the current period ends.
+                </li>
+              </ul>
+            </section>
+
+            <section className="space-y-3">
+              <h2 className="font-display text-2xl font-semibold text-foreground">
+                Refund policy
+              </h2>
+              <p className="text-muted-foreground">
+                Unless required by law, subscription charges already billed for the active period are
+                not prorated after cancellation.
+              </p>
+            </section>
+
+            <section className="space-y-3">
+              <h2 className="font-display text-2xl font-semibold text-foreground">
+                Billing questions
+              </h2>
+              <p className="text-muted-foreground">
+                For billing support, use the Contact page and include the email address tied to your
+                subscription.
+              </p>
+            </section>
+          </div>
+        </div>
+      </section>
+    </Layout>
+  );
+}

--- a/src/pages/Plus.tsx
+++ b/src/pages/Plus.tsx
@@ -199,7 +199,16 @@ export default function PlusPage() {
                   <ArrowRight className="ml-2 h-5 w-5" />
                 </Button>
                 <p className="mt-4 text-center text-xs text-muted-foreground">
-                  Membership is optional and separate from machine purchase.
+                  Membership is optional and separate from machine purchase. By continuing, you
+                  agree to our{' '}
+                  <Link to="/terms" className="underline hover:text-foreground">
+                    Terms
+                  </Link>{' '}
+                  and{' '}
+                  <Link to="/billing-cancellation" className="underline hover:text-foreground">
+                    Billing & Cancellation
+                  </Link>{' '}
+                  policies.
                 </p>
               </div>
             </div>

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -1,0 +1,88 @@
+import { Layout } from '@/components/layout/Layout';
+
+export default function PrivacyPage() {
+  return (
+    <Layout>
+      <section className="bg-gradient-to-b from-cream to-background section-padding">
+        <div className="container-page">
+          <h1 className="font-display text-4xl font-bold text-foreground">Privacy Policy</h1>
+          <p className="mt-4 max-w-3xl text-muted-foreground">
+            Last updated: February 23, 2026. This policy explains how Bloomjoy Sweets collects,
+            uses, and protects personal information when you use this website and member portal.
+          </p>
+        </div>
+      </section>
+
+      <section className="section-padding pt-0">
+        <div className="container-page">
+          <div className="card-elevated max-w-4xl space-y-8 p-6 sm:p-8">
+            <section className="space-y-3">
+              <h2 className="font-display text-2xl font-semibold text-foreground">
+                Information we collect
+              </h2>
+              <p className="text-muted-foreground">
+                We collect information you submit through forms and account settings, such as name,
+                email, phone, shipping details, and support requests. We also collect transaction
+                and subscription metadata needed to operate ordering and membership features.
+              </p>
+            </section>
+
+            <section className="space-y-3">
+              <h2 className="font-display text-2xl font-semibold text-foreground">
+                How we use information
+              </h2>
+              <ul className="list-disc space-y-2 pl-5 text-muted-foreground">
+                <li>Provide products, member services, onboarding, and support.</li>
+                <li>Process purchases, subscriptions, and account operations.</li>
+                <li>Respond to requests and improve site and portal reliability.</li>
+                <li>Maintain records needed for operations, security, and compliance.</li>
+              </ul>
+            </section>
+
+            <section className="space-y-3">
+              <h2 className="font-display text-2xl font-semibold text-foreground">
+                Payments and third-party services
+              </h2>
+              <p className="text-muted-foreground">
+                Billing is processed by Stripe. We do not store full payment card numbers on this
+                site. We also use third-party infrastructure providers to host app data and deliver
+                account functionality.
+              </p>
+            </section>
+
+            <section className="space-y-3">
+              <h2 className="font-display text-2xl font-semibold text-foreground">
+                Data sharing
+              </h2>
+              <p className="text-muted-foreground">
+                We share data only as needed to operate services, complete transactions, provide
+                support, and meet legal obligations. We do not sell personal information.
+              </p>
+            </section>
+
+            <section className="space-y-3">
+              <h2 className="font-display text-2xl font-semibold text-foreground">
+                Data retention and security
+              </h2>
+              <p className="text-muted-foreground">
+                We retain information for as long as needed to provide services and satisfy legal
+                or operational requirements. We use reasonable technical and organizational measures
+                to protect account and transaction data.
+              </p>
+            </section>
+
+            <section className="space-y-3">
+              <h2 className="font-display text-2xl font-semibold text-foreground">
+                Contact
+              </h2>
+              <p className="text-muted-foreground">
+                For privacy questions or requests, contact us through the website contact form on
+                the Contact page.
+              </p>
+            </section>
+          </div>
+        </div>
+      </section>
+    </Layout>
+  );
+}

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -1,0 +1,85 @@
+import { Layout } from '@/components/layout/Layout';
+
+export default function TermsPage() {
+  return (
+    <Layout>
+      <section className="bg-gradient-to-b from-cream to-background section-padding">
+        <div className="container-page">
+          <h1 className="font-display text-4xl font-bold text-foreground">Terms of Service</h1>
+          <p className="mt-4 max-w-3xl text-muted-foreground">
+            Last updated: February 23, 2026. These terms govern use of the Bloomjoy Sweets website,
+            storefront, and member portal.
+          </p>
+        </div>
+      </section>
+
+      <section className="section-padding pt-0">
+        <div className="container-page">
+          <div className="card-elevated max-w-4xl space-y-8 p-6 sm:p-8">
+            <section className="space-y-3">
+              <h2 className="font-display text-2xl font-semibold text-foreground">
+                Use of services
+              </h2>
+              <p className="text-muted-foreground">
+                You agree to use this site and portal for lawful business purposes. You are
+                responsible for account security and for activity under your account credentials.
+              </p>
+            </section>
+
+            <section className="space-y-3">
+              <h2 className="font-display text-2xl font-semibold text-foreground">
+                Products and availability
+              </h2>
+              <p className="text-muted-foreground">
+                Product content, availability, and pricing may change without notice. We may limit
+                quantities, reject, or cancel orders when necessary, including for pricing errors,
+                fraud concerns, or operational constraints.
+              </p>
+            </section>
+
+            <section className="space-y-3">
+              <h2 className="font-display text-2xl font-semibold text-foreground">
+                Membership and support boundaries
+              </h2>
+              <p className="text-muted-foreground">
+                Bloomjoy Plus is optional and provides onboarding, training, and concierge support
+                benefits. Manufacturer technical support remains separate. Bloomjoy support is not a
+                24/7 service unless explicitly stated in a separate written agreement.
+              </p>
+            </section>
+
+            <section className="space-y-3">
+              <h2 className="font-display text-2xl font-semibold text-foreground">
+                Billing and cancellations
+              </h2>
+              <p className="text-muted-foreground">
+                Subscription billing and cancellation are managed through Stripe Customer Portal.
+                See the Billing and Cancellation page for details on renewal and cancellation timing.
+              </p>
+            </section>
+
+            <section className="space-y-3">
+              <h2 className="font-display text-2xl font-semibold text-foreground">
+                Disclaimer and limitation of liability
+              </h2>
+              <p className="text-muted-foreground">
+                Services are provided on an as-available basis. To the maximum extent allowed by
+                law, Bloomjoy Sweets is not liable for indirect, incidental, special, or
+                consequential damages arising from use of this site, portal, or related services.
+              </p>
+            </section>
+
+            <section className="space-y-3">
+              <h2 className="font-display text-2xl font-semibold text-foreground">
+                Contact
+              </h2>
+              <p className="text-muted-foreground">
+                Questions about these terms can be submitted through the website Contact page.
+              </p>
+            </section>
+          </div>
+        </div>
+      </section>
+    </Layout>
+  );
+}

--- a/src/pages/portal/Account.tsx
+++ b/src/pages/portal/Account.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
 import { User, MapPin, CreditCard, ExternalLink } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -317,6 +318,13 @@ export default function AccountPage() {
                   <ExternalLink className="mr-2 h-4 w-4" />
                   {isMember ? (isOpeningPortal ? 'Opening...' : 'Manage Billing') : 'Plus Required'}
                 </Button>
+                <p className="mt-3 text-xs text-muted-foreground">
+                  Review{' '}
+                  <Link to="/billing-cancellation" className="underline hover:text-foreground">
+                    billing and cancellation terms
+                  </Link>
+                  .
+                </p>
               </div>
 
               <div className="mt-6 card-elevated p-6">


### PR DESCRIPTION
## Summary
- Add launch-ready legal pages for Privacy Policy, Terms of Service, and Billing/Cancellation.
- Wire legal routes and add global footer links so all legal content is reachable site-wide.
- Clarify subscription cancellation guidance on Plus and portal Account screens to match Stripe portal behavior.

## Files changed
- Routing: `src/App.tsx`
- Global footer links: `src/components/layout/Footer.tsx`
- New legal pages: `src/pages/Privacy.tsx`, `src/pages/Terms.tsx`, `src/pages/BillingCancellation.tsx`
- Subscription copy updates: `src/pages/Plus.tsx`, `src/pages/portal/Account.tsx`
- Smoke checklist updates: `Docs/QA_SMOKE_TEST_CHECKLIST.md`

## Verification commands + results
- `npm ci` ? pass
- `npm run build` ? pass
- `npm test --if-present` ? pass (no tests configured)
- `npm run lint --if-present` ? pass (existing non-blocking warnings only)

## How to test
1. Checkout branch `agent/high-priority-session`.
2. Run `npm ci`.
3. Run `npm run dev`.
4. Open `http://localhost:5173`.
5. In the footer, open:
   - `/privacy`
   - `/terms`
   - `/billing-cancellation`
6. Verify Plus page legal copy links:
   - `http://localhost:5173/plus`
   - Terms link opens `/terms`
   - Billing & Cancellation link opens `/billing-cancellation`
7. Verify portal account billing guidance link:
   - Log in, then open `http://localhost:5173/portal/account`
   - Billing card includes link to `/billing-cancellation`

Closes #59
