### PR TITLE
P0 training hardening: Vimeo startup UX, module taxonomy filters, and section clarity

### DIFF
--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -7,16 +7,14 @@
 - Write updates in plain language so non-technical readers can follow.
 
 ## Next P0 milestones
-- `#89` P0 Training performance: improve Vimeo load speed and startup UX.
-- `#91` P0 Training UX: clarify "What you will learn" / "Checklist" / "Resources" section purpose.
-- `#90` P0 Training taxonomy: support Module 1/2/3 tags in library UX.
+- Validate and merge the training hardening slice for `#89`, `#90`, and `#91` (build/lint pass and localhost smoke checks on module filtering + detail UX clarity + Vimeo loading state).
 
 ## Owner next steps
 - Execute production auth setup in `Docs/AUTH_OAUTH_BRANDING_RUNBOOK.md` (Google branding, custom auth domain, redirect/origin verification).
 - Complete launch evidence and approvals in `Docs/AUTH_PRODUCTION_SIGNOFF.md`.
 - Enable Supabase Custom Domain add-on for project `ygbzkgxktzqsiygjlqyg` to unblock `auth.bloomjoysweets.com` cutover (required for issue `#78`).
 - Upload Module 2 and Module 3 Vimeo videos when ready and extend `trainings` + `training_assets` with the same seeded pattern used for Module 1.
-- Add Vimeo tags for module segmentation (Module 1/2/3) to support the new P0 training taxonomy work (`#90`).
+- Add Vimeo tags for Module 2/3 as content is uploaded so the new module-filter UX can segment beyond Module 1.
 
 ## Upcoming scope clarification (next sprint)
 - Super-admin requirements and role model are complete for MVP scope (`#37` with implementation slices `#44`-`#48` delivered in PR `#55`).
@@ -67,6 +65,10 @@
 - Auth recovery hardening (`PR #88`): added password reset request + `/reset-password` completion flow.
 - Quote-intake clarity hardening (`PR #88`): machine quote CTA now carries machine-of-interest context into contact submissions.
 - Local QA admin access helper (`PR #88`): optional `VITE_DEV_ADMIN_EMAILS` local-only override for internal Plus feature testing.
+- Training performance hardening (`#89`): training detail now shows a clear Vimeo loading state, adds Vimeo preconnect hints, and emits iframe startup timing analytics.
+- Training detail clarity hardening (`#91`): renamed and clarified post-video sections with helper copy plus explicit empty-state fallbacks for learning outcomes/checklist/resources.
+- Training taxonomy hardening (`#90`): training catalog now supports module-specific filtering/grouping (for example `Module 1/2/3`) and includes an operations script to enforce Vimeo tags (`scripts/vimeo-ensure-tag.mjs`).
+- Vimeo operations update (`#90`): current Vimeo library was normalized so all 17 uploaded videos are tagged `Module 1`.
 
 ## Known risks / blockers
 - Product photography availability (Mini may launch as waitlist/coming soon)
@@ -74,7 +76,7 @@
 - Production credential execution remains owner-controlled (Google/Supabase/SMTP/DNS changes must be completed in dashboard tools before launch sign-off).
 - `#78` currently blocked on Supabase side: Custom Domain add-on is not enabled yet for project `ygbzkgxktzqsiygjlqyg`, so domain create/activate commands cannot run.
 - Vimeo Module 1 is live; Modules 2/3 are pending upload/seed.
-- Training UX feedback indicates Vimeo startup feels slow and learning-section purpose is unclear; now tracked as P0 issues (`#89`, `#91`).
+- Module taxonomy UX is implemented, but cross-module validation is pending until Module 2/3 videos are uploaded/tagged.
 - Lint passes but still shows fast-refresh warnings in generated UI files
 
 ## Environments

--- a/Docs/LOCAL_DEV.md
+++ b/Docs/LOCAL_DEV.md
@@ -41,6 +41,19 @@
    - `provider_hash`
    - `meta.thumbnail_url` (first-party key in `training-thumbnails` bucket, for example `vimeo/<video_id>.jpg`)
 
+## Vimeo module tag sync (operations helper)
+Use this when Vimeo uploads are missing module taxonomy tags (for example `Module 1`).
+
+1) Ensure your local env includes `VIMEO_ACCESS_TOKEN` with Vimeo write access
+2) Dry run:
+   - `node scripts/vimeo-ensure-tag.mjs --tag "Module 1" --dry-run`
+3) Apply updates:
+   - `node scripts/vimeo-ensure-tag.mjs --tag "Module 1"`
+
+Notes:
+- Script is idempotent and skips videos that already have the target tag.
+- Current helper targets all videos visible to the authenticated Vimeo account (`/me/videos`).
+
 ## Supabase auth setup (password + Google + magic link)
 To use all login methods in local dev:
 1) Open Supabase Dashboard -> Authentication -> Providers.

--- a/index.html
+++ b/index.html
@@ -13,6 +13,12 @@
     <meta property="og:description" content="Lovable Generated Project" />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+    <link rel="dns-prefetch" href="//player.vimeo.com" />
+    <link rel="dns-prefetch" href="//i.vimeocdn.com" />
+    <link rel="dns-prefetch" href="//f.vimeocdn.com" />
+    <link rel="preconnect" href="https://player.vimeo.com" crossorigin />
+    <link rel="preconnect" href="https://i.vimeocdn.com" crossorigin />
+    <link rel="preconnect" href="https://f.vimeocdn.com" crossorigin />
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@Lovable" />

--- a/scripts/vimeo-ensure-tag.mjs
+++ b/scripts/vimeo-ensure-tag.mjs
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+
+const API_BASE = 'https://api.vimeo.com';
+const token = process.env.VIMEO_ACCESS_TOKEN;
+
+if (!token) {
+  console.error('Missing VIMEO_ACCESS_TOKEN in environment.');
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const tagFlagIndex = args.findIndex((arg) => arg === '--tag');
+const tag =
+  tagFlagIndex >= 0 && args[tagFlagIndex + 1] ? String(args[tagFlagIndex + 1]).trim() : 'Module 1';
+
+if (!tag) {
+  console.error('Tag cannot be empty.');
+  process.exit(1);
+}
+
+const request = async (path, init = {}) => {
+  const response = await fetch(`${API_BASE}${path}`, {
+    ...init,
+    headers: {
+      Accept: 'application/vnd.vimeo.*+json;version=3.4',
+      Authorization: `bearer ${token}`,
+      ...init.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`${response.status} ${response.statusText} :: ${body.slice(0, 300)}`);
+  }
+
+  if (response.status === 204) {
+    return null;
+  }
+  return response.json();
+};
+
+const extractVideoId = (uri) => {
+  const match = String(uri || '').match(/\/videos\/(\d+)/);
+  return match ? match[1] : null;
+};
+
+const fetchAllVideos = async () => {
+  const videos = [];
+  let page = 1;
+
+  while (true) {
+    const payload = await request(`/me/videos?per_page=100&page=${page}`);
+    const pageItems = Array.isArray(payload?.data) ? payload.data : [];
+    videos.push(...pageItems);
+
+    const next = payload?.paging?.next;
+    if (!next || pageItems.length === 0) {
+      break;
+    }
+    page += 1;
+  }
+
+  return videos;
+};
+
+const fetchVideoTags = async (videoId) => {
+  const payload = await request(`/videos/${videoId}/tags?per_page=100`);
+  const names = Array.isArray(payload?.data)
+    ? payload.data
+        .map((item) => item?.tag)
+        .filter((value) => typeof value === 'string')
+        .map((value) => value.trim())
+        .filter(Boolean)
+    : [];
+
+  return names;
+};
+
+const ensureTagOnVideo = async (videoId, tagValue) => {
+  const encoded = encodeURIComponent(tagValue);
+  await request(`/videos/${videoId}/tags/${encoded}`, { method: 'PUT' });
+};
+
+const main = async () => {
+  console.log(`Ensuring tag "${tag}" on all Vimeo uploads${dryRun ? ' (dry run)' : ''}...`);
+  const videos = await fetchAllVideos();
+  console.log(`Found ${videos.length} videos.`);
+
+  let alreadyTagged = 0;
+  let updated = 0;
+  let failed = 0;
+
+  for (const video of videos) {
+    const videoId = extractVideoId(video?.uri);
+    const name = String(video?.name || `Video ${videoId || 'unknown'}`);
+
+    if (!videoId) {
+      console.warn(`Skipping video with unrecognized URI: ${video?.uri || '(missing)'}`);
+      failed += 1;
+      continue;
+    }
+
+    try {
+      const tags = await fetchVideoTags(videoId);
+      const hasTag = tags.some((existing) => existing.toLowerCase() === tag.toLowerCase());
+
+      if (hasTag) {
+        alreadyTagged += 1;
+        console.log(`[skip] ${videoId} :: ${name} (already tagged)`);
+        continue;
+      }
+
+      if (dryRun) {
+        updated += 1;
+        console.log(`[plan] ${videoId} :: ${name} (would add "${tag}")`);
+        continue;
+      }
+
+      await ensureTagOnVideo(videoId, tag);
+      updated += 1;
+      console.log(`[add] ${videoId} :: ${name}`);
+    } catch (error) {
+      failed += 1;
+      console.warn(`[fail] ${videoId} :: ${name} :: ${error.message}`);
+    }
+  }
+
+  console.log('');
+  console.log('Summary');
+  console.log(`- Total videos: ${videos.length}`);
+  console.log(`- Already tagged: ${alreadyTagged}`);
+  console.log(`- Updated: ${updated}`);
+  console.log(`- Failed: ${failed}`);
+
+  if (failed > 0) {
+    process.exit(2);
+  }
+};
+
+main().catch((error) => {
+  console.error(`Unexpected error: ${error.message}`);
+  process.exit(1);
+});

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -22,6 +22,7 @@ type EventName =
   | 'view_training_catalog'
   | 'open_training_item'
   | 'view_training_detail'
+  | 'training_video_iframe_loaded'
   | 'submit_support_request_concierge'
   | 'submit_support_request_parts'
   | 'submit_support_request_onboarding'

--- a/src/pages/portal/Training.tsx
+++ b/src/pages/portal/Training.tsx
@@ -7,9 +7,34 @@ import { trackEvent } from '@/lib/analytics';
 import { getTrainingTags } from '@/data/trainingContent';
 import { useTrainingLibrary, useTrainingSourceStatus } from '@/lib/trainingRepository';
 
+const MODULE_TAG_PATTERN = /^module\s+(\d+)$/i;
+
+const normalizeModuleTag = (tag: string) => {
+  const trimmed = tag.trim();
+  const match = trimmed.match(MODULE_TAG_PATTERN);
+  if (!match) {
+    return trimmed;
+  }
+  return `Module ${match[1]}`;
+};
+
+const getModuleNumber = (tag: string) => {
+  const match = tag.match(MODULE_TAG_PATTERN);
+  if (!match) {
+    return Number.MAX_SAFE_INTEGER;
+  }
+  return Number.parseInt(match[1], 10);
+};
+
+const extractModuleTag = (tags: string[]) => {
+  const moduleTag = tags.find((tag) => MODULE_TAG_PATTERN.test(tag.trim()));
+  return moduleTag ? normalizeModuleTag(moduleTag) : undefined;
+};
+
 export default function TrainingPage() {
   const [search, setSearch] = useState('');
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [selectedModule, setSelectedModule] = useState<string>('All modules');
   const { data: library = [], isLoading } = useTrainingLibrary();
   const { data: source = 'local' } = useTrainingSourceStatus();
 
@@ -21,13 +46,48 @@ export default function TrainingPage() {
     trackEvent('open_training_item', { id, title });
   };
 
+  const moduleFilters = [...new Set(library.map((item) => extractModuleTag(item.tags)).filter(Boolean))]
+    .map((tag) => String(tag))
+    .sort((a, b) => getModuleNumber(a) - getModuleNumber(b));
+
+  const topicTags = getTrainingTags(library)
+    .filter((tag) => !MODULE_TAG_PATTERN.test(tag.trim()))
+    .sort((a, b) => a.localeCompare(b));
+
   const filteredContent = library.filter((content) => {
     const matchesSearch =
       content.title.toLowerCase().includes(search.toLowerCase()) ||
       content.description.toLowerCase().includes(search.toLowerCase());
+    const contentModuleTag = extractModuleTag(content.tags);
+    const matchesModule = selectedModule === 'All modules' || contentModuleTag === selectedModule;
     const matchesTags =
       selectedTags.length === 0 || selectedTags.some((tag) => content.tags.includes(tag));
-    return matchesSearch && matchesTags;
+    return matchesSearch && matchesModule && matchesTags;
+  });
+
+  const groupedContent = filteredContent.reduce<Record<string, typeof filteredContent>>((acc, item) => {
+    const moduleTag = extractModuleTag(item.tags) ?? 'Unassigned module';
+    if (!acc[moduleTag]) {
+      acc[moduleTag] = [];
+    }
+    acc[moduleTag].push(item);
+    return acc;
+  }, {});
+
+  const groupedEntries = Object.entries(groupedContent).sort(([groupA], [groupB]) => {
+    const groupAIsModule = MODULE_TAG_PATTERN.test(groupA);
+    const groupBIsModule = MODULE_TAG_PATTERN.test(groupB);
+
+    if (groupAIsModule && groupBIsModule) {
+      return getModuleNumber(groupA) - getModuleNumber(groupB);
+    }
+    if (groupAIsModule) {
+      return -1;
+    }
+    if (groupBIsModule) {
+      return 1;
+    }
+    return groupA.localeCompare(groupB);
   });
 
   const toggleTag = (tag: string) => {
@@ -63,8 +123,39 @@ export default function TrainingPage() {
             </div>
           </div>
 
+          <div className="mt-4">
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+              Filter by module
+            </p>
+            <div className="mt-2 flex flex-wrap gap-2">
+              <button
+                onClick={() => setSelectedModule('All modules')}
+                className={`rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+                  selectedModule === 'All modules'
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-muted text-muted-foreground hover:bg-muted/80'
+                }`}
+              >
+                All modules
+              </button>
+              {moduleFilters.map((moduleTag) => (
+                <button
+                  key={moduleTag}
+                  onClick={() => setSelectedModule(moduleTag)}
+                  className={`rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+                    selectedModule === moduleTag
+                      ? 'bg-primary text-primary-foreground'
+                      : 'bg-muted text-muted-foreground hover:bg-muted/80'
+                  }`}
+                >
+                  {moduleTag}
+                </button>
+              ))}
+            </div>
+          </div>
+
           <div className="mt-4 flex flex-wrap gap-2">
-            {getTrainingTags(library).map((tag) => (
+            {topicTags.map((tag) => (
               <button
                 key={tag}
                 onClick={() => toggleTag(tag)}
@@ -79,75 +170,89 @@ export default function TrainingPage() {
             ))}
           </div>
 
-          <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-            {isLoading && (
-              <div className="col-span-full text-sm text-muted-foreground">
-                Loading training content…
-              </div>
-            )}
-            {!isLoading && import.meta.env.DEV && (
-              <div className="col-span-full rounded-xl border border-border bg-muted/40 px-4 py-3 text-xs uppercase tracking-[0.2em] text-muted-foreground">
-                Data source: {source === 'supabase' ? 'Supabase' : 'Local fallback'}
-              </div>
-            )}
-            {filteredContent.map((content) => (
-              <Link
-                key={content.id}
-                to={`/portal/training/${content.id}`}
-                onClick={() => handleOpenItem(content.id, content.title)}
-                className="group card-elevated overflow-hidden transition-all hover:-translate-y-0.5"
-              >
-                <div className="relative aspect-video overflow-hidden bg-muted">
-                  {content.thumbnailUrl && (
-                    <img
-                      src={content.thumbnailUrl}
-                      alt=""
-                      loading="lazy"
-                      className="absolute inset-0 h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"
-                      referrerPolicy="no-referrer"
-                    />
-                  )}
-                  <div
-                    className={`absolute inset-0 flex items-center justify-center transition-colors ${
-                      content.thumbnailUrl ? 'bg-black/20 group-hover:bg-black/10' : ''
-                    }`}
-                  >
-                    <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/90 text-primary-foreground transition-transform group-hover:scale-110">
-                      <Play className="h-5 w-5 fill-current" />
-                    </div>
-                  </div>
-                </div>
-                <div className="p-4">
-                  <h3 className="font-semibold text-foreground group-hover:text-primary">
-                    {content.title}
-                  </h3>
-                  <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
-                    {content.description}
-                  </p>
-                  <div className="mt-3 flex items-center justify-between">
-                    <div className="flex items-center gap-1 text-sm text-muted-foreground">
-                      <Clock className="h-4 w-4" />
-                      {content.duration}
-                    </div>
-                    <div className="flex gap-1">
-                      {content.tags.slice(0, 2).map((tag) => (
-                        <span
-                          key={tag}
-                          className="rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground"
-                        >
-                          {tag}
-                        </span>
-                      ))}
-                    </div>
-                  </div>
-                </div>
-              </Link>
-            ))}
-          </div>
+          {isLoading && (
+            <div className="mt-8 text-sm text-muted-foreground">Loading training content...</div>
+          )}
 
-          {filteredContent.length === 0 && (
+          {!isLoading && import.meta.env.DEV && (
+            <div className="mt-8 rounded-xl border border-border bg-muted/40 px-4 py-3 text-xs uppercase tracking-[0.2em] text-muted-foreground">
+              Data source: {source === 'supabase' ? 'Supabase' : 'Local fallback'}
+            </div>
+          )}
+
+          {!isLoading &&
+            groupedEntries.map(([groupName, items]) => (
+              <section key={groupName} className="mt-8">
+                <div className="flex items-center justify-between gap-3">
+                  <h2 className="font-display text-xl font-semibold text-foreground">{groupName}</h2>
+                  <span className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
+                    {items.length} {items.length === 1 ? 'video' : 'videos'}
+                  </span>
+                </div>
+
+                <div className="mt-4 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                  {items.map((content) => (
+                    <Link
+                      key={content.id}
+                      to={`/portal/training/${content.id}`}
+                      onClick={() => handleOpenItem(content.id, content.title)}
+                      className="group card-elevated overflow-hidden transition-all hover:-translate-y-0.5"
+                    >
+                      <div className="relative aspect-video overflow-hidden bg-muted">
+                        {content.thumbnailUrl && (
+                          <img
+                            src={content.thumbnailUrl}
+                            alt=""
+                            loading="lazy"
+                            className="absolute inset-0 h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"
+                            referrerPolicy="no-referrer"
+                          />
+                        )}
+                        <div
+                          className={`absolute inset-0 flex items-center justify-center transition-colors ${
+                            content.thumbnailUrl ? 'bg-black/20 group-hover:bg-black/10' : ''
+                          }`}
+                        >
+                          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/90 text-primary-foreground transition-transform group-hover:scale-110">
+                            <Play className="h-5 w-5 fill-current" />
+                          </div>
+                        </div>
+                      </div>
+                      <div className="p-4">
+                        <h3 className="font-semibold text-foreground group-hover:text-primary">
+                          {content.title}
+                        </h3>
+                        <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">
+                          {content.description}
+                        </p>
+                        <div className="mt-3 flex items-center justify-between">
+                          <div className="flex items-center gap-1 text-sm text-muted-foreground">
+                            <Clock className="h-4 w-4" />
+                            {content.duration}
+                          </div>
+                          <div className="flex gap-1">
+                            {content.tags.slice(0, 2).map((tag) => (
+                              <span
+                                key={tag}
+                                className="rounded bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+                              >
+                                {tag}
+                              </span>
+                            ))}
+                          </div>
+                        </div>
+                      </div>
+                    </Link>
+                  ))}
+                </div>
+              </section>
+            ))}
+
+          {filteredContent.length === 0 && !isLoading && (
             <div className="mt-12 text-center">
-              <p className="text-muted-foreground">No training content matches your search.</p>
+              <p className="text-muted-foreground">
+                No training content matches your current module, tag, or search filters.
+              </p>
             </div>
           )}
         </div>

--- a/src/pages/portal/TrainingDetail.tsx
+++ b/src/pages/portal/TrainingDetail.tsx
@@ -1,6 +1,6 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
-import { Clock, ChevronLeft, CheckCircle2, FileText, HelpCircle } from 'lucide-react';
+import { Clock, ChevronLeft, CheckCircle2, FileText, HelpCircle, Loader2 } from 'lucide-react';
 import { PortalLayout } from '@/components/portal/PortalLayout';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -11,12 +11,25 @@ export default function TrainingDetailPage() {
   const { id } = useParams();
   const { data: library = [] } = useTrainingLibrary();
   const trainingItem = id ? library.find((item) => item.id === id) : undefined;
+  const [videoLoaded, setVideoLoaded] = useState(false);
+  const [videoLoadStartedAt, setVideoLoadStartedAt] = useState<number | null>(null);
 
   useEffect(() => {
     if (trainingItem) {
       trackEvent('view_training_detail', { id: trainingItem.id });
     }
   }, [trainingItem]);
+
+  useEffect(() => {
+    if (!trainingItem?.embed.url) {
+      setVideoLoaded(true);
+      setVideoLoadStartedAt(null);
+      return;
+    }
+
+    setVideoLoaded(false);
+    setVideoLoadStartedAt(typeof performance !== 'undefined' ? performance.now() : Date.now());
+  }, [trainingItem?.id, trainingItem?.embed.url]);
 
   if (!trainingItem) {
     return (
@@ -40,9 +53,28 @@ export default function TrainingDetailPage() {
     );
   }
 
+  const learningPoints = trainingItem.learningPoints.filter((point) => point.trim().length > 0);
+  const checklistItems = trainingItem.checklist.filter((item) => item.trim().length > 0);
+  const resources = trainingItem.resources;
+
   const related = library
     .filter((item) => item.id !== trainingItem.id)
     .slice(0, 3);
+
+  const handleVideoLoad = () => {
+    setVideoLoaded(true);
+
+    if (!videoLoadStartedAt) {
+      return;
+    }
+
+    const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+    const startupMs = Math.max(0, Math.round(now - videoLoadStartedAt));
+    trackEvent('training_video_iframe_loaded', {
+      id: trainingItem.id,
+      startup_ms: startupMs,
+    });
+  };
 
   return (
     <PortalLayout>
@@ -76,15 +108,38 @@ export default function TrainingDetailPage() {
               </h1>
               <p className="mt-2 text-muted-foreground">{trainingItem.description}</p>
 
-              <div className="mt-6 overflow-hidden rounded-2xl border border-border bg-background">
+              <div className="relative mt-6 overflow-hidden rounded-2xl border border-border bg-background">
                 {trainingItem.embed.url ? (
-                  <iframe
-                    title={trainingItem.embed.title}
-                    className="aspect-video w-full"
-                    src={trainingItem.embed.url}
-                    allow="autoplay; fullscreen; picture-in-picture"
-                    referrerPolicy="strict-origin-when-cross-origin"
-                  />
+                  <>
+                    {!videoLoaded && (
+                      <div className="absolute inset-0 z-10 flex aspect-video items-center justify-center bg-muted/70">
+                        <div
+                          className="rounded-xl border border-border bg-background/95 px-4 py-3 text-center"
+                          role="status"
+                          aria-live="polite"
+                        >
+                          <div className="flex items-center justify-center gap-2 text-sm font-medium text-foreground">
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                            Loading training video
+                          </div>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            Player startup can take a few seconds.
+                          </p>
+                        </div>
+                      </div>
+                    )}
+                    <iframe
+                      title={trainingItem.embed.title}
+                      className={`aspect-video w-full transition-opacity duration-300 ${
+                        videoLoaded ? 'opacity-100' : 'opacity-0'
+                      }`}
+                      src={trainingItem.embed.url}
+                      allow="autoplay; fullscreen; picture-in-picture"
+                      referrerPolicy="strict-origin-when-cross-origin"
+                      loading="eager"
+                      onLoad={handleVideoLoad}
+                    />
+                  </>
                 ) : (
                   <iframe
                     title={trainingItem.embed.title}
@@ -98,43 +153,64 @@ export default function TrainingDetailPage() {
               <div className="mt-8 grid gap-6 md:grid-cols-2">
                 <div className="card-elevated p-6">
                   <h2 className="font-display text-lg font-semibold text-foreground">
-                    What you will learn
+                    After this module, you should be able to
                   </h2>
-                  <ul className="mt-4 space-y-3 text-sm text-muted-foreground">
-                    {trainingItem.learningPoints.map((point) => (
-                      <li key={point} className="flex items-start gap-2">
-                        <CheckCircle2 className="mt-0.5 h-4 w-4 text-primary" />
-                        <span>{point}</span>
-                      </li>
-                    ))}
-                  </ul>
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    Use these outcomes to confirm the key concepts are clear.
+                  </p>
+                  {learningPoints.length === 0 ? (
+                    <p className="mt-4 text-sm text-muted-foreground">
+                      Learning outcomes will be added with the next content update.
+                    </p>
+                  ) : (
+                    <ul className="mt-4 space-y-3 text-sm text-muted-foreground">
+                      {learningPoints.map((point) => (
+                        <li key={point} className="flex items-start gap-2">
+                          <CheckCircle2 className="mt-0.5 h-4 w-4 text-primary" />
+                          <span>{point}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
                 </div>
                 <div className="card-elevated p-6">
                   <h2 className="font-display text-lg font-semibold text-foreground">
-                    Checklist
+                    Do this after watching
                   </h2>
-                  <ul className="mt-4 space-y-3 text-sm text-muted-foreground">
-                    {trainingItem.checklist.map((item) => (
-                      <li key={item} className="flex items-start gap-2">
-                        <CheckCircle2 className="mt-0.5 h-4 w-4 text-sage" />
-                        <span>{item}</span>
-                      </li>
-                    ))}
-                  </ul>
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    Complete these action items to apply the procedure on your machine.
+                  </p>
+                  {checklistItems.length === 0 ? (
+                    <p className="mt-4 text-sm text-muted-foreground">
+                      Checklist steps will be added as this module is finalized.
+                    </p>
+                  ) : (
+                    <ul className="mt-4 space-y-3 text-sm text-muted-foreground">
+                      {checklistItems.map((item) => (
+                        <li key={item} className="flex items-start gap-2">
+                          <CheckCircle2 className="mt-0.5 h-4 w-4 text-sage" />
+                          <span>{item}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
                 </div>
               </div>
 
               <div className="mt-8 card-elevated p-6">
                 <h2 className="font-display text-lg font-semibold text-foreground">
-                  Resources
+                  Job aids and links
                 </h2>
-                {trainingItem.resources.length === 0 ? (
+                <p className="mt-2 text-sm text-muted-foreground">
+                  Open these references when you need details outside the video walkthrough.
+                </p>
+                {resources.length === 0 ? (
                   <p className="mt-3 text-sm text-muted-foreground">
-                    Resources will be added as this module expands.
+                    No job aids are attached yet. Resources will be added as this module expands.
                   </p>
                 ) : (
                   <div className="mt-4 grid gap-4 sm:grid-cols-2">
-                    {trainingItem.resources.map((resource) => (
+                    {resources.map((resource) => (
                       <div key={resource.title} className="rounded-xl border border-border p-4">
                         <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
                           <FileText className="h-4 w-4 text-primary" />


### PR DESCRIPTION
﻿## Summary
- Deliver P0 training hardening for `#89`, `#90`, and `#91` in one slice: Vimeo startup UX, section clarity, and module taxonomy filtering/grouping.
- Add Vimeo operations helper script (`scripts/vimeo-ensure-tag.mjs`) and document tag-sync workflow in `Docs/LOCAL_DEV.md`.
- Confirm live Vimeo taxonomy baseline by ensuring all currently uploaded training videos are tagged `Module 1` (17/17 tagged after sync).

## Files changed
- `src/pages/portal/TrainingDetail.tsx`
- `src/pages/portal/Training.tsx`
- `index.html`
- `src/lib/analytics.ts`
- `scripts/vimeo-ensure-tag.mjs`
- `Docs/LOCAL_DEV.md`
- `Docs/CURRENT_STATUS.md`

## Verification commands + results
- `npm ci` ✅ (completed)
- `npm run build` ✅ (completed)
- `npm test --if-present` ✅ (no test script present; command exits clean)
- `npm run lint --if-present` ✅ (passes; existing baseline fast-refresh warnings only in generated UI files)

## How to test
1. Checkout this branch and run:
   - `npm ci`
   - `npm run dev`
2. Open `http://localhost:8080/login` and sign in with a valid portal account.
3. Go to `http://localhost:8080/portal/training` and verify module taxonomy UX:
   - Module filter row shows `All modules` and any detected `Module N` tags.
   - Selecting `Module 1` filters the catalog and groups cards under `Module 1` heading.
   - Topic tag filters still work together with module filter + search.
4. Open a training detail page (example: `http://localhost:8080/portal/training/<training-id>`) and verify:
   - Vimeo player shows a visible loading state until iframe load completes.
   - Post-video sections have clearer labels/helper copy:
     - `After this module, you should be able to`
     - `Do this after watching`
     - `Job aids and links`
   - Empty-state copy appears cleanly when a section has no content.
5. Optional Vimeo ops check (local):
   - Ensure `VIMEO_ACCESS_TOKEN` is present in env.
   - Run `node scripts/vimeo-ensure-tag.mjs --tag "Module 1" --dry-run`.
   - Expect all current videos to report `[skip] ... (already tagged)`.
