### PR TITLE
Docs: closeout smoke snapshot and auth signoff updates

### DIFF
--- a/Docs/AUTH_PRODUCTION_SIGNOFF.md
+++ b/Docs/AUTH_PRODUCTION_SIGNOFF.md
@@ -74,6 +74,18 @@ Capture evidence links for each required flow.
 - [ ] One network trace or screenshot proving callback host is `auth.bloomjoyusa.com`.
 - [ ] Link evidence in section 5 or launch ticket before Go/No-Go.
 
+## 5.2) Session closeout automation snapshot (2026-03-09)
+Automated API smoke checks were run against production config values:
+- `lead-submission-intake` quote submit returned `200 {"ok":true}`.
+- Matching `lead_submissions` row was created with non-null `internal_notification_sent_at`.
+- Matching `internal_notification_dispatches` row was created with non-null `sent_at`.
+- `auth.signInWithOtp(...)` returned success (`SMOKE_MAGIC_LINK_STATUS=OK`).
+- `auth.resetPasswordForEmail(...)` returned success (`SMOKE_RESET_STATUS=OK`).
+
+Manual evidence still required before go/no-go:
+- Inbox-level confirmation and screenshots for branded auth templates (signup, magic link, recovery).
+- Google OAuth consent/callback-host screenshot evidence from full browser flow.
+
 ## 6) Common auth incidents
 ### 429 rate limit on magic link or OTP
 - Confirm repeated attempts were the trigger.

--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -165,6 +165,7 @@ Execution order is based on launch risk and dependency overlap.
 - SEO CI hardening (`2026-03-09`): added `npm run seo:check` plus CI workflow coverage to validate robots/sitemap, canonical/noindex route outputs, JSON-LD presence on public routes, and redirect guard rules.
 - Submission notifications hardening: quote requests now flow through server-side `lead-submission-intake` and send internal summary emails; Stripe sugar order webhooks now send internal summary emails with duplicate-dispatch protection.
 - Submission notification recovery (`PR #103`, `2026-03-09`): resolved the internal-notification migration version collision by applying `202603090001_internal_notifications_backfill.sql`, aligned `INTERNAL_NOTIFICATION_FROM_EMAIL` to a verified Resend sender on `bloomjoyusa.com`, and revalidated quote-notification dispatch end-to-end (`lead-submission-intake` returns `200`, `internal_notification_sent_at` and dispatch `sent_at` are populated).
+- Session closeout smoke snapshot (`2026-03-09`): production-config API checks passed for quote notification dispatch, magic-link trigger, and password-reset trigger; remaining launch evidence is now limited to manual inbox/browser screenshots in `Docs/AUTH_PRODUCTION_SIGNOFF.md`.
 
 ## Known risks / blockers
 - Product photography availability (Mini may launch as waitlist/coming soon)


### PR DESCRIPTION
## Summary
- Record closeout automation smoke results for notifications and auth triggers in launch sign-off docs.
- Update current status to reflect session closeout verification coverage and remaining manual evidence.

## Files changed
- `Docs/AUTH_PRODUCTION_SIGNOFF.md`
- `Docs/CURRENT_STATUS.md`

## Verification commands + results
- `npm ci` -> pass
- `npm run build` -> pass
- `npm test --if-present` -> pass (no tests present)
- `npm run lint --if-present` -> pass (existing fast-refresh warnings only)

Additional closeout smoke checks (production-config API):
- Quote notification invoke (`lead-submission-intake`) -> `200 {ok:true}`
- Lead row lookup by `client_submission_id` -> non-null `internal_notification_sent_at`
- Dispatch row lookup by `event_key` -> non-null `sent_at`
- Magic link trigger (`auth.signInWithOtp`) -> OK
- Reset trigger (`auth.resetPasswordForEmail`) -> OK

## How to test
1. Checkout branch `agent/session-closeout`.
2. Run `npm ci`.
3. Open:
   - `Docs/AUTH_PRODUCTION_SIGNOFF.md`
   - `Docs/CURRENT_STATUS.md`
4. Confirm section `5.2` in sign-off doc includes closeout API smoke snapshot and explicit manual evidence still required.
5. Confirm current status includes session closeout smoke bullet under recently completed.
6. Optional runtime repeat (with local `.env` configured):
   - POST quote payload to `${VITE_SUPABASE_URL}/functions/v1/lead-submission-intake`.
   - Confirm response `200` and corresponding DB timestamps (`internal_notification_sent_at`, dispatch `sent_at`).

Key URLs:
- `http://localhost:8080/contact`
- `https://ygbzkgxktzqsiygjlqyg.supabase.co/functions/v1/lead-submission-intake`