### PR TITLE
Update sticks offering copy

### DIFF
--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -168,9 +168,9 @@ Execution order is based on launch risk and dependency overlap.
 - UAT signal: sugar presets and sticks packaging/pricing needed to match current shipping realities.
 - Delivered:
   - Sugar quick presets updated to `240 KG`, `400 KG`, and `800 KG` with `400 KG` as the default packaging-friendly target.
-  - Blank paper sticks now use box-based pricing (`$130/box`, `2000 pieces/box`) with required machine-size and address-type selection.
-  - Blank sticks orders under 5 boxes submit procurement requests with shipping estimate context (`$35/box` business, `$40/box` residential).
-  - Blank sticks orders of 5+ boxes now use a dedicated Stripe checkout flow with free shipping.
+  - Bloomjoy branded paper sticks now use box-based pricing (`$130/box`, `2000 pieces/box`) with required machine-size and address-type selection.
+  - Bloomjoy branded sticks orders under 5 boxes submit procurement requests with shipping estimate context (`$35/box` business, `$40/box` residential).
+  - Bloomjoy branded sticks orders of 5+ boxes now use a dedicated Stripe checkout flow with free shipping.
   - Custom sticks remain request-based with artwork upload and a clearly stated `$750` first-order plate fee.
 
 4) **P1 - Resources page Plus-content teasers**
@@ -248,7 +248,7 @@ Execution order is based on launch risk and dependency overlap.
 - Quote-intake clarity hardening (`PR #88`): machine quote CTA now carries machine-of-interest context into contact submissions.
 - Local QA admin access helper (`PR #88`): optional `VITE_DEV_ADMIN_EMAILS` local-only override for internal Plus feature testing.
 - UAT naming consistency hardening (`2026-03-02`): standardized public machine labels to `Commercial Machine`, `Mini Machine`, and `Micro Machine` across home, machines listing, contact, footer, and machine detail headers.
-- UAT supplies packaging alignment (`2026-03-18`): sugar quick presets now align to `240/400/800 KG`, blank paper sticks use box pricing (`$130/box`, `2000 pieces/box`) with size/address selection, 5+ box checkout ships free via dedicated Stripe flow, and custom sticks retain artwork upload with a `$750` first-order plate fee.
+- UAT supplies packaging alignment (`2026-03-18`): sugar quick presets now align to `240/400/800 KG`, Bloomjoy branded paper sticks use box pricing (`$130/box`, `2000 pieces/box`) with size/address selection, 5+ box checkout ships free via dedicated Stripe flow, and custom sticks retain artwork upload with a `$750` first-order plate fee.
 - UAT resources hardening (`2026-03-02`): `/resources` now includes Bloomjoy Plus teaser cards for downloadable procedure docs, daily checklists, and frequently updated member content.
 - Auth launch alignment (`2026-03-22`): auth preflight defaults and auth runbooks now target canonical operator-app routes on `app.bloomjoyusa.com`, while the storefront stays on `www.bloomjoyusa.com` and the callback host remains `auth.bloomjoyusa.com`.
 - Training performance hardening (`#89`): training detail now shows a clear Vimeo loading state, adds Vimeo preconnect hints, and emits iframe startup timing analytics.

--- a/Docs/PRODUCTION_RUNBOOK.md
+++ b/Docs/PRODUCTION_RUNBOOK.md
@@ -148,9 +148,9 @@ Run immediately after deploy:
 - [ ] Sugar checkout test order sends internal summary email to configured operations recipients.
 - [ ] Sugar checkout test order sends customer confirmation email with the branded HTML confirmation layout, order summary, and receipt link.
 - [ ] Sugar checkout test order sends WeCom alert when `WECOM_*` secrets are configured and the WeCom app/network policy allows traffic from the live function egress IPs.
-- [ ] Blank sticks checkout test order (5+ boxes) creates `orders` record in Supabase with size/address/shipping metadata.
-- [ ] Blank sticks checkout test order sends internal summary email to configured operations recipients.
-- [ ] Blank sticks checkout test order sends customer confirmation email with the branded HTML confirmation layout.
+- [ ] Bloomjoy branded sticks checkout test order (5+ boxes) creates `orders` record in Supabase with size/address/shipping metadata.
+- [ ] Bloomjoy branded sticks checkout test order sends internal summary email to configured operations recipients.
+- [ ] Bloomjoy branded sticks checkout test order sends customer confirmation email with the branded HTML confirmation layout.
 - [ ] Plus checkout test subscription creates/updates `subscriptions` record in Supabase.
 - [ ] Quote request on `/contact` sends internal summary email to configured operations recipients.
 - [ ] Quote/order/support events send WeCom alerts to configured internal recipients (or log non-blocking warning on dispatch failure).
@@ -172,7 +172,7 @@ Preferred order of operations:
    - customer email and phone
    - billing and shipping address
    - pricing tier and unit price
-   - sugar color breakdown or blank-sticks order details
+   - sugar color breakdown or Bloomjoy branded stick order details
    - notification status fields
 
 ## 6) Rollback checklist

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -41,10 +41,10 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Sugar page shows Bloomjoy Plus pricing at `$8/kg` only for users whose `subscriptions.status` is `active` or `trialing`
 - [ ] Sugar page handles high-volume setup (e.g., 500KG+) without repetitive click controls
 - [ ] Sticks ordering on `/supplies` allows direct typed quantity input (not only +/- controls)
-- [ ] Sticks ordering clearly supports blank paper sticks and custom paper sticks at `$130/box` with `2000 pieces/box`
-- [ ] Blank sticks flow requires machine size selection and shipping address type selection before request/checkout
-- [ ] Blank sticks orders under 5 boxes submit a procurement lead with box count, size, address type, and estimated shipping summary
-- [ ] Blank sticks orders of 5+ boxes launch direct Stripe checkout with free shipping and do not use the shared cart
+- [ ] Sticks ordering clearly supports Bloomjoy branded paper sticks and custom paper sticks at `$130/box` with `2000 pieces/box`
+- [ ] Bloomjoy branded sticks flow requires machine size selection and shipping address type selection before request/checkout
+- [ ] Bloomjoy branded sticks orders under 5 boxes submit a procurement lead with box count, size, address type, and estimated shipping summary
+- [ ] Bloomjoy branded sticks orders of 5+ boxes launch direct Stripe checkout with free shipping and do not use the shared cart
 - [ ] Custom sticks flow accepts logo/image upload and submits a procurement lead with artwork URL, requested box count, selected size, and `$750` first-order plate-fee note
 - [ ] Shared cart remains sugar-only and legacy stick items do not block checkout
 - [ ] Plus page: pricing and boundaries are visible and clear
@@ -151,11 +151,11 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Sugar checkout completed webhook sends internal order summary email (customer, totals, pricing tier, sugar mix, line items)
 - [ ] Sugar checkout sends customer confirmation email with branded HTML layout, clear totals, shipping address, color quantities, and receipt link
 - [ ] Sugar checkout completed webhook sends a WeCom internal alert with order ID, customer, and sugar breakdown
-- [ ] Blank sticks checkout completes with test card for 5+ boxes and shows free shipping in Stripe Checkout
-- [ ] Blank sticks checkout writes an `orders` row with billing/shipping address, shipping total, receipt URL, and order detail metadata
-- [ ] Blank sticks checkout completed webhook sends internal order summary email with box count, machine size, address type, and shipping total
-- [ ] Blank sticks checkout sends customer confirmation email with branded HTML layout, shipping address, and receipt link
-- [ ] Blank sticks checkout completed webhook sends a WeCom internal alert with order ID, customer, and stick-order summary
+- [ ] Bloomjoy branded sticks checkout completes with test card for 5+ boxes and shows free shipping in Stripe Checkout
+- [ ] Bloomjoy branded sticks checkout writes an `orders` row with billing/shipping address, shipping total, receipt URL, and order detail metadata
+- [ ] Bloomjoy branded sticks checkout completed webhook sends internal order summary email with box count, machine size, address type, and shipping total
+- [ ] Bloomjoy branded sticks checkout sends customer confirmation email with branded HTML layout, shipping address, and receipt link
+- [ ] Bloomjoy branded sticks checkout completed webhook sends a WeCom internal alert with order ID, customer, and stick-order summary
 - [ ] Plus subscription checkout computes expected monthly amount from selected machine count (e.g., 1x=$100, 3x=$300) and completes with test card
 - [ ] Logged-out users on `/plus` are redirected to login before checkout can begin
 - [ ] Stripe subscription from Plus checkout contains `metadata.user_id` and `metadata.machine_count`
@@ -188,7 +188,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Super-admin user can access `/admin/orders`
 - [ ] Admin orders supports search by customer email/order ID and date range filtering
 - [ ] Admin orders detail panel shows billing/shipping address snapshots, pricing tier, unit price, receipt link, and notification statuses
-- [ ] Admin orders detail panel shows sugar color quantities for sugar orders and box/size/address metadata for blank-sticks orders
+- [ ] Admin orders detail panel shows sugar color quantities for sugar orders and box/size/address metadata for Bloomjoy branded stick orders
 - [ ] Admin fulfillment updates create `admin_audit_log` entries with `action=order.fulfillment_updated`
 - [ ] Non-admin user cannot access `/admin/accounts`
 - [ ] Super-admin user can access `/admin/accounts`

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -145,12 +145,12 @@ export const products: Record<string, Product> = {
   },
   'sticks-plain': {
     sku: 'sticks-plain',
-    name: 'Blank Cotton Candy Sticks',
+    name: 'Bloomjoy Branded Cotton Candy Sticks',
     type: 'supply',
     price: STICKS_PRICE_PER_BOX,
     description:
-      'Plain paper sticks, 2000 pieces per box. Available in Commercial/Full 10mm x 300mm and Mini 10mm x 220mm sizes.',
-    shortDescription: `${STICKS_PIECES_PER_BOX} plain paper sticks per box`,
+      'Bloomjoy branded paper sticks, 2000 pieces per box. Available in Commercial/Full 10mm x 300mm and Mini 10mm x 220mm sizes.',
+    shortDescription: `${STICKS_PIECES_PER_BOX} Bloomjoy branded paper sticks per box`,
     features: [
       'Compatible with all Bloomjoy machines',
       'Food-grade materials',

--- a/src/pages/Supplies.tsx
+++ b/src/pages/Supplies.tsx
@@ -97,10 +97,10 @@ export default function SuppliesPage() {
     const sticksCheckoutStatus = params.get('sticksCheckout');
     if (!sticksCheckoutStatus) return;
     if (sticksCheckoutStatus === 'success') {
-      toast.success('Thanks! Your blank stick order is being processed.');
+      toast.success('Thanks! Your Bloomjoy branded stick order is being processed.');
     }
     if (sticksCheckoutStatus === 'cancel') {
-      toast.info('Blank sticks checkout canceled.');
+      toast.info('Bloomjoy branded sticks checkout canceled.');
     }
     params.delete('sticksCheckout');
     const nextQuery = params.toString();
@@ -208,7 +208,7 @@ export default function SuppliesPage() {
 
   const handleSubmitBlankSticksRequest = async () => {
     if (!hasStickSize(stickSize)) {
-      toast.error('Select the machine size before submitting a blank sticks request.');
+      toast.error('Select the machine size before submitting a Bloomjoy branded sticks request.');
       return;
     }
     if (!hasBlankAddressType(blankAddressType)) {
@@ -224,7 +224,7 @@ export default function SuppliesPage() {
         email: sticksContactEmail.trim().toLowerCase(),
         sourcePage: '/supplies',
         message: [
-          'Blank Paper Sticks Request',
+          'Bloomjoy Branded Paper Sticks Request',
           `Requested boxes: ${normalizedStickBoxCount}`,
           `Pieces per box: ${STICKS_PIECES_PER_BOX}`,
           `Selected size: ${getStickSizeLabel(stickSize)}`,
@@ -236,7 +236,7 @@ export default function SuppliesPage() {
         ].join('\n'),
       });
       trackEvent('click_buy_sticks', { variant: 'blank_request', boxes: normalizedStickBoxCount });
-      toast.success('Blank sticks request submitted. We will confirm shipping and fulfillment.');
+      toast.success('Bloomjoy branded sticks request submitted. We will confirm shipping and fulfillment.');
       resetStickRequestFields();
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Unable to submit your request.');
@@ -247,7 +247,7 @@ export default function SuppliesPage() {
 
   const handleStartBlankCheckout = async () => {
     if (!hasStickSize(stickSize)) {
-      toast.error('Select the machine size before starting blank sticks checkout.');
+      toast.error('Select the machine size before starting Bloomjoy branded sticks checkout.');
       return;
     }
     if (!hasBlankAddressType(blankAddressType)) {
@@ -264,7 +264,7 @@ export default function SuppliesPage() {
       );
       window.location.assign(checkoutUrl);
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Unable to start blank sticks checkout.');
+      toast.error(error instanceof Error ? error.message : 'Unable to start Bloomjoy branded sticks checkout.');
       setStartingBlankCheckout(false);
     }
   };
@@ -457,8 +457,9 @@ export default function SuppliesPage() {
                   <span className="text-base font-normal text-muted-foreground">/ {STICKS_PIECES_PER_BOX.toLocaleString()}-piece box</span>
                 </p>
                 <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
-                  Choose blank or custom paper sticks for Commercial/Full or Mini machines. Custom
-                  sticks add a ${CUSTOM_STICKS_FIRST_ORDER_PLATE_FEE} first-order plate fee.
+                  Choose Bloomjoy branded or custom paper sticks for Commercial/Full or Mini
+                  machines. Custom sticks add a ${CUSTOM_STICKS_FIRST_ORDER_PLATE_FEE}{' '}
+                  first-order plate fee.
                 </p>
                 <div className="mt-6 space-y-4">
                   <div className="grid grid-cols-2 gap-2 rounded-xl border border-border bg-muted/30 p-2">
@@ -469,7 +470,7 @@ export default function SuppliesPage() {
                         stickVariant === 'plain' ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'
                       }`}
                     >
-                      Blank sticks
+                      Bloomjoy branded
                     </button>
                     <button
                       type="button"
@@ -497,8 +498,8 @@ export default function SuppliesPage() {
                       </div>
                     </div>
                     <p className="mt-3 text-xs text-muted-foreground">
-                      Blank sticks ship at $35/box to business addresses or $40/box to residential
-                      addresses for orders under {BLANK_STICKS_FREE_SHIPPING_BOX_THRESHOLD} boxes.
+                      Bloomjoy branded sticks ship at $35/box to business addresses or $40/box to
+                      residential addresses for orders under {BLANK_STICKS_FREE_SHIPPING_BOX_THRESHOLD} boxes.
                     </p>
                   </div>
                   <div>
@@ -669,10 +670,10 @@ export default function SuppliesPage() {
                       {blankSticksCheckoutEligible
                         ? startingBlankCheckout
                           ? 'Redirecting...'
-                          : 'Checkout Blank Sticks'
+                          : 'Checkout Bloomjoy Branded Sticks'
                         : submittingSticksRequest
                           ? 'Submitting...'
-                          : 'Submit Blank Stick Request'}
+                          : 'Submit Bloomjoy Branded Stick Request'}
                     </Button>
                   ) : (
                     <Button onClick={handleSubmitCustomSticksRequest} className="w-full" disabled={submittingSticksRequest}>
@@ -681,8 +682,8 @@ export default function SuppliesPage() {
                   )}
 
                   <p className="text-sm text-muted-foreground">
-                    Blank sticks checkout starts at {BLANK_STICKS_FREE_SHIPPING_BOX_THRESHOLD} boxes.
-                    The shared cart remains sugar-only.
+                    Bloomjoy branded sticks checkout starts at {BLANK_STICKS_FREE_SHIPPING_BOX_THRESHOLD}{' '}
+                    boxes. The shared cart remains sugar-only.
                   </p>
 
                   {cartSugarTotalKg > 0 && (

--- a/src/pages/admin/Orders.tsx
+++ b/src/pages/admin/Orders.tsx
@@ -550,7 +550,7 @@ export default function AdminOrdersPage() {
                   {selectedBlankSticks ? (
                     <div className="space-y-2">
                       <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                        Blank Sticks Details
+                        Bloomjoy Branded Stick Details
                       </p>
                       <div className="rounded-lg border border-border/70 bg-background/60 p-3 text-sm text-foreground">
                         <p>Boxes: {selectedBlankSticks.boxCount}</p>

--- a/supabase/functions/_shared/customer-order-email.ts
+++ b/supabase/functions/_shared/customer-order-email.ts
@@ -116,7 +116,7 @@ const formatOrderType = (orderType: OrderType) => {
     case "sugar":
       return "Sugar";
     case "blank_sticks":
-      return "Paper sticks";
+      return "Bloomjoy branded paper sticks";
     default:
       return "Order";
   }
@@ -127,7 +127,7 @@ const formatOrderTypeNoun = (orderType: OrderType) => {
     case "sugar":
       return "sugar";
     case "blank_sticks":
-      return "paper sticks";
+      return "branded paper sticks";
     default:
       return "order";
   }
@@ -190,7 +190,7 @@ const formatAddressLines = (address: AddressSnapshot | null | undefined): string
 const buildOrderSpecificRows = (context: CustomerOrderEmailContext): DetailRow[] => {
   if (context.orderType === "blank_sticks") {
     return [
-      ["Product", "Bloomjoy paper sticks"],
+      ["Product", "Bloomjoy branded paper sticks"],
       ["Boxes", String(context.blankSticks?.box_count ?? "n/a")],
       ["Pieces per box", String(context.blankSticks?.pieces_per_box ?? "n/a")],
       ["Stick size", formatStickSize(context.blankSticks?.stick_size)],
@@ -267,7 +267,7 @@ export const buildCustomerOrderEmail = (
 
   const subject =
     context.orderType === "blank_sticks"
-      ? "Your Bloomjoy paper sticks order is confirmed"
+      ? "Your Bloomjoy branded paper sticks order is confirmed"
       : context.orderType === "sugar"
         ? "Your Bloomjoy sugar order is confirmed"
         : "Your Bloomjoy order is confirmed";

--- a/supabase/functions/stripe-sticks-checkout/index.ts
+++ b/supabase/functions/stripe-sticks-checkout/index.ts
@@ -139,7 +139,7 @@ serve(async (req) => {
       },
       metadata: {
         order_type: "blank_sticks",
-        sticks_type: "blank",
+        sticks_type: "bloomjoy_branded",
         stick_size: stickSize,
         sticks_box_count: String(boxCount),
         sticks_pieces_per_box: String(piecesPerBox),

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -229,7 +229,7 @@ const formatOrderType = (orderType: OrderType) => {
     case "sugar":
       return "Sugar";
     case "blank_sticks":
-      return "Blank sticks";
+      return "Bloomjoy branded sticks";
     default:
       return "Unknown";
   }
@@ -434,7 +434,7 @@ const buildInternalOrderEmail = (context: OrderContext) => {
     context.orderType === "blank_sticks"
       ? [
         "",
-        "Blank Sticks Details:",
+        "Bloomjoy Branded Stick Details:",
         `- Boxes: ${context.blankSticks?.box_count ?? "n/a"}`,
         `- Pieces per box: ${context.blankSticks?.pieces_per_box ?? "n/a"}`,
         `- Stick size: ${formatStickSize(context.blankSticks?.stick_size)}`,
@@ -557,7 +557,7 @@ async function upsertOrder(session: Stripe.Checkout.Session): Promise<OrderConte
 
   if (blankSticks.box_count > 0 || blankSticks.pieces_per_box > 0) {
     lineItems.push({
-      description: "Blank sticks order details",
+      description: "Bloomjoy branded sticks order details",
       quantity: blankSticks.box_count || null,
       amount_total: null,
       currency: expanded.currency,


### PR DESCRIPTION
## Summary
- Replaces customer-facing blank/plain sticks copy with Bloomjoy branded sticks copy on the supplies flow.
- Updates stick product metadata, order/admin/email labels, and checkout metadata to reflect Bloomjoy branded sticks while keeping existing internal `blank_sticks` compatibility identifiers.
- Aligns current status, smoke checklist, and production runbook references with the corrected default sticks offering.

## Files changed
- `src/pages/Supplies.tsx`, `src/lib/products.ts`: supplies page and product metadata copy.
- `src/pages/admin/Orders.tsx`, `supabase/functions/_shared/customer-order-email.ts`, `supabase/functions/stripe-sticks-checkout/index.ts`, `supabase/functions/stripe-webhook/index.ts`: order/admin/email/checkout labels and metadata.
- `Docs/CURRENT_STATUS.md`, `Docs/QA_SMOKE_TEST_CHECKLIST.md`, `Docs/PRODUCTION_RUNBOOK.md`: focused doc wording updates for the sticks flow.

## Verification commands + results
- `npm ci` - passed. npm reported 9 audit findings and a deprecated `glob` warning; install completed successfully.
- `npm run build` - passed. Vite build and public/private route prerender completed successfully; Browserslist data is reported as 10 months old.
- `npm test --if-present` - passed; no test script is present.
- `npm run lint --if-present` - passed with 8 existing `react-refresh/only-export-components` warnings in generated/shared UI files.
- Browser check on `http://127.0.0.1:8081/supplies` - passed using local non-secret placeholder Supabase client env values. Page rendered, no error overlay, visible copy includes `Bloomjoy branded`, visible copy no longer includes `Blank sticks`, and `$750 first-order` spacing is correct. Console showed only existing React Router future-flag warnings.

## How to test
1. From this branch/worktree, run `npm ci`.
2. Ensure local client env values are set in `.env.local` or `.env`: `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`.
3. Run `npm run dev`.
4. Open `http://localhost:8080/supplies`.
5. In the Bloomjoy Paper Sticks card, confirm the two options are `Bloomjoy branded` and `Custom sticks`, and no customer-facing copy offers blank sticks.
6. Select the Bloomjoy branded option, choose a machine size and shipping address type, and confirm the request/checkout button uses Bloomjoy branded wording.

## Open PR overlap
- This branch touches files also modified by open PRs, especially `Docs/CURRENT_STATUS.md`, `Docs/PRODUCTION_RUNBOOK.md`, `Docs/QA_SMOKE_TEST_CHECKLIST.md`, and `supabase/functions/stripe-webhook/index.ts` in PR #143. It also overlaps docs touched by PRs #142, #136, #116, and #112. Re-sync from `main` and re-run verification if any of those merge first.