### PR TITLE
Harden go-live ops alerts and lead visibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ supabase/.temp/
 *.njsproj
 *.sln
 *.sw?
+.vercel

--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -262,12 +262,13 @@ Execution order is based on launch risk and dependency overlap.
 - Session closeout smoke snapshot (`2026-03-09`): production-config API checks passed for quote notification dispatch, magic-link trigger, and password-reset trigger; remaining launch evidence is now limited to manual inbox/browser screenshots in `Docs/AUTH_PRODUCTION_SIGNOFF.md`.
 - WeCom alerting POC merged (`#107` via PR `#108`, `2026-03-10`): quote/order/support flows now attempt WeCom dispatch using server-only `WECOM_*` secrets with token cache + non-blocking failure logging.
 - WeChat onboarding concierge merged (PR `#109`, `2026-03-10`): support flow now includes structured onboarding intake (`phone/device/blocked step/referral`) persisted in `support_requests.intake_meta` and surfaced in `/admin/support` triage filters/cards.
+- Go-live readiness hardening (`2026-04-09`): all contact lead types now alert through `lead-submission-intake`, Mini waitlist now uses a server-side intake with internal email + best-effort WeCom, support intake now sends internal email alerts, Plus subscription activations now alert ops on first `trialing`/`active` webhook transition, `/admin/leads` provides read-only visibility for lead + waitlist inboxes, and direct public inserts to `lead_submissions` / `mini_waitlist_submissions` were removed so public writes must go through Edge Functions.
 
 ## Known risks / blockers
 - Product photography availability (Mini may launch as waitlist/coming soon)
 - Clear support boundary copy must be reviewed early (to prevent support overload)
 - Production credential execution remains owner-controlled (Google/Supabase/SMTP/DNS changes must be completed in dashboard tools before launch sign-off).
-- Internal notification pipeline is restored for quote submissions, but ongoing reliability still depends on keeping Resend/Supabase function secrets valid (`RESEND_API_KEY`, verified sender, recipient list).
+- Internal notification pipeline is restored for leads, waitlist, orders, and support alerts, but ongoing reliability still depends on keeping Resend/Supabase function secrets valid (`RESEND_API_KEY`, verified sender, recipient list).
 - WeCom alert dispatch reliability now depends on owner-managed app policy as well as valid secrets/recipient scope; current live failure is `60020: not allow to access from your ip`.
 - WeChat onboarding concierge UX is live, but operational effectiveness still depends on documented referral-buddy process/SLA ownership (tracked in issue `#110`).
 - `#78` currently blocked on Supabase side: Custom Domain add-on is not enabled yet for project `ygbzkgxktzqsiygjlqyg`, so domain create/activate commands cannot run.

--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -56,16 +56,20 @@
   - duplicate Mini waitlist submit returning `200 {"ok":true,"alreadyExists":true}`
   - Gmail confirmation of `New general inquiry: Codex Final` and `New Mini waitlist sign-up: codex-final-mini-1775767856927@example.com`
   - production host verification for `www`, `app`, and `/admin/leads`
-- Remaining production blockers after the hotfix:
-  - the SQL migration is still pending in production:
-    - `internal_notification_dispatches` still does not accept `lead_submission`, `mini_waitlist`, or `plus_subscription_activated`
-    - `mini_waitlist_submissions.internal_notification_sent_at` is still missing
+- Production follow-through completed later on `2026-04-09`:
+  - applied `202604090001_go_live_readiness_hardening.sql` to production after restoring the missing historical migration file `202603220001_partner_operator_accounts.sql` into the repo
+  - `npm run submission:preflight -- --project-ref ygbzkgxktzqsiygjlqyg` now passes against production
+  - live smoke verification confirmed:
+    - all four `/contact` submission types return `200`, persist rows, stamp `internal_notification_sent_at`, write `lead_submission` dispatch rows, and deliver internal emails
+    - Mini waitlist first-submit and duplicate-submit return `200`, stamp `internal_notification_sent_at`, write `mini_waitlist` dispatch rows, and deliver internal email
+    - anonymous direct inserts to `lead_submissions` and `mini_waitlist_submissions` fail with `42501`
+    - super-admin reads for lead and Mini waitlist rows succeed again through the production RLS path used by `/admin/leads`
+- Remaining production blockers after the migration:
   - `https://bloomjoyusa.com/` still returns `307` instead of the expected permanent `308`
-  - a live Plus activation smoke test still needs to be run after the production SQL migration is applied
+  - a live Plus activation smoke test is still pending because it requires a real billing-path verification
 
 ## Next P0 milestones
-- Apply the production submission migration and confirm the new schema state with `npm run submission:preflight -- --project-ref ygbzkgxktzqsiygjlqyg`.
-- Re-run live `/contact`, Mini waitlist, `/admin/leads`, and Plus activation smoke checks after the migration, then backfill any missed real-customer alerts with `npm run submission:backfill`.
+- Run a safe live Plus activation verification and confirm the one-time `plus_subscription_activated` ops email path.
 - Fix the apex-domain redirect so `https://bloomjoyusa.com/` returns `308` to `https://www.bloomjoyusa.com/`.
 - Clear the remaining WeCom production blocker:
   - confirm whether the Bloomjoy Alerts app enforces an IP allowlist or trusted network restriction in WeCom

--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -35,7 +35,38 @@
   - `node scripts/commerce-preflight.mjs --project-ref ygbzkgxktzqsiygjlqyg`
   - a live `$0` Stripe checkout smoke order after the webhook email redesign deployment
 
+## Go-live submissions hotfix snapshot (2026-04-09)
+- A second production-readiness incident was confirmed on `2026-04-09`:
+  - support request email delivery worked in production, but live lead and Mini waitlist flows were exposed to database schema drift after the new submission functions were deployed before the related migration
+  - `lead-submission-intake` returned `500` after writing the durable `lead_submissions` row when the new dispatch bookkeeping hit the old `internal_notification_dispatches` constraint
+  - `mini-waitlist-intake` returned `500` because production did not yet have `mini_waitlist_submissions.internal_notification_sent_at`
+  - `/admin/leads` could not load the Mini waitlist section against the old schema
+- Emergency remediation is now live in production:
+  - `lead-submission-intake` now keeps customer responses successful after the durable lead row is written, even if notification bookkeeping/schema drift blocks the follow-up write
+  - `mini-waitlist-intake` now tolerates the missing waitlist notification column and still delivers internal email alerts plus friendly duplicate handling
+  - `stripe-webhook` now keeps the first Plus activation alert resilient to the same dispatch-type schema drift
+  - `/admin/leads` now falls back cleanly when production is still missing the Mini waitlist notification timestamp column
+  - production frontend was redeployed so public Mini waitlist traffic now uses the new Edge Function instead of the old direct table insert path
+  - new operator tooling was added:
+    - `npm run submission:preflight` verifies the remote submission schema before deployment
+    - `npm run submission:backfill` replays missed internal alerts for unsent lead/waitlist rows
+- Verified live on `2026-04-09` by:
+  - raw production POST to `lead-submission-intake` returning `200 {"ok":true}` plus internal email delivery
+  - raw production POST to `mini-waitlist-intake` returning `200 {"ok":true,"alreadyExists":false}` plus internal email delivery
+  - duplicate Mini waitlist submit returning `200 {"ok":true,"alreadyExists":true}`
+  - Gmail confirmation of `New general inquiry: Codex Final` and `New Mini waitlist sign-up: codex-final-mini-1775767856927@example.com`
+  - production host verification for `www`, `app`, and `/admin/leads`
+- Remaining production blockers after the hotfix:
+  - the SQL migration is still pending in production:
+    - `internal_notification_dispatches` still does not accept `lead_submission`, `mini_waitlist`, or `plus_subscription_activated`
+    - `mini_waitlist_submissions.internal_notification_sent_at` is still missing
+  - `https://bloomjoyusa.com/` still returns `307` instead of the expected permanent `308`
+  - a live Plus activation smoke test still needs to be run after the production SQL migration is applied
+
 ## Next P0 milestones
+- Apply the production submission migration and confirm the new schema state with `npm run submission:preflight -- --project-ref ygbzkgxktzqsiygjlqyg`.
+- Re-run live `/contact`, Mini waitlist, `/admin/leads`, and Plus activation smoke checks after the migration, then backfill any missed real-customer alerts with `npm run submission:backfill`.
+- Fix the apex-domain redirect so `https://bloomjoyusa.com/` returns `308` to `https://www.bloomjoyusa.com/`.
 - Clear the remaining WeCom production blocker:
   - confirm whether the Bloomjoy Alerts app enforces an IP allowlist or trusted network restriction in WeCom
   - update the WeCom app policy so Supabase Edge Function traffic can send messages successfully

--- a/Docs/PRODUCTION_RUNBOOK.md
+++ b/Docs/PRODUCTION_RUNBOOK.md
@@ -49,6 +49,7 @@ Security rule:
   - [ ] `npm test --if-present`
   - [ ] `npm run lint --if-present`
 - [ ] `npm run commerce:preflight -- --project-ref <project-ref>` passes
+- [ ] `npm run submission:preflight -- --project-ref <project-ref>` passes
 - [ ] Supabase production backup/snapshot confirmed before applying new migrations.
 - [ ] Stripe products/prices verified (`STRIPE_SUGAR_MEMBER_PRICE_ID`, `STRIPE_SUGAR_NON_MEMBER_PRICE_ID`, `STRIPE_STICKS_PRICE_ID`, `STRIPE_PLUS_PRICE_ID`).
 - [ ] Domain and HTTPS confirmed for both production frontend hosts:
@@ -66,6 +67,10 @@ Recommended:
    - `supabase link --project-ref <project-ref>`
 2) Push migrations:
    - `supabase db push`
+
+Important for the `202604090001_go_live_readiness_hardening.sql` slice:
+- Apply the migration before deploying `lead-submission-intake`, `mini-waitlist-intake`, or `stripe-webhook`.
+- Use the revised migration that first normalizes legacy `internal_notification_dispatches.dispatch_type='lead_quote'` rows to `lead_submission` before re-adding the stricter dispatch-type constraint.
 
 ### Step B: Set/refresh Edge Function secrets
 Run once per environment or when values rotate:
@@ -95,6 +100,7 @@ Before continuing, run:
 
 ```bash
 npm run commerce:preflight -- --project-ref <project-ref>
+npm run submission:preflight -- --project-ref <project-ref>
 ```
 
 WeCom note:
@@ -181,6 +187,22 @@ Preferred order of operations:
    - pricing tier and unit price
    - sugar color breakdown or blank-sticks order details
    - notification status fields
+
+## 5c) Incident recovery for missed lead or Mini waitlist notifications
+Use this when a public submission row was durably written but internal ops alerts were missed or schema drift blocked the follow-up bookkeeping.
+
+Preferred order of operations:
+1) Apply the production submission migration and confirm the remote schema with:
+   - `npm run submission:preflight -- --project-ref <project-ref>`
+2) Re-run the affected public smoke flows:
+   - `/contact` for `quote`, `demo`, `procurement`, and `general`
+   - `/machines/mini`
+   - `/admin/leads`
+3) Inspect `lead_submissions` and `mini_waitlist_submissions` for rows where `internal_notification_sent_at is null` during the incident window.
+4) Replay the missed alerts:
+   - `npm run submission:backfill -- --since <ISO timestamp> --dry-run`
+   - `npm run submission:backfill -- --since <ISO timestamp>`
+5) Verify the recovered rows now appear in `/admin/leads` with notification timestamps populated where the production schema supports them.
 
 ## 6) Rollback checklist
 Trigger rollback if critical checkout/auth/data sync regressions are found.

--- a/Docs/PRODUCTION_RUNBOOK.md
+++ b/Docs/PRODUCTION_RUNBOOK.md
@@ -2,7 +2,7 @@
 
 Purpose: provide a single launch-day procedure for Bloomjoy Hub production release and rollback.
 
-Last updated: 2026-04-06
+Last updated: 2026-04-09
 
 ## 1) Roles and ownership
 - Release owner: coordinates launch window and final go/no-go call.
@@ -25,16 +25,16 @@ Set the following values before launch.
 | `STRIPE_STICKS_PRICE_ID` | Server-only | `stripe-sticks-checkout` | Stripe product/price config | Billing owner |
 | `STRIPE_PLUS_PRICE_ID` | Server-only | `stripe-plus-checkout` | Stripe product/price config | Billing owner |
 | `STRIPE_WEBHOOK_SECRET` | Server-only | `stripe-webhook` | Stripe webhook endpoint signing secret | Billing owner |
-| `RESEND_API_KEY` | Server-only | `stripe-webhook`, `lead-submission-intake` | Resend API key | Technical owner |
-| `INTERNAL_NOTIFICATION_FROM_EMAIL` | Server-only | `stripe-webhook`, `lead-submission-intake` | Verified sender in Resend | Technical owner |
-| `INTERNAL_NOTIFICATION_RECIPIENTS` | Server-only | `stripe-webhook`, `lead-submission-intake` | Internal recipient list (comma-separated) | Release owner |
-| `WECOM_CORP_ID` | Server-only | `lead-submission-intake`, `stripe-webhook`, `support-request-intake` | WeCom app settings | Technical owner |
-| `WECOM_AGENT_ID` | Server-only | `lead-submission-intake`, `stripe-webhook`, `support-request-intake` | WeCom app settings | Technical owner |
-| `WECOM_AGENT_SECRET` | Server-only | `lead-submission-intake`, `stripe-webhook`, `support-request-intake` | WeCom app settings | Technical owner |
-| `WECOM_ALERT_TO_USERIDS` | Server-only | `lead-submission-intake`, `stripe-webhook`, `support-request-intake` | WeCom recipient user IDs (comma-separated) | Release owner |
-| `SUPABASE_URL` | Server-only | Stripe/order/support Edge Functions | Supabase project URL | Technical owner |
+| `RESEND_API_KEY` | Server-only | `stripe-webhook`, `lead-submission-intake`, `mini-waitlist-intake`, `support-request-intake` | Resend API key | Technical owner |
+| `INTERNAL_NOTIFICATION_FROM_EMAIL` | Server-only | `stripe-webhook`, `lead-submission-intake`, `mini-waitlist-intake`, `support-request-intake` | Verified sender in Resend | Technical owner |
+| `INTERNAL_NOTIFICATION_RECIPIENTS` | Server-only | `stripe-webhook`, `lead-submission-intake`, `mini-waitlist-intake`, `support-request-intake` | Internal recipient list (comma-separated) | Release owner |
+| `WECOM_CORP_ID` | Server-only | `lead-submission-intake`, `mini-waitlist-intake`, `stripe-webhook`, `support-request-intake` | WeCom app settings | Technical owner |
+| `WECOM_AGENT_ID` | Server-only | `lead-submission-intake`, `mini-waitlist-intake`, `stripe-webhook`, `support-request-intake` | WeCom app settings | Technical owner |
+| `WECOM_AGENT_SECRET` | Server-only | `lead-submission-intake`, `mini-waitlist-intake`, `stripe-webhook`, `support-request-intake` | WeCom app settings | Technical owner |
+| `WECOM_ALERT_TO_USERIDS` | Server-only | `lead-submission-intake`, `mini-waitlist-intake`, `stripe-webhook`, `support-request-intake` | WeCom recipient user IDs (comma-separated) | Release owner |
+| `SUPABASE_URL` | Server-only | Stripe/order/lead/support Edge Functions | Supabase project URL | Technical owner |
 | `SUPABASE_ANON_KEY` | Server-only | `stripe-sugar-checkout`, `stripe-plus-checkout`, `stripe-customer-portal` | Supabase project anon key | Technical owner |
-| `SUPABASE_SERVICE_ROLE_KEY` | Server-only | `stripe-webhook`, `stripe-sugar-checkout`, `lead-submission-intake`, `support-request-intake` | Supabase service role key | Technical owner |
+| `SUPABASE_SERVICE_ROLE_KEY` | Server-only | `stripe-webhook`, `stripe-sugar-checkout`, `lead-submission-intake`, `mini-waitlist-intake`, `support-request-intake` | Supabase service role key | Technical owner |
 
 Security rule:
 - Never place secrets in `VITE_` variables.
@@ -110,6 +110,7 @@ supabase functions deploy stripe-plus-checkout --no-verify-jwt
 supabase functions deploy stripe-customer-portal --no-verify-jwt
 supabase functions deploy stripe-webhook --no-verify-jwt
 supabase functions deploy lead-submission-intake --no-verify-jwt
+supabase functions deploy mini-waitlist-intake --no-verify-jwt
 supabase functions deploy support-request-intake --no-verify-jwt
 ```
 
@@ -153,10 +154,16 @@ Run immediately after deploy:
 - [ ] Blank sticks checkout test order sends customer confirmation email with the branded HTML confirmation layout.
 - [ ] Plus checkout test subscription creates/updates `subscriptions` record in Supabase.
 - [ ] Quote request on `/contact` sends internal summary email to configured operations recipients.
-- [ ] Quote/order/support events send WeCom alerts to configured internal recipients (or log non-blocking warning on dispatch failure).
+- [ ] Demo, procurement, and general contact requests on `/contact` send internal summary email to configured operations recipients.
+- [ ] Mini waitlist submit sends internal summary email to configured operations recipients.
+- [ ] Support request submit sends internal summary email to configured operations recipients.
+- [ ] Lead/waitlist/order/support events send WeCom alerts to configured internal recipients (or log non-blocking warning on dispatch failure).
+- [ ] First Plus subscription activation (`trialing` or `active`) sends an internal summary email to configured operations recipients.
 - [ ] `/admin/orders` shows address, pricing tier, receipt URL, order breakdown, and notification status for the test orders.
+- [ ] `/admin/leads` shows the submitted lead and Mini waitlist rows with notification timestamps.
 - [ ] WeChat onboarding concierge submit on `/portal/support` creates `support_requests.request_type=wechat_onboarding` with populated `intake_meta`.
 - [ ] Stripe customer portal opens from `/portal/account`.
+- [ ] `https://bloomjoyusa.com` returns a permanent redirect to `https://www.bloomjoyusa.com/`.
 - [ ] No critical frontend console errors on key pages.
 
 ## 5b) Incident recovery for missed order sync

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -175,6 +175,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 
 ## Regression sanity
 - [ ] Quote, order, and support primary flows still succeed when WeCom alert delivery fails (verify non-blocking warning logs in function output)
+- [ ] `npm run submission:preflight -- --project-ref <project-ref>` passes before deploying submission-related Edge Functions
 - [ ] `npm run build` passes
 - [ ] `npm run lint` passes (if configured)
 - [ ] `npm run seo:check` passes

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -55,7 +55,10 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Contact/Quote submission creates a `lead_submissions` row in Supabase with expected type/email
 - [ ] Quote submissions send internal notification email with full request summary (name/email/source/type/message)
 - [ ] Quote submissions send a WeCom internal alert to configured `WECOM_ALERT_TO_USERIDS` recipients
+- [ ] Demo, procurement, and general contact submissions also send internal notification email and appear in `/admin/leads`
+- [ ] Blank sticks procurement requests (under 5 boxes) and custom sticks requests send internal notification email and appear in `/admin/leads`
 - [ ] Mini waitlist submit creates a `mini_waitlist_submissions` row (duplicate email shows friendly already-on-list message)
+- [ ] Mini waitlist submit sends internal notification email and appears in `/admin/leads`
 
 ## Auth / portal
 - [ ] Login flow works (magic link or configured method)
@@ -134,6 +137,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Source-PDF download actions for document-first guides resolve through signed `training-documents` URLs rather than public bucket links
 - [ ] Support request forms submit and show success state
 - [ ] Submitted support request appears in `support_requests` table with correct `request_type`, `status=new`, and customer identity
+- [ ] Submitted support request triggers an internal notification email with request type, customer email, and subject
 - [ ] Submitted support request triggers a WeCom alert with request type, customer email, and subject
 - [ ] `/portal/support` -> `View Setup Guide` includes install steps, QR verification timing, contact/group setup, and quick-use actions for translation, photo/video sharing, and group calls
 - [ ] `/portal/support` includes a WeChat onboarding concierge form with phone region/number, blocked-step selection, and referral-needed selection
@@ -156,6 +160,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Plus subscription checkout computes expected monthly amount from selected machine count (e.g., 1x=$100, 3x=$300) and completes with test card
 - [ ] Logged-out users on `/plus` are redirected to login before checkout can begin
 - [ ] Stripe subscription from Plus checkout contains `metadata.user_id` and `metadata.machine_count`
+- [ ] First Plus subscription activation (`trialing` or `active`) sends an internal notification email with subscription ID, customer email, machine count, and period end
 - [ ] Customer Portal link opens (test mode)
 - [ ] Account page Manage Billing opens Stripe portal (test mode)
 - [ ] In Stripe test customer portal, cancel Plus subscription and return to `/portal/account?billing=return`
@@ -176,6 +181,9 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 
 ## Admin (super-admin)
 - [ ] Non-admin user cannot access `/admin/support`
+- [ ] Non-admin user cannot access `/admin/leads`
+- [ ] Super-admin user can access `/admin/leads`
+- [ ] Admin leads inbox supports search and lead-type filtering and shows lead submissions plus Mini waitlist rows with notification timestamps
 - [ ] Super-admin user can access `/admin/support`
 - [ ] Admin can search/filter support queue and update status/priority/assignment/notes
 - [ ] Admin support queue can filter by request type and includes `wechat_onboarding`
@@ -197,3 +205,4 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Super-admin can grant and revoke super-admin role with reason metadata
 - [ ] Audit log view supports filtering and shows role + operational actions (support, orders, machine inventory)
 - [ ] Signed-in super-admin can reach `/admin` from visible navigation without typing the URL manually
+- [ ] Direct client inserts to `lead_submissions` and `mini_waitlist_submissions` with the anon key fail after the RLS hardening

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "seo:check": "node scripts/seo-regression-check.mjs",
     "auth:preflight": "node scripts/auth-preflight.mjs",
     "commerce:preflight": "node scripts/commerce-preflight.mjs",
+    "submission:preflight": "node scripts/submission-preflight.mjs",
+    "submission:backfill": "node scripts/backfill-submission-notifications.mjs",
     "orders:backfill": "node scripts/backfill-stripe-orders.mjs",
     "training:dedupe-catalog": "node scripts/dedupe-training-catalog.mjs",
     "training:sync-guides": "node scripts/sync-training-guides.mjs",

--- a/scripts/backfill-submission-notifications.mjs
+++ b/scripts/backfill-submission-notifications.mjs
@@ -1,0 +1,603 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createClient } from '@supabase/supabase-js';
+
+const DEFAULT_RECIPIENTS = [
+  'etrifari@bloomjoysweets.com',
+  'ian@bloomjoysweets.com',
+];
+const WECOM_API_BASE_URL = 'https://qyapi.weixin.qq.com/cgi-bin';
+const TOKEN_RETRYABLE_ERROR_CODES = new Set([40014, 42001, 42007, 42009]);
+const submissionTypeLabels = {
+  quote: 'quote request',
+  demo: 'demo request',
+  procurement: 'procurement inquiry',
+  general: 'general inquiry',
+};
+const DEFAULTS = {
+  envFiles: ['.env', '.env.local'],
+  since: '',
+  limit: 50,
+  dryRun: false,
+  includeTestData: false,
+  kind: 'all',
+};
+
+let cachedAccessToken = null;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+function parseArgs(argv) {
+  const parsed = { ...DEFAULTS, envFiles: [] };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === '--env-file' && next) {
+      parsed.envFiles.push(next);
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--since' && next) {
+      parsed.since = next;
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--limit' && next) {
+      parsed.limit = Number(next);
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--kind' && next) {
+      parsed.kind = next;
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--dry-run') {
+      parsed.dryRun = true;
+      continue;
+    }
+
+    if (arg === '--include-test-data') {
+      parsed.includeTestData = true;
+    }
+  }
+
+  if (parsed.envFiles.length === 0) {
+    parsed.envFiles = [...DEFAULTS.envFiles];
+  }
+
+  if (!['all', 'leads', 'mini_waitlist'].includes(parsed.kind)) {
+    throw new Error('--kind must be one of: all, leads, mini_waitlist');
+  }
+
+  if (!Number.isFinite(parsed.limit) || parsed.limit <= 0) {
+    throw new Error('--limit must be a positive number.');
+  }
+
+  return parsed;
+}
+
+function parseEnvFile(contents) {
+  const result = {};
+
+  for (const rawLine of contents.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) {
+      continue;
+    }
+
+    const eqIndex = line.indexOf('=');
+    if (eqIndex <= 0) {
+      continue;
+    }
+
+    const key = line.slice(0, eqIndex).trim();
+    let value = line.slice(eqIndex + 1).trim();
+
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    result[key] = value;
+  }
+
+  return result;
+}
+
+function loadEnvFiles(envFiles) {
+  const merged = {};
+  const loadedFiles = [];
+
+  for (const envFile of envFiles) {
+    const absolutePath = path.resolve(repoRoot, envFile);
+    if (!fs.existsSync(absolutePath)) {
+      continue;
+    }
+
+    Object.assign(merged, parseEnvFile(fs.readFileSync(absolutePath, 'utf8')));
+    loadedFiles.push(envFile);
+  }
+
+  return {
+    merged,
+    loadedFiles,
+  };
+}
+
+function parseRecipients(value) {
+  return String(value || '')
+    .split(',')
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function getInternalRecipients(env) {
+  const recipients = parseRecipients(env.INTERNAL_NOTIFICATION_RECIPIENTS);
+  return recipients.length > 0 ? recipients : DEFAULT_RECIPIENTS;
+}
+
+function shouldSkipTestEmail(email, includeTestData) {
+  if (includeTestData) {
+    return false;
+  }
+
+  const normalized = String(email || '').trim().toLowerCase();
+  return normalized.endsWith('@example.com') || normalized.startsWith('codex-');
+}
+
+async function sendInternalEmail(env, subject, text) {
+  const resendApiKey = env.RESEND_API_KEY;
+  const fromEmail = env.INTERNAL_NOTIFICATION_FROM_EMAIL;
+  const recipients = getInternalRecipients(env);
+
+  if (!resendApiKey || !fromEmail) {
+    throw new Error('Missing Resend internal email configuration.');
+  }
+
+  const response = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${resendApiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: fromEmail,
+      to: recipients,
+      subject,
+      text,
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Resend request failed (${response.status}): ${body || 'Unknown error'}`);
+  }
+}
+
+function getWeComConfig(env) {
+  const corpId = String(env.WECOM_CORP_ID || '').trim();
+  const agentId = Number(String(env.WECOM_AGENT_ID || '').trim());
+  const agentSecret = String(env.WECOM_AGENT_SECRET || '').trim();
+  const toUser = String(env.WECOM_ALERT_TO_USERIDS || '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .join('|');
+
+  if (!corpId || !Number.isFinite(agentId) || !agentSecret || !toUser) {
+    return null;
+  }
+
+  return {
+    corpId,
+    agentId,
+    agentSecret,
+    toUser,
+  };
+}
+
+async function fetchWeComAccessToken(config) {
+  const params = new URLSearchParams({
+    corpid: config.corpId,
+    corpsecret: config.agentSecret,
+  });
+
+  const response = await fetch(`${WECOM_API_BASE_URL}/gettoken?${params.toString()}`);
+  if (!response.ok) {
+    throw new Error(`WeCom gettoken request failed (${response.status}).`);
+  }
+
+  const payload = await response.json();
+  const errCode = Number(payload.errcode ?? -1);
+  if (errCode !== 0) {
+    throw new Error(`WeCom gettoken failed (${errCode}): ${payload.errmsg ?? 'Unknown error'}`);
+  }
+
+  cachedAccessToken = {
+    token: String(payload.access_token || '').trim(),
+    expiresAtMs: Date.now() + Number(payload.expires_in ?? 0) * 1000,
+  };
+
+  return cachedAccessToken.token;
+}
+
+async function getWeComAccessToken(config, forceRefresh = false) {
+  if (
+    !forceRefresh &&
+    cachedAccessToken &&
+    Date.now() + 60_000 < cachedAccessToken.expiresAtMs
+  ) {
+    return cachedAccessToken.token;
+  }
+
+  return fetchWeComAccessToken(config);
+}
+
+async function sendWeComAlertSafe(env, title, lines, tag) {
+  const config = getWeComConfig(env);
+  if (!config) {
+    return { ok: false, skipped: true, message: 'WeCom config missing.' };
+  }
+
+  const content = [tag ? `[${tag}] ${title}` : title, ...lines.filter(Boolean)]
+    .join('\n')
+    .slice(0, 1800);
+
+  try {
+    let accessToken = await getWeComAccessToken(config);
+    let response = await fetch(
+      `${WECOM_API_BASE_URL}/message/send?access_token=${encodeURIComponent(accessToken)}`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          touser: config.toUser,
+          msgtype: 'text',
+          agentid: config.agentId,
+          text: {
+            content,
+          },
+          safe: 0,
+        }),
+      }
+    );
+
+    let payload = await response.json();
+    let errCode = Number(payload.errcode ?? -1);
+
+    if (TOKEN_RETRYABLE_ERROR_CODES.has(errCode)) {
+      cachedAccessToken = null;
+      accessToken = await getWeComAccessToken(config, true);
+      response = await fetch(
+        `${WECOM_API_BASE_URL}/message/send?access_token=${encodeURIComponent(accessToken)}`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            touser: config.toUser,
+            msgtype: 'text',
+            agentid: config.agentId,
+            text: {
+              content,
+            },
+            safe: 0,
+          }),
+        }
+      );
+      payload = await response.json();
+      errCode = Number(payload.errcode ?? -1);
+    }
+
+    if (!response.ok || errCode !== 0) {
+      return {
+        ok: false,
+        skipped: false,
+        message: `WeCom message send failed (${errCode}): ${payload.errmsg ?? response.status}`,
+      };
+    }
+
+    return {
+      ok: true,
+      skipped: false,
+      message: 'WeCom alert sent.',
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      skipped: false,
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function buildLeadEmail(row) {
+  const submissionLabel = submissionTypeLabels[row.submission_type] || 'lead submission';
+  return {
+    subject: `New ${submissionLabel}: ${row.name}`,
+    text: [
+      `A new ${submissionLabel} was submitted.`,
+      '',
+      `Submission ID: ${row.id}`,
+      `Submitted At (UTC): ${row.created_at}`,
+      `Inquiry Type: ${row.submission_type}`,
+      `Name: ${row.name}`,
+      `Email: ${row.email}`,
+      `Source Page: ${row.source_page}`,
+      '',
+      'Message:',
+      row.message,
+    ].join('\n'),
+    wecomTitle: `New ${submissionLabel}: ${row.name}`,
+    wecomTag: 'Bloomjoy Lead',
+    wecomLines: [
+      `Submission ID: ${row.id}`,
+      `Submitted At (UTC): ${row.created_at}`,
+      `Inquiry Type: ${row.submission_type}`,
+      `Name: ${row.name}`,
+      `Email: ${row.email}`,
+      `Source Page: ${row.source_page}`,
+      'Message:',
+      row.message,
+    ],
+    dispatchType: 'lead_submission',
+    eventKey: `lead_submission:${row.id}`,
+    sourceTable: 'lead_submissions',
+    sourceId: row.id,
+    meta: {
+      submission_type: row.submission_type,
+      source_page: row.source_page,
+      email: row.email,
+      recovered_by: 'scripts/backfill-submission-notifications',
+    },
+  };
+}
+
+function buildWaitlistEmail(row) {
+  return {
+    subject: `New Mini waitlist sign-up: ${row.email}`,
+    text: [
+      'A new Mini waitlist sign-up was submitted.',
+      '',
+      `Submission ID: ${row.id}`,
+      `Submitted At (UTC): ${row.created_at}`,
+      `Product: ${row.product_slug}`,
+      `Email: ${row.email}`,
+      `Source Page: ${row.source_page}`,
+    ].join('\n'),
+    wecomTitle: 'New Mini waitlist sign-up',
+    wecomTag: 'Bloomjoy Mini',
+    wecomLines: [
+      `Submission ID: ${row.id}`,
+      `Submitted At (UTC): ${row.created_at}`,
+      `Product: ${row.product_slug}`,
+      `Email: ${row.email}`,
+      `Source Page: ${row.source_page}`,
+    ],
+    dispatchType: 'mini_waitlist',
+    eventKey: `mini_waitlist:${row.id}`,
+    sourceTable: 'mini_waitlist_submissions',
+    sourceId: row.id,
+    meta: {
+      product_slug: row.product_slug,
+      source_page: row.source_page,
+      email: row.email,
+      recovered_by: 'scripts/backfill-submission-notifications',
+    },
+  };
+}
+
+async function recordDispatch(supabase, payload) {
+  const { error } = await supabase.from('internal_notification_dispatches').upsert(
+    {
+      event_key: payload.eventKey,
+      dispatch_type: payload.dispatchType,
+      source_table: payload.sourceTable,
+      source_id: payload.sourceId,
+      meta: payload.meta,
+      sent_at: new Date().toISOString(),
+    },
+    {
+      onConflict: 'event_key',
+    }
+  );
+
+  if (error) {
+    throw new Error(error.message || 'Failed to record internal notification dispatch.');
+  }
+}
+
+async function backfillLeads({ supabase, env, since, limit, dryRun, includeTestData }) {
+  let query = supabase
+    .from('lead_submissions')
+    .select(
+      'id, submission_type, name, email, message, source_page, created_at, internal_notification_sent_at'
+    )
+    .is('internal_notification_sent_at', null)
+    .order('created_at', { ascending: true })
+    .limit(limit);
+
+  if (since) {
+    query = query.gte('created_at', since);
+  }
+
+  const { data, error } = await query;
+  if (error) {
+    throw new Error(error.message || 'Unable to load unsent lead submissions.');
+  }
+
+  const rows = (data || []).filter((row) => !shouldSkipTestEmail(row.email, includeTestData));
+  console.log(`INFO: lead submissions queued for backfill: ${rows.length}`);
+
+  for (const row of rows) {
+    const payload = buildLeadEmail(row);
+    if (dryRun) {
+      console.log(`DRY RUN lead ${row.id} -> ${row.email}`);
+      continue;
+    }
+
+    await sendInternalEmail(env, payload.subject, payload.text);
+    const wecomResult = await sendWeComAlertSafe(
+      env,
+      payload.wecomTitle,
+      payload.wecomLines,
+      payload.wecomTag
+    );
+    await supabase
+      .from('lead_submissions')
+      .update({ internal_notification_sent_at: new Date().toISOString() })
+      .eq('id', row.id);
+    await recordDispatch(supabase, payload);
+    console.log(
+      `RECOVERED lead ${row.id} -> ${row.email} (WeCom: ${wecomResult.message})`
+    );
+  }
+}
+
+async function backfillMiniWaitlist({
+  supabase,
+  env,
+  since,
+  limit,
+  dryRun,
+  includeTestData,
+}) {
+  const columnProbe = await supabase
+    .from('mini_waitlist_submissions')
+    .select('id, internal_notification_sent_at')
+    .limit(1);
+
+  const supportsNotificationColumn = !columnProbe.error;
+  const selectedColumns = supportsNotificationColumn
+    ? 'id, product_slug, email, source_page, created_at, internal_notification_sent_at'
+    : 'id, product_slug, email, source_page, created_at';
+
+  if (!supportsNotificationColumn && !since) {
+    throw new Error(
+      'Mini waitlist backfill requires --since until mini_waitlist_submissions.internal_notification_sent_at exists in the target database.'
+    );
+  }
+
+  let query = supabase
+    .from('mini_waitlist_submissions')
+    .select(selectedColumns)
+    .order('created_at', { ascending: true })
+    .limit(limit);
+
+  if (since) {
+    query = query.gte('created_at', since);
+  }
+
+  if (supportsNotificationColumn) {
+    query = query.is('internal_notification_sent_at', null);
+  }
+
+  const { data, error } = await query;
+  if (error) {
+    throw new Error(error.message || 'Unable to load Mini waitlist rows.');
+  }
+
+  const rows = (data || []).filter((row) => !shouldSkipTestEmail(row.email, includeTestData));
+  console.log(`INFO: Mini waitlist rows queued for backfill: ${rows.length}`);
+
+  for (const row of rows) {
+    const payload = buildWaitlistEmail(row);
+    if (dryRun) {
+      console.log(`DRY RUN mini_waitlist ${row.id} -> ${row.email}`);
+      continue;
+    }
+
+    await sendInternalEmail(env, payload.subject, payload.text);
+    const wecomResult = await sendWeComAlertSafe(
+      env,
+      payload.wecomTitle,
+      payload.wecomLines,
+      payload.wecomTag
+    );
+
+    if (supportsNotificationColumn) {
+      await supabase
+        .from('mini_waitlist_submissions')
+        .update({ internal_notification_sent_at: new Date().toISOString() })
+        .eq('id', row.id);
+    }
+
+    await recordDispatch(supabase, payload);
+    console.log(
+      `RECOVERED mini_waitlist ${row.id} -> ${row.email} (WeCom: ${wecomResult.message})`
+    );
+  }
+}
+
+async function run() {
+  const args = parseArgs(process.argv.slice(2));
+  const { merged, loadedFiles } = loadEnvFiles(args.envFiles);
+  const env = { ...merged, ...process.env };
+
+  const supabaseUrl = env.VITE_SUPABASE_URL || env.SUPABASE_URL;
+  const serviceRoleKey = env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error('Missing Supabase URL or service role key.');
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+
+  console.log(
+    `INFO: Loaded env files: ${loadedFiles.length ? loadedFiles.join(', ') : 'process.env only'}`
+  );
+  console.log(
+    `INFO: Backfill mode: kind=${args.kind} since=${args.since || 'none'} limit=${args.limit} dryRun=${args.dryRun}`
+  );
+
+  if (args.kind === 'all' || args.kind === 'leads') {
+    await backfillLeads({
+      supabase,
+      env,
+      since: args.since,
+      limit: args.limit,
+      dryRun: args.dryRun,
+      includeTestData: args.includeTestData,
+    });
+  }
+
+  if (args.kind === 'all' || args.kind === 'mini_waitlist') {
+    await backfillMiniWaitlist({
+      supabase,
+      env,
+      since: args.since,
+      limit: args.limit,
+      dryRun: args.dryRun,
+      includeTestData: args.includeTestData,
+    });
+  }
+
+  console.log('Submission notification backfill completed.');
+}
+
+run().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/submission-preflight.mjs
+++ b/scripts/submission-preflight.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createClient } from '@supabase/supabase-js';
+
+const DEFAULTS = {
+  envFiles: ['.env', '.env.local'],
+  projectRef: '',
+};
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+function parseArgs(argv) {
+  const parsed = { ...DEFAULTS, envFiles: [] };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === '--env-file' && next) {
+      parsed.envFiles.push(next);
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--project-ref' && next) {
+      parsed.projectRef = next;
+      index += 1;
+    }
+  }
+
+  if (parsed.envFiles.length === 0) {
+    parsed.envFiles = [...DEFAULTS.envFiles];
+  }
+
+  return parsed;
+}
+
+function parseEnvFile(contents) {
+  const result = {};
+
+  for (const rawLine of contents.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) {
+      continue;
+    }
+
+    const eqIndex = line.indexOf('=');
+    if (eqIndex <= 0) {
+      continue;
+    }
+
+    const key = line.slice(0, eqIndex).trim();
+    let value = line.slice(eqIndex + 1).trim();
+
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    result[key] = value;
+  }
+
+  return result;
+}
+
+function loadEnvFiles(envFiles) {
+  const merged = {};
+  const loadedFiles = [];
+
+  for (const envFile of envFiles) {
+    const absolutePath = path.resolve(repoRoot, envFile);
+    if (!fs.existsSync(absolutePath)) {
+      continue;
+    }
+
+    Object.assign(merged, parseEnvFile(fs.readFileSync(absolutePath, 'utf8')));
+    loadedFiles.push(envFile);
+  }
+
+  return {
+    merged,
+    loadedFiles,
+  };
+}
+
+async function run() {
+  const args = parseArgs(process.argv.slice(2));
+  const { merged, loadedFiles } = loadEnvFiles(args.envFiles);
+  const env = { ...merged, ...process.env };
+  const errors = [];
+  const warnings = [];
+
+  const supabaseUrl = env.VITE_SUPABASE_URL || env.SUPABASE_URL;
+  const serviceRoleKey = env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl) {
+    errors.push('Missing VITE_SUPABASE_URL or SUPABASE_URL.');
+  }
+
+  if (!serviceRoleKey) {
+    errors.push('Missing SUPABASE_SERVICE_ROLE_KEY.');
+  }
+
+  let projectRefFromUrl = '';
+  if (supabaseUrl) {
+    try {
+      projectRefFromUrl = new URL(supabaseUrl).host.split('.')[0];
+    } catch {
+      errors.push('Supabase URL must be a valid absolute URL.');
+    }
+  }
+
+  if (
+    args.projectRef &&
+    projectRefFromUrl &&
+    args.projectRef !== projectRefFromUrl
+  ) {
+    warnings.push(
+      `Requested project ref ${args.projectRef} does not match the configured Supabase URL (${projectRefFromUrl}).`
+    );
+  }
+
+  if (errors.length > 0) {
+    console.error('Submission preflight failed before connecting:');
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    process.exit(1);
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+
+  const checks = [];
+
+  const columnChecks = [
+    {
+      label: 'lead_submissions.internal_notification_sent_at',
+      table: 'lead_submissions',
+      columns: 'id, internal_notification_sent_at',
+    },
+    {
+      label: 'mini_waitlist_submissions.internal_notification_sent_at',
+      table: 'mini_waitlist_submissions',
+      columns: 'id, internal_notification_sent_at',
+    },
+  ];
+
+  for (const check of columnChecks) {
+    const { error } = await supabase.from(check.table).select(check.columns).limit(1);
+    checks.push({
+      label: check.label,
+      ok: !error,
+      detail: error?.message ?? 'OK',
+    });
+  }
+
+  const dispatchTypes = [
+    'lead_submission',
+    'mini_waitlist',
+    'order_checkout',
+    'plus_subscription_activated',
+  ];
+
+  for (const dispatchType of dispatchTypes) {
+    const eventKey = `submission_preflight:${dispatchType}:${crypto.randomUUID()}`;
+    const insertResult = await supabase.from('internal_notification_dispatches').insert({
+      event_key: eventKey,
+      dispatch_type: dispatchType,
+      source_table: 'submission_preflight',
+      source_id: eventKey,
+      meta: {
+        preflight: true,
+      },
+    });
+
+    if (insertResult.error) {
+      checks.push({
+        label: `dispatch_type:${dispatchType}`,
+        ok: false,
+        detail: insertResult.error.message,
+      });
+      continue;
+    }
+
+    const deleteResult = await supabase
+      .from('internal_notification_dispatches')
+      .delete()
+      .eq('event_key', eventKey);
+
+    checks.push({
+      label: `dispatch_type:${dispatchType}`,
+      ok: !deleteResult.error,
+      detail: deleteResult.error?.message ?? 'OK',
+    });
+  }
+
+  console.log(
+    `INFO: Submission preflight against ${projectRefFromUrl || 'configured Supabase project'}`
+  );
+  if (loadedFiles.length > 0) {
+    console.log(`INFO: Loaded env files: ${loadedFiles.join(', ')}`);
+  }
+
+  for (const check of checks) {
+    const status = check.ok ? 'PASS' : 'FAIL';
+    console.log(`- ${status}: ${check.label} -> ${check.detail}`);
+  }
+
+  if (warnings.length > 0) {
+    console.log('\nWarnings');
+    for (const warning of warnings) {
+      console.log(`- ${warning}`);
+    }
+  }
+
+  const failedChecks = checks.filter((check) => !check.ok);
+  if (failedChecks.length > 0) {
+    process.exit(1);
+  }
+
+  console.log('\nSubmission preflight checks passed.');
+}
+
+run().catch((error) => {
+  console.error('Submission preflight crashed.');
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ const PortalOnboarding = lazy(() => import("./pages/portal/Onboarding"));
 const PortalOrders = lazy(() => import("./pages/portal/Orders"));
 const PortalAccount = lazy(() => import("./pages/portal/Account"));
 const AdminDashboard = lazy(() => import("./pages/admin/Dashboard"));
+const AdminLeads = lazy(() => import("./pages/admin/Leads"));
 const AdminOrders = lazy(() => import("./pages/admin/Orders"));
 const AdminSupport = lazy(() => import("./pages/admin/Support"));
 const AdminAccounts = lazy(() => import("./pages/admin/Accounts"));
@@ -98,6 +99,7 @@ const App = () => (
                   </Route>
                   <Route element={<AdminRoute />}>
                     <Route path="/admin" element={<AdminDashboard />} />
+                    <Route path="/admin/leads" element={<AdminLeads />} />
                     <Route path="/admin/orders" element={<AdminOrders />} />
                     <Route path="/admin/support" element={<AdminSupport />} />
                     <Route path="/admin/accounts" element={<AdminAccounts />} />

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -41,6 +41,11 @@ const adminDestinations = [
     description: 'Operations modules, queue visibility, and internal governance tools.',
   },
   {
+    href: '/admin/leads',
+    label: 'Admin leads',
+    description: 'Inbound lead submissions and Mini waitlist visibility.',
+  },
+  {
     href: '/admin/orders',
     label: 'Admin orders',
     description: 'Fulfillment updates, tracking links, and order operations.',

--- a/src/lib/adminLeads.ts
+++ b/src/lib/adminLeads.ts
@@ -1,0 +1,56 @@
+import { supabaseClient } from '@/lib/supabaseClient';
+
+export type LeadSubmissionType = 'quote' | 'demo' | 'procurement' | 'general';
+
+export type LeadSubmissionRecord = {
+  id: string;
+  submission_type: LeadSubmissionType;
+  name: string;
+  email: string;
+  message: string;
+  source_page: string;
+  created_at: string;
+  internal_notification_sent_at: string | null;
+};
+
+export type MiniWaitlistRecord = {
+  id: string;
+  product_slug: string;
+  email: string;
+  source_page: string;
+  created_at: string;
+  internal_notification_sent_at: string | null;
+};
+
+export type AdminLeadsDashboard = {
+  leadSubmissions: LeadSubmissionRecord[];
+  miniWaitlist: MiniWaitlistRecord[];
+};
+
+export const fetchAdminLeadsDashboard = async (): Promise<AdminLeadsDashboard> => {
+  const [leadResult, waitlistResult] = await Promise.all([
+    supabaseClient
+      .from('lead_submissions')
+      .select(
+        'id, submission_type, name, email, message, source_page, created_at, internal_notification_sent_at'
+      )
+      .order('created_at', { ascending: false }),
+    supabaseClient
+      .from('mini_waitlist_submissions')
+      .select('id, product_slug, email, source_page, created_at, internal_notification_sent_at')
+      .order('created_at', { ascending: false }),
+  ]);
+
+  if (leadResult.error || !leadResult.data) {
+    throw new Error(leadResult.error?.message || 'Unable to load lead submissions.');
+  }
+
+  if (waitlistResult.error || !waitlistResult.data) {
+    throw new Error(waitlistResult.error?.message || 'Unable to load Mini waitlist.');
+  }
+
+  return {
+    leadSubmissions: leadResult.data as LeadSubmissionRecord[],
+    miniWaitlist: waitlistResult.data as MiniWaitlistRecord[],
+  };
+};

--- a/src/lib/adminLeads.ts
+++ b/src/lib/adminLeads.ts
@@ -27,30 +27,74 @@ export type AdminLeadsDashboard = {
   miniWaitlist: MiniWaitlistRecord[];
 };
 
+const isMissingWaitlistNotificationColumn = (code?: string, message?: string) =>
+  code === '42703' &&
+  typeof message === 'string' &&
+  message.includes('mini_waitlist_submissions.internal_notification_sent_at');
+
+const normalizeMiniWaitlistRecords = (
+  rows: Array<Omit<MiniWaitlistRecord, 'internal_notification_sent_at'> & {
+    internal_notification_sent_at?: string | null;
+  }>
+): MiniWaitlistRecord[] =>
+  rows.map((row) => ({
+    ...row,
+    internal_notification_sent_at: row.internal_notification_sent_at ?? null,
+  }));
+
 export const fetchAdminLeadsDashboard = async (): Promise<AdminLeadsDashboard> => {
+  const leadPromise = supabaseClient
+    .from('lead_submissions')
+    .select(
+      'id, submission_type, name, email, message, source_page, created_at, internal_notification_sent_at'
+    )
+    .order('created_at', { ascending: false });
+
+  const waitlistPromise = supabaseClient
+    .from('mini_waitlist_submissions')
+    .select('id, product_slug, email, source_page, created_at, internal_notification_sent_at')
+    .order('created_at', { ascending: false });
+
   const [leadResult, waitlistResult] = await Promise.all([
-    supabaseClient
-      .from('lead_submissions')
-      .select(
-        'id, submission_type, name, email, message, source_page, created_at, internal_notification_sent_at'
-      )
-      .order('created_at', { ascending: false }),
-    supabaseClient
-      .from('mini_waitlist_submissions')
-      .select('id, product_slug, email, source_page, created_at, internal_notification_sent_at')
-      .order('created_at', { ascending: false }),
+    leadPromise,
+    waitlistPromise,
   ]);
 
   if (leadResult.error || !leadResult.data) {
     throw new Error(leadResult.error?.message || 'Unable to load lead submissions.');
   }
 
-  if (waitlistResult.error || !waitlistResult.data) {
+  if (!waitlistResult.error && waitlistResult.data) {
+    return {
+      leadSubmissions: leadResult.data as LeadSubmissionRecord[],
+      miniWaitlist: waitlistResult.data as MiniWaitlistRecord[],
+    };
+  }
+
+  if (
+    !isMissingWaitlistNotificationColumn(
+      waitlistResult.error?.code,
+      waitlistResult.error?.message
+    )
+  ) {
     throw new Error(waitlistResult.error?.message || 'Unable to load Mini waitlist.');
+  }
+
+  const fallbackWaitlistResult = await supabaseClient
+    .from('mini_waitlist_submissions')
+    .select('id, product_slug, email, source_page, created_at')
+    .order('created_at', { ascending: false });
+
+  if (fallbackWaitlistResult.error || !fallbackWaitlistResult.data) {
+    throw new Error(fallbackWaitlistResult.error?.message || 'Unable to load Mini waitlist.');
   }
 
   return {
     leadSubmissions: leadResult.data as LeadSubmissionRecord[],
-    miniWaitlist: waitlistResult.data as MiniWaitlistRecord[],
+    miniWaitlist: normalizeMiniWaitlistRecords(
+      fallbackWaitlistResult.data as Array<
+        Omit<MiniWaitlistRecord, 'internal_notification_sent_at'>
+      >
+    ),
   };
 };

--- a/src/lib/leadSubmissions.ts
+++ b/src/lib/leadSubmissions.ts
@@ -9,6 +9,7 @@ type CreateLeadSubmissionInput = {
   message: string;
   machineInterest?: string;
   sourcePage?: string;
+  website?: string;
 };
 
 export const createLeadSubmission = async ({
@@ -18,6 +19,7 @@ export const createLeadSubmission = async ({
   message,
   machineInterest,
   sourcePage = '/contact',
+  website = '',
 }: CreateLeadSubmissionInput) => {
   const data = await invokeEdgeFunction<{ error?: string }>(
     'lead-submission-intake',
@@ -28,6 +30,7 @@ export const createLeadSubmission = async ({
       message,
       machineInterest,
       sourcePage,
+      website,
       clientSubmissionId: crypto.randomUUID(),
     }
   );

--- a/src/lib/miniWaitlist.ts
+++ b/src/lib/miniWaitlist.ts
@@ -1,25 +1,30 @@
-import { supabaseClient } from '@/lib/supabaseClient';
+import { invokeEdgeFunction } from '@/lib/edgeFunctions';
 
 type CreateMiniWaitlistInput = {
   email: string;
   sourcePage?: string;
+  website?: string;
 };
 
 export const createMiniWaitlistSubmission = async ({
   email,
-  sourcePage = '/products/mini',
+  sourcePage = '/machines/mini',
+  website = '',
 }: CreateMiniWaitlistInput) => {
-  const { error } = await supabaseClient.from('mini_waitlist_submissions').insert({
-    product_slug: 'mini',
-    email,
-    source_page: sourcePage,
-  });
+  const data = await invokeEdgeFunction<{ error?: string; alreadyExists?: boolean }>(
+    'mini-waitlist-intake',
+    {
+      email,
+      sourcePage,
+      website,
+    }
+  );
 
-  if (error?.code === '23505') {
+  if (data?.alreadyExists) {
     throw new Error("You're already on the Mini waitlist.");
   }
 
-  if (error) {
-    throw new Error(error.message || 'Unable to join the waitlist right now.');
+  if (data?.error) {
+    throw new Error(data.error);
   }
 };

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -36,19 +36,6 @@ export default function ContactPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    if (formData.website.trim()) {
-      toast.success('Message sent! We\'ll be in touch soon.');
-      setFormData({
-        name: '',
-        email: '',
-        type: initialType,
-        interest: initialInterest,
-        message: '',
-        website: '',
-      });
-      return;
-    }
-
     setSubmitting(true);
     try {
       const cleanedMessage = formData.message.trim();
@@ -60,6 +47,7 @@ export default function ContactPage() {
         message: cleanedMessage,
         machineInterest: formData.type === 'quote' ? formData.interest.trim() : undefined,
         sourcePage: querySource?.trim() || '/contact',
+        website: formData.website,
       });
       toast.success('Message sent! We\'ll be in touch soon.');
       setFormData({

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -192,7 +192,7 @@ export default function HomePage() {
                 {[
                   'Onboarding checklist & WeChat setup assistance',
                   'Training library access with video guides',
-                  'Member community access',
+                  'Operator playbooks and launch guidance',
                   'Concierge support (triage, best-practices, escalation)',
                 ].map((benefit) => (
                   <div key={benefit} className="flex items-start gap-3">

--- a/src/pages/admin/Dashboard.tsx
+++ b/src/pages/admin/Dashboard.tsx
@@ -1,9 +1,15 @@
 import { Link } from 'react-router-dom';
-import { ShieldCheck, ShoppingBag, LifeBuoy, Users, ClipboardList } from 'lucide-react';
+import { ShieldCheck, ShoppingBag, LifeBuoy, Users, ClipboardList, Inbox } from 'lucide-react';
 import { AppLayout } from '@/components/layout/AppLayout';
 import { Button } from '@/components/ui/button';
 
 const adminModules = [
+  {
+    title: 'Leads Inbox',
+    description: 'Review sales inquiries, procurement requests, and Mini waitlist sign-ups.',
+    icon: Inbox,
+    href: '/admin/leads',
+  },
   {
     title: 'Orders',
     description: 'Search and manage operational order workflows.',
@@ -52,8 +58,8 @@ export default function AdminDashboardPage() {
       <section className="section-padding">
         <div className="container-page">
           <div className="rounded-xl border border-sage/30 bg-sage-light px-4 py-3 text-sm text-sage">
-            Admin workspace is active. Use the modules below for orders, support, accounts, and
-            governance operations.
+            Admin workspace is active. Use the modules below for leads, orders, support, accounts,
+            and governance operations.
           </div>
 
           <div className="mt-6 grid gap-4 md:grid-cols-2">

--- a/src/pages/admin/Leads.tsx
+++ b/src/pages/admin/Leads.tsx
@@ -1,0 +1,310 @@
+import { useMemo, useState } from 'react';
+import { Loader2, RefreshCw } from 'lucide-react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { AppLayout } from '@/components/layout/AppLayout';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  fetchAdminLeadsDashboard,
+  type LeadSubmissionRecord,
+  type LeadSubmissionType,
+  type MiniWaitlistRecord,
+} from '@/lib/adminLeads';
+
+const leadTypeOptions: LeadSubmissionType[] = ['quote', 'demo', 'procurement', 'general'];
+const EMPTY_LEAD_SUBMISSIONS: LeadSubmissionRecord[] = [];
+const EMPTY_MINI_WAITLIST: MiniWaitlistRecord[] = [];
+
+const formatDate = (value: string) =>
+  new Date(value).toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+
+const formatNotificationStatus = (value: string | null) =>
+  value ? `Sent ${formatDate(value)}` : 'Pending email';
+
+const previewMessage = (value: string) => {
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= 120) {
+    return normalized;
+  }
+  return `${normalized.slice(0, 117)}...`;
+};
+
+const matchesLeadSearch = (lead: LeadSubmissionRecord, search: string) => {
+  if (!search) {
+    return true;
+  }
+
+  return (
+    lead.name.toLowerCase().includes(search) ||
+    lead.email.toLowerCase().includes(search) ||
+    lead.message.toLowerCase().includes(search) ||
+    lead.source_page.toLowerCase().includes(search) ||
+    lead.id.toLowerCase().includes(search)
+  );
+};
+
+export default function AdminLeadsPage() {
+  const queryClient = useQueryClient();
+  const [search, setSearch] = useState('');
+  const [leadTypeFilter, setLeadTypeFilter] = useState<'all' | LeadSubmissionType>('all');
+
+  const {
+    data,
+    isLoading,
+    isFetching,
+    error,
+  } = useQuery({
+    queryKey: ['admin-leads-dashboard'],
+    queryFn: fetchAdminLeadsDashboard,
+    staleTime: 1000 * 30,
+  });
+
+  const leadSubmissions = data?.leadSubmissions ?? EMPTY_LEAD_SUBMISSIONS;
+  const miniWaitlist = data?.miniWaitlist ?? EMPTY_MINI_WAITLIST;
+  const normalizedSearch = search.trim().toLowerCase();
+
+  const filteredLeadSubmissions = useMemo(
+    () =>
+      leadSubmissions.filter((lead) => {
+        const matchesType =
+          leadTypeFilter === 'all' || lead.submission_type === leadTypeFilter;
+
+        return matchesType && matchesLeadSearch(lead, normalizedSearch);
+      }),
+    [leadSubmissions, leadTypeFilter, normalizedSearch]
+  );
+
+  const filteredMiniWaitlist = useMemo(
+    () =>
+      miniWaitlist.filter((entry) => {
+        if (!normalizedSearch) {
+          return true;
+        }
+
+        return (
+          entry.email.toLowerCase().includes(normalizedSearch) ||
+          entry.source_page.toLowerCase().includes(normalizedSearch) ||
+          entry.id.toLowerCase().includes(normalizedSearch)
+        );
+      }),
+    [miniWaitlist, normalizedSearch]
+  );
+
+  const summary = useMemo(
+    () => ({
+      totalLeads: leadSubmissions.length,
+      unsentLeads: leadSubmissions.filter((lead) => !lead.internal_notification_sent_at).length,
+      totalWaitlist: miniWaitlist.length,
+      unsentWaitlist: miniWaitlist.filter((entry) => !entry.internal_notification_sent_at).length,
+    }),
+    [leadSubmissions, miniWaitlist]
+  );
+
+  const handleRefresh = async () => {
+    await queryClient.invalidateQueries({ queryKey: ['admin-leads-dashboard'] });
+  };
+
+  return (
+    <AppLayout>
+      <section className="section-padding">
+        <div className="container-page">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                Admin
+              </p>
+              <h1 className="mt-2 font-display text-3xl font-bold text-foreground">
+                Leads Inbox
+              </h1>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Review inbound sales, procurement, and Mini waitlist activity.
+              </p>
+            </div>
+            <Button variant="outline" onClick={handleRefresh} disabled={isFetching}>
+              {isFetching ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <RefreshCw className="mr-2 h-4 w-4" />
+              )}
+              Refresh
+            </Button>
+          </div>
+
+          <div className="mt-6 grid gap-3 sm:grid-cols-4">
+            <div className="rounded-lg border border-border bg-card p-3">
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Lead submissions</p>
+              <p className="mt-1 text-2xl font-semibold text-foreground">{summary.totalLeads}</p>
+            </div>
+            <div className="rounded-lg border border-border bg-card p-3">
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Lead alerts pending</p>
+              <p className="mt-1 text-2xl font-semibold text-foreground">{summary.unsentLeads}</p>
+            </div>
+            <div className="rounded-lg border border-border bg-card p-3">
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Mini waitlist</p>
+              <p className="mt-1 text-2xl font-semibold text-foreground">{summary.totalWaitlist}</p>
+            </div>
+            <div className="rounded-lg border border-border bg-card p-3">
+              <p className="text-xs uppercase tracking-wide text-muted-foreground">Waitlist alerts pending</p>
+              <p className="mt-1 text-2xl font-semibold text-foreground">{summary.unsentWaitlist}</p>
+            </div>
+          </div>
+
+          <div className="mt-4 grid gap-4 md:grid-cols-[minmax(0,1fr)_220px]">
+            <Input
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search by email, name, message, source page, or ID"
+            />
+            <select
+              value={leadTypeFilter}
+              onChange={(event) =>
+                setLeadTypeFilter(event.target.value as 'all' | LeadSubmissionType)
+              }
+              className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+            >
+              <option value="all">All lead types</option>
+              {leadTypeOptions.map((leadType) => (
+                <option key={leadType} value={leadType}>
+                  {leadType}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {error && (
+            <div className="mt-4 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+              Failed to load the leads inbox.
+            </div>
+          )}
+
+          <div className="mt-6 space-y-6">
+            <section className="overflow-hidden rounded-xl border border-border bg-card">
+              <div className="border-b border-border bg-muted/30 px-4 py-3">
+                <h2 className="font-semibold text-foreground">Lead submissions</h2>
+              </div>
+              <table className="w-full">
+                <thead className="border-b border-border bg-muted/40">
+                  <tr>
+                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Contact
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Type
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Source
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Message preview
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Submitted
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Alert
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {isLoading && (
+                    <tr>
+                      <td colSpan={6} className="px-4 py-10 text-center text-sm text-muted-foreground">
+                        Loading lead submissions...
+                      </td>
+                    </tr>
+                  )}
+                  {!isLoading && filteredLeadSubmissions.length === 0 && (
+                    <tr>
+                      <td colSpan={6} className="px-4 py-10 text-center text-sm text-muted-foreground">
+                        No lead submissions found.
+                      </td>
+                    </tr>
+                  )}
+                  {!isLoading &&
+                    filteredLeadSubmissions.map((lead) => (
+                      <tr key={lead.id} className="border-b border-border/70 align-top">
+                        <td className="px-4 py-3">
+                          <div className="text-sm font-medium text-foreground">{lead.name}</div>
+                          <div className="mt-1 text-xs text-muted-foreground">{lead.email}</div>
+                          <div className="mt-1 text-[11px] text-muted-foreground">{lead.id}</div>
+                        </td>
+                        <td className="px-4 py-3 text-sm text-foreground">{lead.submission_type}</td>
+                        <td className="px-4 py-3 text-sm text-foreground">{lead.source_page}</td>
+                        <td className="px-4 py-3 text-sm text-muted-foreground">
+                          {previewMessage(lead.message)}
+                        </td>
+                        <td className="px-4 py-3 text-sm text-foreground">{formatDate(lead.created_at)}</td>
+                        <td className="px-4 py-3 text-sm text-foreground">
+                          {formatNotificationStatus(lead.internal_notification_sent_at)}
+                        </td>
+                      </tr>
+                    ))}
+                </tbody>
+              </table>
+            </section>
+
+            <section className="overflow-hidden rounded-xl border border-border bg-card">
+              <div className="border-b border-border bg-muted/30 px-4 py-3">
+                <h2 className="font-semibold text-foreground">Mini waitlist</h2>
+              </div>
+              <table className="w-full">
+                <thead className="border-b border-border bg-muted/40">
+                  <tr>
+                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Email
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Source
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Submitted
+                    </th>
+                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Alert
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {isLoading && (
+                    <tr>
+                      <td colSpan={4} className="px-4 py-10 text-center text-sm text-muted-foreground">
+                        Loading Mini waitlist...
+                      </td>
+                    </tr>
+                  )}
+                  {!isLoading && filteredMiniWaitlist.length === 0 && (
+                    <tr>
+                      <td colSpan={4} className="px-4 py-10 text-center text-sm text-muted-foreground">
+                        No Mini waitlist entries found.
+                      </td>
+                    </tr>
+                  )}
+                  {!isLoading &&
+                    filteredMiniWaitlist.map((entry) => (
+                      <tr key={entry.id} className="border-b border-border/70">
+                        <td className="px-4 py-3">
+                          <div className="text-sm font-medium text-foreground">{entry.email}</div>
+                          <div className="mt-1 text-[11px] text-muted-foreground">{entry.id}</div>
+                        </td>
+                        <td className="px-4 py-3 text-sm text-foreground">{entry.source_page}</td>
+                        <td className="px-4 py-3 text-sm text-foreground">{formatDate(entry.created_at)}</td>
+                        <td className="px-4 py-3 text-sm text-foreground">
+                          {formatNotificationStatus(entry.internal_notification_sent_at)}
+                        </td>
+                      </tr>
+                    ))}
+                </tbody>
+              </table>
+            </section>
+          </div>
+        </div>
+      </section>
+    </AppLayout>
+  );
+}

--- a/src/pages/products/Mini.tsx
+++ b/src/pages/products/Mini.tsx
@@ -34,17 +34,15 @@ export default function MiniPage() {
   const handleWaitlist = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    if (website.trim()) {
-      setSubmitted(true);
-      toast.success('You\'ve been added to the Mini waitlist!');
-      return;
-    }
-
     setSubmitting(true);
     try {
-      await createMiniWaitlistSubmission({ email: email.trim().toLowerCase() });
+      await createMiniWaitlistSubmission({
+        email: email.trim().toLowerCase(),
+        website,
+      });
       setSubmitted(true);
       setEmail('');
+      setWebsite('');
       toast.success('You\'ve been added to the Mini waitlist!');
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unable to join the waitlist.';

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -16,5 +16,8 @@ verify_jwt = false
 [functions.lead-submission-intake]
 verify_jwt = false
 
+[functions.mini-waitlist-intake]
+verify_jwt = false
+
 [functions.support-request-intake]
 verify_jwt = false

--- a/supabase/functions/lead-submission-intake/index.ts
+++ b/supabase/functions/lead-submission-intake/index.ts
@@ -46,6 +46,9 @@ const submissionTypeLabels: Record<string, string> = {
   general: "general inquiry",
 };
 
+const isDispatchBookkeepingError = (code: string | undefined) =>
+  code === "23514" || code === "42501" || code === "42P01";
+
 const claimDispatch = async (
   eventKey: string,
   dispatchType: "lead_submission",
@@ -68,9 +71,11 @@ const claimDispatch = async (
     return false;
   }
 
-  // Keep quote intake resilient if dispatch bookkeeping cannot write due
-  // transient schema drift or non-service-role function credentials.
-  if (error.code === "42501" || error.code === "42P01") {
+  // Keep lead intake resilient if dispatch bookkeeping cannot write due to
+  // schema drift or missing privileges. The durable submission row already
+  // exists, so the operator follow-up should not surface as a customer-facing
+  // failure.
+  if (isDispatchBookkeepingError(error.code)) {
     console.warn(
       "Dispatch claim fallback: proceeding without dedupe bookkeeping.",
       error
@@ -187,71 +192,72 @@ serve(async (req) => {
       return buildJsonResponse({ ok: true });
     }
 
-    const eventKey = `lead_submission:${leadSubmission.id}`;
-    const dispatchClaimed = await claimDispatch(
-      eventKey,
-      "lead_submission",
-      leadSubmission.id
-    );
-
-    if (!dispatchClaimed) {
-      return buildJsonResponse({ ok: true });
-    }
-
     const submissionLabel =
       submissionTypeLabels[leadSubmission.submission_type] || "lead submission";
-    const internalSubject = `New ${submissionLabel}: ${leadSubmission.name}`;
-    const internalText = [
-      `A new ${submissionLabel} was submitted.`,
-      "",
-      `Submission ID: ${leadSubmission.id}`,
-      `Submitted At (UTC): ${leadSubmission.created_at}`,
-      `Inquiry Type: ${leadSubmission.submission_type}`,
-      `Name: ${leadSubmission.name}`,
-      `Email: ${leadSubmission.email}`,
-      `Source Page: ${leadSubmission.source_page}`,
-      "",
-      "Message:",
-      leadSubmission.message,
-    ].join("\n");
-
     try {
-      await sendInternalEmail({
-        subject: internalSubject,
-        text: internalText,
-      });
-    } catch (error) {
-      console.error("lead-submission-intake internal email failed", error);
-      await releaseDispatch(eventKey);
-      return buildJsonResponse({ ok: true });
-    }
+      const eventKey = `lead_submission:${leadSubmission.id}`;
+      const dispatchClaimed = await claimDispatch(
+        eventKey,
+        "lead_submission",
+        leadSubmission.id
+      );
 
-    await sendWeComAlertSafe({
-      tag: "Bloomjoy Lead",
-      title: `New ${submissionLabel}: ${leadSubmission.name}`,
-      lines: [
+      if (!dispatchClaimed) {
+        return buildJsonResponse({ ok: true });
+      }
+
+      const internalSubject = `New ${submissionLabel}: ${leadSubmission.name}`;
+      const internalText = [
+        `A new ${submissionLabel} was submitted.`,
+        "",
         `Submission ID: ${leadSubmission.id}`,
         `Submitted At (UTC): ${leadSubmission.created_at}`,
         `Inquiry Type: ${leadSubmission.submission_type}`,
         `Name: ${leadSubmission.name}`,
         `Email: ${leadSubmission.email}`,
         `Source Page: ${leadSubmission.source_page}`,
+        "",
         "Message:",
         leadSubmission.message,
-      ],
-    });
+      ].join("\n");
 
-    await Promise.all([
-      supabase
-        .from("lead_submissions")
-        .update({ internal_notification_sent_at: new Date().toISOString() })
-        .eq("id", leadSubmission.id),
-      markDispatchSent(eventKey, {
-        submission_type: leadSubmission.submission_type,
-        source_page: leadSubmission.source_page,
-        email: leadSubmission.email,
-      }),
-    ]);
+      await sendInternalEmail({
+        subject: internalSubject,
+        text: internalText,
+      });
+
+      await sendWeComAlertSafe({
+        tag: "Bloomjoy Lead",
+        title: `New ${submissionLabel}: ${leadSubmission.name}`,
+        lines: [
+          `Submission ID: ${leadSubmission.id}`,
+          `Submitted At (UTC): ${leadSubmission.created_at}`,
+          `Inquiry Type: ${leadSubmission.submission_type}`,
+          `Name: ${leadSubmission.name}`,
+          `Email: ${leadSubmission.email}`,
+          `Source Page: ${leadSubmission.source_page}`,
+          "Message:",
+          leadSubmission.message,
+        ],
+      });
+
+      await Promise.all([
+        supabase
+          .from("lead_submissions")
+          .update({ internal_notification_sent_at: new Date().toISOString() })
+          .eq("id", leadSubmission.id),
+        markDispatchSent(eventKey, {
+          submission_type: leadSubmission.submission_type,
+          source_page: leadSubmission.source_page,
+          email: leadSubmission.email,
+        }),
+      ]);
+    } catch (error) {
+      const eventKey = `lead_submission:${leadSubmission.id}`;
+      console.error("lead-submission-intake notification follow-up failed", error);
+      await releaseDispatch(eventKey);
+      return buildJsonResponse({ ok: true });
+    }
 
     return buildJsonResponse({ ok: true });
   } catch (error) {

--- a/supabase/functions/lead-submission-intake/index.ts
+++ b/supabase/functions/lead-submission-intake/index.ts
@@ -32,10 +32,23 @@ const supabase = supabaseUrl && supabaseServiceRoleKey
   : null;
 
 const sanitizeText = (value: unknown) => (typeof value === "string" ? value.trim() : "");
+const jsonHeaders = { ...corsHeaders, "Content-Type": "application/json" };
+const buildJsonResponse = (body: Record<string, unknown>, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: jsonHeaders,
+  });
+
+const submissionTypeLabels: Record<string, string> = {
+  quote: "quote request",
+  demo: "demo request",
+  procurement: "procurement inquiry",
+  general: "general inquiry",
+};
 
 const claimDispatch = async (
   eventKey: string,
-  dispatchType: "lead_quote",
+  dispatchType: "lead_submission",
   sourceId: string
 ): Promise<boolean> => {
   if (!supabase) return false;
@@ -87,14 +100,12 @@ serve(async (req) => {
   }
 
   try {
+    if (req.method !== "POST") {
+      return buildJsonResponse({ error: "Method not allowed." }, 405);
+    }
+
     if (!supabase) {
-      return new Response(
-        JSON.stringify({ error: "Lead intake is not configured." }),
-        {
-          status: 500,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        }
-      );
+      return buildJsonResponse({ error: "Lead intake is not configured." }, 500);
     }
 
     const body = await req.json();
@@ -106,44 +117,28 @@ serve(async (req) => {
     const message = sanitizeText(body?.message);
     const machineInterest = sanitizeText(body?.machineInterest);
     const clientSubmissionId = sanitizeText(body?.clientSubmissionId).toLowerCase();
+    const website = sanitizeText(body?.website);
+
+    if (website) {
+      return buildJsonResponse({ ok: true });
+    }
 
     if (!validSubmissionTypes.has(submissionType)) {
-      return new Response(
-        JSON.stringify({ error: "Invalid inquiry type." }),
-        {
-          status: 400,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        }
-      );
+      return buildJsonResponse({ error: "Invalid inquiry type." }, 400);
     }
 
     if (!name || !email || !message) {
-      return new Response(
-        JSON.stringify({ error: "Name, email, and message are required." }),
-        {
-          status: 400,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        }
-      );
+      return buildJsonResponse({ error: "Name, email, and message are required." }, 400);
     }
 
     if (!emailPattern.test(email)) {
-      return new Response(
-        JSON.stringify({ error: "Please enter a valid email address." }),
-        {
-          status: 400,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        }
-      );
+      return buildJsonResponse({ error: "Please enter a valid email address." }, 400);
     }
 
     if (!clientSubmissionId || !uuidPattern.test(clientSubmissionId)) {
-      return new Response(
-        JSON.stringify({ error: "Missing submission token. Refresh and try again." }),
-        {
-          status: 400,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        }
+      return buildJsonResponse(
+        { error: "Missing submission token. Refresh and try again." },
+        400
       );
     }
 
@@ -188,28 +183,26 @@ serve(async (req) => {
       leadSubmission = existingLead;
     }
 
-    if (
-      submissionType !== "quote" ||
-      !leadSubmission ||
-      leadSubmission.internal_notification_sent_at
-    ) {
-      return new Response(JSON.stringify({ ok: true }), {
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
+    if (!leadSubmission || leadSubmission.internal_notification_sent_at) {
+      return buildJsonResponse({ ok: true });
     }
 
-    const eventKey = `lead_quote:${leadSubmission.id}`;
-    const dispatchClaimed = await claimDispatch(eventKey, "lead_quote", leadSubmission.id);
+    const eventKey = `lead_submission:${leadSubmission.id}`;
+    const dispatchClaimed = await claimDispatch(
+      eventKey,
+      "lead_submission",
+      leadSubmission.id
+    );
 
     if (!dispatchClaimed) {
-      return new Response(JSON.stringify({ ok: true }), {
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      });
+      return buildJsonResponse({ ok: true });
     }
 
-    const quoteSubject = `New quote request: ${leadSubmission.name}`;
-    const quoteText = [
-      "A new quote request was submitted.",
+    const submissionLabel =
+      submissionTypeLabels[leadSubmission.submission_type] || "lead submission";
+    const internalSubject = `New ${submissionLabel}: ${leadSubmission.name}`;
+    const internalText = [
+      `A new ${submissionLabel} was submitted.`,
       "",
       `Submission ID: ${leadSubmission.id}`,
       `Submitted At (UTC): ${leadSubmission.created_at}`,
@@ -224,17 +217,18 @@ serve(async (req) => {
 
     try {
       await sendInternalEmail({
-        subject: quoteSubject,
-        text: quoteText,
+        subject: internalSubject,
+        text: internalText,
       });
     } catch (error) {
+      console.error("lead-submission-intake internal email failed", error);
       await releaseDispatch(eventKey);
-      throw error;
+      return buildJsonResponse({ ok: true });
     }
 
     await sendWeComAlertSafe({
-      tag: "Bloomjoy Quote",
-      title: `New quote request: ${leadSubmission.name}`,
+      tag: "Bloomjoy Lead",
+      title: `New ${submissionLabel}: ${leadSubmission.name}`,
       lines: [
         `Submission ID: ${leadSubmission.id}`,
         `Submitted At (UTC): ${leadSubmission.created_at}`,
@@ -255,20 +249,13 @@ serve(async (req) => {
       markDispatchSent(eventKey, {
         submission_type: leadSubmission.submission_type,
         source_page: leadSubmission.source_page,
+        email: leadSubmission.email,
       }),
     ]);
 
-    return new Response(JSON.stringify({ ok: true }), {
-      headers: { ...corsHeaders, "Content-Type": "application/json" },
-    });
+    return buildJsonResponse({ ok: true });
   } catch (error) {
     console.error("lead-submission-intake error", error);
-    return new Response(
-      JSON.stringify({ error: "Unable to submit contact request." }),
-      {
-        status: 500,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      }
-    );
+    return buildJsonResponse({ error: "Unable to submit contact request." }, 500);
   }
 });

--- a/supabase/functions/mini-waitlist-intake/index.ts
+++ b/supabase/functions/mini-waitlist-intake/index.ts
@@ -45,6 +45,76 @@ type WaitlistRecord = {
   internal_notification_sent_at: string | null;
 };
 
+const baseSelectedColumns = "id, product_slug, email, source_page, created_at";
+const notificationSelectedColumns = `${baseSelectedColumns}, internal_notification_sent_at`;
+
+const isDispatchBookkeepingError = (code: string | undefined) =>
+  code === "23514" || code === "42501" || code === "42P01";
+
+const isMissingNotificationColumnError = (code: string | undefined) =>
+  code === "42703";
+
+const normalizeWaitlistRecord = (value: Record<string, unknown> | null): WaitlistRecord | null => {
+  if (!value) {
+    return null;
+  }
+
+  return {
+    id: String(value.id ?? ""),
+    product_slug: String(value.product_slug ?? "mini"),
+    email: String(value.email ?? ""),
+    source_page: String(value.source_page ?? "/machines/mini"),
+    created_at: String(value.created_at ?? new Date().toISOString()),
+    internal_notification_sent_at:
+      typeof value.internal_notification_sent_at === "string"
+        ? value.internal_notification_sent_at
+        : null,
+  };
+};
+
+const fetchWaitlistEntry = async (email: string): Promise<{
+  entry: WaitlistRecord | null;
+  supportsNotificationColumn: boolean;
+}> => {
+  if (!supabase) {
+    return { entry: null, supportsNotificationColumn: false };
+  }
+
+  const fullResult = await supabase
+    .from("mini_waitlist_submissions")
+    .select(notificationSelectedColumns)
+    .eq("product_slug", "mini")
+    .eq("email", email)
+    .maybeSingle();
+
+  if (!fullResult.error) {
+    return {
+      entry: normalizeWaitlistRecord(fullResult.data as Record<string, unknown> | null),
+      supportsNotificationColumn: true,
+    };
+  }
+
+  if (!isMissingNotificationColumnError(fullResult.error.code)) {
+    throw new Error(fullResult.error.message || "Unable to load the waitlist entry.");
+  }
+
+  const fallbackResult = await supabase
+    .from("mini_waitlist_submissions")
+    .select(baseSelectedColumns)
+    .eq("product_slug", "mini")
+    .eq("email", email)
+    .maybeSingle();
+
+  if (fallbackResult.error) {
+    throw new Error(fallbackResult.error.message || "Unable to load the waitlist entry.");
+  }
+
+  return {
+    entry: normalizeWaitlistRecord(fallbackResult.data as Record<string, unknown> | null),
+    supportsNotificationColumn: false,
+  };
+};
+
 const claimDispatch = async (eventKey: string, sourceId: string): Promise<boolean> => {
   if (!supabase) return false;
 
@@ -63,7 +133,7 @@ const claimDispatch = async (eventKey: string, sourceId: string): Promise<boolea
     return false;
   }
 
-  if (error.code === "42501" || error.code === "42P01") {
+  if (isDispatchBookkeepingError(error.code)) {
     console.warn(
       "Dispatch claim fallback: proceeding without dedupe bookkeeping.",
       error
@@ -114,20 +184,14 @@ serve(async (req) => {
       return buildJsonResponse({ error: "Please enter a valid email address." }, 400);
     }
 
-    const selectedColumns =
-      "id, product_slug, email, source_page, created_at, internal_notification_sent_at";
-
-    const { data: insertedEntry, error: insertError } = await supabase
+    const { error: insertError } = await supabase
       .from("mini_waitlist_submissions")
       .insert({
         product_slug: "mini",
         email,
         source_page: sourcePage,
-      })
-      .select(selectedColumns)
-      .single();
+      });
 
-    let waitlistEntry = insertedEntry as WaitlistRecord | null;
     let alreadyExists = false;
 
     if (insertError) {
@@ -136,32 +200,29 @@ serve(async (req) => {
       }
 
       alreadyExists = true;
-      const { data: existingEntry, error: existingEntryError } = await supabase
-        .from("mini_waitlist_submissions")
-        .select(selectedColumns)
-        .eq("product_slug", "mini")
-        .eq("email", email)
-        .maybeSingle();
-
-      if (existingEntryError || !existingEntry) {
-        throw new Error("Unable to join the waitlist right now.");
-      }
-
-      waitlistEntry = existingEntry as WaitlistRecord;
     }
+
+    const {
+      entry: waitlistEntry,
+      supportsNotificationColumn,
+    } = await fetchWaitlistEntry(email);
 
     if (!waitlistEntry || waitlistEntry.internal_notification_sent_at) {
       return buildJsonResponse({ ok: true, alreadyExists });
     }
 
-    const eventKey = `mini_waitlist:${waitlistEntry.id}`;
-    const dispatchClaimed = await claimDispatch(eventKey, waitlistEntry.id);
-
-    if (!dispatchClaimed) {
+    if (alreadyExists && !supportsNotificationColumn) {
       return buildJsonResponse({ ok: true, alreadyExists });
     }
 
     try {
+      const eventKey = `mini_waitlist:${waitlistEntry.id}`;
+      const dispatchClaimed = await claimDispatch(eventKey, waitlistEntry.id);
+
+      if (!dispatchClaimed) {
+        return buildJsonResponse({ ok: true, alreadyExists });
+      }
+
       await sendInternalEmail({
         subject: `New Mini waitlist sign-up: ${waitlistEntry.email}`,
         text: [
@@ -174,35 +235,37 @@ serve(async (req) => {
           `Source Page: ${waitlistEntry.source_page}`,
         ].join("\n"),
       });
-    } catch (error) {
-      console.error("mini-waitlist-intake internal email failed", error);
-      await releaseDispatch(eventKey);
-      return buildJsonResponse({ ok: true, alreadyExists });
-    }
 
-    await sendWeComAlertSafe({
-      tag: "Bloomjoy Mini",
-      title: "New Mini waitlist sign-up",
-      lines: [
-        `Submission ID: ${waitlistEntry.id}`,
-        `Submitted At (UTC): ${waitlistEntry.created_at}`,
-        `Product: ${waitlistEntry.product_slug}`,
-        `Email: ${waitlistEntry.email}`,
-        `Source Page: ${waitlistEntry.source_page}`,
-      ],
-    });
+      await sendWeComAlertSafe({
+        tag: "Bloomjoy Mini",
+        title: "New Mini waitlist sign-up",
+        lines: [
+          `Submission ID: ${waitlistEntry.id}`,
+          `Submitted At (UTC): ${waitlistEntry.created_at}`,
+          `Product: ${waitlistEntry.product_slug}`,
+          `Email: ${waitlistEntry.email}`,
+          `Source Page: ${waitlistEntry.source_page}`,
+        ],
+      });
 
-    await Promise.all([
-      supabase
-        .from("mini_waitlist_submissions")
-        .update({ internal_notification_sent_at: new Date().toISOString() })
-        .eq("id", waitlistEntry.id),
-      markDispatchSent(eventKey, {
+      if (supportsNotificationColumn) {
+        await supabase
+          .from("mini_waitlist_submissions")
+          .update({ internal_notification_sent_at: new Date().toISOString() })
+          .eq("id", waitlistEntry.id);
+      }
+
+      await markDispatchSent(eventKey, {
         product_slug: waitlistEntry.product_slug,
         source_page: waitlistEntry.source_page,
         email: waitlistEntry.email,
-      }),
-    ]);
+      });
+    } catch (error) {
+      const eventKey = `mini_waitlist:${waitlistEntry.id}`;
+      console.error("mini-waitlist-intake notification follow-up failed", error);
+      await releaseDispatch(eventKey);
+      return buildJsonResponse({ ok: true, alreadyExists });
+    }
 
     return buildJsonResponse({ ok: true, alreadyExists });
   } catch (error) {

--- a/supabase/functions/mini-waitlist-intake/index.ts
+++ b/supabase/functions/mini-waitlist-intake/index.ts
@@ -1,0 +1,212 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.48.1";
+import { corsHeaders } from "../_shared/cors.ts";
+import { sendInternalEmail } from "../_shared/internal-email.ts";
+import { sendWeComAlertSafe } from "../_shared/wecom-alert.ts";
+
+export const config = {
+  verify_jwt: false,
+};
+
+const supabaseUrl = Deno.env.get("SUPABASE_URL");
+const supabaseServiceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/i;
+
+if (!supabaseUrl) {
+  console.error("Missing SUPABASE_URL");
+}
+
+if (!supabaseServiceRoleKey) {
+  console.error("Missing SUPABASE_SERVICE_ROLE_KEY");
+}
+
+const supabase = supabaseUrl && supabaseServiceRoleKey
+  ? createClient(supabaseUrl, supabaseServiceRoleKey, {
+      auth: {
+        persistSession: false,
+      },
+    })
+  : null;
+
+const sanitizeText = (value: unknown) => (typeof value === "string" ? value.trim() : "");
+const jsonHeaders = { ...corsHeaders, "Content-Type": "application/json" };
+const buildJsonResponse = (body: Record<string, unknown>, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: jsonHeaders,
+  });
+
+type WaitlistRecord = {
+  id: string;
+  product_slug: string;
+  email: string;
+  source_page: string;
+  created_at: string;
+  internal_notification_sent_at: string | null;
+};
+
+const claimDispatch = async (eventKey: string, sourceId: string): Promise<boolean> => {
+  if (!supabase) return false;
+
+  const { error } = await supabase.from("internal_notification_dispatches").insert({
+    event_key: eventKey,
+    dispatch_type: "mini_waitlist",
+    source_table: "mini_waitlist_submissions",
+    source_id: sourceId,
+  });
+
+  if (!error) {
+    return true;
+  }
+
+  if (error.code === "23505") {
+    return false;
+  }
+
+  if (error.code === "42501" || error.code === "42P01") {
+    console.warn(
+      "Dispatch claim fallback: proceeding without dedupe bookkeeping.",
+      error
+    );
+    return true;
+  }
+
+  throw new Error(error.message || "Failed to claim Mini waitlist notification.");
+};
+
+const releaseDispatch = async (eventKey: string) => {
+  if (!supabase) return;
+  await supabase.from("internal_notification_dispatches").delete().eq("event_key", eventKey);
+};
+
+const markDispatchSent = async (eventKey: string, meta: Record<string, unknown>) => {
+  if (!supabase) return;
+  await supabase
+    .from("internal_notification_dispatches")
+    .update({ sent_at: new Date().toISOString(), meta })
+    .eq("event_key", eventKey);
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    if (req.method !== "POST") {
+      return buildJsonResponse({ error: "Method not allowed." }, 405);
+    }
+
+    if (!supabase) {
+      return buildJsonResponse({ error: "Mini waitlist intake is not configured." }, 500);
+    }
+
+    const body = await req.json();
+    const email = sanitizeText(body?.email).toLowerCase();
+    const sourcePage = sanitizeText(body?.sourcePage) || "/machines/mini";
+    const website = sanitizeText(body?.website);
+
+    if (website) {
+      return buildJsonResponse({ ok: true });
+    }
+
+    if (!emailPattern.test(email)) {
+      return buildJsonResponse({ error: "Please enter a valid email address." }, 400);
+    }
+
+    const selectedColumns =
+      "id, product_slug, email, source_page, created_at, internal_notification_sent_at";
+
+    const { data: insertedEntry, error: insertError } = await supabase
+      .from("mini_waitlist_submissions")
+      .insert({
+        product_slug: "mini",
+        email,
+        source_page: sourcePage,
+      })
+      .select(selectedColumns)
+      .single();
+
+    let waitlistEntry = insertedEntry as WaitlistRecord | null;
+    let alreadyExists = false;
+
+    if (insertError) {
+      if (insertError.code !== "23505") {
+        throw new Error(insertError.message || "Unable to join the waitlist right now.");
+      }
+
+      alreadyExists = true;
+      const { data: existingEntry, error: existingEntryError } = await supabase
+        .from("mini_waitlist_submissions")
+        .select(selectedColumns)
+        .eq("product_slug", "mini")
+        .eq("email", email)
+        .maybeSingle();
+
+      if (existingEntryError || !existingEntry) {
+        throw new Error("Unable to join the waitlist right now.");
+      }
+
+      waitlistEntry = existingEntry as WaitlistRecord;
+    }
+
+    if (!waitlistEntry || waitlistEntry.internal_notification_sent_at) {
+      return buildJsonResponse({ ok: true, alreadyExists });
+    }
+
+    const eventKey = `mini_waitlist:${waitlistEntry.id}`;
+    const dispatchClaimed = await claimDispatch(eventKey, waitlistEntry.id);
+
+    if (!dispatchClaimed) {
+      return buildJsonResponse({ ok: true, alreadyExists });
+    }
+
+    try {
+      await sendInternalEmail({
+        subject: `New Mini waitlist sign-up: ${waitlistEntry.email}`,
+        text: [
+          "A new Mini waitlist sign-up was submitted.",
+          "",
+          `Submission ID: ${waitlistEntry.id}`,
+          `Submitted At (UTC): ${waitlistEntry.created_at}`,
+          `Product: ${waitlistEntry.product_slug}`,
+          `Email: ${waitlistEntry.email}`,
+          `Source Page: ${waitlistEntry.source_page}`,
+        ].join("\n"),
+      });
+    } catch (error) {
+      console.error("mini-waitlist-intake internal email failed", error);
+      await releaseDispatch(eventKey);
+      return buildJsonResponse({ ok: true, alreadyExists });
+    }
+
+    await sendWeComAlertSafe({
+      tag: "Bloomjoy Mini",
+      title: "New Mini waitlist sign-up",
+      lines: [
+        `Submission ID: ${waitlistEntry.id}`,
+        `Submitted At (UTC): ${waitlistEntry.created_at}`,
+        `Product: ${waitlistEntry.product_slug}`,
+        `Email: ${waitlistEntry.email}`,
+        `Source Page: ${waitlistEntry.source_page}`,
+      ],
+    });
+
+    await Promise.all([
+      supabase
+        .from("mini_waitlist_submissions")
+        .update({ internal_notification_sent_at: new Date().toISOString() })
+        .eq("id", waitlistEntry.id),
+      markDispatchSent(eventKey, {
+        product_slug: waitlistEntry.product_slug,
+        source_page: waitlistEntry.source_page,
+        email: waitlistEntry.email,
+      }),
+    ]);
+
+    return buildJsonResponse({ ok: true, alreadyExists });
+  } catch (error) {
+    console.error("mini-waitlist-intake error", error);
+    return buildJsonResponse({ error: "Unable to join the waitlist right now." }, 500);
+  }
+});

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -94,6 +94,10 @@ type PersistedOrderRow = {
   wecom_alert_sent_at: string | null;
 };
 
+type NotificationDispatchType =
+  | "order_checkout"
+  | "plus_subscription_activated";
+
 type OrderContext = {
   orderId: string;
   session: Stripe.Checkout.Session;
@@ -117,8 +121,21 @@ type OrderContext = {
   existingWeComAlertSentAt: string | null;
 };
 
+type SubscriptionContext = {
+  stripeSubscriptionId: string;
+  stripeCustomerId: string;
+  customerEmail: string | null;
+  resolvedUserId: string;
+  status: string;
+  currentPeriodEnd: string | null;
+  cancelAtPeriodEnd: boolean;
+  machineCount: number | null;
+};
+
 const claimDispatch = async (
   eventKey: string,
+  dispatchType: NotificationDispatchType,
+  sourceTable: string,
   sourceId: string,
   meta: Record<string, unknown>
 ): Promise<boolean> => {
@@ -126,8 +143,8 @@ const claimDispatch = async (
 
   const { error } = await supabase.from("internal_notification_dispatches").insert({
     event_key: eventKey,
-    dispatch_type: "order_checkout",
-    source_table: "orders",
+    dispatch_type: dispatchType,
+    source_table: sourceTable,
     source_id: sourceId,
     meta,
   });
@@ -336,7 +353,7 @@ async function resolveUserIdByEmail(email: string | null | undefined) {
 }
 
 async function upsertSubscription(subscription: Stripe.Subscription) {
-  if (!supabase) return;
+  if (!supabase) return null;
 
   const metadataUserId = subscription.metadata?.user_id;
   const customer =
@@ -354,7 +371,7 @@ async function upsertSubscription(subscription: Stripe.Subscription) {
     resolvedUserId = await resolveUserId(metadataUserId);
     if (!resolvedUserId) {
       console.warn("Subscription metadata user_id did not resolve", subscription.id);
-      return;
+      return null;
     }
   } else {
     resolvedUserId = await resolveUserIdByEmail(customerEmail);
@@ -362,12 +379,18 @@ async function upsertSubscription(subscription: Stripe.Subscription) {
 
   if (!resolvedUserId) {
     console.warn("No matching user for subscription", subscription.id);
-    return;
+    return null;
   }
 
   const currentPeriodEnd = subscription.current_period_end
     ? new Date(subscription.current_period_end * 1000).toISOString()
     : null;
+  const machineCount =
+    parseNumber(subscription.metadata?.machine_count) ||
+    subscription.items.data.reduce(
+      (total: number, item: Stripe.SubscriptionItem) => total + (item.quantity ?? 0),
+      0
+    );
 
   const payload = {
     user_id: resolvedUserId,
@@ -384,7 +407,19 @@ async function upsertSubscription(subscription: Stripe.Subscription) {
 
   if (error) {
     console.error("Failed to upsert subscription", error);
+    return null;
   }
+
+  return {
+    stripeSubscriptionId: subscription.id,
+    stripeCustomerId: String(subscription.customer),
+    customerEmail,
+    resolvedUserId,
+    status: subscription.status,
+    currentPeriodEnd,
+    cancelAtPeriodEnd: subscription.cancel_at_period_end,
+    machineCount: machineCount > 0 ? machineCount : null,
+  } satisfies SubscriptionContext;
 }
 
 const buildLineItemSummary = (lineItems: StripeLineItemSummary[]) =>
@@ -670,11 +705,17 @@ const sendInternalOrderNotification = async (context: OrderContext) => {
   }
 
   const eventKey = `order_checkout:internal:${context.session.id}`;
-  const dispatchClaimed = await claimDispatch(eventKey, context.orderId, {
-    checkout_session_id: context.session.id,
-    order_type: context.orderType,
-    channel: "internal_email",
-  });
+  const dispatchClaimed = await claimDispatch(
+    eventKey,
+    "order_checkout",
+    "orders",
+    context.orderId,
+    {
+      checkout_session_id: context.session.id,
+      order_type: context.orderType,
+      channel: "internal_email",
+    }
+  );
 
   if (!dispatchClaimed) {
     return;
@@ -710,11 +751,17 @@ const sendCustomerConfirmation = async (context: OrderContext) => {
   }
 
   const eventKey = `order_checkout:customer:${context.session.id}`;
-  const dispatchClaimed = await claimDispatch(eventKey, context.orderId, {
-    checkout_session_id: context.session.id,
-    order_type: context.orderType,
-    channel: "customer_confirmation",
-  });
+  const dispatchClaimed = await claimDispatch(
+    eventKey,
+    "order_checkout",
+    "orders",
+    context.orderId,
+    {
+      checkout_session_id: context.session.id,
+      order_type: context.orderType,
+      channel: "customer_confirmation",
+    }
+  );
 
   if (!dispatchClaimed) {
     return;
@@ -781,11 +828,17 @@ const sendWeComOrderAlert = async (context: OrderContext) => {
   }
 
   const eventKey = `order_checkout:wecom:${context.session.id}`;
-  const dispatchClaimed = await claimDispatch(eventKey, context.orderId, {
-    checkout_session_id: context.session.id,
-    order_type: context.orderType,
-    channel: "wecom_alert",
-  });
+  const dispatchClaimed = await claimDispatch(
+    eventKey,
+    "order_checkout",
+    "orders",
+    context.orderId,
+    {
+      checkout_session_id: context.session.id,
+      order_type: context.orderType,
+      channel: "wecom_alert",
+    }
+  );
 
   if (!dispatchClaimed) {
     return;
@@ -823,6 +876,81 @@ const sendOrderNotifications = async (context: OrderContext | null) => {
   await sendInternalOrderNotification(context);
   await sendCustomerConfirmation(context);
   await sendWeComOrderAlert(context);
+};
+
+const sendPlusSubscriptionActivationAlert = async (
+  context: SubscriptionContext | null
+) => {
+  if (!supabase || !context) {
+    return;
+  }
+
+  if (context.status !== "trialing" && context.status !== "active") {
+    return;
+  }
+
+  const eventKey = `plus_subscription_activated:${context.stripeSubscriptionId}`;
+  const dispatchClaimed = await claimDispatch(
+    eventKey,
+    "plus_subscription_activated",
+    "subscriptions",
+    context.stripeSubscriptionId,
+    {
+      stripe_subscription_id: context.stripeSubscriptionId,
+      user_id: context.resolvedUserId,
+      status: context.status,
+    }
+  );
+
+  if (!dispatchClaimed) {
+    return;
+  }
+
+  const subject = `Bloomjoy Plus activated: ${context.customerEmail ?? context.resolvedUserId}`;
+  const emailLines = [
+    "A Bloomjoy Plus subscription reached an active state.",
+    "",
+    `Stripe Subscription ID: ${context.stripeSubscriptionId}`,
+    `Stripe Customer ID: ${context.stripeCustomerId}`,
+    `Resolved User ID: ${context.resolvedUserId}`,
+    `Customer Email: ${context.customerEmail ?? "n/a"}`,
+    `Status: ${context.status}`,
+    `Machine Count: ${context.machineCount ?? "n/a"}`,
+    `Current Period End (UTC): ${context.currentPeriodEnd ?? "n/a"}`,
+    `Cancel At Period End: ${context.cancelAtPeriodEnd ? "yes" : "no"}`,
+  ];
+
+  try {
+    await sendInternalEmail({
+      subject,
+      text: emailLines.join("\n"),
+    });
+  } catch (error) {
+    console.error("stripe-webhook plus activation email failed", error);
+    await releaseDispatch(eventKey);
+    return;
+  }
+
+  await sendWeComAlertResult({
+    tag: "Bloomjoy Plus",
+    title: `Plus subscription active: ${context.customerEmail ?? context.resolvedUserId}`,
+    lines: [
+      `Stripe Subscription ID: ${context.stripeSubscriptionId}`,
+      `Resolved User ID: ${context.resolvedUserId}`,
+      `Customer Email: ${context.customerEmail ?? "n/a"}`,
+      `Status: ${context.status}`,
+      `Machine Count: ${context.machineCount ?? "n/a"}`,
+      `Current Period End (UTC): ${context.currentPeriodEnd ?? "n/a"}`,
+    ],
+  });
+
+  await markDispatchSent(eventKey, {
+    stripe_subscription_id: context.stripeSubscriptionId,
+    user_id: context.resolvedUserId,
+    customer_email: context.customerEmail,
+    status: context.status,
+    machine_count: context.machineCount,
+  });
 };
 
 serve(async (req) => {
@@ -875,7 +1003,8 @@ serve(async (req) => {
       case "customer.subscription.updated":
       case "customer.subscription.deleted": {
         const subscription = event.data.object as Stripe.Subscription;
-        await upsertSubscription(subscription);
+        const subscriptionContext = await upsertSubscription(subscription);
+        await sendPlusSubscriptionActivationAlert(subscriptionContext);
         break;
       }
       default:

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -132,6 +132,13 @@ type SubscriptionContext = {
   machineCount: number | null;
 };
 
+const shouldFallbackDispatchClaim = (
+  dispatchType: NotificationDispatchType,
+  code: string | undefined
+) =>
+  dispatchType === "plus_subscription_activated" &&
+  (code === "23514" || code === "42501" || code === "42P01");
+
 const claimDispatch = async (
   eventKey: string,
   dispatchType: NotificationDispatchType,
@@ -155,6 +162,14 @@ const claimDispatch = async (
 
   if (error.code === "23505") {
     return false;
+  }
+
+  if (shouldFallbackDispatchClaim(dispatchType, error.code)) {
+    console.warn(
+      "Dispatch claim fallback: proceeding without dedupe bookkeeping.",
+      { eventKey, dispatchType, error },
+    );
+    return true;
   }
 
   throw new Error(error.message || "Failed to claim order notification dispatch.");

--- a/supabase/functions/support-request-intake/index.ts
+++ b/supabase/functions/support-request-intake/index.ts
@@ -2,6 +2,7 @@ import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.48.1";
 import { resolveSupabaseAccessToken } from "../_shared/auth.ts";
 import { corsHeaders } from "../_shared/cors.ts";
+import { sendInternalEmail } from "../_shared/internal-email.ts";
 import { sendWeComAlertSafe } from "../_shared/wecom-alert.ts";
 
 const supabaseUrl = Deno.env.get("SUPABASE_URL");
@@ -161,20 +162,35 @@ serve(async (req) => {
           ]
         : [];
 
+    const alertLines = [
+      `Support Request ID: ${supportRequest.id}`,
+      `Submitted At (UTC): ${supportRequest.created_at}`,
+      `Request Type: ${supportRequest.request_type}`,
+      `Customer User ID: ${supportRequest.customer_user_id}`,
+      `Customer Email: ${supportRequest.customer_email}`,
+      `Subject: ${supportRequest.subject}`,
+      ...onboardingLines,
+      "Message:",
+      supportRequest.message || "(none provided)",
+    ];
+
+    try {
+      await sendInternalEmail({
+        subject: `New support request: ${supportRequest.subject}`,
+        text: [
+          "A new support request was submitted.",
+          "",
+          ...alertLines,
+        ].join("\n"),
+      });
+    } catch (error) {
+      console.error("support-request-intake internal email failed", error);
+    }
+
     await sendWeComAlertSafe({
       tag: "Bloomjoy Support",
       title: `New ${supportRequest.request_type} request`,
-      lines: [
-        `Support Request ID: ${supportRequest.id}`,
-        `Submitted At (UTC): ${supportRequest.created_at}`,
-        `Request Type: ${supportRequest.request_type}`,
-        `Customer User ID: ${supportRequest.customer_user_id}`,
-        `Customer Email: ${supportRequest.customer_email}`,
-        `Subject: ${supportRequest.subject}`,
-        ...onboardingLines,
-        "Message:",
-        supportRequest.message || "(none provided)",
-      ],
+      lines: alertLines,
     });
 
     return new Response(JSON.stringify({ supportRequest }), {

--- a/supabase/migrations/202603220001_partner_operator_accounts.sql
+++ b/supabase/migrations/202603220001_partner_operator_accounts.sql
@@ -1,0 +1,891 @@
+﻿-- Partner/operator account access and invite flow for training UAT.
+
+create table if not exists public.customer_accounts (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  operator_seat_limit integer not null default 50 check (operator_seat_limit >= 0),
+  created_by_user_id uuid references auth.users (id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.customer_account_memberships (
+  id uuid primary key default gen_random_uuid(),
+  account_id uuid not null references public.customer_accounts (id) on delete cascade,
+  user_id uuid not null references auth.users (id) on delete cascade,
+  email text not null,
+  role text not null check (role in ('partner', 'operator')),
+  invited_by_user_id uuid references auth.users (id) on delete set null,
+  joined_at timestamptz not null default now(),
+  revoked_at timestamptz,
+  revoked_by_user_id uuid references auth.users (id) on delete set null,
+  revoke_reason text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.customer_account_invites (
+  id uuid primary key default gen_random_uuid(),
+  account_id uuid not null references public.customer_accounts (id) on delete cascade,
+  email text not null,
+  role text not null check (role in ('partner', 'operator')),
+  invited_by_user_id uuid references auth.users (id) on delete set null,
+  accepted_by_user_id uuid references auth.users (id) on delete set null,
+  accepted_at timestamptz,
+  revoked_at timestamptz,
+  revoked_by_user_id uuid references auth.users (id) on delete set null,
+  revoke_reason text,
+  last_sent_at timestamptz,
+  last_send_error text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists customer_account_memberships_account_role_idx
+  on public.customer_account_memberships (account_id, role)
+  where revoked_at is null;
+
+create index if not exists customer_account_memberships_user_id_idx
+  on public.customer_account_memberships (user_id);
+
+create unique index if not exists customer_account_memberships_active_user_idx
+  on public.customer_account_memberships (user_id)
+  where revoked_at is null;
+
+create index if not exists customer_account_memberships_active_email_idx
+  on public.customer_account_memberships (lower(email))
+  where revoked_at is null;
+
+create index if not exists customer_account_invites_account_role_idx
+  on public.customer_account_invites (account_id, role)
+  where accepted_at is null and revoked_at is null;
+
+create unique index if not exists customer_account_invites_pending_email_idx
+  on public.customer_account_invites (lower(email))
+  where accepted_at is null and revoked_at is null;
+
+drop trigger if exists customer_accounts_set_updated_at on public.customer_accounts;
+create trigger customer_accounts_set_updated_at
+before update on public.customer_accounts
+for each row execute function public.set_updated_at();
+
+drop trigger if exists customer_account_memberships_set_updated_at on public.customer_account_memberships;
+create trigger customer_account_memberships_set_updated_at
+before update on public.customer_account_memberships
+for each row execute function public.set_updated_at();
+
+drop trigger if exists customer_account_invites_set_updated_at on public.customer_account_invites;
+create trigger customer_account_invites_set_updated_at
+before update on public.customer_account_invites
+for each row execute function public.set_updated_at();
+
+create or replace function public.normalize_account_email(email_input text)
+returns text
+language sql
+immutable
+as $$
+  select lower(trim(coalesce(email_input, '')));
+$$;
+
+create or replace function public.has_active_customer_account_membership(
+  p_user_id uuid,
+  p_account_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.customer_account_memberships cam
+    where cam.user_id = p_user_id
+      and cam.account_id = p_account_id
+      and cam.revoked_at is null
+  );
+$$;
+
+create or replace function public.is_partner_on_customer_account(
+  p_user_id uuid,
+  p_account_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.customer_account_memberships cam
+    where cam.user_id = p_user_id
+      and cam.account_id = p_account_id
+      and cam.role = 'partner'
+      and cam.revoked_at is null
+  );
+$$;
+
+create or replace function public.get_active_customer_account_id(p_user_id uuid)
+returns uuid
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select cam.account_id
+  from public.customer_account_memberships cam
+  where cam.user_id = p_user_id
+    and cam.revoked_at is null
+  order by case when cam.role = 'partner' then 0 else 1 end, cam.created_at asc
+  limit 1;
+$$;
+
+create or replace function public.get_active_customer_account_role(p_user_id uuid)
+returns text
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select cam.role
+  from public.customer_account_memberships cam
+  where cam.user_id = p_user_id
+    and cam.revoked_at is null
+  order by case when cam.role = 'partner' then 0 else 1 end, cam.created_at asc
+  limit 1;
+$$;
+
+create or replace function public.get_portal_access_tier_for_user(p_user_id uuid)
+returns text
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  active_role text;
+  has_active_plus boolean := false;
+begin
+  if p_user_id is null then
+    return 'baseline';
+  end if;
+
+  if public.is_super_admin(p_user_id) then
+    return 'plus';
+  end if;
+
+  active_role := public.get_active_customer_account_role(p_user_id);
+
+  select exists (
+    select 1
+    from public.subscriptions s
+    where s.user_id = p_user_id
+      and s.status in ('active', 'trialing')
+      and (s.current_period_end is null or s.current_period_end > now())
+  )
+  into has_active_plus;
+
+  if has_active_plus or active_role = 'partner' then
+    return 'plus';
+  end if;
+
+  if active_role = 'operator' then
+    return 'training';
+  end if;
+
+  return 'baseline';
+end;
+$$;
+
+create or replace function public.can_manage_customer_account_operators_for_user(p_user_id uuid)
+returns boolean
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+begin
+  if p_user_id is null then
+    return false;
+  end if;
+
+  return public.is_super_admin(p_user_id)
+    or public.get_active_customer_account_role(p_user_id) = 'partner';
+end;
+$$;
+
+create or replace function public.get_portal_access_context_for_user(p_user_id uuid)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  active_account_id uuid;
+  active_account_role text;
+  is_admin_user boolean := false;
+  access_tier text := 'baseline';
+begin
+  if p_user_id is null then
+    return jsonb_build_object(
+      'account_id', null,
+      'account_role', null,
+      'access_tier', 'baseline',
+      'can_manage_operators', false,
+      'is_admin', false
+    );
+  end if;
+
+  is_admin_user := public.is_super_admin(p_user_id);
+  active_account_id := public.get_active_customer_account_id(p_user_id);
+  active_account_role := public.get_active_customer_account_role(p_user_id);
+  access_tier := public.get_portal_access_tier_for_user(p_user_id);
+
+  return jsonb_build_object(
+    'account_id', active_account_id,
+    'account_role', active_account_role,
+    'access_tier', access_tier,
+    'can_manage_operators', public.can_manage_customer_account_operators_for_user(p_user_id),
+    'is_admin', is_admin_user
+  );
+end;
+$$;
+
+create or replace function public.get_portal_access_context()
+returns jsonb
+language sql
+stable
+security definer
+set search_path = public, auth
+as $$
+  select public.get_portal_access_context_for_user(auth.uid());
+$$;
+
+create or replace function public.can_access_members_only_training()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, auth
+as $$
+  select public.get_portal_access_tier_for_user(auth.uid()) in ('training', 'plus');
+$$;
+
+create or replace function public.can_access_plus_portal()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, auth
+as $$
+  select public.get_portal_access_tier_for_user(auth.uid()) = 'plus';
+$$;
+
+create or replace function public.can_access_plus_portal_for_user(p_user_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select public.get_portal_access_tier_for_user(p_user_id) = 'plus';
+$$;
+
+grant execute on function public.has_active_customer_account_membership(uuid, uuid) to authenticated, service_role;
+grant execute on function public.is_partner_on_customer_account(uuid, uuid) to authenticated, service_role;
+grant execute on function public.get_active_customer_account_id(uuid) to authenticated, service_role;
+grant execute on function public.get_active_customer_account_role(uuid) to authenticated, service_role;
+grant execute on function public.get_portal_access_tier_for_user(uuid) to authenticated, service_role;
+grant execute on function public.can_manage_customer_account_operators_for_user(uuid) to authenticated, service_role;
+grant execute on function public.get_portal_access_context_for_user(uuid) to authenticated, service_role;
+grant execute on function public.get_portal_access_context() to authenticated, service_role;
+grant execute on function public.can_access_plus_portal() to authenticated, service_role;
+grant execute on function public.can_access_plus_portal_for_user(uuid) to authenticated, service_role;
+grant execute on function public.can_access_members_only_training() to authenticated, service_role;
+
+alter table public.customer_accounts enable row level security;
+alter table public.customer_account_memberships enable row level security;
+alter table public.customer_account_invites enable row level security;
+
+drop policy if exists "customer_accounts_select_member_or_admin" on public.customer_accounts;
+drop policy if exists "customer_account_memberships_select_partner_or_self" on public.customer_account_memberships;
+drop policy if exists "customer_account_invites_select_partner_or_admin" on public.customer_account_invites;
+
+create policy "customer_accounts_select_member_or_admin"
+on public.customer_accounts
+for select
+to authenticated
+using (
+  public.is_super_admin(auth.uid())
+  or public.has_active_customer_account_membership(auth.uid(), id)
+);
+
+create policy "customer_account_memberships_select_partner_or_self"
+on public.customer_account_memberships
+for select
+to authenticated
+using (
+  public.is_super_admin(auth.uid())
+  or (auth.uid() = user_id and revoked_at is null)
+  or public.is_partner_on_customer_account(auth.uid(), account_id)
+);
+
+create policy "customer_account_invites_select_partner_or_admin"
+on public.customer_account_invites
+for select
+to authenticated
+using (
+  public.is_super_admin(auth.uid())
+  or public.is_partner_on_customer_account(auth.uid(), account_id)
+);
+
+drop function if exists public.create_customer_account_invite_as_actor(uuid, text, text, text);
+create or replace function public.create_customer_account_invite_as_actor(
+  p_actor_user_id uuid,
+  p_invite_email text,
+  p_role text,
+  p_account_name text default null
+)
+returns public.customer_account_invites
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  normalized_email text := public.normalize_account_email(p_invite_email);
+  normalized_role text := lower(trim(coalesce(p_role, '')));
+  actor_account_id uuid;
+  actor_account_role text;
+  actor_is_admin boolean := false;
+  created_account public.customer_accounts;
+  created_invite public.customer_account_invites;
+  existing_user_id uuid;
+  seat_limit integer;
+  active_operator_count integer;
+  pending_operator_count integer;
+  normalized_account_name text;
+begin
+  if p_actor_user_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  if normalized_email = '' then
+    raise exception 'Invite email is required';
+  end if;
+
+  if normalized_role not in ('partner', 'operator') then
+    raise exception 'Invalid invite role: %', p_role;
+  end if;
+
+  actor_is_admin := public.is_super_admin(p_actor_user_id);
+  actor_account_id := public.get_active_customer_account_id(p_actor_user_id);
+  actor_account_role := public.get_active_customer_account_role(p_actor_user_id);
+
+  if normalized_role = 'partner' then
+    if not actor_is_admin then
+      raise exception 'Admin access required';
+    end if;
+
+    normalized_account_name := nullif(trim(coalesce(p_account_name, '')), '');
+
+    insert into public.customer_accounts (
+      name,
+      operator_seat_limit,
+      created_by_user_id
+    )
+    values (
+      coalesce(normalized_account_name, split_part(normalized_email, '@', 1) || ' team'),
+      50,
+      p_actor_user_id
+    )
+    returning * into created_account;
+
+    actor_account_id := created_account.id;
+  else
+    if actor_account_id is null or actor_account_role <> 'partner' then
+      raise exception 'Partner access required';
+    end if;
+
+    if exists (
+      select 1
+      from auth.users au
+      where au.id = p_actor_user_id
+        and public.normalize_account_email(au.email) = normalized_email
+    ) then
+      raise exception 'You cannot invite your own email address';
+    end if;
+
+    select ca.operator_seat_limit
+    into seat_limit
+    from public.customer_accounts ca
+    where ca.id = actor_account_id
+    limit 1;
+
+    select count(*)
+    into active_operator_count
+    from public.customer_account_memberships cam
+    where cam.account_id = actor_account_id
+      and cam.role = 'operator'
+      and cam.revoked_at is null;
+
+    select count(*)
+    into pending_operator_count
+    from public.customer_account_invites cai
+    where cai.account_id = actor_account_id
+      and cai.role = 'operator'
+      and cai.accepted_at is null
+      and cai.revoked_at is null;
+
+    if coalesce(active_operator_count, 0) + coalesce(pending_operator_count, 0) >= coalesce(seat_limit, 50) then
+      raise exception 'Operator seat limit reached (%). Revoke an operator or pending invite before adding another.', coalesce(seat_limit, 50);
+    end if;
+  end if;
+
+  if exists (
+    select 1
+    from public.customer_account_invites cai
+    where public.normalize_account_email(cai.email) = normalized_email
+      and cai.accepted_at is null
+      and cai.revoked_at is null
+  ) then
+    raise exception 'A pending invite already exists for %', normalized_email;
+  end if;
+
+  if exists (
+    select 1
+    from public.customer_account_memberships cam
+    where public.normalize_account_email(cam.email) = normalized_email
+      and cam.revoked_at is null
+  ) then
+    raise exception 'This email already has active customer-account access';
+  end if;
+
+  select au.id
+  into existing_user_id
+  from auth.users au
+  where public.normalize_account_email(au.email) = normalized_email
+  limit 1;
+
+  if existing_user_id is not null and exists (
+    select 1
+    from public.customer_account_memberships cam
+    where cam.user_id = existing_user_id
+      and cam.revoked_at is null
+  ) then
+    raise exception 'This email already has active customer-account access';
+  end if;
+
+  insert into public.customer_account_invites (
+    account_id,
+    email,
+    role,
+    invited_by_user_id
+  )
+  values (
+    actor_account_id,
+    normalized_email,
+    normalized_role,
+    p_actor_user_id
+  )
+  returning * into created_invite;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    p_actor_user_id,
+    case
+      when normalized_role = 'partner' then 'customer_account.partner_invited'
+      else 'customer_account.operator_invited'
+    end,
+    'customer_account_invite',
+    created_invite.id::text,
+    '{}'::jsonb,
+    to_jsonb(created_invite),
+    jsonb_build_object(
+      'account_id', actor_account_id,
+      'email', normalized_email,
+      'role', normalized_role
+    )
+  );
+
+  return created_invite;
+end;
+$$;
+
+drop function if exists public.record_customer_account_invite_delivery_as_actor(uuid, uuid, text);
+create or replace function public.record_customer_account_invite_delivery_as_actor(
+  p_actor_user_id uuid,
+  p_invite_id uuid,
+  p_send_error text default null
+)
+returns public.customer_account_invites
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  invite_row public.customer_account_invites;
+  actor_can_manage boolean := false;
+  normalized_send_error text := nullif(trim(coalesce(p_send_error, '')), '');
+begin
+  if p_actor_user_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  select *
+  into invite_row
+  from public.customer_account_invites cai
+  where cai.id = p_invite_id;
+
+  if invite_row.id is null then
+    raise exception 'Invite not found';
+  end if;
+
+  if invite_row.revoked_at is not null then
+    raise exception 'Invite has already been revoked';
+  end if;
+
+  if invite_row.accepted_at is not null then
+    raise exception 'Invite has already been accepted';
+  end if;
+
+  actor_can_manage := public.is_super_admin(p_actor_user_id)
+    or (
+      invite_row.role = 'operator'
+      and public.is_partner_on_customer_account(p_actor_user_id, invite_row.account_id)
+    );
+
+  if not actor_can_manage then
+    raise exception 'Access denied';
+  end if;
+
+  update public.customer_account_invites
+  set
+    last_sent_at = now(),
+    last_send_error = normalized_send_error
+  where id = invite_row.id
+  returning * into invite_row;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    p_actor_user_id,
+    'customer_account.invite_delivery_recorded',
+    'customer_account_invite',
+    invite_row.id::text,
+    '{}'::jsonb,
+    to_jsonb(invite_row),
+    jsonb_build_object(
+      'account_id', invite_row.account_id,
+      'email', invite_row.email,
+      'delivery_status', case when normalized_send_error is null then 'sent' else 'failed' end,
+      'send_error', normalized_send_error
+    )
+  );
+
+  return invite_row;
+end;
+$$;
+
+drop function if exists public.revoke_customer_account_access_as_actor(uuid, uuid, uuid, text);
+create or replace function public.revoke_customer_account_access_as_actor(
+  p_actor_user_id uuid,
+  p_membership_id uuid default null,
+  p_invite_id uuid default null,
+  p_reason text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  membership_row public.customer_account_memberships;
+  invite_row public.customer_account_invites;
+  actor_account_id uuid;
+  actor_account_role text;
+  actor_is_admin boolean := false;
+  normalized_reason text := nullif(trim(coalesce(p_reason, '')), '');
+begin
+  if p_actor_user_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  if p_membership_id is null and p_invite_id is null then
+    raise exception 'Membership or invite id is required';
+  end if;
+
+  actor_is_admin := public.is_super_admin(p_actor_user_id);
+  actor_account_id := public.get_active_customer_account_id(p_actor_user_id);
+  actor_account_role := public.get_active_customer_account_role(p_actor_user_id);
+
+  if p_membership_id is not null then
+    select *
+    into membership_row
+    from public.customer_account_memberships cam
+    where cam.id = p_membership_id;
+
+    if membership_row.id is null then
+      raise exception 'Membership not found';
+    end if;
+
+    if membership_row.revoked_at is not null then
+      return jsonb_build_object('status', 'already_revoked', 'entity', 'membership');
+    end if;
+
+    if not actor_is_admin and not (
+      membership_row.role = 'operator'
+      and actor_account_id = membership_row.account_id
+      and actor_account_role = 'partner'
+    ) then
+      raise exception 'Access denied';
+    end if;
+
+    update public.customer_account_memberships
+    set
+      revoked_at = now(),
+      revoked_by_user_id = p_actor_user_id,
+      revoke_reason = coalesce(normalized_reason, 'Access revoked')
+    where id = membership_row.id
+    returning * into membership_row;
+
+    insert into public.admin_audit_log (
+      actor_user_id,
+      action,
+      entity_type,
+      entity_id,
+      target_user_id,
+      before,
+      after,
+      meta
+    )
+    values (
+      p_actor_user_id,
+      case
+        when membership_row.role = 'partner' then 'customer_account.partner_revoked'
+        else 'customer_account.operator_revoked'
+      end,
+      'customer_account_membership',
+      membership_row.id::text,
+      membership_row.user_id,
+      '{}'::jsonb,
+      to_jsonb(membership_row),
+      jsonb_build_object(
+        'account_id', membership_row.account_id,
+        'email', membership_row.email,
+        'reason', coalesce(normalized_reason, 'Access revoked')
+      )
+    );
+
+    return jsonb_build_object(
+      'status', 'revoked',
+      'entity', 'membership',
+      'membership_id', membership_row.id,
+      'account_id', membership_row.account_id
+    );
+  end if;
+
+  select *
+  into invite_row
+  from public.customer_account_invites cai
+  where cai.id = p_invite_id;
+
+  if invite_row.id is null then
+    raise exception 'Invite not found';
+  end if;
+
+  if invite_row.revoked_at is not null then
+    return jsonb_build_object('status', 'already_revoked', 'entity', 'invite');
+  end if;
+
+  if invite_row.accepted_at is not null then
+    raise exception 'Accepted invites must be revoked through the membership record';
+  end if;
+
+  if not actor_is_admin and not (
+    actor_account_id = invite_row.account_id
+    and actor_account_role = 'partner'
+    and invite_row.role = 'operator'
+  ) then
+    raise exception 'Access denied';
+  end if;
+
+  update public.customer_account_invites
+  set
+    revoked_at = now(),
+    revoked_by_user_id = p_actor_user_id,
+    revoke_reason = coalesce(normalized_reason, 'Invite revoked')
+  where id = invite_row.id
+  returning * into invite_row;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    p_actor_user_id,
+    case
+      when invite_row.role = 'partner' then 'customer_account.partner_invite_revoked'
+      else 'customer_account.operator_invite_revoked'
+    end,
+    'customer_account_invite',
+    invite_row.id::text,
+    '{}'::jsonb,
+    to_jsonb(invite_row),
+    jsonb_build_object(
+      'account_id', invite_row.account_id,
+      'email', invite_row.email,
+      'reason', coalesce(normalized_reason, 'Invite revoked')
+    )
+  );
+
+  return jsonb_build_object(
+    'status', 'revoked',
+    'entity', 'invite',
+    'invite_id', invite_row.id,
+    'account_id', invite_row.account_id
+  );
+end;
+$$;
+
+drop function if exists public.accept_customer_account_invite();
+create or replace function public.accept_customer_account_invite()
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  current_user_id uuid := auth.uid();
+  current_email text := public.normalize_account_email(coalesce(auth.jwt() ->> 'email', ''));
+  invite_row public.customer_account_invites;
+  existing_membership public.customer_account_memberships;
+  accepted_membership public.customer_account_memberships;
+begin
+  if current_user_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  if current_email = '' then
+    select public.normalize_account_email(au.email)
+    into current_email
+    from auth.users au
+    where au.id = current_user_id
+    limit 1;
+  end if;
+
+  if current_email = '' then
+    return public.get_portal_access_context();
+  end if;
+
+  select *
+  into invite_row
+  from public.customer_account_invites cai
+  where public.normalize_account_email(cai.email) = current_email
+    and cai.accepted_at is null
+    and cai.revoked_at is null
+  order by cai.created_at asc
+  limit 1;
+
+  if invite_row.id is null then
+    return public.get_portal_access_context();
+  end if;
+
+  select *
+  into existing_membership
+  from public.customer_account_memberships cam
+  where cam.user_id = current_user_id
+    and cam.revoked_at is null
+  limit 1;
+
+  if existing_membership.id is not null then
+    if existing_membership.account_id <> invite_row.account_id or existing_membership.role <> invite_row.role then
+      raise exception 'This user already has active customer-account access';
+    end if;
+
+    accepted_membership := existing_membership;
+  else
+    insert into public.customer_account_memberships (
+      account_id,
+      user_id,
+      email,
+      role,
+      invited_by_user_id,
+      joined_at
+    )
+    values (
+      invite_row.account_id,
+      current_user_id,
+      current_email,
+      invite_row.role,
+      invite_row.invited_by_user_id,
+      now()
+    )
+    returning * into accepted_membership;
+  end if;
+
+  update public.customer_account_invites
+  set
+    accepted_at = coalesce(accepted_at, now()),
+    accepted_by_user_id = current_user_id,
+    last_send_error = null
+  where id = invite_row.id
+  returning * into invite_row;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    target_user_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    current_user_id,
+    case
+      when invite_row.role = 'partner' then 'customer_account.partner_accepted'
+      else 'customer_account.operator_accepted'
+    end,
+    'customer_account_membership',
+    accepted_membership.id::text,
+    current_user_id,
+    '{}'::jsonb,
+    to_jsonb(accepted_membership),
+    jsonb_build_object(
+      'account_id', accepted_membership.account_id,
+      'email', accepted_membership.email,
+      'invite_id', invite_row.id
+    )
+  );
+
+  return public.get_portal_access_context();
+end;
+$$;
+
+grant execute on function public.create_customer_account_invite_as_actor(uuid, text, text, text) to authenticated, service_role;
+grant execute on function public.record_customer_account_invite_delivery_as_actor(uuid, uuid, text) to authenticated, service_role;
+grant execute on function public.revoke_customer_account_access_as_actor(uuid, uuid, uuid, text) to authenticated, service_role;
+grant execute on function public.accept_customer_account_invite() to authenticated, service_role;

--- a/supabase/migrations/202604090001_go_live_readiness_hardening.sql
+++ b/supabase/migrations/202604090001_go_live_readiness_hardening.sql
@@ -1,11 +1,11 @@
+alter table public.internal_notification_dispatches
+  drop constraint if exists internal_notification_dispatches_dispatch_type_check;
+
 update public.internal_notification_dispatches
 set
   dispatch_type = 'lead_submission',
   event_key = regexp_replace(event_key, '^lead_quote:', 'lead_submission:')
 where dispatch_type = 'lead_quote';
-
-alter table public.internal_notification_dispatches
-  drop constraint if exists internal_notification_dispatches_dispatch_type_check;
 
 alter table public.internal_notification_dispatches
   add constraint internal_notification_dispatches_dispatch_type_check

--- a/supabase/migrations/202604090001_go_live_readiness_hardening.sql
+++ b/supabase/migrations/202604090001_go_live_readiness_hardening.sql
@@ -1,3 +1,9 @@
+update public.internal_notification_dispatches
+set
+  dispatch_type = 'lead_submission',
+  event_key = regexp_replace(event_key, '^lead_quote:', 'lead_submission:')
+where dispatch_type = 'lead_quote';
+
 alter table public.internal_notification_dispatches
   drop constraint if exists internal_notification_dispatches_dispatch_type_check;
 

--- a/supabase/migrations/202604090001_go_live_readiness_hardening.sql
+++ b/supabase/migrations/202604090001_go_live_readiness_hardening.sql
@@ -1,0 +1,19 @@
+alter table public.internal_notification_dispatches
+  drop constraint if exists internal_notification_dispatches_dispatch_type_check;
+
+alter table public.internal_notification_dispatches
+  add constraint internal_notification_dispatches_dispatch_type_check
+  check (
+    dispatch_type in (
+      'lead_submission',
+      'mini_waitlist',
+      'order_checkout',
+      'plus_subscription_activated'
+    )
+  );
+
+alter table public.mini_waitlist_submissions
+  add column if not exists internal_notification_sent_at timestamptz;
+
+drop policy if exists "lead_submissions_insert_public" on public.lead_submissions;
+drop policy if exists "mini_waitlist_submissions_insert_public" on public.mini_waitlist_submissions;


### PR DESCRIPTION
## Summary
- Harden lead, Mini waitlist, support, and Plus subscription activation alerts so internal email is the primary ops channel and WeCom stays best-effort.
- Add a read-only `/admin/leads` inbox and move Mini waitlist intake behind a Supabase Edge Function instead of public table inserts.
- Lock down public inserts for lead and waitlist tables, add the supporting migration/config, and update go-live docs, smoke checks, and runbook coverage.

## Files changed
- Supabase Edge Functions: `lead-submission-intake`, new `mini-waitlist-intake`, `support-request-intake`, and `stripe-webhook`
- Admin/UI: new `/admin/leads` page, admin nav/dashboard wiring, contact + Mini form submissions, and home-page copy cleanup
- Data/config/docs: migration for dispatch types + notification timestamp + RLS hardening, `supabase/config.toml`, `Docs/CURRENT_STATUS.md`, `Docs/QA_SMOKE_TEST_CHECKLIST.md`, and `Docs/PRODUCTION_RUNBOOK.md`

## Verification commands + results
- `npm ci` ✅
- `npm run build` ✅
- `npm test --if-present` ✅ (no test script present, command exited successfully)
- `npm run lint --if-present` ✅ (existing React fast-refresh warnings only)
- `npm run seo:check` ✅
- `npm run auth:preflight` ⚠️ blocked locally because `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` are not set in this worktree; `VITE_GOOGLE_CLIENT_ID` is also warned as unset
- `deno check supabase/functions/lead-submission-intake/index.ts` ✅
- `deno check supabase/functions/mini-waitlist-intake/index.ts` ✅
- `deno check supabase/functions/support-request-intake/index.ts` ✅
- `deno check supabase/functions/stripe-webhook/index.ts` ✅

## How to test
1. Check out `agent/go-live-readiness` and run `npm ci`.
2. Start the app with `npm run dev`.
3. Open `http://localhost:8080/contact` and submit one entry each for `quote`, `demo`, `procurement`, and `general`.
4. Open `http://localhost:8080/supplies` and submit the under-5 blank sticks flow plus a custom procurement request.
5. Open `http://localhost:8080/machines/mini` and submit the Mini waitlist form twice with the same email; confirm the second response is the friendly duplicate path.
6. Sign in as a super-admin and verify `http://localhost:8080/admin/leads` shows both lead submissions and Mini waitlist rows, supports search/filtering, and highlights missing notification timestamps.
7. Sign in as a portal user and submit `http://localhost:8080/portal/support`; confirm the request still succeeds even if secondary notification delivery fails.
8. Deploy the migration and updated Edge Functions, then run a Stripe test Plus checkout and a follow-up subscription status change; confirm subscriptions still upsert and only the first `trialing` or `active` transition sends the ops activation alert.
9. In the deployed environment, verify anon direct inserts to `lead_submissions` and `mini_waitlist_submissions` fail after the RLS hardening.
10. Verify `https://bloomjoyusa.com` returns a permanent redirect to `https://www.bloomjoyusa.com/`.

## Notes
- The repo already contains a permanent `308` apex redirect rule, so if production still responds with `307` the remaining issue is likely deployment or domain-layer configuration rather than application code.
- This PR does not add lead assignment/status workflow; `/admin/leads` is intentionally read-only in this slice.