### PR TITLE
[codex] Add WeCom relay fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,5 +37,10 @@ WECOM_AGENT_ID=
 # Secret from App Management -> your app details (do not expose client-side)
 WECOM_AGENT_SECRET=
 # Optional comma-separated recipient user IDs for alert fanout
-# Example: ethan.trifari,ops.manager
+# Example direct send: ethantrifari,GuoYanHong
 WECOM_ALERT_TO_USERIDS=
+# Optional static-egress relay URL used by Supabase Edge Functions instead of
+# calling WeCom directly. Recommended if WeCom enforces trusted IPs.
+WECOM_RELAY_URL=
+# Shared HMAC secret between the Edge Functions caller and the relay service.
+WECOM_RELAY_HMAC_SECRET=

--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -30,6 +30,7 @@
   - presents totals, shipping details, item breakdown, receipt access, and support next steps in a customer-friendly layout
 - Remaining production issue:
   - WeCom token auth now succeeds, but live message sends are still blocked by WeCom IP policy (`60020: not allow to access from your ip`)
+  - Observed Supabase Edge Function egress IPs already changed across live retries (`52.13.72.229` on the last `40001` failure, `44.252.107.253` on the latest `60020` failure), so a strict WeCom trusted-IP allowlist is not a stable long-term fix unless Bloomjoy inserts a static-egress proxy or self-hosted relay in front of WeCom
   - internal email and customer confirmation email are currently working in production
 - Verified on `2026-04-06` by:
   - `node scripts/commerce-preflight.mjs --project-ref ygbzkgxktzqsiygjlqyg`
@@ -38,7 +39,8 @@
 ## Next P0 milestones
 - Clear the remaining WeCom production blocker:
   - confirm whether the Bloomjoy Alerts app enforces an IP allowlist or trusted network restriction in WeCom
-  - update the WeCom app policy so Supabase Edge Function traffic can send messages successfully
+  - if the WeCom app can run without a trusted-IP restriction, remove/relax that policy and re-test
+  - if Bloomjoy must keep a trusted-IP restriction, move WeCom delivery behind a static-egress proxy or self-hosted relay before re-testing
   - re-run the live `$0` order smoke test and confirm `wecom_alert_sent_at` populates in `public.orders`
 - Unblock and complete issue `#99` (dedicated Resend account for `bloomjoysweets.com`) so production auth and transactional email ownership can move off the currently blocked setup.
 
@@ -268,7 +270,7 @@ Execution order is based on launch risk and dependency overlap.
 - Clear support boundary copy must be reviewed early (to prevent support overload)
 - Production credential execution remains owner-controlled (Google/Supabase/SMTP/DNS changes must be completed in dashboard tools before launch sign-off).
 - Internal notification pipeline is restored for quote submissions, but ongoing reliability still depends on keeping Resend/Supabase function secrets valid (`RESEND_API_KEY`, verified sender, recipient list).
-- WeCom alert dispatch reliability now depends on owner-managed app policy as well as valid secrets/recipient scope; current live failure is `60020: not allow to access from your ip`.
+- WeCom alert dispatch reliability now depends on owner-managed app policy as well as valid secrets/recipient scope; current live failure is `60020: not allow to access from your ip`, and the observed Supabase egress IP already changed across live retries.
 - WeChat onboarding concierge UX is live, but operational effectiveness still depends on documented referral-buddy process/SLA ownership (tracked in issue `#110`).
 - `#78` currently blocked on Supabase side: Custom Domain add-on is not enabled yet for project `ygbzkgxktzqsiygjlqyg`, so domain create/activate commands cannot run.
 - Additional Vimeo uploads may exist before the portal catalog is synced; uploaded videos are not discoverable until `trainings` and `training_assets` are populated in Supabase.

--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -6,7 +6,7 @@
 - First priority is to **stabilize the POC** and align it to the MVP routing + docs workflow.
 - Write updates in plain language so non-technical readers can follow.
 
-## Emergency commerce remediation snapshot (2026-04-06)
+## Emergency commerce remediation snapshot (2026-04-08)
 - A production payments incident was confirmed on `2026-04-06`:
   - sugar checkout was publicly charging the Bloomjoy Plus member rate (`$8/kg`) instead of the public rate (`$10/kg`)
   - `stripe-webhook` was failing on every invocation because it used synchronous Stripe signature verification instead of `await constructEventAsync(...)`
@@ -31,6 +31,9 @@
 - Remaining production issue:
   - WeCom token auth now succeeds, but live message sends are still blocked by WeCom IP policy (`60020: not allow to access from your ip`)
   - Observed Supabase Edge Function egress IPs already changed across live retries (`52.13.72.229` on the last `40001` failure, `44.252.107.253` on the latest `60020` failure), so a strict WeCom trusted-IP allowlist is not a stable long-term fix unless Bloomjoy inserts a static-egress proxy or self-hosted relay in front of WeCom
+  - Manual WeCom app send was re-verified on `2026-04-08`, and both intended recipients are valid internal members with exact Account IDs `ethantrifari` and `GuoYanHong`
+  - Production `WECOM_ALERT_TO_USERIDS` was corrected to `ethantrifari,GuoYanHong` on `2026-04-08`
+  - Repo support for a signed WeCom relay is now prepared on branch `agent/wecom-alert-debug`; production still needs that relay hosted on infrastructure with a fixed public IP before WeCom order alerts can pass
   - internal email and customer confirmation email are currently working in production
 - Verified on `2026-04-06` by:
   - `node scripts/commerce-preflight.mjs --project-ref ygbzkgxktzqsiygjlqyg`
@@ -38,10 +41,11 @@
 
 ## Next P0 milestones
 - Clear the remaining WeCom production blocker:
-  - confirm whether the Bloomjoy Alerts app enforces an IP allowlist or trusted network restriction in WeCom
-  - if the WeCom app can run without a trusted-IP restriction, remove/relax that policy and re-test
-  - if Bloomjoy must keep a trusted-IP restriction, move WeCom delivery behind a static-egress proxy or self-hosted relay before re-testing
-  - re-run the live `$0` order smoke test and confirm `wecom_alert_sent_at` populates in `public.orders`
+  - host the new `scripts/wecom-alert-relay.mjs` service on a tiny VM or similar infrastructure with a fixed public IP
+  - allowlist only that relay IP in WeCom if Bloomjoy keeps WeCom trusted-IP enforcement enabled
+  - set `WECOM_RELAY_URL` and `WECOM_RELAY_HMAC_SECRET` in Supabase Edge Function secrets
+  - run the relay smoke test, then re-run the live `$0` order smoke test and confirm `wecom_alert_sent_at` populates
+  - if Bloomjoy can fully remove WeCom trusted-IP enforcement instead, direct WeCom delivery may be kept without the relay
 - Unblock and complete issue `#99` (dedicated Resend account for `bloomjoysweets.com`) so production auth and transactional email ownership can move off the currently blocked setup.
 
 ## Operator app surface split (2026-03-22)

--- a/Docs/DECISIONS.md
+++ b/Docs/DECISIONS.md
@@ -1,5 +1,20 @@
 # Decisions
 
+## 2026-04-08 - WeCom alert delivery must support a static-egress relay
+Production WeCom alert delivery must support a relay endpoint with fixed outbound IP instead of relying only on direct Supabase Edge Function calls to the WeCom API.
+
+**Canonical choice**
+- Supabase Edge Functions may call WeCom directly when no IP restriction applies.
+- If WeCom enforces trusted-IP policy, Supabase Edge Functions should send alerts to a small HTTPS relay using:
+  - `WECOM_RELAY_URL`
+  - `WECOM_RELAY_HMAC_SECRET`
+- The relay is responsible for the final WeCom API calls using the existing `WECOM_CORP_ID`, `WECOM_AGENT_ID`, `WECOM_AGENT_SECRET`, and `WECOM_ALERT_TO_USERIDS` values.
+
+**Why this choice**
+- Live production failures now show WeCom API error `60020: not allow to access from your ip`.
+- Bloomjoy already observed multiple Supabase egress IPs across live retries, so allowlisting direct Supabase IPs is not a durable fix.
+- This keeps customer-facing checkout behavior unchanged while isolating the WeCom network-policy workaround to the alerting path only.
+
 ## 2026-04-06 - Emergency commerce remediation: Plus-only sugar pricing, durable order capture, and customer confirmations
 For sugar ordering, Bloomjoy Plus members receive the discounted rate and all other buyers pay the public rate.
 

--- a/Docs/LOCAL_DEV.md
+++ b/Docs/LOCAL_DEV.md
@@ -189,11 +189,15 @@ For production deployment order and rollback, use `Docs/PRODUCTION_RUNBOOK.md`.
    - `supabase secrets set WECOM_CORP_ID=...`
    - `supabase secrets set WECOM_AGENT_ID=...`
    - `supabase secrets set WECOM_AGENT_SECRET=...`
-   - `supabase secrets set WECOM_ALERT_TO_USERIDS=ethan.trifari,ops.manager`
+   - `supabase secrets set WECOM_ALERT_TO_USERIDS=ethantrifari,GuoYanHong`
+   - Optional relay mode instead of direct WeCom API calls:
+     - `supabase secrets set WECOM_RELAY_URL=https://<fixed-ip-host>/wecom-alert`
+     - `supabase secrets set WECOM_RELAY_HMAC_SECRET=...`
    - Ensure `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and `SUPABASE_SERVICE_ROLE_KEY` are available to functions
 3) Run the commerce release preflight before deploy:
    - Local env check: `npm run commerce:preflight`
    - Remote secret presence check: `npm run commerce:preflight -- --project-ref <project-ref>`
+   - Relay-based WeCom delivery is also supported. Set either the direct `WECOM_*` credentials or `WECOM_RELAY_URL` + `WECOM_RELAY_HMAC_SECRET`.
 4) Run functions locally:
    - `supabase functions serve stripe-sugar-checkout --no-verify-jwt`
    - `supabase functions serve stripe-sticks-checkout --no-verify-jwt`
@@ -203,6 +207,29 @@ For production deployment order and rollback, use `Docs/PRODUCTION_RUNBOOK.md`.
    - `supabase functions serve lead-submission-intake --no-verify-jwt`
    - `supabase functions serve support-request-intake --no-verify-jwt`
 5) Ensure `.env` has `VITE_SUPABASE_URL` + `VITE_SUPABASE_ANON_KEY` for the SPA.
+
+## WeCom relay helper (recommended when WeCom enforces trusted IPs)
+Use this when WeCom rejects Supabase Edge Function traffic with `60020: not allow to access from your ip`.
+
+1) On the relay host, set:
+   - `WECOM_CORP_ID`
+   - `WECOM_AGENT_ID`
+   - `WECOM_AGENT_SECRET`
+   - `WECOM_ALERT_TO_USERIDS`
+   - `WECOM_RELAY_HMAC_SECRET`
+2) Start the relay:
+   - `npm run wecom-relay:serve`
+3) Confirm the relay is up:
+   - `curl http://127.0.0.1:8787/health`
+4) From the caller environment, set:
+   - `WECOM_RELAY_URL=https://<your-fixed-ip-host>/wecom-alert`
+   - `WECOM_RELAY_HMAC_SECRET=<same shared secret>`
+5) Send a smoke alert through the relay:
+   - `npm run wecom-relay:smoke -- --title "Bloomjoy relay smoke"`
+
+Notes:
+- The relay should run on infrastructure with a fixed public IP. A tiny VM with an elastic/static IP is the intended production target.
+- Keep TLS termination in front of the relay for production. The local `http://127.0.0.1:8787` example is only for machine-local validation.
 
 ## Stripe order backfill helper
 Use this when a paid Stripe checkout must be imported into `public.orders` because webhook replay is unavailable or the webhook failed before persistence.

--- a/Docs/PRODUCTION_RUNBOOK.md
+++ b/Docs/PRODUCTION_RUNBOOK.md
@@ -99,6 +99,7 @@ npm run commerce:preflight -- --project-ref <project-ref>
 
 WeCom note:
 - If token auth succeeds but live sends fail with `60020: not allow to access from your ip`, the remaining issue is WeCom-side network/IP policy, not the secret values. Fix the app/network restriction in WeCom admin, then re-run a live smoke order.
+- Do not assume one observed Supabase function IP is permanent. If live retries show different egress IPs, a WeCom trusted-IP allowlist will keep breaking unless Bloomjoy removes that restriction or routes WeCom calls through infrastructure with static outbound IPs.
 
 ### Step C: Deploy Stripe Edge Functions
 Deploy all current checkout/submission functions:

--- a/Docs/PRODUCTION_RUNBOOK.md
+++ b/Docs/PRODUCTION_RUNBOOK.md
@@ -2,7 +2,7 @@
 
 Purpose: provide a single launch-day procedure for Bloomjoy Hub production release and rollback.
 
-Last updated: 2026-04-06
+Last updated: 2026-04-08
 
 ## 1) Roles and ownership
 - Release owner: coordinates launch window and final go/no-go call.
@@ -32,6 +32,8 @@ Set the following values before launch.
 | `WECOM_AGENT_ID` | Server-only | `lead-submission-intake`, `stripe-webhook`, `support-request-intake` | WeCom app settings | Technical owner |
 | `WECOM_AGENT_SECRET` | Server-only | `lead-submission-intake`, `stripe-webhook`, `support-request-intake` | WeCom app settings | Technical owner |
 | `WECOM_ALERT_TO_USERIDS` | Server-only | `lead-submission-intake`, `stripe-webhook`, `support-request-intake` | WeCom recipient user IDs (comma-separated) | Release owner |
+| `WECOM_RELAY_URL` | Server-only | `lead-submission-intake`, `stripe-webhook`, `support-request-intake` | Fixed-IP WeCom relay URL | Technical owner |
+| `WECOM_RELAY_HMAC_SECRET` | Server-only | `lead-submission-intake`, `stripe-webhook`, `support-request-intake` | Shared secret between Edge Functions and relay | Technical owner |
 | `SUPABASE_URL` | Server-only | Stripe/order/support Edge Functions | Supabase project URL | Technical owner |
 | `SUPABASE_ANON_KEY` | Server-only | `stripe-sugar-checkout`, `stripe-plus-checkout`, `stripe-customer-portal` | Supabase project anon key | Technical owner |
 | `SUPABASE_SERVICE_ROLE_KEY` | Server-only | `stripe-webhook`, `stripe-sugar-checkout`, `lead-submission-intake`, `support-request-intake` | Supabase service role key | Technical owner |
@@ -82,10 +84,14 @@ supabase secrets set STRIPE_WEBHOOK_SECRET=...
 supabase secrets set RESEND_API_KEY=...
 supabase secrets set INTERNAL_NOTIFICATION_FROM_EMAIL=...
 supabase secrets set INTERNAL_NOTIFICATION_RECIPIENTS=etrifari@bloomjoysweets.com,ian@bloomjoysweets.com
+# Direct WeCom mode (use when WeCom does not enforce trusted IPs):
 supabase secrets set WECOM_CORP_ID=...
 supabase secrets set WECOM_AGENT_ID=...
 supabase secrets set WECOM_AGENT_SECRET=...
-supabase secrets set WECOM_ALERT_TO_USERIDS=ethan.trifari,ops.manager
+supabase secrets set WECOM_ALERT_TO_USERIDS=ethantrifari,GuoYanHong
+# Relay mode (recommended when WeCom trusted IPs are enforced):
+supabase secrets set WECOM_RELAY_URL=https://<fixed-ip-host>/wecom-alert
+supabase secrets set WECOM_RELAY_HMAC_SECRET=...
 supabase secrets set SUPABASE_URL=...
 supabase secrets set SUPABASE_ANON_KEY=...
 supabase secrets set SUPABASE_SERVICE_ROLE_KEY=...
@@ -100,6 +106,42 @@ npm run commerce:preflight -- --project-ref <project-ref>
 WeCom note:
 - If token auth succeeds but live sends fail with `60020: not allow to access from your ip`, the remaining issue is WeCom-side network/IP policy, not the secret values. Fix the app/network restriction in WeCom admin, then re-run a live smoke order.
 - Do not assume one observed Supabase function IP is permanent. If live retries show different egress IPs, a WeCom trusted-IP allowlist will keep breaking unless Bloomjoy removes that restriction or routes WeCom calls through infrastructure with static outbound IPs.
+- Recommended durable fix: host `scripts/wecom-alert-relay.mjs` on a small VM with a fixed public IP, allowlist only that IP in WeCom if needed, and point Supabase at the relay via `WECOM_RELAY_URL` + `WECOM_RELAY_HMAC_SECRET`.
+
+### Step B1: If WeCom trusted IPs are enforced, deploy the relay first
+Use this only when direct Supabase-to-WeCom traffic is blocked by WeCom IP policy.
+
+Relay host requirements:
+- fixed public IPv4 address
+- HTTPS termination for the relay endpoint
+- Node 20+ runtime
+- outbound internet access to `https://qyapi.weixin.qq.com`
+
+Relay host env vars:
+- `WECOM_CORP_ID`
+- `WECOM_AGENT_ID`
+- `WECOM_AGENT_SECRET`
+- `WECOM_ALERT_TO_USERIDS=ethantrifari,GuoYanHong`
+- `WECOM_RELAY_HMAC_SECRET=<shared secret>`
+
+Relay boot command:
+
+```bash
+npm ci
+npm run wecom-relay:serve
+```
+
+Relay verification:
+
+```bash
+curl https://<fixed-ip-host>/health
+npm run wecom-relay:smoke -- --relay-url https://<fixed-ip-host>/wecom-alert --hmac-secret <shared secret> --title "Bloomjoy production relay smoke"
+```
+
+Expected result:
+- `/health` returns `ok: true`
+- smoke returns `HTTP 200`
+- both intended internal WeCom recipients receive the test message
 
 ### Step C: Deploy Stripe Edge Functions
 Deploy all current checkout/submission functions:
@@ -148,7 +190,7 @@ Run immediately after deploy:
 - [ ] Sugar checkout test order stores customer contact, billing/shipping address, pricing tier, receipt URL, and color breakdown in `orders`.
 - [ ] Sugar checkout test order sends internal summary email to configured operations recipients.
 - [ ] Sugar checkout test order sends customer confirmation email with the branded HTML confirmation layout, order summary, and receipt link.
-- [ ] Sugar checkout test order sends WeCom alert when `WECOM_*` secrets are configured and the WeCom app/network policy allows traffic from the live function egress IPs.
+- [ ] Sugar checkout test order sends WeCom alert when direct WeCom access is allowed or when `WECOM_RELAY_URL` + `WECOM_RELAY_HMAC_SECRET` are configured to a healthy fixed-IP relay.
 - [ ] Blank sticks checkout test order (5+ boxes) creates `orders` record in Supabase with size/address/shipping metadata.
 - [ ] Blank sticks checkout test order sends internal summary email to configured operations recipients.
 - [ ] Blank sticks checkout test order sends customer confirmation email with the branded HTML confirmation layout.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "seo:check": "node scripts/seo-regression-check.mjs",
     "auth:preflight": "node scripts/auth-preflight.mjs",
     "commerce:preflight": "node scripts/commerce-preflight.mjs",
+    "wecom-relay:serve": "node scripts/wecom-alert-relay.mjs",
+    "wecom-relay:smoke": "node scripts/wecom-relay-smoke.mjs",
     "orders:backfill": "node scripts/backfill-stripe-orders.mjs",
     "training:dedupe-catalog": "node scripts/dedupe-training-catalog.mjs",
     "training:sync-guides": "node scripts/sync-training-guides.mjs",

--- a/scripts/commerce-preflight.mjs
+++ b/scripts/commerce-preflight.mjs
@@ -131,6 +131,23 @@ function parseRecipients(value) {
     .filter(Boolean);
 }
 
+function hasValue(value) {
+  return !!value && String(value).trim() !== '';
+}
+
+function hasDirectWeComConfig(env) {
+  return (
+    hasValue(env.WECOM_CORP_ID) &&
+    hasValue(env.WECOM_AGENT_ID) &&
+    hasValue(env.WECOM_AGENT_SECRET) &&
+    hasValue(env.WECOM_ALERT_TO_USERIDS)
+  );
+}
+
+function hasRelayWeComConfig(env) {
+  return hasValue(env.WECOM_RELAY_URL) && hasValue(env.WECOM_RELAY_HMAC_SECRET);
+}
+
 function isValidUrl(value) {
   try {
     const url = new URL(value);
@@ -189,10 +206,6 @@ function run() {
     'INTERNAL_NOTIFICATION_FROM_EMAIL',
     'INTERNAL_NOTIFICATION_RECIPIENTS',
     'STRIPE_SUGAR_NON_MEMBER_PRICE_ID',
-    'WECOM_CORP_ID',
-    'WECOM_AGENT_ID',
-    'WECOM_AGENT_SECRET',
-    'WECOM_ALERT_TO_USERIDS',
   ];
 
   for (const key of requiredKeys) {
@@ -205,6 +218,47 @@ function run() {
     errors.push(
       'Missing member sugar price. Set STRIPE_SUGAR_MEMBER_PRICE_ID (preferred) or legacy STRIPE_SUGAR_PRICE_ID.'
     );
+  }
+
+  const hasDirectWeCom = hasDirectWeComConfig(env);
+  const hasRelayWeCom = hasRelayWeComConfig(env);
+
+  if (!hasDirectWeCom && !hasRelayWeCom) {
+    errors.push(
+      'Missing WeCom alert configuration. Set either WECOM_CORP_ID/WECOM_AGENT_ID/WECOM_AGENT_SECRET/WECOM_ALERT_TO_USERIDS or WECOM_RELAY_URL/WECOM_RELAY_HMAC_SECRET.'
+    );
+  }
+
+  if (
+    hasValue(env.WECOM_CORP_ID) ||
+    hasValue(env.WECOM_AGENT_ID) ||
+    hasValue(env.WECOM_AGENT_SECRET) ||
+    hasValue(env.WECOM_ALERT_TO_USERIDS)
+  ) {
+    const missingDirectKeys = [
+      'WECOM_CORP_ID',
+      'WECOM_AGENT_ID',
+      'WECOM_AGENT_SECRET',
+      'WECOM_ALERT_TO_USERIDS',
+    ].filter((key) => !hasValue(env[key]));
+
+    if (missingDirectKeys.length > 0) {
+      errors.push(
+        `WeCom direct-send config is partial. Missing: ${missingDirectKeys.join(', ')}.`
+      );
+    }
+  }
+
+  if (hasValue(env.WECOM_RELAY_URL) || hasValue(env.WECOM_RELAY_HMAC_SECRET)) {
+    const missingRelayKeys = ['WECOM_RELAY_URL', 'WECOM_RELAY_HMAC_SECRET'].filter(
+      (key) => !hasValue(env[key])
+    );
+
+    if (missingRelayKeys.length > 0) {
+      errors.push(
+        `WeCom relay config is partial. Missing: ${missingRelayKeys.join(', ')}.`
+      );
+    }
   }
 
   if (env.STRIPE_SUGAR_PRICE_ID && !env.STRIPE_SUGAR_MEMBER_PRICE_ID) {
@@ -225,8 +279,16 @@ function run() {
     errors.push('INTERNAL_NOTIFICATION_FROM_EMAIL must be a valid sender email address.');
   }
 
-  if (!isRemoteSource && env.WECOM_AGENT_ID && !/^\d+$/.test(String(env.WECOM_AGENT_ID).trim())) {
+  if (
+    !isRemoteSource &&
+    env.WECOM_AGENT_ID &&
+    !/^\d+$/.test(String(env.WECOM_AGENT_ID).trim())
+  ) {
     errors.push('WECOM_AGENT_ID must be numeric.');
+  }
+
+  if (!isRemoteSource && env.WECOM_RELAY_URL && !isValidUrl(env.WECOM_RELAY_URL)) {
+    errors.push('WECOM_RELAY_URL must be a valid absolute URL.');
   }
 
   if (!isRemoteSource) {
@@ -253,7 +315,7 @@ function run() {
     'Webhook secret present',
     'Member and non-member sugar price IDs configured',
     'Internal email sender and recipients configured',
-    'WeCom alert secrets configured',
+    'WeCom alert path configured (direct or relay)',
     'Supabase service-role and anon keys configured',
   ]);
 

--- a/scripts/wecom-alert-relay.mjs
+++ b/scripts/wecom-alert-relay.mjs
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+
+import http from 'node:http';
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+const WECOM_API_BASE_URL = 'https://qyapi.weixin.qq.com/cgi-bin';
+const ACCESS_TOKEN_REFRESH_BUFFER_MS = 60 * 1000;
+const MAX_TEXT_CONTENT_LENGTH = 1800;
+const MAX_REQUEST_BODY_BYTES = 32 * 1024;
+const TOKEN_RETRYABLE_ERROR_CODES = new Set([40014, 42001, 42007, 42009]);
+
+let cachedAccessToken = null;
+
+function sanitize(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function parseToUser(value) {
+  return String(value || '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .join('|');
+}
+
+function parsePositiveNumber(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function getRelayConfig() {
+  const corpId = sanitize(process.env.WECOM_CORP_ID);
+  const agentIdRaw = sanitize(process.env.WECOM_AGENT_ID);
+  const agentSecret = sanitize(process.env.WECOM_AGENT_SECRET);
+  const toUserRaw = sanitize(process.env.WECOM_ALERT_TO_USERIDS);
+  const hmacSecret = sanitize(process.env.WECOM_RELAY_HMAC_SECRET);
+  const host = sanitize(process.env.WECOM_RELAY_BIND_HOST) || '0.0.0.0';
+  const port = parsePositiveNumber(process.env.PORT, 8787);
+  const maxSkewSeconds = parsePositiveNumber(
+    process.env.WECOM_RELAY_MAX_SKEW_SECONDS,
+    300
+  );
+
+  if (!corpId || !agentIdRaw || !agentSecret || !toUserRaw || !hmacSecret) {
+    throw new Error(
+      'Missing relay configuration. Set WECOM_CORP_ID, WECOM_AGENT_ID, WECOM_AGENT_SECRET, WECOM_ALERT_TO_USERIDS, and WECOM_RELAY_HMAC_SECRET.'
+    );
+  }
+
+  const agentId = Number(agentIdRaw);
+  if (!Number.isFinite(agentId)) {
+    throw new Error('WECOM_AGENT_ID must be numeric.');
+  }
+
+  const toUser = parseToUser(toUserRaw);
+  if (!toUser) {
+    throw new Error('WECOM_ALERT_TO_USERIDS must contain at least one valid user ID.');
+  }
+
+  return {
+    corpId,
+    agentId,
+    agentSecret,
+    toUser,
+    hmacSecret,
+    host,
+    port,
+    maxSkewMs: maxSkewSeconds * 1000,
+  };
+}
+
+function sendJson(response, statusCode, payload) {
+  response.writeHead(statusCode, { 'Content-Type': 'application/json' });
+  response.end(JSON.stringify(payload));
+}
+
+function buildContent({ title, lines, tag }) {
+  const header = tag ? `[${tag}] ${title}` : title;
+  const content = [header, ...lines.filter(Boolean)].join('\n');
+  return content.length <= MAX_TEXT_CONTENT_LENGTH
+    ? content
+    : `${content.slice(0, MAX_TEXT_CONTENT_LENGTH - 3)}...`;
+}
+
+function hasValidCachedToken() {
+  return (
+    !!cachedAccessToken &&
+    Date.now() + ACCESS_TOKEN_REFRESH_BUFFER_MS < cachedAccessToken.expiresAtMs
+  );
+}
+
+async function fetchAccessToken(config) {
+  const params = new URLSearchParams({
+    corpid: config.corpId,
+    corpsecret: config.agentSecret,
+  });
+
+  const response = await fetch(`${WECOM_API_BASE_URL}/gettoken?${params.toString()}`);
+  if (!response.ok) {
+    throw new Error(`WeCom gettoken request failed (${response.status}).`);
+  }
+
+  const payload = await response.json();
+  const errCode = Number(payload.errcode ?? -1);
+  if (errCode !== 0) {
+    throw new Error(
+      `WeCom gettoken failed (${errCode}): ${payload.errmsg ?? 'Unknown error'}`
+    );
+  }
+
+  const accessToken = sanitize(payload.access_token);
+  const expiresIn = Number(payload.expires_in ?? 0);
+  if (!accessToken || !Number.isFinite(expiresIn) || expiresIn <= 0) {
+    throw new Error('WeCom gettoken response was missing token metadata.');
+  }
+
+  cachedAccessToken = {
+    token: accessToken,
+    expiresAtMs: Date.now() + expiresIn * 1000,
+  };
+
+  return accessToken;
+}
+
+async function getAccessToken(config, forceRefresh = false) {
+  if (!forceRefresh && hasValidCachedToken()) {
+    return cachedAccessToken.token;
+  }
+
+  return fetchAccessToken(config);
+}
+
+async function sendMessageWithToken(config, accessToken, content) {
+  const response = await fetch(
+    `${WECOM_API_BASE_URL}/message/send?access_token=${encodeURIComponent(accessToken)}`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        touser: config.toUser,
+        msgtype: 'text',
+        agentid: config.agentId,
+        text: {
+          content,
+        },
+        safe: 0,
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(`WeCom message send request failed (${response.status}).`);
+  }
+
+  const payload = await response.json();
+  const errCode = Number(payload.errcode ?? -1);
+  return {
+    ok: errCode === 0,
+    errCode,
+    errMessage: payload.errmsg ?? 'Unknown error',
+  };
+}
+
+async function sendAlert(config, input) {
+  const content = buildContent(input);
+  let accessToken = await getAccessToken(config);
+  let sendResult = await sendMessageWithToken(config, accessToken, content);
+
+  if (!sendResult.ok && TOKEN_RETRYABLE_ERROR_CODES.has(sendResult.errCode)) {
+    cachedAccessToken = null;
+    accessToken = await getAccessToken(config, true);
+    sendResult = await sendMessageWithToken(config, accessToken, content);
+  }
+
+  if (!sendResult.ok) {
+    throw new Error(
+      `WeCom message send failed (${sendResult.errCode}): ${sendResult.errMessage}`
+    );
+  }
+}
+
+function readRequestBody(request) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let totalBytes = 0;
+
+    request.on('data', (chunk) => {
+      totalBytes += chunk.length;
+      if (totalBytes > MAX_REQUEST_BODY_BYTES) {
+        reject(new Error('Request body exceeded maximum size.'));
+        request.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+
+    request.on('end', () => {
+      resolve(Buffer.concat(chunks).toString('utf8'));
+    });
+
+    request.on('error', (error) => {
+      reject(error);
+    });
+  });
+}
+
+function validateSignature(config, timestamp, body, receivedSignature) {
+  const numericTimestamp = Number(timestamp);
+  if (!Number.isFinite(numericTimestamp)) {
+    return false;
+  }
+
+  if (Math.abs(Date.now() - numericTimestamp) > config.maxSkewMs) {
+    return false;
+  }
+
+  const expectedSignature = createHmac('sha256', config.hmacSecret)
+    .update(`${timestamp}.${body}`)
+    .digest('hex');
+
+  const receivedBuffer = Buffer.from(receivedSignature, 'utf8');
+  const expectedBuffer = Buffer.from(expectedSignature, 'utf8');
+
+  return (
+    receivedBuffer.length === expectedBuffer.length &&
+    timingSafeEqual(receivedBuffer, expectedBuffer)
+  );
+}
+
+function parseAlertPayload(body) {
+  let payload;
+  try {
+    payload = JSON.parse(body);
+  } catch {
+    throw new Error('Request body must be valid JSON.');
+  }
+
+  const title = sanitize(payload?.title);
+  const tag = sanitize(payload?.tag) || undefined;
+  const lines = Array.isArray(payload?.lines)
+    ? payload.lines.map((entry) => sanitize(entry)).filter(Boolean)
+    : [];
+
+  if (!title) {
+    throw new Error('Alert title is required.');
+  }
+
+  return { title, tag, lines };
+}
+
+async function main() {
+  const config = getRelayConfig();
+
+  const server = http.createServer(async (request, response) => {
+    try {
+      const requestUrl = new URL(request.url || '/', `http://${request.headers.host || 'localhost'}`);
+
+      if (request.method === 'GET' && requestUrl.pathname === '/health') {
+        sendJson(response, 200, {
+          ok: true,
+          service: 'wecom-alert-relay',
+          direct_send_configured: true,
+          recipient_count: config.toUser.split('|').filter(Boolean).length,
+        });
+        return;
+      }
+
+      if (request.method !== 'POST' || requestUrl.pathname !== '/wecom-alert') {
+        sendJson(response, 404, { ok: false, message: 'Not found.' });
+        return;
+      }
+
+      const body = await readRequestBody(request);
+      const timestamp = sanitize(request.headers['x-bloomjoy-timestamp']);
+      const signature = sanitize(request.headers['x-bloomjoy-signature']);
+
+      if (!timestamp || !signature) {
+        sendJson(response, 401, { ok: false, message: 'Missing relay signature headers.' });
+        return;
+      }
+
+      if (!validateSignature(config, timestamp, body, signature)) {
+        sendJson(response, 401, { ok: false, message: 'Invalid relay signature.' });
+        return;
+      }
+
+      const alertInput = parseAlertPayload(body);
+      await sendAlert(config, alertInput);
+      sendJson(response, 200, { ok: true, message: 'WeCom alert sent.' });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error('wecom-alert-relay error', message);
+      sendJson(response, 502, { ok: false, message });
+    }
+  });
+
+  server.listen(config.port, config.host, () => {
+    console.log(
+      `wecom-alert-relay listening on http://${config.host}:${config.port} with ${config.toUser.split('|').filter(Boolean).length} configured recipient(s).`
+    );
+  });
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
+});

--- a/scripts/wecom-relay-smoke.mjs
+++ b/scripts/wecom-relay-smoke.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+import { createHmac } from 'node:crypto';
+
+function sanitize(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function parseArgs(argv) {
+  const parsed = {
+    title: 'Bloomjoy relay smoke test',
+    tag: 'Bloomjoy Relay',
+    lines: [],
+    relayUrl: sanitize(process.env.WECOM_RELAY_URL),
+    hmacSecret: sanitize(process.env.WECOM_RELAY_HMAC_SECRET),
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === '--relay-url' && next) {
+      parsed.relayUrl = next;
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--hmac-secret' && next) {
+      parsed.hmacSecret = next;
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--title' && next) {
+      parsed.title = next;
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--tag' && next) {
+      parsed.tag = next;
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--line' && next) {
+      parsed.lines.push(next);
+      index += 1;
+    }
+  }
+
+  return parsed;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (!args.relayUrl || !args.hmacSecret) {
+    throw new Error(
+      'Set WECOM_RELAY_URL and WECOM_RELAY_HMAC_SECRET, or pass --relay-url and --hmac-secret.'
+    );
+  }
+
+  const payload = {
+    title: args.title,
+    tag: args.tag,
+    lines:
+      args.lines.length > 0
+        ? args.lines
+        : [`Triggered at ${new Date().toISOString()}`],
+  };
+
+  const body = JSON.stringify(payload);
+  const timestamp = Date.now().toString();
+  const signature = createHmac('sha256', args.hmacSecret)
+    .update(`${timestamp}.${body}`)
+    .digest('hex');
+
+  const response = await fetch(args.relayUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Bloomjoy-Timestamp': timestamp,
+      'X-Bloomjoy-Signature': signature,
+    },
+    body,
+  });
+
+  const text = await response.text();
+  console.log(`HTTP ${response.status}`);
+  if (text) {
+    console.log(text);
+  }
+
+  if (!response.ok) {
+    process.exit(1);
+  }
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  process.exit(1);
+});

--- a/supabase/functions/_shared/wecom-alert.ts
+++ b/supabase/functions/_shared/wecom-alert.ts
@@ -5,12 +5,20 @@ const TOKEN_RETRYABLE_ERROR_CODES = new Set([40014, 42001, 42007, 42009]);
 
 let cachedAccessToken: { token: string; expiresAtMs: number } | null = null;
 let hasWarnedMissingConfig = false;
+let hasWarnedMissingRelayConfig = false;
+
+const textEncoder = new TextEncoder();
 
 type WeComConfig = {
   corpId: string;
   agentId: number;
   agentSecret: string;
   toUser: string;
+};
+
+type WeComRelayConfig = {
+  url: string;
+  hmacSecret: string;
 };
 
 type WeComApiResponse = {
@@ -48,7 +56,79 @@ const parseToUser = (value: string): string =>
     .filter(Boolean)
     .join("|");
 
-const getConfig = (): WeComConfig | null => {
+const parseRelayUrl = (value: string): string | null => {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:" && url.protocol !== "http:") {
+      return null;
+    }
+    return url.toString();
+  } catch {
+    return null;
+  }
+};
+
+const hexEncode = (buffer: ArrayBuffer): string =>
+  Array.from(new Uint8Array(buffer))
+    .map((value) => value.toString(16).padStart(2, "0"))
+    .join("");
+
+const signRelayPayload = async (
+  hmacSecret: string,
+  timestamp: string,
+  body: string
+): Promise<string> => {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    textEncoder.encode(hmacSecret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    textEncoder.encode(`${timestamp}.${body}`)
+  );
+
+  return hexEncode(signature);
+};
+
+const getRelayConfig = (): WeComRelayConfig | null => {
+  const relayUrlRaw = sanitize(Deno.env.get("WECOM_RELAY_URL"));
+  const relaySecret = sanitize(Deno.env.get("WECOM_RELAY_HMAC_SECRET"));
+
+  if (!relayUrlRaw && !relaySecret) {
+    return null;
+  }
+
+  if (!relayUrlRaw || !relaySecret) {
+    if (!hasWarnedMissingRelayConfig) {
+      console.warn(
+        "WeCom relay is partially configured. Set both WECOM_RELAY_URL and WECOM_RELAY_HMAC_SECRET."
+      );
+      hasWarnedMissingRelayConfig = true;
+    }
+    return null;
+  }
+
+  const relayUrl = parseRelayUrl(relayUrlRaw);
+  if (!relayUrl) {
+    if (!hasWarnedMissingRelayConfig) {
+      console.warn("WECOM_RELAY_URL must be a valid absolute http(s) URL.");
+      hasWarnedMissingRelayConfig = true;
+    }
+    return null;
+  }
+
+  return {
+    url: relayUrl,
+    hmacSecret: relaySecret,
+  };
+};
+
+const getDirectConfig = (): WeComConfig | null => {
   const corpId = sanitize(Deno.env.get("WECOM_CORP_ID"));
   const agentIdRaw = sanitize(Deno.env.get("WECOM_AGENT_ID"));
   const agentSecret = sanitize(Deno.env.get("WECOM_AGENT_SECRET"));
@@ -203,20 +283,79 @@ const sendAlertWithConfig = async (
   }
 };
 
+const sendAlertViaRelay = async (
+  relayConfig: WeComRelayConfig,
+  input: WeComAlertInput
+): Promise<void> => {
+  const body = JSON.stringify(input);
+  const timestamp = Date.now().toString();
+  const signature = await signRelayPayload(
+    relayConfig.hmacSecret,
+    timestamp,
+    body
+  );
+
+  const response = await fetch(relayConfig.url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Bloomjoy-Timestamp": timestamp,
+      "X-Bloomjoy-Signature": signature,
+    },
+    body,
+  });
+
+  const responseText = await response.text();
+  let responsePayload: { ok?: boolean; message?: string } | null = null;
+
+  if (responseText) {
+    try {
+      responsePayload = JSON.parse(responseText) as {
+        ok?: boolean;
+        message?: string;
+      };
+    } catch {
+      responsePayload = null;
+    }
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      responsePayload?.message
+        ? `WeCom relay failed (${response.status}): ${responsePayload.message}`
+        : `WeCom relay request failed (${response.status}).`
+    );
+  }
+
+  if (responsePayload?.ok === false) {
+    throw new Error(
+      responsePayload.message || "WeCom relay reported an unknown failure."
+    );
+  }
+};
+
 export async function sendWeComAlert(input: WeComAlertInput): Promise<void> {
-  const config = getConfig();
-  if (!config) {
+  const relayConfig = getRelayConfig();
+  if (relayConfig) {
+    await sendAlertViaRelay(relayConfig, input);
+    return;
+  }
+
+  const directConfig = getDirectConfig();
+  if (!directConfig) {
     throw new Error("WeCom alert configuration is missing.");
   }
 
-  await sendAlertWithConfig(config, input);
+  await sendAlertWithConfig(directConfig, input);
 }
 
 export async function sendWeComAlertResult(
   input: WeComAlertInput
 ): Promise<WeComAlertResult> {
-  const config = getConfig();
-  if (!config) {
+  const relayConfig = getRelayConfig();
+  const directConfig = relayConfig ? null : getDirectConfig();
+
+  if (!relayConfig && !directConfig) {
     return {
       ok: false,
       skipped: true,
@@ -225,11 +364,15 @@ export async function sendWeComAlertResult(
   }
 
   try {
-    await sendAlertWithConfig(config, input);
+    if (relayConfig) {
+      await sendAlertViaRelay(relayConfig, input);
+    } else if (directConfig) {
+      await sendAlertWithConfig(directConfig, input);
+    }
     return {
       ok: true,
       skipped: false,
-      message: "WeCom alert sent.",
+      message: relayConfig ? "WeCom alert sent via relay." : "WeCom alert sent.",
     };
   } catch (error) {
     console.warn("WeCom alert send failed (non-blocking).", error);


### PR DESCRIPTION
# Summary
- add a signed WeCom relay fallback so Supabase Edge Functions can deliver alerts through fixed-egress infrastructure when WeCom trusted-IP policy blocks direct sends
- add relay helper scripts and update commerce preflight to accept either direct WeCom credentials or relay configuration
- update current-status, decision, local-dev, and production-runbook docs with the verified recipient IDs and the exact relay rollout path

# Files changed
- `supabase/functions/_shared/wecom-alert.ts`
- `scripts/wecom-alert-relay.mjs`
- `scripts/wecom-relay-smoke.mjs`
- `scripts/commerce-preflight.mjs`
- `package.json`
- `.env.example`
- `Docs/CURRENT_STATUS.md`
- `Docs/DECISIONS.md`
- `Docs/LOCAL_DEV.md`
- `Docs/PRODUCTION_RUNBOOK.md`

# Root cause / current production state
- Direct production WeCom sends are still blocked by WeCom API error `60020: not allow to access from your ip`.
- Observed Supabase egress IPs already changed across live retries, including `44.252.107.253`, `52.13.36.77`, `35.93.97.178`, and `52.13.72.229`.
- Manual WeCom app send was re-verified on `2026-04-08`, and both intended recipients received the message.
- Verified internal member Account IDs are `ethantrifari` and `GuoYanHong`.
- Production `WECOM_ALERT_TO_USERIDS` was corrected to `ethantrifari,GuoYanHong` on `2026-04-08`.
- Internal email and customer confirmation email are already working in production; `wecom_alert_sent_at` is still `0` until the relay is hosted or WeCom trusted-IP enforcement is removed.

# Verification commands + results
- `npm ci` : pass
- `npm run build` : pass
- `npm test --if-present` : no test script present, command exits cleanly
- `npm run lint --if-present` : pass with existing fast-refresh warnings only
- `npm run commerce:preflight -- --project-ref ygbzkgxktzqsiygjlqyg` : pass
- `node --check scripts/wecom-alert-relay.mjs` : pass
- `node --check scripts/wecom-relay-smoke.mjs` : pass
- `node --check scripts/commerce-preflight.mjs` : pass
- `deno check supabase/functions/_shared/wecom-alert.ts` : pass
- local relay handshake smoke with dummy credentials:
  - `GET /health` returned `ok: true`
  - signed relay smoke reached the relay and failed only at upstream WeCom `gettoken` with expected dummy-credential error `40013 invalid corpid`

# How to test
- In this worktree, run `npm ci`
- Run `npm run build`
- Run `npm run lint --if-present`
- Optional localhost sanity check: run `npm run dev` and open `http://localhost:8080`
- Optional local relay check:
  - set local `WECOM_CORP_ID`, `WECOM_AGENT_ID`, `WECOM_AGENT_SECRET`, `WECOM_ALERT_TO_USERIDS`, and `WECOM_RELAY_HMAC_SECRET`
  - run `npm run wecom-relay:serve`
  - in a second terminal, run `npm run wecom-relay:smoke -- --relay-url http://127.0.0.1:8787/wecom-alert --hmac-secret <same-secret>`
- Production rollout path:
  - host `scripts/wecom-alert-relay.mjs` on a fixed-IP VM or similar infrastructure
  - set Supabase secrets `WECOM_RELAY_URL` and `WECOM_RELAY_HMAC_SECRET`
  - run `npm run commerce:preflight -- --project-ref ygbzkgxktzqsiygjlqyg`
  - run the relay smoke against the hosted relay
  - run one fresh live `$0` Stripe order smoke and confirm `wecom_alert_sent_at` populates
