### PR TITLE
P2: improve Plus unsubscribe return flow in account portal

### DIFF
--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -90,6 +90,9 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Stripe subscription from Plus checkout contains `metadata.user_id` and `metadata.machine_count`
 - [ ] Customer Portal link opens (test mode)
 - [ ] Account page Manage Billing opens Stripe portal (test mode)
+- [ ] In Stripe test customer portal, cancel Plus subscription and return to `/portal/account?billing=return`
+- [ ] Return to account shows confirmation that billing status was refreshed after Stripe portal return
+- [ ] After canceling, account membership card shows end-of-period cancellation state/banner
 - [ ] Stripe webhook updates subscriptions/orders tables (via Stripe CLI or Dashboard test event)
 
 ## Auth launch hardening (production-only)

--- a/src/lib/stripeCheckout.ts
+++ b/src/lib/stripeCheckout.ts
@@ -38,7 +38,7 @@ export async function openCustomerPortal(email: string, origin: string) {
     {
       body: {
         email,
-        returnUrl: `${origin}/portal/account`,
+        returnUrl: `${origin}/portal/account?billing=return`,
       },
     }
   );

--- a/src/pages/portal/Account.tsx
+++ b/src/pages/portal/Account.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Link } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { User, MapPin, CreditCard, ExternalLink } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -36,7 +36,10 @@ const formatMembershipStatus = (status: string) =>
 
 export default function AccountPage() {
   const { user } = useAuth();
+  const location = useLocation();
+  const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const hasHandledBillingReturn = useRef(false);
   const [isOpeningPortal, setIsOpeningPortal] = useState(false);
   const [profileForm, setProfileForm] = useState<PortalAccountProfileInput>(DEFAULT_PROFILE_FORM);
 
@@ -47,7 +50,11 @@ export default function AccountPage() {
     staleTime: 1000 * 30,
   });
 
-  const { data: membershipSummary, isLoading: isMembershipLoading } = useQuery({
+  const {
+    data: membershipSummary,
+    isLoading: isMembershipLoading,
+    refetch: refetchMembershipSummary,
+  } = useQuery({
     queryKey: ['portal-membership-summary', user?.id],
     queryFn: () => fetchPortalMembershipSummary(user!.id),
     enabled: Boolean(user?.id),
@@ -86,6 +93,28 @@ export default function AccountPage() {
     });
   }, [accountProfile]);
 
+  useEffect(() => {
+    const searchParams = new URLSearchParams(location.search);
+    if (searchParams.get('billing') !== 'return' || hasHandledBillingReturn.current) {
+      return;
+    }
+
+    hasHandledBillingReturn.current = true;
+    void refetchMembershipSummary();
+    toast.success('Returned from Stripe billing portal. Membership status has been refreshed.');
+
+    searchParams.delete('billing');
+    const nextSearch = searchParams.toString();
+
+    navigate(
+      {
+        pathname: location.pathname,
+        search: nextSearch ? `?${nextSearch}` : '',
+      },
+      { replace: true }
+    );
+  }, [location.pathname, location.search, navigate, refetchMembershipSummary]);
+
   const effectiveMembershipStatus = membershipSummary?.status ?? user?.membershipStatus ?? 'none';
   const isMember = hasPlusAccess(effectiveMembershipStatus);
   const membershipStatusLabel = useMemo(() => {
@@ -115,7 +144,10 @@ export default function AccountPage() {
       const portalUrl = await openCustomerPortal(user.email, window.location.origin);
       window.location.assign(portalUrl);
     } catch (error) {
-      const message = error instanceof Error ? error.message : 'Unable to open billing portal.';
+      const message =
+        error instanceof Error && error.message
+          ? `${error.message} Please try again, or contact support if the issue continues.`
+          : 'Unable to open the Stripe billing portal right now. Please try again, or contact support if the issue continues.';
       toast.error(message);
       setIsOpeningPortal(false);
     }
@@ -306,7 +338,7 @@ export default function AccountPage() {
                 </div>
                 <p className="mt-4 text-sm text-muted-foreground">
                   {isMember
-                    ? 'Manage your subscription and payment methods through the Stripe customer portal.'
+                    ? 'Manage your payment methods, invoices, and cancellations through the Stripe customer portal.'
                     : 'Upgrade to Plus to unlock premium training, onboarding, and concierge support.'}
                 </p>
                 <Button
@@ -316,7 +348,7 @@ export default function AccountPage() {
                   disabled={isOpeningPortal || !user?.email || !isMember || isMembershipLoading}
                 >
                   <ExternalLink className="mr-2 h-4 w-4" />
-                  {isMember ? (isOpeningPortal ? 'Opening...' : 'Manage Billing') : 'Plus Required'}
+                  {isMember ? (isOpeningPortal ? 'Opening...' : 'Open Billing Portal') : 'Plus Required'}
                 </Button>
                 <p className="mt-3 text-xs text-muted-foreground">
                   Review{' '}


### PR DESCRIPTION
## Summary
- Improve Plus unsubscribe UX by returning Stripe billing sessions to `/portal/account?billing=return` and handling the return state in account UI.
- Refresh membership data immediately after portal return, show confirmation feedback, and remove the temporary `billing=return` query param.
- Clarify billing copy/button text so users understand cancellations happen in Stripe Customer Portal; extend smoke checklist with explicit unsubscribe validation steps.

## Files changed
- `src/lib/stripeCheckout.ts` (customer portal return URL)
- `src/pages/portal/Account.tsx` (billing return handling, copy updates, portal error messaging)
- `Docs/QA_SMOKE_TEST_CHECKLIST.md` (unsubscribe smoke coverage)

## Verification commands + results
- `npm ci` ✅
- `npm run build` ✅
- `npm test --if-present` ✅ (no test suite output in this repo)
- `npm run lint --if-present` ✅ (existing `react-refresh/only-export-components` warnings only)
- `npm run seo:check` ✅

## How to test
1. In this branch, run `npm ci`.
2. Start app: `npm run dev`.
3. Log in with a Plus-enabled test user and open [http://localhost:8080/portal/account](http://localhost:8080/portal/account).
4. Click **Open Billing Portal** and complete/cancel from Stripe test portal.
5. Return to account and confirm:
   - A confirmation toast appears indicating billing status was refreshed.
   - URL query `billing=return` is removed after handling.
   - If cancellation was set in Stripe, the membership card shows end-of-period cancellation state/banner.
6. Open [http://localhost:8080/billing-cancellation](http://localhost:8080/billing-cancellation) and confirm copy aligns with Stripe portal cancellation flow.

Closes #53