### PR TITLE
Fix stale localhost URL in QA smoke checklist

### DIFF
--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -4,7 +4,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 
 ## Global
 - [ ] App starts: `npm ci` then `npm run dev`
-- [ ] Open the URL printed in the terminal (usually http://localhost:5173)
+- [ ] Open the URL printed in the terminal (usually http://localhost:8080)
 - [ ] No console errors on home page load
 - [ ] Mobile header/nav works (basic)
 


### PR DESCRIPTION
## Summary
- Fix stale localhost URL in QA smoke checklist to match current Vite dev port.

## Files changed
- `Docs/QA_SMOKE_TEST_CHECKLIST.md`

## Verification commands + results
- `npm ci` ✅
- `npm run build` ✅
- `npm test --if-present` ✅ (no test script present)
- `npm run lint --if-present` ✅ (warnings only; no lint errors)

## How to test
1. Checkout `agent/hygiene-final-pass`.
2. Open `Docs/QA_SMOKE_TEST_CHECKLIST.md`.
3. Confirm Global step now says `http://localhost:8080`.