### PR TITLE
Fix portal training progress first-load fetch

### DIFF
--- a/src/lib/trainingRepository.ts
+++ b/src/lib/trainingRepository.ts
@@ -451,7 +451,8 @@ export const useTrainingProgress = (userId?: string, enabled = true) =>
     queryKey: ['training-progress', userId ?? 'anonymous'],
     queryFn: fetchTrainingProgress,
     enabled: enabled && Boolean(userId),
-    initialData: [] as TrainingProgressRecord[],
+    placeholderData: [] as TrainingProgressRecord[],
+    refetchOnMount: 'always',
     staleTime: 1000 * 30,
   });
 
@@ -460,7 +461,8 @@ export const useTrainingCertificates = (userId?: string, enabled = true) =>
     queryKey: ['training-certifications', userId ?? 'anonymous'],
     queryFn: fetchTrainingCertificates,
     enabled: enabled && Boolean(userId),
-    initialData: [] as TrainingCertificate[],
+    placeholderData: [] as TrainingCertificate[],
+    refetchOnMount: 'always',
     staleTime: 1000 * 30,
   });
 


### PR DESCRIPTION
## Summary
- fetch training progress and certificate queries on first portal mount instead of treating empty placeholder state as fresh data
- keep progress/certificate UI responsive while still showing empty placeholder arrays during the request
- fix the production regression discovered during post-merge rollout smoke where dashboard/training stayed at `0/8` and never requested progress/certificate data

## Files changed
- `src/lib/trainingRepository.ts`

## Verification commands + results
- `npm ci` (previously complete in this worktree; no dependency changes in this follow-up)
- `npm run build` ?
- `npm test --if-present` (no test script present)
- `npm run lint --if-present` ? (existing fast-refresh warnings only)
- `npm run seo:check` ?

## How to test
1. Open `http://localhost:8080/login` after `npm run dev`
2. Sign in with a Plus-enabled user
3. Visit `http://localhost:8080/portal` and confirm the training card reflects existing progress instead of staying at `0/8`
4. Visit `http://localhost:8080/portal/training` and confirm required counts, completion badges, and certificate state load on first page view
5. Mark a training complete, refresh, and confirm the same state persists after reload/re-login
