### PR TITLE
Add admin-managed free Plus grants

### DIFF
--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -194,6 +194,14 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Non-admin user cannot access `/admin/accounts`
 - [ ] Super-admin user can access `/admin/accounts`
 - [ ] Admin account search returns rows by email/user ID and shows membership/order/support summary data
+- [ ] Admin account search can find an existing Supabase Auth user by email even if they do not have orders yet
+- [ ] Admin Accounts shows paid subscription status separately from free Plus grant status
+- [ ] Super-admin cannot grant free Plus access without a future expiry date and grant reason
+- [ ] Super-admin cannot grant free Plus access while the account has an active paid Stripe subscription that is not scheduled to cancel
+- [ ] Super-admin can grant or extend free Plus access and the customer can reach Plus-only portal pages without a paid Stripe subscription
+- [ ] Super-admin can revoke free Plus access with a required reason and the customer is blocked from Plus-only portal pages after access is revoked
+- [ ] Free Plus grant, extension, and revoke actions create `admin_audit_log` entries with `entity_type=plus_access_grant`
+- [ ] Grant-only customers see waived Plus access on `/portal/account` and are not offered the Stripe billing portal unless they also have a paid subscription
 - [ ] Admin machine count edits require update reason and persist in `customer_machine_inventory`
 - [ ] Machine count edits create `admin_audit_log` entries with `action=machine_inventory.upserted`
 - [ ] Non-admin user cannot access `/admin/audit`

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -3,13 +3,19 @@ import type { AuthError, User as SupabaseUser } from '@supabase/supabase-js';
 import { supabaseClient } from '@/lib/supabaseClient';
 import { trackEvent, identifyUser } from '@/lib/analytics';
 import { getCanonicalUrlForSurface } from '@/lib/appSurface';
-import { hasPlusAccess, type MembershipStatus } from '@/lib/membership';
+import {
+  emptyPlusAccessSummary,
+  type MembershipStatus,
+  type PlusAccessSummary,
+} from '@/lib/membership';
+import { fetchMyPlusAccess } from '@/lib/plusAccess';
 
 interface User {
   id: string;
   email: string;
   membershipStatus?: MembershipStatus;
   membershipPlan?: string;
+  plusAccess: PlusAccessSummary;
   isAdmin: boolean;
 }
 
@@ -29,12 +35,6 @@ interface AuthContextType {
   isMember: boolean;
   isAdmin: boolean;
 }
-
-type SubscriptionRecord = {
-  status: string;
-  current_period_end: string | null;
-  updated_at: string;
-};
 
 type AdminRoleRecord = {
   role: string;
@@ -65,54 +65,6 @@ const devAdminEmailAllowlist = getDevAdminEmailAllowlist();
 const hasDevAdminEmailOverride = (email: string): boolean =>
   import.meta.env.DEV && devAdminEmailAllowlist.has(email.toLowerCase());
 
-const normalizeMembershipStatus = (status: string | undefined): MembershipStatus => {
-  if (!status) return 'none';
-
-  switch (status) {
-    case 'active':
-    case 'trialing':
-    case 'past_due':
-    case 'canceled':
-    case 'inactive':
-    case 'none':
-      return status;
-    default:
-      return 'none';
-  }
-};
-
-const getMembershipStatus = async (userId: string): Promise<MembershipStatus> => {
-  const { data, error } = await supabaseClient
-    .from('subscriptions')
-    .select('status,current_period_end,updated_at')
-    .eq('user_id', userId)
-    .order('updated_at', { ascending: false });
-
-  if (error || !data || data.length === 0) {
-    return 'none';
-  }
-
-  const records = data as SubscriptionRecord[];
-  const now = Date.now();
-
-  const activeMembership = records.find((subscription) => {
-    const normalizedStatus = normalizeMembershipStatus(subscription.status);
-    const isPlus = normalizedStatus === 'active' || normalizedStatus === 'trialing';
-    const periodEnd =
-      subscription.current_period_end !== null
-        ? new Date(subscription.current_period_end).getTime()
-        : null;
-
-    return isPlus && (periodEnd === null || periodEnd > now);
-  });
-
-  if (activeMembership) {
-    return normalizeMembershipStatus(activeMembership.status);
-  }
-
-  return normalizeMembershipStatus(records[0]?.status);
-};
-
 const getIsAdmin = async (userId: string): Promise<boolean> => {
   const { data, error } = await supabaseClient
     .from('admin_roles')
@@ -130,10 +82,18 @@ const getIsAdmin = async (userId: string): Promise<boolean> => {
   return Boolean((data as AdminRoleRecord | null)?.role);
 };
 
+const getPlusAccess = async (): Promise<PlusAccessSummary> => {
+  try {
+    return await fetchMyPlusAccess();
+  } catch {
+    return emptyPlusAccessSummary;
+  }
+};
+
 const buildAuthUser = async (supabaseUser: SupabaseUser): Promise<User> => {
   const email = supabaseUser.email ?? '';
-  const [membershipStatus, dbIsAdmin] = await Promise.all([
-    getMembershipStatus(supabaseUser.id),
+  const [plusAccess, dbIsAdmin] = await Promise.all([
+    getPlusAccess(),
     getIsAdmin(supabaseUser.id),
   ]);
   const isAdmin = dbIsAdmin || hasDevAdminEmailOverride(email);
@@ -141,8 +101,9 @@ const buildAuthUser = async (supabaseUser: SupabaseUser): Promise<User> => {
   return {
     id: supabaseUser.id,
     email,
-    membershipStatus,
-    membershipPlan: hasPlusAccess(membershipStatus) ? 'Plus Basic' : undefined,
+    membershipStatus: plusAccess.membershipStatus,
+    membershipPlan: plusAccess.hasPlusAccess || isAdmin ? 'Plus Basic' : undefined,
+    plusAccess,
     isAdmin,
   };
 };
@@ -316,7 +277,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         signIn,
         signOut,
         isAuthenticated: !!user,
-        isMember: hasPlusAccess(user?.membershipStatus) || (user?.isAdmin ?? false),
+        isMember: Boolean(user?.plusAccess.hasPlusAccess) || (user?.isAdmin ?? false),
         isAdmin: user?.isAdmin ?? false,
       }}
     >

--- a/src/lib/accountProfile.ts
+++ b/src/lib/accountProfile.ts
@@ -1,5 +1,6 @@
 import { supabaseClient } from '@/lib/supabaseClient';
-import type { MembershipStatus } from '@/lib/membership';
+import type { PlusAccessSummary } from '@/lib/membership';
+import { fetchMyPlusAccess } from '@/lib/plusAccess';
 
 export type CustomerProfileRecord = {
   user_id: string;
@@ -28,54 +29,7 @@ export type PortalAccountProfileInput = {
   shippingCountry: string;
 };
 
-export type PortalMembershipSummary = {
-  status: MembershipStatus;
-  currentPeriodEnd: string | null;
-  cancelAtPeriodEnd: boolean;
-};
-
-type SubscriptionRecord = {
-  status: string;
-  current_period_end: string | null;
-  cancel_at_period_end: boolean;
-  updated_at: string;
-};
-
-const normalizeMembershipStatus = (status: string | undefined): MembershipStatus => {
-  if (!status) return 'none';
-
-  switch (status) {
-    case 'active':
-    case 'trialing':
-    case 'past_due':
-    case 'canceled':
-    case 'inactive':
-    case 'none':
-      return status;
-    default:
-      return 'none';
-  }
-};
-
-const resolveMembershipRecord = (records: SubscriptionRecord[]): SubscriptionRecord | null => {
-  if (!records.length) {
-    return null;
-  }
-
-  const now = Date.now();
-  const active = records.find((record) => {
-    const normalizedStatus = normalizeMembershipStatus(record.status);
-    const periodEnd =
-      record.current_period_end !== null ? new Date(record.current_period_end).getTime() : null;
-
-    return (
-      (normalizedStatus === 'active' || normalizedStatus === 'trialing') &&
-      (periodEnd === null || periodEnd > now)
-    );
-  });
-
-  return active ?? records[0];
-};
+export type PortalMembershipSummary = PlusAccessSummary;
 
 export const fetchPortalAccountProfile = async (
   userId: string
@@ -125,32 +79,7 @@ export const upsertPortalAccountProfile = async (
 };
 
 export const fetchPortalMembershipSummary = async (
-  userId: string
+  _userId: string
 ): Promise<PortalMembershipSummary> => {
-  const { data, error } = await supabaseClient
-    .from('subscriptions')
-    .select('status,current_period_end,cancel_at_period_end,updated_at')
-    .eq('user_id', userId)
-    .order('updated_at', { ascending: false });
-
-  if (error) {
-    throw new Error(error.message || 'Unable to load membership details.');
-  }
-
-  const records = (data as SubscriptionRecord[] | null) ?? [];
-  const selected = resolveMembershipRecord(records);
-
-  if (!selected) {
-    return {
-      status: 'none',
-      currentPeriodEnd: null,
-      cancelAtPeriodEnd: false,
-    };
-  }
-
-  return {
-    status: normalizeMembershipStatus(selected.status),
-    currentPeriodEnd: selected.current_period_end,
-    cancelAtPeriodEnd: selected.cancel_at_period_end,
-  };
+  return fetchMyPlusAccess();
 };

--- a/src/lib/adminAccounts.ts
+++ b/src/lib/adminAccounts.ts
@@ -1,4 +1,5 @@
 import { supabaseClient } from '@/lib/supabaseClient';
+import type { PlusAccessSource } from '@/lib/membership';
 
 export type MachineType = 'commercial' | 'mini' | 'micro';
 
@@ -7,6 +8,14 @@ export type AdminAccountSummary = {
   customer_email: string | null;
   membership_status: string | null;
   current_period_end: string | null;
+  membership_cancel_at_period_end: boolean;
+  paid_subscription_active: boolean;
+  plus_access_source: PlusAccessSource;
+  has_plus_access: boolean;
+  plus_grant_id: string | null;
+  plus_grant_starts_at: string | null;
+  plus_grant_expires_at: string | null;
+  plus_grant_active: boolean;
   total_orders: number;
   last_order_at: string | null;
   open_support_requests: number;
@@ -26,11 +35,36 @@ export type CustomerMachineInventoryRecord = {
   updated_at: string;
 };
 
+export type PlusAccessGrantRecord = {
+  id: string;
+  user_id: string;
+  starts_at: string;
+  expires_at: string;
+  grant_reason: string;
+  granted_by: string | null;
+  revoked_at: string | null;
+  revoked_by: string | null;
+  revoke_reason: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
 type UpsertMachineInventoryInput = {
   customerUserId: string;
   machineType: MachineType;
   quantity: number;
   updatedReason: string;
+};
+
+type GrantPlusAccessInput = {
+  customerUserId: string;
+  expiresAt: string;
+  reason: string;
+};
+
+type RevokePlusAccessInput = {
+  grantId: string;
+  reason: string;
 };
 
 export const fetchAdminAccountSummaries = async (
@@ -81,4 +115,38 @@ export const upsertMachineInventoryAdmin = async ({
   }
 
   return data as CustomerMachineInventoryRecord;
+};
+
+export const grantPlusAccessAdmin = async ({
+  customerUserId,
+  expiresAt,
+  reason,
+}: GrantPlusAccessInput): Promise<PlusAccessGrantRecord> => {
+  const { data, error } = await supabaseClient.rpc('admin_grant_plus_access', {
+    p_customer_user_id: customerUserId,
+    p_expires_at: expiresAt,
+    p_reason: reason,
+  });
+
+  if (error || !data) {
+    throw new Error(error?.message || 'Unable to grant free Plus access.');
+  }
+
+  return data as PlusAccessGrantRecord;
+};
+
+export const revokePlusAccessAdmin = async ({
+  grantId,
+  reason,
+}: RevokePlusAccessInput): Promise<PlusAccessGrantRecord> => {
+  const { data, error } = await supabaseClient.rpc('admin_revoke_plus_access', {
+    p_grant_id: grantId,
+    p_reason: reason,
+  });
+
+  if (error || !data) {
+    throw new Error(error?.message || 'Unable to revoke free Plus access.');
+  }
+
+  return data as PlusAccessGrantRecord;
 };

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -38,6 +38,8 @@ type EventName =
   | 'admin_support_request_updated'
   | 'admin_order_fulfillment_updated'
   | 'admin_machine_inventory_updated'
+  | 'admin_plus_access_granted'
+  | 'admin_plus_access_revoked'
   | 'admin_role_granted'
   | 'admin_role_revoked';
 

--- a/src/lib/membership.ts
+++ b/src/lib/membership.ts
@@ -6,6 +6,62 @@ export type MembershipStatus =
   | 'inactive'
   | 'none';
 
+export type PlusAccessSource = 'paid_subscription' | 'free_grant' | 'admin' | 'none';
+
+export type PlusAccessSummary = {
+  hasPlusAccess: boolean;
+  source: PlusAccessSource;
+  membershipStatus: MembershipStatus;
+  currentPeriodEnd: string | null;
+  cancelAtPeriodEnd: boolean;
+  paidSubscriptionActive: boolean;
+  freeGrantId: string | null;
+  freeGrantStartsAt: string | null;
+  freeGrantExpiresAt: string | null;
+  freeGrantActive: boolean;
+};
+
 // Keep membership checks aligned with subscriptions table policy logic.
 export const hasPlusAccess = (status: MembershipStatus | undefined): boolean =>
   status === 'active' || status === 'trialing';
+
+export const normalizeMembershipStatus = (status: string | undefined): MembershipStatus => {
+  if (!status) return 'none';
+
+  switch (status) {
+    case 'active':
+    case 'trialing':
+    case 'past_due':
+    case 'canceled':
+    case 'inactive':
+    case 'none':
+      return status;
+    default:
+      return 'none';
+  }
+};
+
+export const normalizePlusAccessSource = (source: string | undefined): PlusAccessSource => {
+  switch (source) {
+    case 'paid_subscription':
+    case 'free_grant':
+    case 'admin':
+    case 'none':
+      return source;
+    default:
+      return 'none';
+  }
+};
+
+export const emptyPlusAccessSummary: PlusAccessSummary = {
+  hasPlusAccess: false,
+  source: 'none',
+  membershipStatus: 'none',
+  currentPeriodEnd: null,
+  cancelAtPeriodEnd: false,
+  paidSubscriptionActive: false,
+  freeGrantId: null,
+  freeGrantStartsAt: null,
+  freeGrantExpiresAt: null,
+  freeGrantActive: false,
+};

--- a/src/lib/plusAccess.ts
+++ b/src/lib/plusAccess.ts
@@ -1,0 +1,53 @@
+import { supabaseClient } from '@/lib/supabaseClient';
+import {
+  emptyPlusAccessSummary,
+  normalizeMembershipStatus,
+  normalizePlusAccessSource,
+  type PlusAccessSummary,
+} from '@/lib/membership';
+
+type PlusAccessRpcRecord = {
+  has_plus_access: boolean | null;
+  source: string | null;
+  membership_status: string | null;
+  current_period_end: string | null;
+  cancel_at_period_end: boolean | null;
+  paid_subscription_active: boolean | null;
+  free_grant_id: string | null;
+  free_grant_starts_at: string | null;
+  free_grant_expires_at: string | null;
+  free_grant_active: boolean | null;
+};
+
+const mapPlusAccessRecord = (record: PlusAccessRpcRecord | null): PlusAccessSummary => {
+  if (!record) {
+    return emptyPlusAccessSummary;
+  }
+
+  return {
+    hasPlusAccess: Boolean(record.has_plus_access),
+    source: normalizePlusAccessSource(record.source ?? undefined),
+    membershipStatus: normalizeMembershipStatus(record.membership_status ?? undefined),
+    currentPeriodEnd: record.current_period_end,
+    cancelAtPeriodEnd: Boolean(record.cancel_at_period_end),
+    paidSubscriptionActive: Boolean(record.paid_subscription_active),
+    freeGrantId: record.free_grant_id,
+    freeGrantStartsAt: record.free_grant_starts_at,
+    freeGrantExpiresAt: record.free_grant_expires_at,
+    freeGrantActive: Boolean(record.free_grant_active),
+  };
+};
+
+export const fetchMyPlusAccess = async (): Promise<PlusAccessSummary> => {
+  const { data, error } = await supabaseClient.rpc('get_my_plus_access');
+
+  if (error) {
+    throw new Error(error.message || 'Unable to load Plus access.');
+  }
+
+  const record = Array.isArray(data)
+    ? ((data as PlusAccessRpcRecord[])[0] ?? null)
+    : ((data as PlusAccessRpcRecord | null) ?? null);
+
+  return mapPlusAccessRecord(record);
+};

--- a/src/pages/admin/Accounts.tsx
+++ b/src/pages/admin/Accounts.tsx
@@ -7,6 +7,8 @@ import { Input } from '@/components/ui/input';
 import {
   fetchAdminAccountSummaries,
   fetchMachineInventoryForAccount,
+  grantPlusAccessAdmin,
+  revokePlusAccessAdmin,
   type AdminAccountSummary,
   type MachineType,
   upsertMachineInventoryAdmin,
@@ -26,9 +28,41 @@ const emptyQuantities: Record<MachineType, number> = {
   micro: 0,
 };
 
+const freePlusExpiryPresets = [
+  { label: '30 days', days: 30 },
+  { label: '90 days', days: 90 },
+  { label: '180 days', days: 180 },
+  { label: '1 year', days: 365 },
+];
+
+const formatDateInput = (date: Date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+};
+
+const getPresetExpiryDate = (days: number) => {
+  const date = new Date();
+  date.setDate(date.getDate() + days);
+  return formatDateInput(date);
+};
+
+const parseExpiryDateEndOfDay = (value: string): Date | null => {
+  const [year, month, day] = value.split('-').map((part) => Number(part));
+
+  if (!year || !month || !day) {
+    return null;
+  }
+
+  const date = new Date(year, month - 1, day, 23, 59, 59, 999);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
 const formatDate = (value: string | null) => {
   if (!value) {
-    return '—';
+    return 'n/a';
   }
 
   return new Date(value).toLocaleString(undefined, {
@@ -48,8 +82,33 @@ const formatMembership = (status: string | null) => {
   return status;
 };
 
+const formatAccessSource = (account: AdminAccountSummary) => {
+  switch (account.plus_access_source) {
+    case 'paid_subscription':
+      return 'Paid Plus';
+    case 'free_grant':
+      return 'Free Plus grant';
+    case 'admin':
+      return 'Super-admin override';
+    default:
+      return 'No Plus access';
+  }
+};
+
+const formatFreeGrant = (account: AdminAccountSummary) => {
+  if (!account.plus_grant_id) {
+    return 'none';
+  }
+
+  const expiry = formatDate(account.plus_grant_expires_at);
+  return account.plus_grant_active ? `active until ${expiry}` : `expired ${expiry}`;
+};
+
 const getPrimarySortDate = (account: AdminAccountSummary) =>
-  account.last_order_at ?? account.last_machine_update_at ?? account.current_period_end;
+  account.last_order_at ??
+  account.last_machine_update_at ??
+  account.plus_grant_expires_at ??
+  account.current_period_end;
 
 export default function AdminAccountsPage() {
   const queryClient = useQueryClient();
@@ -58,6 +117,11 @@ export default function AdminAccountsPage() {
   const [quantities, setQuantities] = useState<Record<MachineType, number>>(emptyQuantities);
   const [updateReason, setUpdateReason] = useState('');
   const [isSaving, setIsSaving] = useState(false);
+  const [grantExpiryDate, setGrantExpiryDate] = useState(() => getPresetExpiryDate(90));
+  const [grantReason, setGrantReason] = useState('');
+  const [revokeReason, setRevokeReason] = useState('');
+  const [isGrantSaving, setIsGrantSaving] = useState(false);
+  const [isRevokingGrant, setIsRevokingGrant] = useState(false);
 
   const {
     data: accounts = [],
@@ -82,6 +146,15 @@ export default function AdminAccountsPage() {
   }, [accounts, selectedUserId]);
 
   const selectedAccount = accounts.find((account) => account.user_id === selectedUserId) ?? null;
+  const paidSubscriptionBlocksGrant = Boolean(
+    selectedAccount?.paid_subscription_active && !selectedAccount.membership_cancel_at_period_end
+  );
+
+  useEffect(() => {
+    setGrantExpiryDate(getPresetExpiryDate(90));
+    setGrantReason('');
+    setRevokeReason('');
+  }, [selectedUserId]);
 
   const {
     data: machineInventory = [],
@@ -165,6 +238,88 @@ export default function AdminAccountsPage() {
       toast.error(message);
     } finally {
       setIsSaving(false);
+    }
+  };
+
+  const setGrantExpiryPreset = (days: number) => {
+    setGrantExpiryDate(getPresetExpiryDate(days));
+  };
+
+  const savePlusGrant = async () => {
+    if (!selectedAccount) {
+      return;
+    }
+
+    if (paidSubscriptionBlocksGrant) {
+      toast.error('Cancel or schedule cancellation for the paid Stripe subscription first.');
+      return;
+    }
+
+    if (!grantReason.trim()) {
+      toast.error('Grant reason is required.');
+      return;
+    }
+
+    const expiry = parseExpiryDateEndOfDay(grantExpiryDate);
+    if (!expiry || expiry <= new Date()) {
+      toast.error('Grant expiry must be a future date.');
+      return;
+    }
+
+    setIsGrantSaving(true);
+    try {
+      await grantPlusAccessAdmin({
+        customerUserId: selectedAccount.user_id,
+        expiresAt: expiry.toISOString(),
+        reason: grantReason.trim(),
+      });
+
+      trackEvent('admin_plus_access_granted', {
+        user_id: selectedAccount.user_id,
+        expires_at: expiry.toISOString(),
+      });
+      toast.success(selectedAccount.plus_grant_id ? 'Free Plus access updated.' : 'Free Plus access granted.');
+      setGrantReason('');
+      await refreshAccounts();
+    } catch (grantError) {
+      const message =
+        grantError instanceof Error ? grantError.message : 'Unable to grant free Plus access.';
+      toast.error(message);
+    } finally {
+      setIsGrantSaving(false);
+    }
+  };
+
+  const revokePlusGrant = async () => {
+    if (!selectedAccount?.plus_grant_id) {
+      return;
+    }
+
+    if (!revokeReason.trim()) {
+      toast.error('Revoke reason is required.');
+      return;
+    }
+
+    setIsRevokingGrant(true);
+    try {
+      await revokePlusAccessAdmin({
+        grantId: selectedAccount.plus_grant_id,
+        reason: revokeReason.trim(),
+      });
+
+      trackEvent('admin_plus_access_revoked', {
+        user_id: selectedAccount.user_id,
+        grant_id: selectedAccount.plus_grant_id,
+      });
+      toast.success('Free Plus access revoked.');
+      setRevokeReason('');
+      await refreshAccounts();
+    } catch (revokeError) {
+      const message =
+        revokeError instanceof Error ? revokeError.message : 'Unable to revoke free Plus access.';
+      toast.error(message);
+    } finally {
+      setIsRevokingGrant(false);
     }
   };
 
@@ -259,7 +414,13 @@ export default function AdminAccountsPage() {
                           <div className="mt-1 text-xs text-muted-foreground">{account.user_id}</div>
                         </td>
                         <td className="px-4 py-3 text-sm text-foreground">
-                          {formatMembership(account.membership_status)}
+                          <div>Paid: {formatMembership(account.membership_status)}</div>
+                          <div className="mt-1 text-xs text-muted-foreground">
+                            Free: {formatFreeGrant(account)}
+                          </div>
+                          <div className="mt-1 text-xs text-muted-foreground">
+                            Access: {formatAccessSource(account)}
+                          </div>
                         </td>
                         <td className="px-4 py-3 text-sm text-foreground">{account.total_orders}</td>
                         <td className="px-4 py-3 text-sm text-foreground">
@@ -289,26 +450,148 @@ export default function AdminAccountsPage() {
                   </div>
 
                   <div className="rounded-md border border-border bg-muted/20 p-3 text-sm">
-                    <div className="flex items-center justify-between">
-                      <span className="text-muted-foreground">Membership</span>
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="text-muted-foreground">Paid subscription</span>
                       <span className="font-medium text-foreground">
                         {formatMembership(selectedAccount.membership_status)}
                       </span>
                     </div>
-                    <div className="mt-1 flex items-center justify-between">
-                      <span className="text-muted-foreground">Next period end</span>
+                    <div className="mt-1 flex items-center justify-between gap-3">
+                      <span className="text-muted-foreground">Paid period end</span>
                       <span className="text-foreground">
                         {formatDate(selectedAccount.current_period_end)}
                       </span>
                     </div>
-                    <div className="mt-1 flex items-center justify-between">
-                      <span className="text-muted-foreground">Last order</span>
-                      <span className="text-foreground">{formatDate(selectedAccount.last_order_at)}</span>
+                    {selectedAccount.paid_subscription_active && (
+                      <div className="mt-1 flex items-center justify-between gap-3">
+                        <span className="text-muted-foreground">Paid cancellation</span>
+                        <span className="text-foreground">
+                          {selectedAccount.membership_cancel_at_period_end
+                            ? 'Scheduled'
+                            : 'Not scheduled'}
+                        </span>
+                      </div>
+                    )}
+                    <div className="mt-1 flex items-center justify-between gap-3">
+                      <span className="text-muted-foreground">Free Plus grant</span>
+                      <span className="text-foreground">{formatFreeGrant(selectedAccount)}</span>
                     </div>
-                    <div className="mt-1 flex items-center justify-between">
-                      <span className="text-muted-foreground">Open support</span>
-                      <span className="text-foreground">{selectedAccount.open_support_requests}</span>
+                    <div className="mt-1 flex items-center justify-between gap-3">
+                      <span className="text-muted-foreground">Effective access</span>
+                      <span className="font-medium text-foreground">
+                        {formatAccessSource(selectedAccount)}
+                      </span>
                     </div>
+                    <div className="mt-3 border-t border-border/70 pt-3">
+                      <div className="flex items-center justify-between gap-3">
+                        <span className="text-muted-foreground">Last order</span>
+                        <span className="text-foreground">
+                          {formatDate(selectedAccount.last_order_at)}
+                        </span>
+                      </div>
+                      <div className="mt-1 flex items-center justify-between gap-3">
+                        <span className="text-muted-foreground">Open support</span>
+                        <span className="text-foreground">
+                          {selectedAccount.open_support_requests}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="rounded-md border border-border bg-background p-3">
+                    <h3 className="text-sm font-semibold text-foreground">Free Plus access</h3>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Grants unlock Plus-only portal access without creating or changing a Stripe
+                      subscription.
+                    </p>
+
+                    {paidSubscriptionBlocksGrant && (
+                      <div className="mt-3 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+                        This account has an active paid Stripe subscription. Cancel it or schedule
+                        cancellation before granting free access.
+                      </div>
+                    )}
+
+                    <div className="mt-4 flex flex-wrap gap-2">
+                      {freePlusExpiryPresets.map((preset) => (
+                        <Button
+                          key={preset.days}
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() => setGrantExpiryPreset(preset.days)}
+                        >
+                          {preset.label}
+                        </Button>
+                      ))}
+                    </div>
+
+                    <div className="mt-3">
+                      <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        Grant expiry
+                      </label>
+                      <Input
+                        type="date"
+                        value={grantExpiryDate}
+                        onChange={(event) => setGrantExpiryDate(event.target.value)}
+                      />
+                    </div>
+
+                    <div className="mt-3">
+                      <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        Grant reason
+                      </label>
+                      <Input
+                        value={grantReason}
+                        onChange={(event) => setGrantReason(event.target.value)}
+                        placeholder="Required reason for waiving the Plus fee"
+                      />
+                    </div>
+
+                    <Button
+                      className="mt-3"
+                      onClick={savePlusGrant}
+                      disabled={isGrantSaving || paidSubscriptionBlocksGrant}
+                    >
+                      {isGrantSaving ? (
+                        <>
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          Saving...
+                        </>
+                      ) : selectedAccount.plus_grant_id ? (
+                        'Extend Free Plus'
+                      ) : (
+                        'Grant Free Plus'
+                      )}
+                    </Button>
+
+                    {selectedAccount.plus_grant_id && (
+                      <div className="mt-4 border-t border-border/70 pt-3">
+                        <label className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                          Revoke reason
+                        </label>
+                        <Input
+                          value={revokeReason}
+                          onChange={(event) => setRevokeReason(event.target.value)}
+                          placeholder="Required reason for revoking the grant"
+                        />
+                        <Button
+                          className="mt-3"
+                          variant="outline"
+                          onClick={revokePlusGrant}
+                          disabled={isRevokingGrant}
+                        >
+                          {isRevokingGrant ? (
+                            <>
+                              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                              Revoking...
+                            </>
+                          ) : (
+                            'Revoke Free Plus'
+                          )}
+                        </Button>
+                      </div>
+                    )}
                   </div>
 
                   {inventoryError && (

--- a/src/pages/portal/Account.tsx
+++ b/src/pages/portal/Account.tsx
@@ -116,18 +116,47 @@ export default function AccountPage() {
     );
   }, [location.pathname, location.search, navigate, refetchMembershipSummary]);
 
-  const effectiveMembershipStatus = membershipSummary?.status ?? user?.membershipStatus ?? 'none';
-  const isMember = hasPlusAccess(effectiveMembershipStatus);
+  const effectiveMembershipStatus =
+    membershipSummary?.membershipStatus ?? user?.membershipStatus ?? 'none';
+  const hasSummaryPlusAccess =
+    membershipSummary?.hasPlusAccess ?? user?.plusAccess.hasPlusAccess ?? false;
+  const isMember = hasSummaryPlusAccess || hasPlusAccess(effectiveMembershipStatus);
+  const hasPaidBilling =
+    membershipSummary?.paidSubscriptionActive ??
+    user?.plusAccess.paidSubscriptionActive ??
+    hasPlusAccess(effectiveMembershipStatus);
+  const accessSource = membershipSummary?.source ?? user?.plusAccess.source ?? 'none';
+  const currentPeriodEnd =
+    membershipSummary?.currentPeriodEnd ?? user?.plusAccess.currentPeriodEnd ?? null;
+  const cancelAtPeriodEnd =
+    membershipSummary?.cancelAtPeriodEnd ?? user?.plusAccess.cancelAtPeriodEnd ?? false;
+  const freeGrantExpiresAt =
+    membershipSummary?.freeGrantExpiresAt ?? user?.plusAccess.freeGrantExpiresAt ?? null;
+  const freeGrantExpiryLabel = freeGrantExpiresAt
+    ? new Date(freeGrantExpiresAt).toLocaleDateString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      })
+    : null;
   const membershipStatusLabel = useMemo(() => {
+    if (accessSource === 'free_grant' && freeGrantExpiryLabel) {
+      return `Waived until ${freeGrantExpiryLabel}`;
+    }
+
+    if (accessSource === 'admin') {
+      return 'Admin access';
+    }
+
     if (effectiveMembershipStatus === 'none') {
       return 'Upgrade available';
     }
 
     return formatMembershipStatus(effectiveMembershipStatus);
-  }, [effectiveMembershipStatus]);
+  }, [accessSource, effectiveMembershipStatus, freeGrantExpiryLabel]);
   const nextBillingLabel =
-    isMember && membershipSummary?.currentPeriodEnd
-      ? new Date(membershipSummary.currentPeriodEnd).toLocaleDateString(undefined, {
+    hasPaidBilling && currentPeriodEnd
+      ? new Date(currentPeriodEnd).toLocaleDateString(undefined, {
           year: 'numeric',
           month: 'short',
           day: 'numeric',
@@ -195,21 +224,28 @@ export default function AccountPage() {
                 : []),
             ]}
             actions={
-              isMember ? (
+              hasPaidBilling ? (
                 <Button
                   variant="outline"
                   onClick={handleManageBilling}
                   disabled={isOpeningPortal || isMembershipLoading}
                 >
-                  {isOpeningPortal ? 'Opening billing…' : 'Manage Billing'}
+                  {isOpeningPortal ? 'Opening billing...' : 'Manage Billing'}
                 </Button>
-              ) : (
+              ) : !isMember ? (
                 <Button asChild variant="outline">
                   <Link to="/plus">View Plus Membership</Link>
                 </Button>
-              )
+              ) : undefined
             }
           />
+
+          {accessSource === 'free_grant' && freeGrantExpiryLabel && (
+            <div className="mt-4 rounded-md border border-primary/20 bg-primary/5 px-4 py-3 text-sm text-primary">
+              Plus access is waived through {freeGrantExpiryLabel}. No subscription fee is being
+              billed for this grant.
+            </div>
+          )}
 
           <div className="mt-6 grid gap-6 lg:grid-cols-3 lg:gap-8">
             {/* Profile */}
@@ -362,19 +398,27 @@ export default function AccountPage() {
                   <h2 className="font-display text-lg font-semibold text-foreground">Billing</h2>
                 </div>
                 <p className="mt-4 text-sm text-muted-foreground">
-                  {isMember
+                  {hasPaidBilling
                     ? 'Manage your payment methods, invoices, and cancellations through the Stripe customer portal.'
-                    : 'Upgrade to Plus to unlock premium training, onboarding, and concierge support.'}
+                    : isMember
+                      ? 'Your current Plus access is waived by Bloomjoy. No Stripe billing action is needed for this grant.'
+                      : 'Upgrade to Plus to unlock premium training, onboarding, and concierge support.'}
                 </p>
-                <Button
-                  variant="outline"
-                  className="mt-4 w-full"
-                  onClick={handleManageBilling}
-                  disabled={isOpeningPortal || !user?.email || !isMember || isMembershipLoading}
-                >
-                  <ExternalLink className="mr-2 h-4 w-4" />
-                  {isMember ? (isOpeningPortal ? 'Opening...' : 'Open Billing Portal') : 'Plus Required'}
-                </Button>
+                {hasPaidBilling ? (
+                  <Button
+                    variant="outline"
+                    className="mt-4 w-full"
+                    onClick={handleManageBilling}
+                    disabled={isOpeningPortal || !user?.email || isMembershipLoading}
+                  >
+                    <ExternalLink className="mr-2 h-4 w-4" />
+                    {isOpeningPortal ? 'Opening...' : 'Open Billing Portal'}
+                  </Button>
+                ) : !isMember ? (
+                  <Button asChild variant="outline" className="mt-4 w-full">
+                    <Link to="/plus">View Plus Membership</Link>
+                  </Button>
+                ) : null}
                 <p className="mt-3 text-xs text-muted-foreground">
                   Review{' '}
                   <Link to="/billing-cancellation" className="underline hover:text-foreground">
@@ -406,13 +450,17 @@ export default function AccountPage() {
                 </div>
                 {isMember && (
                   <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
-                    <span className="text-sm text-muted-foreground">Next billing</span>
+                    <span className="text-sm text-muted-foreground">
+                      {hasPaidBilling ? 'Next billing' : 'Waived until'}
+                    </span>
                     <span className="text-sm text-foreground">
-                      {nextBillingLabel ?? 'Not available'}
+                      {hasPaidBilling
+                        ? nextBillingLabel ?? 'Not available'
+                        : freeGrantExpiryLabel ?? 'Not available'}
                     </span>
                   </div>
                 )}
-                {membershipSummary?.cancelAtPeriodEnd && (
+                {cancelAtPeriodEnd && hasPaidBilling && (
                   <div className="mt-3 rounded-md border border-amber/30 bg-amber/10 px-3 py-2 text-xs text-amber">
                     Subscription is set to cancel at the end of the current billing period.
                   </div>

--- a/supabase/migrations/202604140001_plus_access_grants.sql
+++ b/supabase/migrations/202604140001_plus_access_grants.sql
@@ -1,0 +1,570 @@
+-- Free Bloomjoy Plus access grants managed by super admins.
+
+create table if not exists public.plus_access_grants (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users (id) on delete cascade,
+  starts_at timestamptz not null default now(),
+  expires_at timestamptz not null,
+  grant_reason text not null check (length(trim(grant_reason)) > 0),
+  granted_by uuid references auth.users (id) on delete set null,
+  revoked_at timestamptz,
+  revoked_by uuid references auth.users (id) on delete set null,
+  revoke_reason text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint plus_access_grants_valid_window check (expires_at > starts_at),
+  constraint plus_access_grants_revoke_reason_required check (
+    revoked_at is null
+    or length(trim(coalesce(revoke_reason, ''))) > 0
+  )
+);
+
+create unique index if not exists plus_access_grants_one_open_per_user_idx
+  on public.plus_access_grants (user_id)
+  where revoked_at is null;
+
+create index if not exists plus_access_grants_user_id_idx
+  on public.plus_access_grants (user_id);
+
+create index if not exists plus_access_grants_open_expiry_idx
+  on public.plus_access_grants (user_id, expires_at)
+  where revoked_at is null;
+
+drop trigger if exists plus_access_grants_set_updated_at on public.plus_access_grants;
+
+create trigger plus_access_grants_set_updated_at
+before update on public.plus_access_grants
+for each row execute function public.set_updated_at();
+
+alter table public.plus_access_grants enable row level security;
+
+drop policy if exists "plus_access_grants_select_super_admin" on public.plus_access_grants;
+
+create policy "plus_access_grants_select_super_admin"
+on public.plus_access_grants
+for select
+using ((select public.is_super_admin(auth.uid())));
+
+create or replace function public.has_active_plus_grant(uid uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.plus_access_grants g
+    where g.user_id = uid
+      and g.revoked_at is null
+      and g.starts_at <= now()
+      and g.expires_at > now()
+  );
+$$;
+
+create or replace function public.has_plus_access(uid uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select
+    exists (
+      select 1
+      from public.subscriptions s
+      where s.user_id = uid
+        and s.status in ('active', 'trialing')
+        and (s.current_period_end is null or s.current_period_end > now())
+    )
+    or public.has_active_plus_grant(uid);
+$$;
+
+create or replace function public.can_access_members_only_training()
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, auth
+as $$
+  select public.has_plus_access(auth.uid())
+    or public.is_super_admin(auth.uid());
+$$;
+
+revoke execute on function public.has_active_plus_grant(uuid) from public;
+revoke execute on function public.has_plus_access(uuid) from public;
+grant execute on function public.can_access_members_only_training() to authenticated;
+
+drop function if exists public.get_my_plus_access();
+
+create or replace function public.get_my_plus_access()
+returns table (
+  has_plus_access boolean,
+  source text,
+  membership_status text,
+  current_period_end timestamptz,
+  cancel_at_period_end boolean,
+  paid_subscription_active boolean,
+  free_grant_id uuid,
+  free_grant_starts_at timestamptz,
+  free_grant_expires_at timestamptz,
+  free_grant_active boolean
+)
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  current_user_id uuid;
+begin
+  current_user_id := auth.uid();
+
+  if current_user_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  return query
+  with subscription_candidates as (
+    select
+      s.status,
+      s.current_period_end,
+      s.cancel_at_period_end,
+      s.updated_at,
+      (
+        s.status in ('active', 'trialing')
+        and (s.current_period_end is null or s.current_period_end > now())
+      ) as is_active
+    from public.subscriptions s
+    where s.user_id = current_user_id
+  ),
+  selected_subscription as (
+    select *
+    from subscription_candidates sc
+    order by sc.is_active desc, sc.updated_at desc
+    limit 1
+  ),
+  selected_grant as (
+    select
+      g.id,
+      g.starts_at,
+      g.expires_at,
+      (
+        g.revoked_at is null
+        and g.starts_at <= now()
+        and g.expires_at > now()
+      ) as is_active
+    from public.plus_access_grants g
+    where g.user_id = current_user_id
+      and g.revoked_at is null
+    order by g.updated_at desc
+    limit 1
+  ),
+  resolved as (
+    select
+      coalesce(ss.is_active, false) as paid_active,
+      coalesce(sg.is_active, false) as grant_active,
+      public.is_super_admin(current_user_id) as admin_active,
+      ss.status,
+      ss.current_period_end,
+      ss.cancel_at_period_end,
+      sg.id as grant_id,
+      sg.starts_at as grant_starts_at,
+      sg.expires_at as grant_expires_at
+    from (select 1) anchor
+    left join selected_subscription ss on true
+    left join selected_grant sg on true
+  )
+  select
+    (r.paid_active or r.grant_active or r.admin_active) as has_plus_access,
+    case
+      when r.paid_active then 'paid_subscription'
+      when r.grant_active then 'free_grant'
+      when r.admin_active then 'admin'
+      else 'none'
+    end as source,
+    coalesce(r.status, 'none') as membership_status,
+    r.current_period_end,
+    coalesce(r.cancel_at_period_end, false) as cancel_at_period_end,
+    r.paid_active as paid_subscription_active,
+    r.grant_id as free_grant_id,
+    r.grant_starts_at as free_grant_starts_at,
+    r.grant_expires_at as free_grant_expires_at,
+    r.grant_active as free_grant_active
+  from resolved r;
+end;
+$$;
+
+grant execute on function public.get_my_plus_access() to authenticated;
+
+drop function if exists public.admin_grant_plus_access(uuid, timestamptz, text);
+
+create or replace function public.admin_grant_plus_access(
+  p_customer_user_id uuid,
+  p_expires_at timestamptz,
+  p_reason text
+)
+returns public.plus_access_grants
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  before_row public.plus_access_grants;
+  after_row public.plus_access_grants;
+  normalized_reason text;
+  action_name text;
+begin
+  if not public.is_super_admin(auth.uid()) then
+    raise exception 'Admin access required';
+  end if;
+
+  normalized_reason := trim(coalesce(p_reason, ''));
+
+  if p_customer_user_id is null then
+    raise exception 'Customer user ID is required';
+  end if;
+
+  if not exists (
+    select 1
+    from auth.users u
+    where u.id = p_customer_user_id
+  ) then
+    raise exception 'No user found for target account';
+  end if;
+
+  if normalized_reason = '' then
+    raise exception 'Grant reason is required';
+  end if;
+
+  if p_expires_at is null or p_expires_at <= now() then
+    raise exception 'Grant expiry must be in the future';
+  end if;
+
+  if exists (
+    select 1
+    from public.subscriptions s
+    where s.user_id = p_customer_user_id
+      and s.status in ('active', 'trialing')
+      and (s.current_period_end is null or s.current_period_end > now())
+      and s.cancel_at_period_end = false
+  ) then
+    raise exception 'Cancel or schedule cancellation for the paid Stripe subscription before granting free Plus access';
+  end if;
+
+  select *
+  into before_row
+  from public.plus_access_grants g
+  where g.user_id = p_customer_user_id
+    and g.revoked_at is null
+  limit 1;
+
+  if before_row.id is null then
+    insert into public.plus_access_grants (
+      user_id,
+      starts_at,
+      expires_at,
+      grant_reason,
+      granted_by
+    )
+    values (
+      p_customer_user_id,
+      now(),
+      p_expires_at,
+      normalized_reason,
+      auth.uid()
+    )
+    returning * into after_row;
+
+    action_name := 'plus_access.granted';
+  else
+    update public.plus_access_grants
+    set
+      expires_at = p_expires_at,
+      grant_reason = normalized_reason,
+      granted_by = auth.uid()
+    where id = before_row.id
+    returning * into after_row;
+
+    action_name := 'plus_access.extended';
+  end if;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    target_user_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    auth.uid(),
+    action_name,
+    'plus_access_grant',
+    after_row.id::text,
+    after_row.user_id,
+    coalesce(to_jsonb(before_row), '{}'::jsonb),
+    to_jsonb(after_row),
+    jsonb_build_object(
+      'reason',
+      normalized_reason,
+      'expires_at',
+      p_expires_at
+    )
+  );
+
+  return after_row;
+end;
+$$;
+
+grant execute on function public.admin_grant_plus_access(uuid, timestamptz, text) to authenticated;
+
+drop function if exists public.admin_revoke_plus_access(uuid, text);
+
+create or replace function public.admin_revoke_plus_access(
+  p_grant_id uuid,
+  p_reason text
+)
+returns public.plus_access_grants
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  before_row public.plus_access_grants;
+  after_row public.plus_access_grants;
+  normalized_reason text;
+begin
+  if not public.is_super_admin(auth.uid()) then
+    raise exception 'Admin access required';
+  end if;
+
+  normalized_reason := trim(coalesce(p_reason, ''));
+
+  if p_grant_id is null then
+    raise exception 'Grant ID is required';
+  end if;
+
+  if normalized_reason = '' then
+    raise exception 'Revoke reason is required';
+  end if;
+
+  select *
+  into before_row
+  from public.plus_access_grants g
+  where g.id = p_grant_id
+    and g.revoked_at is null
+  limit 1;
+
+  if before_row.id is null then
+    raise exception 'No active or open Plus grant found';
+  end if;
+
+  update public.plus_access_grants
+  set
+    revoked_at = now(),
+    revoked_by = auth.uid(),
+    revoke_reason = normalized_reason
+  where id = before_row.id
+  returning * into after_row;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    target_user_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    auth.uid(),
+    'plus_access.revoked',
+    'plus_access_grant',
+    after_row.id::text,
+    after_row.user_id,
+    to_jsonb(before_row),
+    to_jsonb(after_row),
+    jsonb_build_object('reason', normalized_reason)
+  );
+
+  return after_row;
+end;
+$$;
+
+grant execute on function public.admin_revoke_plus_access(uuid, text) to authenticated;
+
+drop function if exists public.admin_get_account_summaries(text);
+
+create or replace function public.admin_get_account_summaries(
+  p_search text default null
+)
+returns table (
+  user_id uuid,
+  customer_email text,
+  membership_status text,
+  current_period_end timestamptz,
+  total_orders bigint,
+  last_order_at timestamptz,
+  open_support_requests bigint,
+  total_machine_count bigint,
+  last_machine_update_at timestamptz,
+  membership_cancel_at_period_end boolean,
+  paid_subscription_active boolean,
+  plus_access_source text,
+  has_plus_access boolean,
+  plus_grant_id uuid,
+  plus_grant_starts_at timestamptz,
+  plus_grant_expires_at timestamptz,
+  plus_grant_active boolean
+)
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  normalized_search text;
+begin
+  if not public.is_super_admin(auth.uid()) then
+    raise exception 'Admin access required';
+  end if;
+
+  normalized_search := nullif(trim(lower(coalesce(p_search, ''))), '');
+
+  return query
+  with membership_candidates as (
+    select
+      s.user_id,
+      s.status,
+      s.current_period_end,
+      s.cancel_at_period_end,
+      s.updated_at,
+      (
+        s.status in ('active', 'trialing')
+        and (s.current_period_end is null or s.current_period_end > now())
+      ) as paid_subscription_active
+    from public.subscriptions s
+  ),
+  membership as (
+    select distinct on (mc.user_id)
+      mc.user_id,
+      mc.status,
+      mc.current_period_end,
+      mc.cancel_at_period_end,
+      mc.updated_at,
+      mc.paid_subscription_active
+    from membership_candidates mc
+    order by mc.user_id, mc.paid_subscription_active desc, mc.updated_at desc
+  ),
+  grant_rollup as (
+    select
+      g.user_id,
+      g.id,
+      g.starts_at,
+      g.expires_at,
+      g.updated_at,
+      (
+        g.revoked_at is null
+        and g.starts_at <= now()
+        and g.expires_at > now()
+      ) as grant_active
+    from public.plus_access_grants g
+    where g.revoked_at is null
+  ),
+  order_rollup as (
+    select
+      o.user_id,
+      max(o.customer_email) filter (where o.customer_email is not null) as customer_email,
+      count(*) as total_orders,
+      max(o.created_at) as last_order_at
+    from public.orders o
+    where o.user_id is not null
+    group by o.user_id
+  ),
+  support_rollup as (
+    select
+      s.customer_user_id as user_id,
+      max(s.customer_email) as customer_email,
+      count(*) filter (where s.status not in ('resolved', 'closed')) as open_support_requests
+    from public.support_requests s
+    group by s.customer_user_id
+  ),
+  machine_rollup as (
+    select
+      m.customer_user_id as user_id,
+      sum(m.quantity)::bigint as total_machine_count,
+      max(m.updated_at) as last_machine_update_at
+    from public.customer_machine_inventory m
+    group by m.customer_user_id
+  ),
+  auth_match as (
+    select
+      u.id as user_id,
+      u.email as customer_email
+    from auth.users u
+    where normalized_search is not null
+      and (
+        u.id::text like '%' || normalized_search || '%'
+        or lower(coalesce(u.email, '')) like '%' || normalized_search || '%'
+      )
+  ),
+  all_users as (
+    select m.user_id from membership m
+    union
+    select g.user_id from grant_rollup g
+    union
+    select o.user_id from order_rollup o
+    union
+    select s.user_id from support_rollup s
+    union
+    select m.user_id from machine_rollup m
+    union
+    select a.user_id from auth_match a
+  )
+  select
+    au.user_id,
+    coalesce(auth_user.email, am.customer_email, sr.customer_email, orr.customer_email) as customer_email,
+    mb.status as membership_status,
+    mb.current_period_end,
+    coalesce(orr.total_orders, 0)::bigint as total_orders,
+    orr.last_order_at,
+    coalesce(sr.open_support_requests, 0)::bigint as open_support_requests,
+    coalesce(mr.total_machine_count, 0)::bigint as total_machine_count,
+    mr.last_machine_update_at,
+    coalesce(mb.cancel_at_period_end, false) as membership_cancel_at_period_end,
+    coalesce(mb.paid_subscription_active, false) as paid_subscription_active,
+    case
+      when coalesce(mb.paid_subscription_active, false) then 'paid_subscription'
+      when coalesce(grant_rollup.grant_active, false) then 'free_grant'
+      when public.is_super_admin(au.user_id) then 'admin'
+      else 'none'
+    end as plus_access_source,
+    (
+      coalesce(mb.paid_subscription_active, false)
+      or coalesce(grant_rollup.grant_active, false)
+      or public.is_super_admin(au.user_id)
+    ) as has_plus_access,
+    grant_rollup.id as plus_grant_id,
+    grant_rollup.starts_at as plus_grant_starts_at,
+    grant_rollup.expires_at as plus_grant_expires_at,
+    coalesce(grant_rollup.grant_active, false) as plus_grant_active
+  from all_users au
+  left join membership mb on mb.user_id = au.user_id
+  left join grant_rollup on grant_rollup.user_id = au.user_id
+  left join order_rollup orr on orr.user_id = au.user_id
+  left join support_rollup sr on sr.user_id = au.user_id
+  left join machine_rollup mr on mr.user_id = au.user_id
+  left join auth_match am on am.user_id = au.user_id
+  left join auth.users auth_user on auth_user.id = au.user_id
+  where (
+    normalized_search is null
+    or au.user_id::text like '%' || normalized_search || '%'
+    or lower(coalesce(auth_user.email, am.customer_email, sr.customer_email, orr.customer_email, '')) like '%' || normalized_search || '%'
+  )
+  order by coalesce(orr.last_order_at, mr.last_machine_update_at, grant_rollup.updated_at, mb.updated_at) desc nulls last;
+end;
+$$;
+
+grant execute on function public.admin_get_account_summaries(text) to authenticated;


### PR DESCRIPTION
## Summary
- Adds admin-managed free Bloomjoy Plus grants as a separate entitlement from paid Stripe subscriptions.
- Wires effective Plus access through paid subscription, free grant, or super-admin override without changing Stripe checkout/webhook behavior.
- Adds Admin Accounts grant/extend/revoke controls and portal account messaging for waived Plus access.

## Files changed
- Supabase migration for `plus_access_grants`, access helper RPCs, grant/revoke RPCs, and expanded admin account summaries.
- Frontend access helpers plus AuthContext, Portal Account, and Admin Accounts updates.
- QA smoke checklist additions for free Plus grant flows.

## Verification commands + results
- `npm ci` - passed; npm reported existing audit findings (`4 moderate`, `5 high`).
- `npm run build` - passed; prerender completed for public/private routes.
- `npm test --if-present` - passed; no test script is present.
- `npm run lint --if-present` - passed with existing fast-refresh warnings in shadcn/generated UI files and `AuthContext.tsx`.

Additional check:
- `git diff --check` - passed.
- `npx tsc -p tsconfig.app.json --noEmit` - failed on existing project-wide issues outside this slice (`replaceAll` with ES2020 libs, existing analytics event names, and training item typing).
- `npm run auth:preflight` - could not pass in the new worktree because no local `.env` is present there (`VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` missing).

## How to test
1. Check out this branch in its worktree: `C:\Repos\wt-plus-free-grants`.
2. Ensure `.env` or `.env.local` includes `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`.
3. Apply the migration `supabase/migrations/202604140001_plus_access_grants.sql` to the target Supabase database.
4. Run `npm ci` and `npm run dev`.
5. Open `http://localhost:8080/admin/accounts` as a super-admin.
6. Search for an existing Supabase Auth user by email, grant free Plus access with a future expiry and reason, and confirm the account row shows free grant access separately from paid subscription status.
7. Sign in as the grant-only customer and confirm `/portal/training`, `/portal/onboarding`, and `/portal/support` are accessible, while `/portal/account` says Plus access is waived and does not offer Stripe billing portal actions.
8. Return to `/admin/accounts`, revoke the grant with a reason, and confirm the customer is blocked from Plus-only portal pages again.
9. Open `/admin/audit` and confirm grant/extend/revoke actions appear with `entity_type=plus_access_grant`.

No test credentials are included in this PR; use the local super-admin and customer accounts configured for the target Supabase environment.