### PR TITLE
Document access model roadmap

### DIFF
--- a/Docs/BACKLOG.md
+++ b/Docs/BACKLOG.md
@@ -93,3 +93,9 @@ Guidelines:
    - Define referral-buddy onboarding runbook and response-time SLA.
    - Validate 1-week WeCom delivery reliability for quote/order/support alerts.
    - Capture sign-off evidence for onboarding intake + non-blocking alert failure behavior.
+
+28. **Consolidate scalable account roles and entitlement model** (`#150`)
+   - Define the durable model for identity, customer accounts/orgs, account membership roles, product entitlements, and internal staff roles.
+   - Add one canonical server-backed access context for route guards, RLS helpers, pricing decisions, support intake, and admin pages.
+   - Reconcile current free Plus grants, proposed training-only operator grants, and stale partner/operator invite work before adding more access paths.
+   - Dependency: keep changes incremental and preserve existing Plus/admin behavior while migrating callers onto the shared access context.

--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -49,6 +49,13 @@
   - re-run the live `$0` order smoke test and confirm `wecom_alert_sent_at` populates in `public.orders`
 - Unblock and complete issue `#99` (dedicated Resend account for `bloomjoysweets.com`) so production auth and transactional email ownership can move off the currently blocked setup.
 
+## Access model roadmap (2026-04-14)
+- Current `main` supports Supabase identity, paid Plus subscription access, DB-driven `super_admin`, and admin-managed free Plus grants.
+- Training-only operator access is proposed in PR `#148` so Plus members can grant training access without granting the full paid Plus bundle.
+- Long-term consolidation of customer-account roles and product entitlements is tracked in issue `#150`.
+- Until issue `#150` lands, avoid adding more one-off access tables or route checks without tying them back to the future account membership + entitlement model.
+- PR `#136` should be reconciled against issue `#150` before merge because it overlaps partner/operator invite semantics.
+
 ## Operator app surface split (2026-03-22)
 - Authenticated operator routes now have a dedicated application shell and canonical host instead of inheriting the public sales navbar/footer.
 - Canonical host roles for this slice:

--- a/Docs/DECISIONS.md
+++ b/Docs/DECISIONS.md
@@ -1,5 +1,28 @@
 # Decisions
 
+## 2026-04-14 - Access model consolidation roadmap
+The current MVP access model is acceptable short term, but it should not grow through more unrelated role/grant checks.
+
+**Current access sources**
+- Supabase Auth user identity
+- Paid Plus subscription access from `subscriptions`
+- Internal `super_admin` access from `admin_roles`
+- Admin-managed free Plus grants from `plus_access_grants`
+- Proposed training-only operator grants from PR `#148`
+
+**Target model**
+- Identity: Supabase Auth user
+- Customer account/org: the business, location, franchisee, or fleet that owns machines and billing context
+- Account membership role: `owner`, `account_admin`, `billing_manager`, `operator`, or `support_contact`
+- Product entitlement: explicit access such as `training`, `plus_portal`, `member_sugar_pricing`, `concierge_support`, `billing_portal`, or `admin_console`
+- Internal staff role: scoped Bloomjoy operations roles such as `support_agent`, `orders_ops`, `training_admin`, `billing_ops`, and existing `super_admin`
+
+**Implementation direction**
+- Track this as issue `#150`.
+- Add a canonical server-backed access-context layer before adding another major portal/admin access path.
+- Keep training-only operator access incremental, but treat it as a product entitlement rather than a paid Plus membership.
+- Reconcile stale partner/operator invite work against this model before merge.
+
 ## 2026-04-06 - Emergency commerce remediation: Plus-only sugar pricing, durable order capture, and customer confirmations
 For sugar ordering, Bloomjoy Plus members receive the discounted rate and all other buyers pay the public rate.
 


### PR DESCRIPTION
## Summary
- Documents the scalable account roles + entitlement roadmap in `Docs/DECISIONS.md`.
- Adds current-status guidance that ties PRs `#136`/`#148` and issue `#150` together.
- Adds the future consolidation task to the P2 backlog.

## Files changed
- `Docs/CURRENT_STATUS.md` - adds the 2026-04-14 access model roadmap note.
- `Docs/DECISIONS.md` - records the target model for identity, customer accounts, account roles, product entitlements, and internal staff roles.
- `Docs/BACKLOG.md` - tracks issue `#150` as the P2 implementation follow-up.

## Verification commands + results
- `npm ci` - passed; npm reports existing 9 audit findings (4 moderate, 5 high).
- `npm run build` - passed.
- `npm test --if-present` - passed; no test script output.
- `npm run lint --if-present` - passed with existing fast-refresh warnings only.
- `git diff --check` - passed.

## How to test
1. From `C:\Repos\wt-access-model-roadmap`, run `npm ci`.
2. Run `npm run dev`.
3. Open the local URL printed by Vite, usually `http://localhost:8080`.
4. Review the docs pages in the branch, especially `Docs/CURRENT_STATUS.md`, `Docs/DECISIONS.md`, and `Docs/BACKLOG.md`.

No test credentials are required because this PR changes documentation only.

Closes #150? No. This PR creates the roadmap/docs trail; issue `#150` remains open for implementation.