### PR TITLE
Docs closeout: SEO production verification and redirect follow-up

### DIFF
--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -9,6 +9,19 @@
 ## Next P0 milestones
 - Validate and merge the training hardening slice for `#89`, `#90`, and `#91` (build/lint pass and localhost smoke checks on module filtering + detail UX clarity + Vimeo loading state).
 
+## SEO production verification snapshot (2026-03-09)
+- Verified live on `https://www.bloomjoyusa.com` after merge of PRs `#100` and `#101`:
+  - Public routes direct-load with `200` (`/machines`, `/supplies`, `/plus`, `/resources`, `/contact`, legal routes).
+  - Private/auth routes return `200` with `noindex` controls (`meta[name="robots"]` + `X-Robots-Tag` on `/portal`, `/admin`, `/login`).
+  - `robots.txt` is reachable and includes sitemap reference.
+  - `sitemap.xml` is reachable and lists public marketing/legal routes.
+  - Legacy routes redirect permanently:
+    - `/products` -> `/machines` (`308`)
+    - `/products/mini` -> `/machines/mini` (`308`)
+  - Public page source includes route-specific metadata + JSON-LD (`Organization`, `WebSite`, `WebPage`).
+- Follow-up needed:
+  - Apex domain still responds with `307` redirect to `https://www.bloomjoyusa.com/` (host canonicalization works, but permanent redirect expectation is not yet met at edge/domain level).
+
 ## Sales information alignment (2026-03-09)
 - Source sales sheets reviewed:
   - `Commercial Sales Sheet.pdf` (Quote `20260201B3`, dated `2026-02-01`, price effective `2026-05-30`)
@@ -161,6 +174,7 @@ Execution order is based on launch risk and dependency overlap.
 - Vimeo Module 1 is live; Modules 2/3 are pending upload/seed.
 - Module taxonomy UX is implemented, but cross-module validation is pending until Module 2/3 videos are uploaded/tagged.
 - Lint passes but still shows fast-refresh warnings in generated UI files
+- Apex host canonicalization currently returns `307` (`https://bloomjoyusa.com` -> `https://www.bloomjoyusa.com/`) instead of preferred permanent redirect behavior.
 
 ## Environments
 - Local: `npm run dev` on a PR branch/worktree

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -14,6 +14,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] View page source on a direct-loaded private route (for example `/portal`) and confirm robots is `noindex`
 - [ ] `robots.txt` is reachable and includes a sitemap reference
 - [ ] `sitemap.xml` is reachable and lists core public routes
+- [ ] Apex host (`https://bloomjoyusa.com`) redirects to canonical host (`https://www.bloomjoyusa.com/`) with permanent redirect behavior
 - [ ] Legacy paths (`/products`, `/products/mini`, `/products/micro`, `/products/commercial-robotic-machine`) return permanent redirects to `/machines*`
 - [ ] No console errors on home page load
 - [ ] Mobile header/nav works (basic)


### PR DESCRIPTION
## Summary
- Document production SEO verification results after merge of PRs `#100` and `#101`.
- Record one residual follow-up: apex host currently redirects with `307` (canonicalization works, but permanent redirect expectation is not yet met).
- Extend smoke checklist with explicit apex-host canonical redirect validation.

## Files changed
- `Docs/CURRENT_STATUS.md`
- `Docs/QA_SMOKE_TEST_CHECKLIST.md`

## Verification commands + results
- `npm ci` -> pass
- `npm run build` -> pass
- `npm test --if-present` -> pass (no test script output)
- `npm run lint --if-present` -> pass with existing `react-refresh/only-export-components` warnings only (no errors)
- `npm run seo:check` -> pass

## How to test
1. `git checkout agent/seo-closeout`
2. `npm ci`
3. `npm run build`
4. `npm run seo:check`
5. Confirm docs updates:
   - `Docs/CURRENT_STATUS.md` includes `SEO production verification snapshot (2026-03-09)` and apex redirect follow-up note
   - `Docs/QA_SMOKE_TEST_CHECKLIST.md` includes apex host canonical redirect check item
6. Optional live checks:
   - `curl -I https://www.bloomjoyusa.com/machines`
   - `curl -I https://www.bloomjoyusa.com/portal`
   - `curl -I https://www.bloomjoyusa.com/products/mini`
   - `curl -I https://bloomjoyusa.com`

## Overlap / risk notes
- No open PR overlap at PR creation time (`gh pr list --state open` returned none).