### PR TITLE
Simplify Plus pricing to flat monthly

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ STRIPE_SUGAR_PRICE_ID=
 STRIPE_SUGAR_MEMBER_PRICE_ID=
 STRIPE_SUGAR_NON_MEMBER_PRICE_ID=
 STRIPE_STICKS_PRICE_ID=
-# Stripe recurring unit price for Plus (set to $100/month per machine)
+# Stripe recurring monthly price for Plus (set to $100/month)
 STRIPE_PLUS_PRICE_ID=
 SUPABASE_URL=
 SUPABASE_ANON_KEY=

--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -217,7 +217,7 @@ Execution order is based on launch risk and dependency overlap.
 13) Replace placeholder public-site imagery with real Bloomjoy assets (machines, supplies, and about page visuals)
 
 ## Recently completed (post-P0)
-- Plus pricing model by machine count (`$100 per machine/month`) with Stripe quantity-based checkout
+- Plus pricing model simplified to flat account pricing (`$100/month`) with Stripe checkout quantity fixed at `1`
 - Supplies UX improvement: typed bulk quantity input for paper stick box ordering
 - Public-site asset refresh: real machine/supplies/about photography, improved model image coverage, and homepage machine card visuals
 - Machine detail UX upgrade: per-model image galleries with selectable thumbnails

--- a/Docs/DECISIONS.md
+++ b/Docs/DECISIONS.md
@@ -116,18 +116,18 @@ We will use a **dedicated `subscriptions` table** synced from Stripe webhooks as
 - Use RLS policies that allow training data when the subscription status is `active` or `trialing`.
 - Optional: keep a denormalized `profiles.is_member` flag as a cache, but derive it from `subscriptions` only.
 
-## 2026-02-21 — Plus pricing model by machine count (MVP)
-We will price Bloomjoy Plus at **$100 per machine per month** using Stripe subscription quantity.
+## 2026-04-14 — Plus flat account pricing (supersedes 2026-02-21)
+We will price Bloomjoy Plus at **$100 per month per customer account**.
 
 **Pricing model**
-- Single recurring Stripe price (`STRIPE_PLUS_PRICE_ID`) set to $100/month per unit
-- Checkout quantity = selected machine count
-- Monthly charge = `machine_count * $100`
+- Single recurring Stripe price (`STRIPE_PLUS_PRICE_ID`) set to $100/month
+- Checkout quantity is always `1`
+- Monthly charge is a flat `$100`
 
 **MVP scope choice**
-- Machine count is self-declared at checkout (user selects count in UI)
 - Keep webhook and `subscriptions` schema unchanged for membership gating compatibility
-- Use quantity-based subscriptions now; revisit account-linked inventory pricing after MVP
+- Machine inventory stays in the admin portal for operational context only
+- Existing live subscriptions with quantity greater than `1` will be adjusted manually in Stripe by the billing owner
 
 ## 2026-02-23 - Super-admin MVP role model and operations choices (`#37`)
 For MVP admin operations, we will use a single internal role and keep workflow complexity minimal.

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -156,9 +156,9 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Bloomjoy branded sticks checkout completed webhook sends internal order summary email with box count, machine size, address type, and shipping total
 - [ ] Bloomjoy branded sticks checkout sends customer confirmation email with branded HTML layout, shipping address, and receipt link
 - [ ] Bloomjoy branded sticks checkout completed webhook sends a WeCom internal alert with order ID, customer, and stick-order summary
-- [ ] Plus subscription checkout computes expected monthly amount from selected machine count (e.g., 1x=$100, 3x=$300) and completes with test card
+- [ ] Plus subscription checkout shows flat `$100/month` account pricing and completes with test card
 - [ ] Logged-out users on `/plus` are redirected to login before checkout can begin
-- [ ] Stripe subscription from Plus checkout contains `metadata.user_id` and `metadata.machine_count`
+- [ ] Stripe subscription from Plus checkout contains `metadata.user_id` and `metadata.billing_model=flat_monthly`
 - [ ] Customer Portal link opens (test mode)
 - [ ] Account page Manage Billing opens Stripe portal (test mode)
 - [ ] In Stripe test customer portal, cancel Plus subscription and return to `/portal/account?billing=return`

--- a/scripts/prerender-public-routes.mjs
+++ b/scripts/prerender-public-routes.mjs
@@ -65,7 +65,7 @@ const publicRoutes = [
     path: "/plus",
     title: "Bloomjoy Plus | Membership",
     description:
-      "View Bloomjoy Plus membership benefits, support boundaries, and per-machine monthly pricing.",
+      "View Bloomjoy Plus membership benefits, support boundaries, and flat monthly pricing.",
     ogType: "website",
   },
   {

--- a/src/components/seo/RouteSeoManager.tsx
+++ b/src/components/seo/RouteSeoManager.tsx
@@ -92,7 +92,7 @@ const routeSeoRules: Array<{ match: (pathname: string) => boolean; seo: RouteSeo
     seo: {
       title: "Bloomjoy Plus | Membership",
       description:
-        "View Bloomjoy Plus membership benefits, support boundaries, and per-machine monthly pricing.",
+        "View Bloomjoy Plus membership benefits, support boundaries, and flat monthly pricing.",
       robots: PUBLIC_ROBOTS,
       surface: "marketing",
     },

--- a/src/lib/stripeCheckout.ts
+++ b/src/lib/stripeCheckout.ts
@@ -13,14 +13,10 @@ interface BlankSticksCheckoutInput {
   addressType: BlankSticksAddressType;
 }
 
-export async function startPlusCheckout(
-  origin: string,
-  machineCount: number
-) {
+export async function startPlusCheckout(origin: string) {
   const data = await invokeEdgeFunction<CheckoutResponse>(
     'stripe-plus-checkout',
     {
-      machineCount,
       successUrl: `${origin}/plus?checkout=success`,
       cancelUrl: `${origin}/plus?checkout=cancel`,
     },

--- a/src/pages/BillingCancellation.tsx
+++ b/src/pages/BillingCancellation.tsx
@@ -25,7 +25,7 @@ export default function BillingCancellationPage() {
                 Subscription billing
               </h2>
               <p className="text-muted-foreground">
-                Bloomjoy Plus Basic is billed monthly based on machine count at checkout. Charges
+                Bloomjoy Plus Basic is billed at a flat monthly account price. Charges
                 recur automatically each billing cycle unless canceled.
               </p>
             </section>

--- a/src/pages/Plus.tsx
+++ b/src/pages/Plus.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { Check, ArrowRight, Minus, Plus } from 'lucide-react';
+import { Check, ArrowRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Layout } from '@/components/layout/Layout';
 import { trackEvent } from '@/lib/analytics';
 import { startPlusCheckout } from '@/lib/stripeCheckout';
@@ -28,19 +27,12 @@ const benefits = [
   },
 ];
 
-const PRICE_PER_MACHINE_MONTHLY = 100;
-const MIN_MACHINE_COUNT = 1;
-const MAX_MACHINE_COUNT = 25;
-
-const clampMachineCount = (value: number) =>
-  Math.min(MAX_MACHINE_COUNT, Math.max(MIN_MACHINE_COUNT, Math.floor(value)));
+const PLUS_MONTHLY_PRICE = 100;
 
 export default function PlusPage() {
   const { user } = useAuth();
   const navigate = useNavigate();
   const [isStartingCheckout, setIsStartingCheckout] = useState(false);
-  const [machineCount, setMachineCount] = useState(MIN_MACHINE_COUNT);
-  const monthlyTotal = machineCount * PRICE_PER_MACHINE_MONTHLY;
 
   useEffect(() => {
     trackEvent('view_plus_pricing');
@@ -70,26 +62,19 @@ export default function PlusPage() {
     }
 
     trackEvent('start_plus_checkout', {
-      machine_count: machineCount,
-      monthly_total: monthlyTotal,
+      billing_model: 'flat_monthly',
+      monthly_total: PLUS_MONTHLY_PRICE,
       user_id: user.id,
     });
     try {
       setIsStartingCheckout(true);
-      const checkoutUrl = await startPlusCheckout(window.location.origin, machineCount);
+      const checkoutUrl = await startPlusCheckout(window.location.origin);
       window.location.assign(checkoutUrl);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unable to start checkout.';
       toast.error(message);
       setIsStartingCheckout(false);
     }
-  };
-
-  const updateMachineCount = (nextValue: number) => {
-    if (!Number.isFinite(nextValue)) {
-      return;
-    }
-    setMachineCount(clampMachineCount(nextValue));
   };
 
   return (
@@ -120,55 +105,20 @@ export default function PlusPage() {
                 <h2 className="font-display text-2xl font-bold">Plus Basic</h2>
                 <div className="mt-4 flex items-baseline justify-center gap-1">
                   <span className="font-display text-5xl font-bold">$100</span>
-                  <span className="text-muted">/machine/month</span>
+                  <span className="text-muted">/month</span>
                 </div>
                 <p className="mt-2 text-sm text-muted">
-                  Monthly total updates by machine count. Cancel anytime.
+                  Flat monthly membership for your Bloomjoy account. Cancel anytime.
                 </p>
               </div>
               <div className="p-8">
                 <div className="rounded-xl border border-border bg-muted/30 p-4">
                   <p className="text-sm font-semibold text-foreground">
-                    How many machines should Plus cover?
+                    One simple account price
                   </p>
-                  <div className="mt-3 flex items-center gap-3">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      onClick={() => updateMachineCount(machineCount - 1)}
-                      disabled={machineCount <= MIN_MACHINE_COUNT || isStartingCheckout}
-                      aria-label="Decrease machine count"
-                    >
-                      <Minus className="h-4 w-4" />
-                    </Button>
-                    <Input
-                      type="number"
-                      min={MIN_MACHINE_COUNT}
-                      max={MAX_MACHINE_COUNT}
-                      value={machineCount}
-                      onChange={(event) => updateMachineCount(Number(event.target.value))}
-                      className="h-10 w-24 text-center"
-                    />
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="icon"
-                      onClick={() => updateMachineCount(machineCount + 1)}
-                      disabled={machineCount >= MAX_MACHINE_COUNT || isStartingCheckout}
-                      aria-label="Increase machine count"
-                    >
-                      <Plus className="h-4 w-4" />
-                    </Button>
-                    <p className="text-sm text-muted-foreground">
-                      <span className="font-semibold text-foreground">
-                        ${monthlyTotal}/month
-                      </span>{' '}
-                      for {machineCount} machine{machineCount === 1 ? '' : 's'}
-                    </p>
-                  </div>
-                  <p className="mt-2 text-xs text-muted-foreground">
-                    Minimum {MIN_MACHINE_COUNT} machine, maximum {MAX_MACHINE_COUNT}.
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    Plus is billed at <span className="font-semibold text-foreground">$100/month</span>{' '}
+                    for the customer account, separate from the number of machines tracked for operations.
                   </p>
                 </div>
                 <ul className="mt-8 space-y-4">

--- a/supabase/functions/stripe-plus-checkout/index.ts
+++ b/supabase/functions/stripe-plus-checkout/index.ts
@@ -12,8 +12,6 @@ const stripeSecretKey = Deno.env.get("STRIPE_SECRET_KEY");
 const plusPriceId = Deno.env.get("STRIPE_PLUS_PRICE_ID");
 const supabaseUrl = Deno.env.get("SUPABASE_URL");
 const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY");
-const MIN_MACHINE_COUNT = 1;
-const MAX_MACHINE_COUNT = 25;
 
 if (!stripeSecretKey) {
   console.error("Missing STRIPE_SECRET_KEY");
@@ -108,7 +106,6 @@ serve(async (req) => {
     const body = await req.json();
     const successUrl = body?.successUrl;
     const cancelUrl = body?.cancelUrl;
-    const machineCount = Number(body?.machineCount);
 
     if (!successUrl || !cancelUrl) {
       return new Response(
@@ -120,35 +117,21 @@ serve(async (req) => {
       );
     }
 
-    if (
-      !Number.isInteger(machineCount) ||
-      machineCount < MIN_MACHINE_COUNT ||
-      machineCount > MAX_MACHINE_COUNT
-    ) {
-      return new Response(
-        JSON.stringify({ error: `Machine count must be between ${MIN_MACHINE_COUNT} and ${MAX_MACHINE_COUNT}.` }),
-        {
-          status: 400,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        }
-      );
-    }
-
     const session = await stripe.checkout.sessions.create({
       mode: "subscription",
-      line_items: [{ price: plusPriceId, quantity: machineCount }],
+      line_items: [{ price: plusPriceId, quantity: 1 }],
       success_url: successUrl,
       cancel_url: cancelUrl,
       customer_email: authResult.user.email ?? undefined,
       client_reference_id: authResult.user.id,
       allow_promotion_codes: true,
       metadata: {
-        machine_count: String(machineCount),
+        billing_model: "flat_monthly",
         user_id: authResult.user.id,
       },
       subscription_data: {
         metadata: {
-          machine_count: String(machineCount),
+          billing_model: "flat_monthly",
           user_id: authResult.user.id,
         },
       },


### PR DESCRIPTION
## Summary
- Simplifies Bloomjoy Plus from per-machine billing to flat `$100/month` account pricing.
- Removes the machine-count selector from `/plus` and sends Plus checkout without `machineCount`.
- Creates Plus Checkout Sessions with `quantity: 1` and `metadata.billing_model=flat_monthly` while preserving `metadata.user_id`.

## Files changed
- Public Plus and billing copy: `/plus`, billing/cancellation copy, route SEO, prerender metadata.
- Stripe checkout path: client checkout helper and `stripe-plus-checkout` Supabase Edge Function.
- Project docs/config: `.env.example`, `Docs/DECISIONS.md`, `Docs/CURRENT_STATUS.md`, and `Docs/QA_SMOKE_TEST_CHECKLIST.md`.

## Verification commands + results
- `npm ci` - pass. Completed after stopping the local Vite server that was holding `esbuild.exe`; npm reported existing dependency audit/deprecation warnings.
- `npm run build` - pass. Vite build completed and prerendered 13 public routes and 15 private routes.
- `npm test --if-present` - pass. No test script is configured, so npm exited successfully without running tests.
- `npm run lint --if-present` - pass with 8 existing `react-refresh/only-export-components` warnings in shared UI/Auth files.
- `npm run seo:check` - pass. SEO regression checks validated 13 public routes and 15 private routes.

Additional checks:
- `npm run commerce:preflight` - blocked in this worktree because local server-only secrets/env vars are not present (`STRIPE_PLUS_PRICE_ID`, Supabase keys, Resend, WeCom, sugar/sticks price IDs). No secrets were copied into the worktree.
- Browser smoke on `http://127.0.0.1:8087/plus` with non-secret placeholder Vite env values - pass. `/plus` rendered `$100/month`, no machine-count selector, no Vite overlay, 0 console errors, and the logged-out CTA routed to `/login`. The only browser warnings were existing React Router v7 future-flag warnings.

## How to test
1. Check out this branch in its worktree or locally: `agent/flat-plus-pricing`.
2. Create local env values from `.env.example`; at minimum set `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` for the SPA. Do not copy server secrets into `VITE_` vars.
3. Run `npm ci` and `npm run dev`.
4. Open `http://localhost:8080/plus` and confirm Plus Basic shows flat `$100/month` account pricing with no machine-count selector.
5. While logged out, click `Log In to Start Membership` and confirm it routes to `http://localhost:8080/login`.
6. With local Supabase Edge Functions and Stripe test secrets configured, log in and start Plus checkout. Confirm the Stripe Checkout subscription line item uses quantity `1`, and the resulting subscription metadata includes `user_id` and `billing_model=flat_monthly`.
7. Check `http://localhost:8080/billing-cancellation` for flat monthly billing copy and `http://localhost:8080/portal/account` for the existing Manage Billing portal flow.