### PR TITLE
Document Resend decision for auth email launch hardening (#77)

### DIFF
--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -11,6 +11,7 @@
 
 ## Owner next steps
 - Execute production auth setup in `Docs/AUTH_OAUTH_BRANDING_RUNBOOK.md` (Google branding, custom auth domain, redirect/origin verification).
+- Provision and configure Resend SMTP for production auth emails per decision `2026-03-02` in `Docs/DECISIONS.md` (`#77`).
 - Complete launch evidence and approvals in `Docs/AUTH_PRODUCTION_SIGNOFF.md`.
 - Enable Supabase Custom Domain add-on for project `ygbzkgxktzqsiygjlqyg` to unblock `auth.bloomjoysweets.com` cutover (required for issue `#78`).
 - Upload Module 2 and Module 3 Vimeo videos when ready and extend `trainings` + `training_assets` with the same seeded pattern used for Module 1.

--- a/Docs/DECISIONS.md
+++ b/Docs/DECISIONS.md
@@ -139,3 +139,16 @@ Training library cards now prefer first-party thumbnail values from `training_as
 **Implementation notes**
 - Frontend resolves storage keys via `supabaseClient.storage.from('training-thumbnails').getPublicUrl(...)`.
 - Default visual fallback remains first-party (`/placeholder.svg`) for rows missing a thumbnail value.
+
+## 2026-03-02 - Auth transactional email provider for launch hardening (`#77`)
+For production auth email branding and deliverability, we will use **Resend** as the SMTP provider for Supabase Auth emails.
+
+**Why this choice**
+- Fastest path to branded sender setup for launch timelines.
+- Clear domain authentication workflow (SPF/DKIM) with strong deliverability posture.
+- Keeps implementation minimal by using Supabase Auth SMTP configuration (no app rewrite).
+
+**Implementation notes**
+- Configure and verify Bloomjoy sender domain in Resend.
+- Use Resend SMTP credentials in Supabase Auth email settings for signup confirmation, magic link, and recovery templates.
+- Record final test evidence in `Docs/AUTH_PRODUCTION_SIGNOFF.md`.


### PR DESCRIPTION
﻿## Summary
- Document decision to use **Resend** for production auth transactional email in `Docs/DECISIONS.md` (`#77`).
- Add owner action item in `Docs/CURRENT_STATUS.md` to provision/configure Resend SMTP.

## Files changed
- `Docs/DECISIONS.md`
- `Docs/CURRENT_STATUS.md`

## Verification commands + results
- `npm ci` ✅
- `npm run build` ✅
- `npm test --if-present` ✅ (no test script present; command exits clean)
- `npm run lint --if-present` ✅ (passes with existing baseline fast-refresh warnings only)

## How to test
1. Checkout `agent/resend-decision`.
2. Confirm the new decision entry exists in `Docs/DECISIONS.md`:
   - `2026-03-02 - Auth transactional email provider for launch hardening (#77)`
3. Confirm `Docs/CURRENT_STATUS.md` owner next steps include Resend provisioning/configuration guidance.
