### PR TITLE
P1: fix horizontal overflow on mobile account page

### DIFF
--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -34,6 +34,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Non-Plus login is blocked from premium pages (`/portal/training`, `/portal/onboarding`, `/portal/support`) with clear Plus messaging
 - [ ] `/portal/orders` loads real `orders` data for the logged-in user (no mock rows)
 - [ ] `/portal/account` shows live membership status and period from `subscriptions` (no hardcoded next billing date)
+- [ ] `/portal/account` has no horizontal page overflow on mobile viewports (360x800, 390x844, 414x896)
 - [ ] `/portal/account` profile save persists and reloads from `customer_profiles`
 - [ ] `/portal/account` shipping save persists and reloads from `customer_profiles`
 - [ ] Onboarding checklist progress updates when steps are toggled

--- a/src/pages/portal/Account.tsx
+++ b/src/pages/portal/Account.tsx
@@ -149,14 +149,14 @@ export default function AccountPage() {
 
   return (
     <PortalLayout>
-      <section className="section-padding">
+      <section className="section-padding overflow-x-clip">
         <div className="container-page">
           <h1 className="font-display text-3xl font-bold text-foreground">Account Settings</h1>
 
           <div className="mt-8 grid gap-8 lg:grid-cols-3">
             {/* Profile */}
-            <div className="lg:col-span-2">
-              <div className="card-elevated p-6">
+            <div className="min-w-0 lg:col-span-2">
+              <div className="card-elevated min-w-0 p-6">
                 <div className="flex items-center gap-3">
                   <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
                     <User className="h-5 w-5 text-primary" />
@@ -209,7 +209,7 @@ export default function AccountPage() {
               </div>
 
               {/* Shipping */}
-              <div className="mt-6 card-elevated p-6">
+              <div className="mt-6 card-elevated min-w-0 p-6">
                 <div className="flex items-center gap-3">
                   <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
                     <MapPin className="h-5 w-5 text-primary" />
@@ -295,8 +295,8 @@ export default function AccountPage() {
             </div>
 
             {/* Billing */}
-            <div>
-              <div className="card-elevated p-6">
+            <div className="min-w-0">
+              <div className="card-elevated min-w-0 p-6">
                 <div className="flex items-center gap-3">
                   <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10">
                     <CreditCard className="h-5 w-5 text-primary" />
@@ -319,28 +319,28 @@ export default function AccountPage() {
                 </Button>
               </div>
 
-              <div className="mt-6 card-elevated p-6">
+              <div className="mt-6 card-elevated min-w-0 p-6">
                 <h3 className="font-semibold text-foreground">Membership</h3>
-                <div className="mt-4 flex items-center justify-between">
+                <div className="mt-4 flex flex-wrap items-center justify-between gap-2">
                   <span className="text-sm text-muted-foreground">Plan</span>
                   <span className="font-semibold text-foreground">
                     {isMember ? 'Plus Basic' : 'Baseline'}
                   </span>
                 </div>
-                <div className="mt-2 flex items-center justify-between">
+                <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
                   <span className="text-sm text-muted-foreground">Status</span>
                   {isMember ? (
-                    <span className="rounded-full bg-sage-light px-2 py-0.5 text-xs font-semibold text-sage">
+                    <span className="max-w-full rounded-full bg-sage-light px-2 py-0.5 text-xs font-semibold text-sage">
                       {membershipStatusLabel}
                     </span>
                   ) : (
-                    <span className="rounded-full bg-primary/10 px-2 py-0.5 text-xs font-semibold text-primary">
+                    <span className="max-w-full rounded-full bg-primary/10 px-2 py-0.5 text-xs font-semibold text-primary">
                       {membershipStatusLabel}
                     </span>
                   )}
                 </div>
                 {isMember && (
-                  <div className="mt-2 flex items-center justify-between">
+                  <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
                     <span className="text-sm text-muted-foreground">Next billing</span>
                     <span className="text-sm text-foreground">
                       {nextBillingLabel ?? 'Not available'}


### PR DESCRIPTION
## Summary
- Fix horizontal overflow risk on `/portal/account` mobile layouts by tightening responsive width constraints.
- Add wrapping behavior for membership metadata rows that can force overflow on narrow screens.
- Add an explicit mobile overflow smoke check for the account page.

## Files changed
- `src/pages/portal/Account.tsx`
- `Docs/QA_SMOKE_TEST_CHECKLIST.md`

## Verification commands + results
- `npm ci` ? pass
- `npm run build` ? pass
- `npm test --if-present` ? pass (no tests configured)
- `npm run lint --if-present` ? pass (existing non-blocking warnings only)

## How to test
1. Checkout branch `agent/mobile-account-overflow-fix`.
2. Run `npm ci`.
3. Run `npm run dev`.
4. Log in and open `http://localhost:5173/portal/account`.
5. In responsive mode, verify there is no horizontal page scrolling at:
   - 360x800
   - 390x844
   - 414x896
6. Verify primary actions remain usable without side scrolling:
   - `Save Changes`
   - `Update Address`
   - `Manage Billing` / `Plus Required`

## Multi-PR overlap note
- This PR and #69 both modify `Docs/QA_SMOKE_TEST_CHECKLIST.md`. If #69 merges first, sync `main` and re-run verification before final merge.

Closes #49
