### PR TITLE
feat: WeCom internal alerts POC for quote/order/support events

### DIFF
--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -46,6 +46,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Quote flow preserves machine context (for example, Commercial CTA preselects "Machine of Interest" on `/contact`)
 - [ ] Contact/Quote submission creates a `lead_submissions` row in Supabase with expected type/email
 - [ ] Quote submissions send internal notification email with full request summary (name/email/source/type/message)
+- [ ] Quote submissions send a WeCom internal alert to configured `WECOM_ALERT_TO_USERIDS` recipients
 - [ ] Mini waitlist submit creates a `mini_waitlist_submissions` row (duplicate email shows friendly already-on-list message)
 
 ## Auth / portal
@@ -80,11 +81,13 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Training detail sections below video ("What you will learn", "Checklist", "Resources") have clear purpose and readable structure
 - [ ] Support request forms submit and show success state
 - [ ] Submitted support request appears in `support_requests` table with correct `request_type`, `status=new`, and customer identity
+- [ ] Submitted support request triggers a WeCom alert with request type, customer email, and subject
 
 ## Payments (test mode)
 - [ ] Sugar checkout completes with test card for high-quantity equal split (e.g., 500KG total)
 - [ ] Sugar checkout completes with test card for unequal split mix (custom per-color quantities)
 - [ ] Sugar checkout completed webhook sends internal order summary email (customer, totals, sugar mix, line items)
+- [ ] Sugar checkout completed webhook sends a WeCom internal alert with order ID, customer, and sugar breakdown
 - [ ] Plus subscription checkout computes expected monthly amount from selected machine count (e.g., 1x=$100, 3x=$300) and completes with test card
 - [ ] Logged-out users on `/plus` are redirected to login before checkout can begin
 - [ ] Stripe subscription from Plus checkout contains `metadata.user_id` and `metadata.machine_count`
@@ -101,6 +104,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Production auth smoke evidence is captured in `Docs/AUTH_PRODUCTION_SIGNOFF.md`
 
 ## Regression sanity
+- [ ] Quote, order, and support primary flows still succeed when WeCom alert delivery fails (verify non-blocking warning logs in function output)
 - [ ] `npm run build` passes
 - [ ] `npm run lint` passes (if configured)
 - [ ] `npm run seo:check` passes

--- a/src/lib/supportRequests.ts
+++ b/src/lib/supportRequests.ts
@@ -26,10 +26,12 @@ export type SupportRequestRecord = {
   updated_at: string;
 };
 
+type SupportRequestIntakeResponse = {
+  supportRequest: SupportRequestRecord;
+};
+
 type CreateSupportRequestInput = {
   requestType: SupportRequestType;
-  customerUserId: string;
-  customerEmail: string;
   subject: string;
   message: string;
 };
@@ -44,28 +46,25 @@ type UpdateSupportRequestInput = {
 
 export const createSupportRequest = async ({
   requestType,
-  customerUserId,
-  customerEmail,
   subject,
   message,
 }: CreateSupportRequestInput): Promise<SupportRequestRecord> => {
-  const { data, error } = await supabaseClient
-    .from('support_requests')
-    .insert({
-      request_type: requestType,
-      customer_user_id: customerUserId,
-      customer_email: customerEmail,
-      subject,
-      message,
-    })
-    .select('*')
-    .single();
+  const { data, error } = await supabaseClient.functions.invoke<SupportRequestIntakeResponse>(
+    'support-request-intake',
+    {
+      body: {
+        requestType,
+        subject,
+        message,
+      },
+    }
+  );
 
-  if (error || !data) {
+  if (error || !data?.supportRequest) {
     throw new Error(error?.message || 'Unable to submit support request.');
   }
 
-  return data as SupportRequestRecord;
+  return data.supportRequest;
 };
 
 export const fetchSupportRequests = async (): Promise<SupportRequestRecord[]> => {

--- a/src/pages/portal/Support.tsx
+++ b/src/pages/portal/Support.tsx
@@ -27,8 +27,6 @@ export default function SupportPage() {
     try {
       await createSupportRequest({
         requestType: type,
-        customerUserId: user.id,
-        customerEmail: user.email,
         subject: formData.subject.trim(),
         message: formData.message.trim(),
       });

--- a/supabase/functions/_shared/wecom-alert.ts
+++ b/supabase/functions/_shared/wecom-alert.ts
@@ -1,0 +1,222 @@
+const WECOM_API_BASE_URL = "https://qyapi.weixin.qq.com/cgi-bin";
+const ACCESS_TOKEN_REFRESH_BUFFER_MS = 60 * 1000;
+const MAX_TEXT_CONTENT_LENGTH = 1800;
+const TOKEN_RETRYABLE_ERROR_CODES = new Set([40014, 42001, 42007, 42009]);
+
+let cachedAccessToken: { token: string; expiresAtMs: number } | null = null;
+let hasWarnedMissingConfig = false;
+
+type WeComConfig = {
+  corpId: string;
+  agentId: number;
+  agentSecret: string;
+  toUser: string;
+};
+
+type WeComApiResponse = {
+  errcode?: number;
+  errmsg?: string;
+  access_token?: string;
+  expires_in?: number;
+};
+
+type WeComSendResponse = {
+  ok: boolean;
+  errCode: number;
+  errMessage: string;
+};
+
+export type WeComAlertInput = {
+  title: string;
+  lines: string[];
+  tag?: string;
+};
+
+const sanitize = (value: string | undefined | null) =>
+  typeof value === "string" ? value.trim() : "";
+
+const parseToUser = (value: string): string =>
+  value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .join("|");
+
+const getConfig = (): WeComConfig | null => {
+  const corpId = sanitize(Deno.env.get("WECOM_CORP_ID"));
+  const agentIdRaw = sanitize(Deno.env.get("WECOM_AGENT_ID"));
+  const agentSecret = sanitize(Deno.env.get("WECOM_AGENT_SECRET"));
+  const toUserRaw = sanitize(Deno.env.get("WECOM_ALERT_TO_USERIDS"));
+
+  if (!corpId || !agentIdRaw || !agentSecret || !toUserRaw) {
+    if (!hasWarnedMissingConfig) {
+      console.warn(
+        "WeCom alerting is disabled: missing one or more WECOM_* env vars."
+      );
+      hasWarnedMissingConfig = true;
+    }
+    return null;
+  }
+
+  const agentId = Number(agentIdRaw);
+  if (!Number.isFinite(agentId)) {
+    console.warn("WECOM_AGENT_ID must be a numeric value.");
+    return null;
+  }
+
+  const toUser = parseToUser(toUserRaw);
+  if (!toUser) {
+    console.warn("WECOM_ALERT_TO_USERIDS did not contain any valid user IDs.");
+    return null;
+  }
+
+  return {
+    corpId,
+    agentId,
+    agentSecret,
+    toUser,
+  };
+};
+
+const buildContent = ({ title, lines, tag }: WeComAlertInput): string => {
+  const header = tag ? `[${tag}] ${title}` : title;
+  const content = [header, ...lines.filter(Boolean)].join("\n");
+
+  if (content.length <= MAX_TEXT_CONTENT_LENGTH) {
+    return content;
+  }
+
+  return `${content.slice(0, MAX_TEXT_CONTENT_LENGTH - 3)}...`;
+};
+
+const hasValidCachedToken = (): boolean =>
+  !!cachedAccessToken &&
+  Date.now() + ACCESS_TOKEN_REFRESH_BUFFER_MS < cachedAccessToken.expiresAtMs;
+
+const fetchAccessToken = async (config: WeComConfig): Promise<string> => {
+  const params = new URLSearchParams({
+    corpid: config.corpId,
+    corpsecret: config.agentSecret,
+  });
+
+  const response = await fetch(`${WECOM_API_BASE_URL}/gettoken?${params.toString()}`);
+  if (!response.ok) {
+    throw new Error(`WeCom gettoken request failed (${response.status}).`);
+  }
+
+  const payload = (await response.json()) as WeComApiResponse;
+  const errCode = Number(payload.errcode ?? -1);
+  if (errCode !== 0) {
+    throw new Error(
+      `WeCom gettoken failed (${errCode}): ${payload.errmsg ?? "Unknown error"}`
+    );
+  }
+
+  const accessToken = sanitize(payload.access_token);
+  const expiresIn = Number(payload.expires_in ?? 0);
+  if (!accessToken || !Number.isFinite(expiresIn) || expiresIn <= 0) {
+    throw new Error("WeCom gettoken response was missing token metadata.");
+  }
+
+  cachedAccessToken = {
+    token: accessToken,
+    expiresAtMs: Date.now() + expiresIn * 1000,
+  };
+
+  return accessToken;
+};
+
+const getAccessToken = async (
+  config: WeComConfig,
+  forceRefresh = false
+): Promise<string> => {
+  if (!forceRefresh && hasValidCachedToken() && cachedAccessToken) {
+    return cachedAccessToken.token;
+  }
+
+  return fetchAccessToken(config);
+};
+
+const sendMessageWithToken = async (
+  config: WeComConfig,
+  accessToken: string,
+  content: string
+): Promise<WeComSendResponse> => {
+  const response = await fetch(
+    `${WECOM_API_BASE_URL}/message/send?access_token=${encodeURIComponent(accessToken)}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        touser: config.toUser,
+        msgtype: "text",
+        agentid: config.agentId,
+        text: {
+          content,
+        },
+        safe: 0,
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`WeCom message send request failed (${response.status}).`);
+  }
+
+  const payload = (await response.json()) as WeComApiResponse;
+  const errCode = Number(payload.errcode ?? -1);
+
+  return {
+    ok: errCode === 0,
+    errCode,
+    errMessage: payload.errmsg ?? "Unknown error",
+  };
+};
+
+const sendAlertWithConfig = async (
+  config: WeComConfig,
+  input: WeComAlertInput
+): Promise<void> => {
+  const content = buildContent(input);
+
+  let accessToken = await getAccessToken(config);
+  let sendResult = await sendMessageWithToken(config, accessToken, content);
+
+  if (!sendResult.ok && TOKEN_RETRYABLE_ERROR_CODES.has(sendResult.errCode)) {
+    cachedAccessToken = null;
+    accessToken = await getAccessToken(config, true);
+    sendResult = await sendMessageWithToken(config, accessToken, content);
+  }
+
+  if (!sendResult.ok) {
+    throw new Error(
+      `WeCom message send failed (${sendResult.errCode}): ${sendResult.errMessage}`
+    );
+  }
+};
+
+export async function sendWeComAlert(input: WeComAlertInput): Promise<void> {
+  const config = getConfig();
+  if (!config) {
+    throw new Error("WeCom alert configuration is missing.");
+  }
+
+  await sendAlertWithConfig(config, input);
+}
+
+export async function sendWeComAlertSafe(input: WeComAlertInput): Promise<boolean> {
+  const config = getConfig();
+  if (!config) {
+    return false;
+  }
+
+  try {
+    await sendAlertWithConfig(config, input);
+    return true;
+  } catch (error) {
+    console.warn("WeCom alert send failed (non-blocking).", error);
+    return false;
+  }
+}

--- a/supabase/functions/lead-submission-intake/index.ts
+++ b/supabase/functions/lead-submission-intake/index.ts
@@ -2,6 +2,7 @@ import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.48.1";
 import { corsHeaders } from "../_shared/cors.ts";
 import { sendInternalEmail } from "../_shared/internal-email.ts";
+import { sendWeComAlertSafe } from "../_shared/wecom-alert.ts";
 
 export const config = {
   verify_jwt: false,
@@ -230,6 +231,21 @@ serve(async (req) => {
       await releaseDispatch(eventKey);
       throw error;
     }
+
+    await sendWeComAlertSafe({
+      tag: "Bloomjoy Quote",
+      title: `New quote request: ${leadSubmission.name}`,
+      lines: [
+        `Submission ID: ${leadSubmission.id}`,
+        `Submitted At (UTC): ${leadSubmission.created_at}`,
+        `Inquiry Type: ${leadSubmission.submission_type}`,
+        `Name: ${leadSubmission.name}`,
+        `Email: ${leadSubmission.email}`,
+        `Source Page: ${leadSubmission.source_page}`,
+        "Message:",
+        leadSubmission.message,
+      ],
+    });
 
     await Promise.all([
       supabase

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -3,6 +3,7 @@ import Stripe from "https://esm.sh/stripe@12.18.0?target=deno";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.48.1";
 import { corsHeaders } from "../_shared/cors.ts";
 import { sendInternalEmail } from "../_shared/internal-email.ts";
+import { sendWeComAlertSafe } from "../_shared/wecom-alert.ts";
 
 export const config = {
   verify_jwt: false,
@@ -345,6 +346,22 @@ async function sendOrderNotification(
     await releaseDispatch(eventKey);
     throw error;
   }
+
+  await sendWeComAlertSafe({
+    tag: "Bloomjoy Order",
+    title: `New sugar order: ${session.id}`,
+    lines: [
+      `Checkout Session ID: ${session.id}`,
+      `Payment Status: ${session.payment_status || "unpaid"}`,
+      `Amount Total: ${formatCurrency(session.amount_total, session.currency)}`,
+      `Customer Email: ${session.customer_details?.email ?? session.customer_email ?? "n/a"}`,
+      `Customer Name: ${customerDetails?.name ?? "n/a"}`,
+      `Shipping Name: ${shippingDetails?.name ?? "n/a"}`,
+      `Sugar Total KG: ${context.sugarMix.total_kg}`,
+      `White/Blue/Orange/Red KG: ${context.sugarMix.white_kg}/${context.sugarMix.blue_kg}/${context.sugarMix.orange_kg}/${context.sugarMix.red_kg}`,
+      `Line Items: ${context.lineItems.length}`,
+    ],
+  });
 
   await Promise.all([
     supabase

--- a/supabase/functions/support-request-intake/index.ts
+++ b/supabase/functions/support-request-intake/index.ts
@@ -1,0 +1,144 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.48.1";
+import { corsHeaders } from "../_shared/cors.ts";
+import { sendWeComAlertSafe } from "../_shared/wecom-alert.ts";
+
+const supabaseUrl = Deno.env.get("SUPABASE_URL");
+const supabaseServiceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+const validRequestTypes = new Set(["concierge", "parts"]);
+
+if (!supabaseUrl) {
+  console.error("Missing SUPABASE_URL");
+}
+
+if (!supabaseServiceRoleKey) {
+  console.error("Missing SUPABASE_SERVICE_ROLE_KEY");
+}
+
+const supabase = supabaseUrl && supabaseServiceRoleKey
+  ? createClient(supabaseUrl, supabaseServiceRoleKey, {
+      auth: { persistSession: false },
+    })
+  : null;
+
+const sanitizeText = (value: unknown) => (typeof value === "string" ? value.trim() : "");
+
+const parseAccessToken = (authorizationHeader: string | null): string => {
+  if (!authorizationHeader) return "";
+  const match = authorizationHeader.match(/^Bearer\s+(.+)$/i);
+  return match?.[1]?.trim() ?? "";
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    if (req.method !== "POST") {
+      return new Response(JSON.stringify({ error: "Method not allowed." }), {
+        status: 405,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    if (!supabase) {
+      return new Response(
+        JSON.stringify({ error: "Support intake is not configured." }),
+        {
+          status: 500,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    const accessToken = parseAccessToken(req.headers.get("Authorization"));
+    if (!accessToken) {
+      return new Response(JSON.stringify({ error: "Unauthorized." }), {
+        status: 401,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const { data: authData, error: authError } = await supabase.auth.getUser(accessToken);
+    const user = authData?.user;
+    if (authError || !user) {
+      return new Response(JSON.stringify({ error: "Unauthorized." }), {
+        status: 401,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const body = await req.json();
+
+    const requestType = sanitizeText(body?.requestType).toLowerCase();
+    const subject = sanitizeText(body?.subject);
+    const message = sanitizeText(body?.message);
+    const customerEmail = sanitizeText(user.email).toLowerCase();
+
+    if (!validRequestTypes.has(requestType)) {
+      return new Response(JSON.stringify({ error: "Invalid support request type." }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    if (!customerEmail) {
+      return new Response(JSON.stringify({ error: "Missing account email address." }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    if (!subject) {
+      return new Response(JSON.stringify({ error: "Subject is required." }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const { data: supportRequest, error: insertError } = await supabase
+      .from("support_requests")
+      .insert({
+        request_type: requestType,
+        customer_user_id: user.id,
+        customer_email: customerEmail,
+        subject,
+        message,
+      })
+      .select("*")
+      .single();
+
+    if (insertError || !supportRequest) {
+      throw new Error(insertError?.message || "Unable to submit support request.");
+    }
+
+    await sendWeComAlertSafe({
+      tag: "Bloomjoy Support",
+      title: `New ${supportRequest.request_type} request`,
+      lines: [
+        `Support Request ID: ${supportRequest.id}`,
+        `Submitted At (UTC): ${supportRequest.created_at}`,
+        `Request Type: ${supportRequest.request_type}`,
+        `Customer User ID: ${supportRequest.customer_user_id}`,
+        `Customer Email: ${supportRequest.customer_email}`,
+        `Subject: ${supportRequest.subject}`,
+        "Message:",
+        supportRequest.message || "(none provided)",
+      ],
+    });
+
+    return new Response(JSON.stringify({ supportRequest }), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    console.error("support-request-intake error", error);
+    return new Response(
+      JSON.stringify({ error: "Unable to submit support request." }),
+      {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      }
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- Add a shared server-side WeCom helper (`_shared/wecom-alert.ts`) with access-token fetch/cache, retry-on-token-expiry, and non-blocking safe send behavior.
- Wire WeCom alerts into existing quote (`lead-submission-intake`) and sugar order (`stripe-webhook`) server-side notification flows.
- Add authenticated `support-request-intake` edge function, route portal support submissions through it, and extend QA smoke coverage for WeCom alert checks.

## Files changed
- `supabase/functions/_shared/wecom-alert.ts` (new)
- `supabase/functions/lead-submission-intake/index.ts`
- `supabase/functions/stripe-webhook/index.ts`
- `supabase/functions/support-request-intake/index.ts` (new)
- `src/lib/supportRequests.ts`
- `src/pages/portal/Support.tsx`
- `Docs/QA_SMOKE_TEST_CHECKLIST.md`

## Verification commands + results
- `npm ci` ✅ pass
- `npm run build` ✅ pass
- `npm test --if-present` ✅ pass (no test script output in this repo)
- `npm run lint --if-present` ✅ pass (existing baseline fast-refresh warnings only)

## How to test
1. Checkout branch `agent/wecom-alerts-poc` and run `npm ci`.
2. Configure server-only function secrets (do **not** use `VITE_`):
   - `WECOM_CORP_ID`
   - `WECOM_AGENT_ID`
   - `WECOM_AGENT_SECRET`
   - `WECOM_ALERT_TO_USERIDS`
3. Run required local functions:
   - `supabase functions serve lead-submission-intake --no-verify-jwt`
   - `supabase functions serve stripe-webhook --no-verify-jwt`
   - `supabase functions serve support-request-intake`
4. Start app: `npm run dev` and open `http://localhost:8080`.
5. Quote flow check:
   - Open `http://localhost:8080/contact`
   - Submit a quote request
   - Confirm success response, `lead_submissions` row insert, and WeCom alert delivery
6. Support flow check (logged-in user):
   - Open `http://localhost:8080/portal/support`
   - Submit concierge or parts request
   - Confirm success toast, `support_requests` row insert, and WeCom alert delivery
7. Order flow check:
   - Complete sugar checkout in test mode and deliver `checkout.session.completed` to `stripe-webhook`
   - Confirm order upsert plus WeCom alert delivery
8. Non-blocking failure-path check:
   - Temporarily set an invalid `WECOM_AGENT_SECRET`
   - Re-run quote/support/order submissions
   - Confirm primary flows still succeed while function logs WeCom warning(s)

## Notes
- WeCom secrets remain server-side only and are not referenced by client `VITE_` env vars.
- No open-PR overlap detected at PR creation time.

Closes #107