### PR TITLE
docs: session closeout updates for wecom/wechat and ops hygiene

### DIFF
--- a/Docs/BACKLOG.md
+++ b/Docs/BACKLOG.md
@@ -82,3 +82,9 @@ Guidelines:
 23. Basic admin view for support requests
 24. Remove temporary static admin email allowlist and rely on `admin_roles` + RLS only
 25. Replace third-party Vimeo thumbnail fallback (`vumbnail`) with first-party stored thumbnail URLs
+
+## P2 - Ops hardening follow-ups
+26. **Operationalize WeCom alerts + WeChat onboarding concierge** (`#110`)
+   - Define referral-buddy onboarding runbook and response-time SLA.
+   - Validate 1-week WeCom delivery reliability for quote/order/support alerts.
+   - Capture sign-off evidence for onboarding intake + non-blocking alert failure behavior.

--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -7,7 +7,12 @@
 - Write updates in plain language so non-technical readers can follow.
 
 ## Next P0 milestones
-- Validate and merge the training hardening slice for `#89`, `#90`, and `#91` (build/lint pass and localhost smoke checks on module filtering + detail UX clarity + Vimeo loading state).
+- Unblock and complete issue `#99` (dedicated Resend account for `bloomjoysweets.com`) so production auth and transactional email ownership can move off the currently blocked setup.
+
+## Session closeout snapshot (2026-03-10)
+- PR `#108` merged: WeCom internal-alert POC is now wired server-side for quote/order/support events with non-blocking failure handling.
+- PR `#109` merged: portal + admin support now include WeChat onboarding concierge intake (`request_type=wechat_onboarding` + structured `intake_meta`) and queue filtering/metrics.
+- New follow-up issue opened and added to project board: `#110` (operationalize WeCom alert reliability + WeChat onboarding concierge runbook/SLA).
 
 ## SEO production verification snapshot (2026-03-09)
 - Verified live on `https://www.bloomjoyusa.com` after merge of PRs `#100` and `#101`:
@@ -99,6 +104,7 @@ Execution order is based on launch risk and dependency overlap.
 - Enable Supabase Custom Domain add-on for project `ygbzkgxktzqsiygjlqyg` to unblock `auth.bloomjoyusa.com` cutover (required for issue `#78`).
 - Upload Module 2 and Module 3 Vimeo videos when ready and extend `trainings` + `training_assets` with the same seeded pattern used for Module 1.
 - Add Vimeo tags for Module 2/3 as content is uploaded so the new module-filter UX can segment beyond Module 1.
+- Execute issue `#110` to operationalize WeCom alert monitoring and WeChat onboarding concierge process ownership (referral buddy roster + SLA + weekly reliability snapshot).
 
 ## Upcoming scope clarification (next sprint)
 - Super-admin requirements and role model are complete for MVP scope (`#37` with implementation slices `#44`-`#48` delivered in PR `#55`).
@@ -166,12 +172,16 @@ Execution order is based on launch risk and dependency overlap.
 - Submission notifications hardening: quote requests now flow through server-side `lead-submission-intake` and send internal summary emails; Stripe sugar order webhooks now send internal summary emails with duplicate-dispatch protection.
 - Submission notification recovery (`PR #103`, `2026-03-09`): resolved the internal-notification migration version collision by applying `202603090001_internal_notifications_backfill.sql`, aligned `INTERNAL_NOTIFICATION_FROM_EMAIL` to a verified Resend sender on `bloomjoyusa.com`, and revalidated quote-notification dispatch end-to-end (`lead-submission-intake` returns `200`, `internal_notification_sent_at` and dispatch `sent_at` are populated).
 - Session closeout smoke snapshot (`2026-03-09`): production-config API checks passed for quote notification dispatch, magic-link trigger, and password-reset trigger; remaining launch evidence is now limited to manual inbox/browser screenshots in `Docs/AUTH_PRODUCTION_SIGNOFF.md`.
+- WeCom alerting POC merged (`#107` via PR `#108`, `2026-03-10`): quote/order/support flows now attempt WeCom dispatch using server-only `WECOM_*` secrets with token cache + non-blocking failure logging.
+- WeChat onboarding concierge merged (PR `#109`, `2026-03-10`): support flow now includes structured onboarding intake (`phone/device/blocked step/referral`) persisted in `support_requests.intake_meta` and surfaced in `/admin/support` triage filters/cards.
 
 ## Known risks / blockers
 - Product photography availability (Mini may launch as waitlist/coming soon)
 - Clear support boundary copy must be reviewed early (to prevent support overload)
 - Production credential execution remains owner-controlled (Google/Supabase/SMTP/DNS changes must be completed in dashboard tools before launch sign-off).
 - Internal notification pipeline is restored for quote submissions, but ongoing reliability still depends on keeping Resend/Supabase function secrets valid (`RESEND_API_KEY`, verified sender, recipient list).
+- WeCom alert dispatch reliability now depends on owner-managed function secrets and app visibility scope (`WECOM_CORP_ID`, `WECOM_AGENT_ID`, `WECOM_AGENT_SECRET`, `WECOM_ALERT_TO_USERIDS`).
+- WeChat onboarding concierge UX is live, but operational effectiveness still depends on documented referral-buddy process/SLA ownership (tracked in issue `#110`).
 - `#78` currently blocked on Supabase side: Custom Domain add-on is not enabled yet for project `ygbzkgxktzqsiygjlqyg`, so domain create/activate commands cannot run.
 - Vimeo Module 1 is live; Modules 2/3 are pending upload/seed.
 - Module taxonomy UX is implemented, but cross-module validation is pending until Module 2/3 videos are uploaded/tagged.

--- a/Docs/DECISIONS.md
+++ b/Docs/DECISIONS.md
@@ -182,3 +182,39 @@ To keep sales copy and quote intake consistent with current sales materials, we 
 **Implementation notes**
 - Keep custom wrap handling as a manual design handoff (no self-serve design builder in MVP).
 - Ensure public product copy, quote CTA language, and smoke checklist coverage stay aligned to these rules.
+
+## 2026-03-10 - WeCom as the internal ops-alert POC channel
+For current operations-event alerting, we will use **WeCom app messaging** from Supabase Edge Functions (quote, order, and support events).
+
+**Scope**
+- Quote submission alerts (`lead-submission-intake`)
+- Sugar order alerts (`stripe-webhook`)
+- Support request alerts (`support-request-intake`)
+
+**Why this choice**
+- Keeps WeCom credentials server-side only (`WECOM_*` function secrets).
+- Aligns to actual ops communication channel without changing customer-facing auth flows.
+- Adds non-blocking behavior so core quote/order/support flows continue if WeCom is unavailable.
+
+**Implementation notes**
+- Token lifecycle handled server-side with cached `access_token` fetch/refresh.
+- Recipient fanout controlled by `WECOM_ALERT_TO_USERIDS` (comma-separated user IDs).
+- WeCom dispatch failures are logged as warnings and do not fail core business transactions.
+
+## 2026-03-10 - WeChat onboarding concierge intake model
+To reduce WeChat onboarding friction, we will treat onboarding blockers as a first-class support request type.
+
+**Canonical model**
+- `support_requests.request_type` includes `wechat_onboarding`.
+- Structured onboarding context is stored in `support_requests.intake_meta` (JSON), including:
+  - `phone_region`
+  - `phone_number`
+  - `device_type`
+  - `blocked_step`
+  - `referral_needed`
+  - optional `wechat_id`
+
+**Why this choice**
+- Keeps portal intake simple while giving ops consistent triage data.
+- Avoids one-off DM triage by standardizing onboarding requests in existing support queue tooling.
+- Preserves backward compatibility with existing support request status/priority/admin-audit flows.

--- a/Docs/LOCAL_DEV.md
+++ b/Docs/LOCAL_DEV.md
@@ -35,6 +35,7 @@
 ## Supabase setup (training library + memberships)
 1) Apply migration: `supabase/migrations/20260122_training_and_membership.sql`
    - Orders sync migration: `supabase/migrations/20260202_orders.sql`
+   - WeChat onboarding support migration: `supabase/migrations/202603100001_wechat_onboarding_support.sql`
 2) Seed data (optional for local dev): `supabase/seed/20260122_training_seed.sql`
 3) Populate Vimeo fields after account setup:
    - `provider_video_id`
@@ -118,6 +119,10 @@ For production deployment order and rollback, use `Docs/PRODUCTION_RUNBOOK.md`.
    - `supabase secrets set RESEND_API_KEY=...`
    - `supabase secrets set INTERNAL_NOTIFICATION_FROM_EMAIL=...`
    - `supabase secrets set INTERNAL_NOTIFICATION_RECIPIENTS=etrifari@bloomjoysweets.com,ian@bloomjoysweets.com`
+   - `supabase secrets set WECOM_CORP_ID=...`
+   - `supabase secrets set WECOM_AGENT_ID=...`
+   - `supabase secrets set WECOM_AGENT_SECRET=...`
+   - `supabase secrets set WECOM_ALERT_TO_USERIDS=ethan.trifari,ops.manager`
    - Ensure `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are available to functions
 3) Run functions locally:
    - `supabase functions serve stripe-sugar-checkout --no-verify-jwt`
@@ -125,6 +130,7 @@ For production deployment order and rollback, use `Docs/PRODUCTION_RUNBOOK.md`.
    - `supabase functions serve stripe-customer-portal --no-verify-jwt`
    - `supabase functions serve stripe-webhook --no-verify-jwt`
    - `supabase functions serve lead-submission-intake --no-verify-jwt`
+   - `supabase functions serve support-request-intake`
 4) Ensure `.env` has `VITE_SUPABASE_URL` + `VITE_SUPABASE_ANON_KEY` for the SPA.
 
 ## Common issues

--- a/Docs/PRODUCTION_RUNBOOK.md
+++ b/Docs/PRODUCTION_RUNBOOK.md
@@ -2,7 +2,7 @@
 
 Purpose: provide a single launch-day procedure for Bloomjoy Hub production release and rollback.
 
-Last updated: 2026-02-27
+Last updated: 2026-03-10
 
 ## 1) Roles and ownership
 - Release owner: coordinates launch window and final go/no-go call.
@@ -25,8 +25,12 @@ Set the following values before launch.
 | `RESEND_API_KEY` | Server-only | `stripe-webhook`, `lead-submission-intake` | Resend API key | Technical owner |
 | `INTERNAL_NOTIFICATION_FROM_EMAIL` | Server-only | `stripe-webhook`, `lead-submission-intake` | Verified sender in Resend | Technical owner |
 | `INTERNAL_NOTIFICATION_RECIPIENTS` | Server-only | `stripe-webhook`, `lead-submission-intake` | Internal recipient list (comma-separated) | Release owner |
-| `SUPABASE_URL` | Server-only | `stripe-webhook`, `lead-submission-intake` | Supabase project URL | Technical owner |
-| `SUPABASE_SERVICE_ROLE_KEY` | Server-only | `stripe-webhook`, `lead-submission-intake` | Supabase service role key | Technical owner |
+| `WECOM_CORP_ID` | Server-only | `lead-submission-intake`, `stripe-webhook`, `support-request-intake` | WeCom app settings | Technical owner |
+| `WECOM_AGENT_ID` | Server-only | `lead-submission-intake`, `stripe-webhook`, `support-request-intake` | WeCom app settings | Technical owner |
+| `WECOM_AGENT_SECRET` | Server-only | `lead-submission-intake`, `stripe-webhook`, `support-request-intake` | WeCom app settings | Technical owner |
+| `WECOM_ALERT_TO_USERIDS` | Server-only | `lead-submission-intake`, `stripe-webhook`, `support-request-intake` | WeCom recipient user IDs (comma-separated) | Release owner |
+| `SUPABASE_URL` | Server-only | `stripe-webhook`, `lead-submission-intake`, `support-request-intake` | Supabase project URL | Technical owner |
+| `SUPABASE_SERVICE_ROLE_KEY` | Server-only | `stripe-webhook`, `lead-submission-intake`, `support-request-intake` | Supabase service role key | Technical owner |
 
 Security rule:
 - Never place secrets in `VITE_` variables.
@@ -67,12 +71,16 @@ supabase secrets set STRIPE_WEBHOOK_SECRET=...
 supabase secrets set RESEND_API_KEY=...
 supabase secrets set INTERNAL_NOTIFICATION_FROM_EMAIL=...
 supabase secrets set INTERNAL_NOTIFICATION_RECIPIENTS=etrifari@bloomjoysweets.com,ian@bloomjoysweets.com
+supabase secrets set WECOM_CORP_ID=...
+supabase secrets set WECOM_AGENT_ID=...
+supabase secrets set WECOM_AGENT_SECRET=...
+supabase secrets set WECOM_ALERT_TO_USERIDS=ethan.trifari,ops.manager
 supabase secrets set SUPABASE_URL=...
 supabase secrets set SUPABASE_SERVICE_ROLE_KEY=...
 ```
 
 ### Step C: Deploy Stripe Edge Functions
-Deploy all five functions:
+Deploy all six functions:
 
 ```bash
 supabase functions deploy stripe-sugar-checkout
@@ -80,6 +88,7 @@ supabase functions deploy stripe-plus-checkout
 supabase functions deploy stripe-customer-portal
 supabase functions deploy stripe-webhook
 supabase functions deploy lead-submission-intake
+supabase functions deploy support-request-intake
 ```
 
 ### Step D: Configure Stripe webhook endpoint
@@ -109,6 +118,8 @@ Run immediately after deploy:
 - [ ] Sugar checkout test order sends internal summary email to configured operations recipients.
 - [ ] Plus checkout test subscription creates/updates `subscriptions` record in Supabase.
 - [ ] Quote request on `/contact` sends internal summary email to configured operations recipients.
+- [ ] Quote/order/support events send WeCom alerts to configured internal recipients (or log non-blocking warning on dispatch failure).
+- [ ] WeChat onboarding concierge submit on `/portal/support` creates `support_requests.request_type=wechat_onboarding` with populated `intake_meta`.
 - [ ] Stripe customer portal opens from `/portal/account`.
 - [ ] No critical frontend console errors on key pages.
 
@@ -128,6 +139,7 @@ Rollback order:
      - `stripe-plus-checkout`
      - `stripe-customer-portal`
      - `stripe-webhook`
+     - `support-request-intake`
 3) Secrets:
    - Restore prior secrets only if rotation caused failure.
 4) Database:


### PR DESCRIPTION
## Summary
- Finalized session closeout docs for merged WeCom/WeChat work (`#108`, `#109`) and refreshed near-term priorities in `Docs/CURRENT_STATUS.md`.
- Added formal decisions for WeCom internal-alert channel usage and WeChat onboarding concierge intake model in `Docs/DECISIONS.md`.
- Completed documentation hygiene for local/prod ops (new function secrets/deploy steps) and created follow-up issue `#110` on the project board.

## Files changed
- `Docs/CURRENT_STATUS.md`
- `Docs/DECISIONS.md`
- `Docs/LOCAL_DEV.md`
- `Docs/PRODUCTION_RUNBOOK.md`
- `Docs/BACKLOG.md`

## Verification commands + results
- `npm ci` ✅ pass
- `npm run build` ✅ pass
- `npm test --if-present` ✅ pass (no test script output in this repo)
- `npm run lint --if-present` ✅ pass (existing baseline fast-refresh warnings only)

## How to test
1. Checkout branch `agent/session-closeout-docs`.
2. Run:
   - `npm ci`
   - `npm run build`
   - `npm test --if-present`
   - `npm run lint --if-present`
3. Review updated docs directly:
   - `Docs/CURRENT_STATUS.md`
   - `Docs/DECISIONS.md`
   - `Docs/LOCAL_DEV.md`
   - `Docs/PRODUCTION_RUNBOOK.md`
   - `Docs/BACKLOG.md`
4. Confirm board/update hygiene:
   - Issue `#110` exists and is on project **Bloomjoy Hub Priorities** in `Todo`.

## Notes
- Opened follow-up tracking issue: https://github.com/ethtri/bloomjoy-hub/issues/110
- No open-PR file-overlap risk at PR creation time.