### PR TITLE
Auth preflight: align Google OAuth guidance with canonical host

### DIFF
--- a/Docs/AUTH_OAUTH_BRANDING_RUNBOOK.md
+++ b/Docs/AUTH_OAUTH_BRANDING_RUNBOOK.md
@@ -2,7 +2,7 @@
 
 Purpose: make Google sign-in show Bloomjoy branding and move OAuth callbacks off `<project-ref>.supabase.co` to a Bloomjoy-owned auth subdomain.
 
-Last updated: 2026-03-01
+Last updated: 2026-03-15
 
 ## 1) Prerequisites
 - Domain access for Bloomjoy DNS (to create CNAME/TXT records).
@@ -11,7 +11,8 @@ Last updated: 2026-03-01
 - Supabase custom domain add-on enabled (required by Supabase to use custom auth hostname).
 - App URLs decided in advance:
   - Local app URL: `http://localhost:8080` (or your active Vite port)
-  - Production app URL (example): `https://bloomjoyusa.com`
+  - Production app URL (canonical): `https://www.bloomjoyusa.com`
+  - Production apex redirect URL: `https://bloomjoyusa.com`
   - Auth hostname target (recommended): `auth.bloomjoyusa.com`
 
 ## 1.1) Execution tracker (issue #78)
@@ -32,29 +33,37 @@ Record status as `Not started`, `In progress`, `Done`, or `Blocked`.
 - Redirect URLs used by app flows:
   - `http://localhost:8080/portal`
   - `http://localhost:8080/reset-password`
-  - `https://bloomjoyusa.com/portal` (example)
-  - `https://bloomjoyusa.com/reset-password` (example)
+  - `https://www.bloomjoyusa.com/portal`
+  - `https://www.bloomjoyusa.com/reset-password`
+  - `https://bloomjoyusa.com/portal` (temporary apex allowlist during cutover)
+  - `https://bloomjoyusa.com/reset-password` (temporary apex allowlist during cutover)
 
-Current project snapshot (2026-03-01):
+Current project snapshot (2026-03-15):
 - Bloomjoy Hub project ref: `ygbzkgxktzqsiygjlqyg`
-- Current blocker: Supabase Custom Domain add-on is not enabled yet, so domain commands fail until billing/add-on enablement is complete.
+- `supabase domains get --project-ref ygbzkgxktzqsiygjlqyg` currently returns `Please enable the Custom Domain add-on for the project first.`
+- Current auth regression evidence: live Google sign-in is falling back to `http://localhost:3000/#access_token=...`, which indicates Supabase Site URL and/or the deployed production redirect allowlist is still on stale host values.
 
 ## 2.1) Copy/paste setup values (Bloomjoy)
 Use these exact values when configuring Google OAuth + Supabase auth settings:
 
 - Google OAuth Authorized JavaScript origins:
   - `http://localhost:8080`
+  - `https://www.bloomjoyusa.com`
   - `https://bloomjoyusa.com`
 - Google OAuth Authorized redirect URIs:
   - `https://ygbzkgxktzqsiygjlqyg.supabase.co/auth/v1/callback` (temporary during cutover)
   - `https://auth.bloomjoyusa.com/auth/v1/callback` (target)
 - Supabase Auth URL configuration:
-  - Site URL: `https://bloomjoyusa.com`
+  - Site URL: `https://www.bloomjoyusa.com`
   - Additional redirects:
     - `http://localhost:8080`
     - `http://localhost:8080/login`
     - `http://localhost:8080/portal`
     - `http://localhost:8080/reset-password`
+    - `https://www.bloomjoyusa.com`
+    - `https://www.bloomjoyusa.com/login`
+    - `https://www.bloomjoyusa.com/portal`
+    - `https://www.bloomjoyusa.com/reset-password`
     - `https://bloomjoyusa.com`
     - `https://bloomjoyusa.com/login`
     - `https://bloomjoyusa.com/portal`
@@ -124,7 +133,8 @@ Google Cloud Console -> Credentials -> OAuth 2.0 Client IDs:
 
 1) Authorized JavaScript origins:
 - `http://localhost:8080`
-- Production app origin (example): `https://bloomjoyusa.com`
+- `https://www.bloomjoyusa.com`
+- `https://bloomjoyusa.com`
 
 2) Authorized redirect URIs:
 - `https://<PROJECT_REF>.supabase.co/auth/v1/callback` (temporary during cutover)
@@ -136,12 +146,16 @@ Supabase Dashboard -> Authentication:
 1) URL Configuration
 - Site URL:
   - local dev: `http://localhost:8080`
-  - production: `https://bloomjoyusa.com` (example)
+  - production: `https://www.bloomjoyusa.com`
 - Additional redirect URLs include:
   - `http://localhost:8080`
   - `http://localhost:8080/login`
   - `http://localhost:8080/portal`
   - `http://localhost:8080/reset-password`
+  - `https://www.bloomjoyusa.com`
+  - `https://www.bloomjoyusa.com/login`
+  - `https://www.bloomjoyusa.com/portal`
+  - `https://www.bloomjoyusa.com/reset-password`
   - `https://bloomjoyusa.com`
   - `https://bloomjoyusa.com/login`
   - `https://bloomjoyusa.com/portal`
@@ -160,6 +174,7 @@ Supabase Dashboard -> Authentication:
 Repo auth redirect behavior:
 - Login and Google auth redirects use `window.location.origin` and route to `/portal`.
 - Password recovery redirects use `window.location.origin` and route to `/reset-password`.
+- If Google sign-in lands on bare `http://localhost:3000/#access_token=...`, the fallback is coming from Supabase project settings, not this repo's redirect helper.
 
 ## 8) Verification checklist
 - Localhost:
@@ -167,8 +182,9 @@ Repo auth redirect behavior:
   - [ ] Consent screen shows Bloomjoy app name/logo/support email.
   - [ ] OAuth callback returns to `/portal` and session is created.
 - Deployed environment:
-  - [ ] Repeat verification on staging or production app domain.
+  - [ ] Repeat verification on `https://www.bloomjoyusa.com/login` (and keep apex allowlisted during cutover if needed).
   - [ ] Browser network trace shows callback host `auth.bloomjoyusa.com` (not `<PROJECT_REF>.supabase.co`).
+  - [ ] Final post-auth browser URL is `https://www.bloomjoyusa.com/portal` (not `http://localhost:3000`).
   - [ ] No auth-console errors during sign-in.
   - [ ] Record screenshot/evidence links in `Docs/AUTH_PRODUCTION_SIGNOFF.md`.
 
@@ -192,6 +208,14 @@ Repo auth redirect behavior:
   - Re-check Google client ID/secret in Supabase provider config.
   - Re-check Supabase URL Configuration allowlist and Site URL.
   - Confirm app origin and callback URI entries match current environment.
+
+### Redirect lands on `http://localhost:3000/#access_token=...`
+- Cause: Supabase Site URL is still a legacy localhost value, or the deployed production origin is not present in the redirect allowlist so Supabase falls back to the configured Site URL.
+- Fix:
+  - Set Supabase Site URL to `https://www.bloomjoyusa.com`.
+  - Add `https://www.bloomjoyusa.com`, `/login`, `/portal`, and `/reset-password` to Supabase redirect URLs.
+  - Keep apex `https://bloomjoyusa.com` redirect URLs allowlisted during cutover/canonicalization cleanup.
+  - Retry from `https://www.bloomjoyusa.com/login` and confirm the final browser URL is `https://www.bloomjoyusa.com/portal`.
 
 ## 10) Launch hardening follow-up
 Anything still pending for production approval/review stays tracked in issue `#77`:

--- a/Docs/AUTH_PRODUCTION_SIGNOFF.md
+++ b/Docs/AUTH_PRODUCTION_SIGNOFF.md
@@ -2,7 +2,7 @@
 
 Purpose: convert deferred auth launch hardening into an execution checklist with clear ownership and evidence capture.
 
-Last updated: 2026-03-01
+Last updated: 2026-03-15
 
 ## 1) Owners and launch window
 - Launch date/time:
@@ -34,8 +34,8 @@ Status values: `Not started`, `In progress`, `Done`, `Blocked`.
 | Google OAuth callback host resolves to `auth.bloomjoyusa.com` in live flow |  |  |  |
 | Google OAuth client secret rotated after setup-sharing activity |  |  |  |
 | Supabase Google provider updated with current client credentials |  |  |  |
-| Supabase Site URL set to production URL |  |  |  |
-| Supabase redirect URL allowlist includes `/login`, `/portal`, `/reset-password`, callback paths |  |  |  |
+| Supabase Site URL set to `https://www.bloomjoyusa.com` |  |  |  |
+| Supabase redirect URL allowlist includes `https://www.bloomjoyusa.com` routes plus apex `https://bloomjoyusa.com` cutover aliases |  |  |  |
 
 ## 4) Security and reliability checks
 ### Email OTP and rate limits
@@ -100,6 +100,12 @@ Manual evidence still required before go/no-go:
 ### `unauthorized_domain`
 - Add/verify domain ownership in Google OAuth branding configuration.
 - Confirm production origin is in authorized JavaScript origins.
+
+### Redirect lands on `http://localhost:3000/#access_token=...`
+- Treat this as a stale Supabase URL Configuration issue first.
+- Confirm Supabase Site URL is `https://www.bloomjoyusa.com`.
+- Confirm redirect allowlist includes `https://www.bloomjoyusa.com`, `/login`, `/portal`, and `/reset-password`.
+- Keep apex `https://bloomjoyusa.com` entries allowlisted during cutover if traffic can still start there.
 
 ## 7) Go/No-Go sign-off
 - [ ] All checklist items in sections 3-5 are complete.

--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -53,15 +53,19 @@ Execution order is based on launch risk and dependency overlap.
 - Supabase remote migrations were pushed successfully to project `ygbzkgxktzqsiygjlqyg`, including:
   - `202603020001_custom_sticks_artwork_intake.sql`
 - Auth preflight status in this worktree:
-  - `npm run auth:preflight`: pass with `bloomjoyusa.com` values
+  - `npm run auth:preflight`: pass with canonical `www.bloomjoyusa.com` plus apex redirect-allowlist values
   - `npm run auth:preflight -- --require-custom-auth-domain`: expected fail until custom auth domain cutover is completed (`auth.bloomjoyusa.com`)
 
 1) **P0 - Auth redirect/domain cutover regression (Google login)**
 - UAT signal: Google callback currently lands on `localhost:3000` (`ERR_CONNECTION_REFUSED`) instead of the live domain flow.
-- Likely cause: OAuth/Supabase redirect/origin settings are still on legacy host values while the new deployment is on `bloomjoyusa.com`.
+- Fresh evidence (2026-03-15):
+  - User-captured live Google login returns to `http://localhost:3000/#access_token=...` with no `/portal` path.
+  - Repo audit confirms the app requests `${window.location.origin}/portal` for Google OAuth redirect, so the bare localhost fallback points to stale Supabase Site URL and/or missing allowlist entries for `https://www.bloomjoyusa.com`.
+  - `supabase domains get --project-ref ygbzkgxktzqsiygjlqyg` currently returns `Please enable the Custom Domain add-on for the project first.`
+- Likely cause: OAuth/Supabase redirect/origin settings are still on legacy host values while the production deployment is on canonical `https://www.bloomjoyusa.com`.
 - Plan:
-  - Update auth docs/checklists and auth preflight defaults from legacy Bloomjoy hostnames to the active `bloomjoyusa.com` hostnames.
-  - Validate Google OAuth origins + redirect URIs and Supabase Site URL + additional redirects for both local (`http://localhost:8080`) and production (`https://bloomjoyusa.com` + auth host).
+  - Update auth docs/checklists and auth preflight defaults from legacy Bloomjoy hostnames to canonical `https://www.bloomjoyusa.com`, while keeping apex `https://bloomjoyusa.com` allowlisted during cutover.
+  - Validate Google OAuth origins + redirect URIs and Supabase Site URL + additional redirects for both local (`http://localhost:8080`) and production (`https://www.bloomjoyusa.com` + apex alias + auth host).
   - Re-run `npm run auth:preflight` with local env configured and capture callback-host evidence in launch sign-off docs.
 - Owner dependency: Google Cloud + Supabase dashboard redirect/origin updates (credentials and DNS are owner-controlled).
 

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -57,6 +57,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Password sign-in works for an existing email/password user
 - [ ] Forgot-password flow sends reset email and `/reset-password` successfully updates password
 - [ ] Google sign-in works when Supabase Google provider is enabled
+- [ ] Google sign-in returns to the app host `/portal` route (for production: `https://www.bloomjoyusa.com/portal`, not `http://localhost:3000`)
 - [ ] Google sign-in button follows official GIS rendering when `VITE_GOOGLE_CLIENT_ID` is configured locally
 - [ ] For auth launch hardening, Google consent screen shows Bloomjoy branding (name/logo/support email)
 - [ ] For auth launch hardening, Google callback host uses `auth.bloomjoyusa.com` (not `<project-ref>.supabase.co`)

--- a/scripts/auth-preflight.mjs
+++ b/scripts/auth-preflight.mjs
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 const DEFAULTS = {
   appOrigin: 'http://localhost:8080',
-  prodAppOrigin: 'https://bloomjoyusa.com',
+  prodAppOrigin: 'https://www.bloomjoyusa.com',
   projectRef: 'ygbzkgxktzqsiygjlqyg',
   customAuthHost: 'auth.bloomjoyusa.com',
   requireCustomAuthDomain: false,
@@ -124,6 +124,28 @@ function validUrl(value) {
   }
 }
 
+function getRelatedOrigins(origin) {
+  if (!validUrl(origin)) {
+    return [origin];
+  }
+
+  const url = new URL(origin);
+  const origins = [url.origin];
+  const isLocalHost = url.hostname === 'localhost' || url.hostname === '127.0.0.1';
+
+  if (isLocalHost) {
+    return origins;
+  }
+
+  if (url.hostname.startsWith('www.')) {
+    origins.push(`${url.protocol}//${url.hostname.slice(4)}`);
+  } else {
+    origins.push(`${url.protocol}//www.${url.hostname}`);
+  }
+
+  return [...new Set(origins)];
+}
+
 function printList(title, values) {
   console.log(`\n${title}`);
   for (const value of values) {
@@ -218,10 +240,23 @@ function run() {
 
   const googleRedirectLegacy = `https://${args.projectRef}.supabase.co/auth/v1/callback`;
   const googleRedirectCustom = `https://${args.customAuthHost}/auth/v1/callback`;
+  const productionOrigins = getRelatedOrigins(args.prodAppOrigin);
+  const additionalRedirectUrls = [
+    `${args.appOrigin}`,
+    `${args.appOrigin}/login`,
+    `${args.appOrigin}/portal`,
+    `${args.appOrigin}/reset-password`,
+    ...productionOrigins.flatMap((origin) => [
+      `${origin}`,
+      `${origin}/login`,
+      `${origin}/portal`,
+      `${origin}/reset-password`,
+    ]),
+  ];
 
   printList('Google OAuth Authorized JavaScript origins (copy/paste)', [
     args.appOrigin,
-    args.prodAppOrigin,
+    ...productionOrigins,
   ]);
 
   printList('Google OAuth Authorized redirect URIs (copy/paste)', [
@@ -230,15 +265,8 @@ function run() {
   ]);
 
   printList('Supabase URL Configuration values (copy/paste)', [
-    `Site URL: ${args.prodAppOrigin}`,
-    `Additional redirect URL: ${args.appOrigin}`,
-    `Additional redirect URL: ${args.appOrigin}/login`,
-    `Additional redirect URL: ${args.appOrigin}/portal`,
-    `Additional redirect URL: ${args.appOrigin}/reset-password`,
-    `Additional redirect URL: ${args.prodAppOrigin}`,
-    `Additional redirect URL: ${args.prodAppOrigin}/login`,
-    `Additional redirect URL: ${args.prodAppOrigin}/portal`,
-    `Additional redirect URL: ${args.prodAppOrigin}/reset-password`,
+    `Site URL: ${productionOrigins[0]}`,
+    ...additionalRedirectUrls.map((value) => `Additional redirect URL: ${value}`),
   ]);
 
   if (warnings.length > 0) {


### PR DESCRIPTION
Summary
- align `auth:preflight` output to the canonical production host `https://www.bloomjoyusa.com` and include apex cutover aliases
- update auth runbooks/status docs with the confirmed `http://localhost:3000/#access_token=...` failure mode and remediation steps
- document the current Supabase custom-domain CLI blocker and the expected final Google login URL

Files changed
- `scripts/auth-preflight.mjs`
- `Docs/AUTH_OAUTH_BRANDING_RUNBOOK.md`
- `Docs/AUTH_PRODUCTION_SIGNOFF.md`
- `Docs/CURRENT_STATUS.md`
- `Docs/QA_SMOKE_TEST_CHECKLIST.md`

Verification commands + results
- `npm ci` ? completed successfully; npm reported 5 existing vulnerabilities in the dependency graph
- `npm run build` ? passed
- `npm test --if-present` ? no test script defined; command exited successfully
- `npm run lint --if-present` ? passed with existing `react-refresh/only-export-components` warnings in generated/shared UI files and `src/contexts/AuthContext.tsx`
- `npm run auth:preflight -- --env-file ..\Bloomjoy_hub\.env` ? passed with `www` + apex redirect guidance
- `npm run auth:preflight -- --env-file ..\Bloomjoy_hub\.env --require-custom-auth-domain` ? expected failure because `VITE_SUPABASE_URL` still points at `ygbzkgxktzqsiygjlqyg.supabase.co`
- `supabase domains get --project-ref ygbzkgxktzqsiygjlqyg --output json` reports: `Please enable the Custom Domain add-on for the project first.`

How to test
- `npm ci`
- `npm run auth:preflight -- --env-file ..\Bloomjoy_hub\.env`
- Confirm the script prints `Site URL: https://www.bloomjoyusa.com` and includes both `https://www.bloomjoyusa.com/*` and `https://bloomjoyusa.com/*` redirect entries
- Review `Docs/AUTH_OAUTH_BRANDING_RUNBOOK.md` for the new `localhost:3000/#access_token=...` troubleshooting section
- In Supabase dashboard, set Site URL to `https://www.bloomjoyusa.com` and add redirect URLs for `https://www.bloomjoyusa.com`, `/login`, `/portal`, `/reset-password`, plus apex aliases during cutover
- Retry Google sign-in from `https://www.bloomjoyusa.com/login` and confirm the final URL is `https://www.bloomjoyusa.com/portal` instead of `http://localhost:3000`

Notes
- This PR touches `Docs/CURRENT_STATUS.md`, which is a shared status file and may need a rebase if another docs/status PR merges first.
