### PR TITLE
Simplify supplies ordering UX

### DIFF
--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -13,6 +13,12 @@
   - Home and `/machines` now present Mini as available now instead of coming soon
   - historical `mini_waitlist_submissions` data remains for ops reference only
 
+## Supplies ordering UX simplification (2026-04-14)
+- `/supplies` now guides visitors into one ordering path at a time instead of showing sugar, branded sticks, and custom sticks workflows all at once.
+- The page supports direct links for `/supplies?order=sugar`, `/supplies?order=sticks`, and `/supplies?order=custom`.
+- Sugar still uses the 400 KG default equal split, with color-level adjustments tucked behind a "Customize Color Mix" control.
+- Bloomjoy branded sticks keep the existing under-5-box confirmation path and 5+ box direct checkout path, while custom sticks now have their own focused request flow.
+
 ## Emergency commerce remediation snapshot (2026-04-06)
 - A production payments incident was confirmed on `2026-04-06`:
   - sugar checkout was publicly charging the Bloomjoy Plus member rate (`$8/kg`) instead of the public rate (`$10/kg`)

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -35,18 +35,20 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Mini page shows live-availability copy, `$4,000`, and no Mini waitlist form or waitlist success/error state
 - [ ] Mini page CTA opens `/contact?type=quote&interest=mini&source=/machines/mini`
 - [ ] Micro machine page shows the updated target/list price (`$2,200`)
-- [ ] `/supplies` sugar and sticks product cards render professional white-background product shots without black background artifacts or awkward clipping on desktop and mobile
-- [ ] Sugar page supports one-click equal split across white/blue/orange/red and allows custom per-color override
-- [ ] Sugar page quick presets show `240 KG`, `400 KG`, and `800 KG`, with `400 KG` as the default target
-- [ ] Sugar page shows public pricing at `$10/kg` for signed-out or non-Plus users
-- [ ] Sugar page shows Bloomjoy Plus pricing at `$8/kg` only for users whose `subscriptions.status` is `active` or `trialing`
-- [ ] Sugar page handles high-volume setup (e.g., 500KG+) without repetitive click controls
-- [ ] Sticks ordering on `/supplies` allows direct typed quantity input (not only +/- controls)
+- [ ] `/supplies` product images render professional white-background product shots without black background artifacts or awkward clipping on desktop and mobile
+- [ ] `/supplies` defaults to Sugar ordering; `/supplies?order=sugar`, `/supplies?order=sticks`, and `/supplies?order=custom` direct-load with the matching selected flow
+- [ ] Supplies order chooser switches between Sugar, Bloomjoy Branded Sticks, and Custom Sticks without showing every order flow at once
+- [ ] Sugar flow supports one-click equal split across white/blue/orange/red and allows custom per-color override behind the "Customize Color Mix" control
+- [ ] Sugar flow quick presets show `240 KG`, `400 KG`, and `800 KG`, with `400 KG` as the default target
+- [ ] Sugar flow shows public pricing at `$10/kg` for signed-out or non-Plus users
+- [ ] Sugar flow shows Bloomjoy Plus pricing at `$8/kg` only for users whose `subscriptions.status` is `active` or `trialing`
+- [ ] Sugar flow handles high-volume setup (e.g., 500KG+) without repetitive click controls
+- [ ] Sticks ordering on `/supplies?order=sticks` allows direct typed quantity input (not only +/- controls)
 - [ ] Sticks ordering clearly supports Bloomjoy branded paper sticks and custom paper sticks at `$130/box` with `2000 pieces/box`
-- [ ] Bloomjoy branded sticks flow requires machine size selection and shipping address type selection before request/checkout
+- [ ] Bloomjoy branded sticks flow requires machine size selection and delivery location type selection before request/checkout
 - [ ] Bloomjoy branded sticks orders under 5 boxes submit a procurement lead with box count, size, address type, and estimated shipping summary
 - [ ] Bloomjoy branded sticks orders of 5+ boxes launch direct Stripe checkout with free shipping and do not use the shared cart
-- [ ] Custom sticks flow accepts logo/image upload and submits a procurement lead with artwork URL, requested box count, selected size, and `$750` first-order plate-fee note
+- [ ] Custom sticks flow on `/supplies?order=custom` accepts logo/image upload and submits a procurement lead with artwork URL, requested box count, selected size, and `$750` first-order plate-fee note
 - [ ] Shared cart remains sugar-only and legacy stick items do not block checkout
 - [ ] Plus page: pricing and boundaries are visible and clear
 - [ ] Resources page shows Bloomjoy Plus teaser content for locked downloads (procedure docs, daily checklists, frequent updates)

--- a/src/pages/Supplies.tsx
+++ b/src/pages/Supplies.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type ChangeEvent } from 'react';
-import { Link } from 'react-router-dom';
-import { ArrowRight, ShoppingCart, Upload } from 'lucide-react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { ArrowRight, ChevronDown, ShoppingCart, Upload } from 'lucide-react';
 import { toast } from 'sonner';
 import { Layout } from '@/components/layout/Layout';
 import { Button } from '@/components/ui/button';
@@ -10,6 +10,7 @@ import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Textarea } from '@/components/ui/textarea';
 import sugarProduct from '@/assets/real/sugar-product.jpg';
 import sticksProduct from '@/assets/real/sticks-product.jpg';
+import { useAuth } from '@/contexts/AuthContext';
 import { trackEvent } from '@/lib/analytics';
 import { useCart } from '@/lib/cart';
 import {
@@ -19,9 +20,8 @@ import {
   validateCustomSticksArtwork,
 } from '@/lib/customSticksArtwork';
 import { createLeadSubmission } from '@/lib/leadSubmissions';
-import { startBlankSticksCheckout } from '@/lib/stripeCheckout';
-import { useAuth } from '@/contexts/AuthContext';
 import { hasPlusAccess } from '@/lib/membership';
+import { startBlankSticksCheckout } from '@/lib/stripeCheckout';
 import {
   BLANK_STICKS_ADDRESS_TYPE_OPTIONS,
   BLANK_STICKS_FREE_SHIPPING_BOX_THRESHOLD,
@@ -31,7 +31,6 @@ import {
   STICK_SIZE_OPTIONS,
   type BlankSticksAddressType,
   type StickSize,
-  type StickVariant,
   formatBlankSticksShippingSummary,
   getBlankSticksAddressTypeLabel,
   getBlankSticksShippingRatePerBox,
@@ -47,35 +46,91 @@ import {
   NON_MEMBER_SUGAR_PRICE_PER_KG,
   PLUS_MEMBER_SUGAR_PRICE_PER_KG,
   SUGAR_COLOR_OPTIONS,
-  getSugarPricePerKg,
   type SugarMix,
   type SugarSku,
   buildEqualSugarSplit,
   createEmptySugarMix,
   getSugarColorBreakdown,
   getSugarMixTotalKg,
+  getSugarPricePerKg,
   updateSugarMixQuantity,
 } from '@/lib/sugar';
+import { cn } from '@/lib/utils';
 
 const getSugarName = (color: string, flavor: string) =>
   `Premium Cotton Candy Sugar - ${color} (${flavor}) (1KG)`;
 
 type SelectedStickSize = StickSize | '';
 type SelectedBlankAddressType = BlankSticksAddressType | '';
+type SupplyOrderMode = 'sugar' | 'sticks' | 'custom';
+
+const SUPPLY_ORDER_MODES: SupplyOrderMode[] = ['sugar', 'sticks', 'custom'];
 
 const hasStickSize = (value: SelectedStickSize): value is StickSize => value !== '';
 const hasBlankAddressType = (
   value: SelectedBlankAddressType
 ): value is BlankSticksAddressType => value !== '';
 
+const isSupplyOrderMode = (value: string | null): value is SupplyOrderMode =>
+  !!value && SUPPLY_ORDER_MODES.includes(value as SupplyOrderMode);
+
+const resolveSupplyOrderMode = (value: string | null): SupplyOrderMode =>
+  isSupplyOrderMode(value) ? value : 'sugar';
+
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  currency: 'USD',
+  maximumFractionDigits: 0,
+  style: 'currency',
+});
+
+const numberFormatter = new Intl.NumberFormat('en-US');
+
+const formatCurrency = (value: number): string => currencyFormatter.format(value);
+const formatNumber = (value: number): string => numberFormatter.format(value);
+
+const orderOptions: Array<{
+  value: SupplyOrderMode;
+  title: string;
+  eyebrow: string;
+  summary: string;
+  image: string;
+  imageAlt: string;
+}> = [
+  {
+    value: 'sugar',
+    title: 'Sugar',
+    eyebrow: 'Cart checkout',
+    summary: 'Start from a 400 KG equal split and adjust only if needed.',
+    image: sugarProduct,
+    imageAlt: 'Premium Cotton Candy Sugar bags',
+  },
+  {
+    value: 'sticks',
+    title: 'Bloomjoy Branded Sticks',
+    eyebrow: 'Checkout or confirmation',
+    summary: 'Order standard branded sticks by machine size and box count.',
+    image: sticksProduct,
+    imageAlt: 'Bloomjoy branded cotton candy sticks',
+  },
+  {
+    value: 'custom',
+    title: 'Custom Sticks',
+    eyebrow: 'Proofing request',
+    summary: 'Upload artwork and Bloomjoy will confirm proofing and timing.',
+    image: sticksProduct,
+    imageAlt: 'Custom cotton candy sticks artwork reference',
+  },
+];
+
 export default function SuppliesPage() {
   const { user, loading: isAuthLoading } = useAuth();
   const { addItem, items } = useCart();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const selectedOrderMode = resolveSupplyOrderMode(searchParams.get('order'));
   const hasPlusMembership = hasPlusAccess(user?.membershipStatus);
   const sugarPricePerKg = getSugarPricePerKg(hasPlusMembership);
   const [targetTotalKg, setTargetTotalKg] = useState(DEFAULT_BULK_SUGAR_KG);
   const [sticksBoxCount, setSticksBoxCount] = useState(1);
-  const [stickVariant, setStickVariant] = useState<StickVariant>('plain');
   const [stickSize, setStickSize] = useState<SelectedStickSize>('');
   const [blankAddressType, setBlankAddressType] = useState<SelectedBlankAddressType>('');
   const [customArtworkFile, setCustomArtworkFile] = useState<File | null>(null);
@@ -84,6 +139,7 @@ export default function SuppliesPage() {
   const [sticksRequestNotes, setSticksRequestNotes] = useState('');
   const [submittingSticksRequest, setSubmittingSticksRequest] = useState(false);
   const [startingBlankCheckout, setStartingBlankCheckout] = useState(false);
+  const [showSugarMix, setShowSugarMix] = useState(false);
   const [sugarMix, setSugarMix] = useState<SugarMix>(() =>
     buildEqualSugarSplit(DEFAULT_BULK_SUGAR_KG)
   );
@@ -93,39 +149,49 @@ export default function SuppliesPage() {
   }, []);
 
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const sticksCheckoutStatus = params.get('sticksCheckout');
+    const rawOrderMode = searchParams.get('order');
+    if (!rawOrderMode || isSupplyOrderMode(rawOrderMode)) return;
+
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.set('order', 'sugar');
+    setSearchParams(nextParams, { replace: true });
+  }, [searchParams, setSearchParams]);
+
+  useEffect(() => {
+    const sticksCheckoutStatus = searchParams.get('sticksCheckout');
     if (!sticksCheckoutStatus) return;
+
     if (sticksCheckoutStatus === 'success') {
       toast.success('Thanks! Your Bloomjoy branded stick order is being processed.');
     }
     if (sticksCheckoutStatus === 'cancel') {
       toast.info('Bloomjoy branded sticks checkout canceled.');
     }
-    params.delete('sticksCheckout');
-    const nextQuery = params.toString();
-    window.history.replaceState(
-      {},
-      '',
-      nextQuery ? `${window.location.pathname}?${nextQuery}` : window.location.pathname
-    );
-  }, []);
+
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.delete('sticksCheckout');
+    nextParams.set('order', 'sticks');
+    setSearchParams(nextParams, { replace: true });
+  }, [searchParams, setSearchParams]);
 
   const mixTotalKg = getSugarMixTotalKg(sugarMix);
   const mixTotalCost = mixTotalKg * sugarPricePerKg;
   const cartSugarBreakdown = getSugarColorBreakdown(items);
   const cartSugarTotalKg = getSugarMixTotalKg(cartSugarBreakdown);
   const normalizedStickBoxCount = normalizeStickBoxCount(sticksBoxCount);
-  const blankSticksCheckoutEligible =
-    stickVariant === 'plain' && shouldUseBlankSticksDirectCheckout(normalizedStickBoxCount);
-  const blankSticksShippingTotal =
-    stickVariant === 'plain' && hasBlankAddressType(blankAddressType)
-      ? getBlankSticksShippingTotal(normalizedStickBoxCount, blankAddressType)
-      : null;
-  const blankSticksShippingRate =
-    stickVariant === 'plain' && hasBlankAddressType(blankAddressType)
-      ? getBlankSticksShippingRatePerBox(blankAddressType)
-      : null;
+  const blankSticksCheckoutEligible = shouldUseBlankSticksDirectCheckout(normalizedStickBoxCount);
+  const blankSticksShippingTotal = hasBlankAddressType(blankAddressType)
+    ? getBlankSticksShippingTotal(normalizedStickBoxCount, blankAddressType)
+    : null;
+  const blankSticksShippingRate = hasBlankAddressType(blankAddressType)
+    ? getBlankSticksShippingRatePerBox(blankAddressType)
+    : null;
+
+  const selectOrderMode = (mode: SupplyOrderMode) => {
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.set('order', mode);
+    setSearchParams(nextParams);
+  };
 
   const updateColorQuantity = (sku: SugarSku, rawValue: number) => {
     setSugarMix((currentMix) => updateSugarMixQuantity(currentMix, sku, rawValue));
@@ -212,7 +278,7 @@ export default function SuppliesPage() {
       return;
     }
     if (!hasBlankAddressType(blankAddressType)) {
-      toast.error('Select business or residential shipping before submitting.');
+      toast.error('Select business or residential delivery before submitting.');
       return;
     }
     if (!validateSticksContactFields()) return;
@@ -236,7 +302,9 @@ export default function SuppliesPage() {
         ].join('\n'),
       });
       trackEvent('click_buy_sticks', { variant: 'blank_request', boxes: normalizedStickBoxCount });
-      toast.success('Bloomjoy branded sticks request submitted. We will confirm shipping and fulfillment.');
+      toast.success(
+        'Bloomjoy branded sticks request submitted. We will confirm shipping and fulfillment.'
+      );
       resetStickRequestFields();
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Unable to submit your request.');
@@ -251,7 +319,7 @@ export default function SuppliesPage() {
       return;
     }
     if (!hasBlankAddressType(blankAddressType)) {
-      toast.error('Select business or residential shipping before checkout.');
+      toast.error('Select business or residential delivery before checkout.');
       return;
     }
     setStartingBlankCheckout(true);
@@ -264,7 +332,9 @@ export default function SuppliesPage() {
       );
       window.location.assign(checkoutUrl);
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Unable to start Bloomjoy branded sticks checkout.');
+      toast.error(
+        error instanceof Error ? error.message : 'Unable to start Bloomjoy branded sticks checkout.'
+      );
       setStartingBlankCheckout(false);
     }
   };
@@ -312,387 +382,862 @@ export default function SuppliesPage() {
 
   return (
     <Layout>
-      <section className="bg-gradient-to-b from-cream to-background section-padding">
-        <div className="container-page text-center">
-          <h1 className="font-display text-4xl font-bold text-foreground sm:text-5xl">Supplies</h1>
-          <p className="mx-auto mt-4 max-w-3xl text-lg text-muted-foreground">
-            Bulk sugar ordering built for operator packaging. Configure white, blue, orange, and
-            red in one flow with quick presets tuned for 240KG, 400KG, and 800KG shipments.
-          </p>
+      <section className="border-b border-border bg-background py-8 sm:py-10">
+        <div className="container-page">
+          <div className="mx-auto max-w-3xl text-center">
+            <h1 className="font-display text-4xl font-bold text-foreground sm:text-5xl">
+              Supplies
+            </h1>
+            <p className="mx-auto mt-3 max-w-2xl text-base leading-7 text-muted-foreground sm:text-lg">
+              Choose what you need first. The order details stay focused on that one path.
+            </p>
+          </div>
+
+          <div
+            aria-label="Choose supplies order type"
+            className="mt-7 grid gap-3 md:grid-cols-3"
+            role="group"
+          >
+            {orderOptions.map((option) => {
+              const isSelected = selectedOrderMode === option.value;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  aria-pressed={isSelected}
+                  onClick={() => selectOrderMode(option.value)}
+                  className={cn(
+                    'group flex min-h-32 gap-4 rounded-lg border bg-background p-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
+                    isSelected
+                      ? 'border-primary bg-primary/5 text-foreground'
+                      : 'border-border text-muted-foreground hover:border-primary/60 hover:text-foreground'
+                  )}
+                >
+                  <img
+                    src={option.image}
+                    alt={option.imageAlt}
+                    className="h-20 w-20 flex-none rounded-lg bg-muted object-cover"
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="block text-xs font-semibold uppercase tracking-[0.12em] text-primary">
+                      {option.eyebrow}
+                    </span>
+                    <span className="mt-1 block text-base font-semibold text-foreground">
+                      {option.title}
+                    </span>
+                    <span className="mt-1 block text-sm leading-5">{option.summary}</span>
+                  </span>
+                </button>
+              );
+            })}
+          </div>
         </div>
       </section>
 
-      <section className="section-padding">
+      <section className="py-8 sm:py-12">
         <div className="container-page">
-          <div className="grid gap-8 md:grid-cols-2 lg:gap-12">
-            <div className="card-elevated overflow-hidden">
-              <div className="aspect-square overflow-hidden bg-muted">
-                <img src={sugarProduct} alt="Premium Cotton Candy Sugar" className="h-full w-full object-cover" />
-              </div>
-              <div className="p-6">
-                <h2 className="font-display text-xl font-semibold text-foreground">Premium Cotton Candy Sugar</h2>
-                  <p className="mt-1 font-display text-2xl font-bold text-primary">
-                  ${sugarPricePerKg}{' '}
-                  <span className="text-base font-normal text-muted-foreground">/ 1KG bag</span>
-                </p>
-                <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
-                  Pick your mix across all four core colors and use packaging-friendly quick presets
-                  for the most common shipment sizes. Bloomjoy Plus members pay $
-                  {PLUS_MEMBER_SUGAR_PRICE_PER_KG}/KG. Everyone else pays $
-                  {NON_MEMBER_SUGAR_PRICE_PER_KG}/KG.
-                </p>
-                <p className="mt-2 text-xs text-muted-foreground">
-                  {isAuthLoading
-                    ? 'Checking member pricing...'
-                    : hasPlusMembership
-                      ? 'Plus pricing is active for this session.'
-                      : 'Standard pricing is active. Log in with an active Bloomjoy Plus membership to pay $8/KG.'}
-                </p>
-                <div className="mt-6 rounded-xl border border-border bg-muted/30 p-4">
-                  <p className="text-sm font-semibold text-foreground">Bulk Order Builder</p>
-                  <div className="mt-3 flex flex-wrap items-end gap-3">
+          {selectedOrderMode === 'sugar' && (
+            <div className="mx-auto max-w-5xl">
+              <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_18rem]">
+                <div className="min-w-0 space-y-5">
+                  <div className="flex flex-col gap-4 border-b border-border pb-5 sm:flex-row sm:items-end sm:justify-between">
                     <div>
-                      <Label className="text-xs uppercase tracking-[0.12em] text-muted-foreground">Total Target (KG)</Label>
-                      <Input
-                        type="number"
-                        min={0}
-                        max={MAX_SUGAR_KG_TOTAL}
-                        value={targetTotalKg}
-                        onChange={(event) => {
-                          const value = Number(event.target.value);
-                          setTargetTotalKg(
-                            Number.isFinite(value)
-                              ? Math.min(MAX_SUGAR_KG_TOTAL, Math.max(0, Math.floor(value)))
-                              : 0
-                          );
-                        }}
-                        className="mt-1 h-9 w-32"
-                      />
+                      <p className="text-sm font-semibold uppercase tracking-[0.12em] text-primary">
+                        Sugar
+                      </p>
+                      <h2 className="mt-2 font-display text-3xl font-bold text-foreground">
+                        Build a bulk sugar mix
+                      </h2>
+                      <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+                        Start with a shipment size, keep the equal split, or open the color mix
+                        only when you need a different breakdown.
+                      </p>
                     </div>
-                    <Button type="button" variant="outline" size="sm" onClick={() => setSugarMix(buildEqualSugarSplit(targetTotalKg))}>
-                      Equal Split (25% each)
-                    </Button>
-                    <Button type="button" variant="ghost" size="sm" onClick={() => setSugarMix(createEmptySugarMix())}>
-                      Clear
-                    </Button>
+                    <div className="text-left sm:text-right" aria-live="polite">
+                      <p className="font-display text-2xl font-bold text-primary">
+                        {formatCurrency(sugarPricePerKg)}
+                        <span className="text-base font-normal text-muted-foreground"> / KG</span>
+                      </p>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {isAuthLoading
+                          ? 'Checking member pricing…'
+                          : hasPlusMembership
+                            ? 'Plus pricing is active.'
+                            : `Standard pricing. Plus members pay ${formatCurrency(
+                                PLUS_MEMBER_SUGAR_PRICE_PER_KG
+                              )}/KG.`}
+                      </p>
+                    </div>
                   </div>
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    {BULK_SUGAR_PRESETS_KG.map((presetKg) => (
-                      <Button
-                        key={presetKg}
-                        type="button"
-                        variant={targetTotalKg === presetKg ? 'default' : 'outline'}
-                        size="sm"
-                        onClick={() => handlePreset(presetKg)}
-                      >
-                        {presetKg} KG
-                      </Button>
-                    ))}
-                  </div>
-                  <div className="mt-4 space-y-2">
-                    {SUGAR_COLOR_OPTIONS.map((option) => {
-                      const cartQuantity = cartSugarBreakdown[option.sku];
-                      return (
-                        <div key={option.sku} className="grid grid-cols-[1fr_auto] items-center gap-3 rounded-lg border border-border bg-background p-3">
-                          <div>
-                            <p className="font-semibold text-foreground">
-                              {option.color}{' '}
-                              <span className="text-sm font-normal text-muted-foreground">({option.flavor})</span>
-                            </p>
-                            <p className="text-xs text-muted-foreground">In cart: {cartQuantity} KG</p>
-                          </div>
+
+                  <div className="rounded-lg border border-border bg-background p-4 sm:p-5">
+                    <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+                      <div>
+                        <h3 className="text-lg font-semibold text-foreground">
+                          Choose Shipment Size
+                        </h3>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                          400 KG is the default packaging-friendly order.
+                        </p>
+                      </div>
+                      <div className="flex flex-col gap-2 sm:items-end">
+                        <Label
+                          htmlFor="sugar-total-target"
+                          className="text-xs uppercase tracking-[0.12em] text-muted-foreground"
+                        >
+                          Total Target (KG)
+                        </Label>
+                        <div className="flex gap-2">
                           <Input
+                            id="sugar-total-target"
+                            name="sugar_total_target_kg"
                             type="number"
+                            inputMode="numeric"
                             min={0}
-                            value={sugarMix[option.sku]}
-                            onChange={(event) => updateColorQuantity(option.sku, Number(event.target.value))}
-                            className="h-9 w-24 text-right"
+                            max={MAX_SUGAR_KG_TOTAL}
+                            value={targetTotalKg}
+                            onChange={(event) => {
+                              const value = Number(event.target.value);
+                              setTargetTotalKg(
+                                Number.isFinite(value)
+                                  ? Math.min(MAX_SUGAR_KG_TOTAL, Math.max(0, Math.floor(value)))
+                                  : 0
+                              );
+                            }}
+                            className="h-10 w-32 text-right"
                           />
+                          <Button
+                            type="button"
+                            variant="outline"
+                            onClick={() => setSugarMix(buildEqualSugarSplit(targetTotalKg))}
+                          >
+                            Apply Split
+                          </Button>
                         </div>
-                      );
-                    })}
+                      </div>
+                    </div>
+
+                    <div className="mt-4 flex flex-wrap gap-2">
+                      {BULK_SUGAR_PRESETS_KG.map((presetKg) => (
+                        <Button
+                          key={presetKg}
+                          type="button"
+                          variant={targetTotalKg === presetKg ? 'default' : 'outline'}
+                          onClick={() => handlePreset(presetKg)}
+                        >
+                          {presetKg} KG
+                        </Button>
+                      ))}
+                    </div>
+
+                    <div className="mt-5 grid gap-3 sm:grid-cols-3">
+                      <div className="rounded-lg border border-primary/20 bg-primary/5 p-3">
+                        <p className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                          Total Sugar
+                        </p>
+                        <p className="mt-1 text-xl font-semibold text-foreground">
+                          {formatNumber(mixTotalKg)} KG
+                        </p>
+                      </div>
+                      <div className="rounded-lg border border-border bg-muted/20 p-3">
+                        <p className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                          1KG Bags
+                        </p>
+                        <p className="mt-1 text-xl font-semibold text-foreground">
+                          {formatNumber(mixTotalKg)}
+                        </p>
+                      </div>
+                      <div className="rounded-lg border border-border bg-muted/20 p-3">
+                        <p className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                          Subtotal
+                        </p>
+                        <p className="mt-1 text-xl font-semibold text-foreground">
+                          {formatCurrency(mixTotalCost)}
+                        </p>
+                      </div>
+                    </div>
+
+                    <div className="mt-5 flex flex-col gap-3 sm:flex-row">
+                      <Button
+                        type="button"
+                        className="w-full sm:w-auto"
+                        onClick={handleAddSugarMixToCart}
+                        disabled={mixTotalKg <= 0}
+                      >
+                        <ShoppingCart className="mr-2 h-4 w-4" aria-hidden="true" />
+                        Add Sugar Mix to Cart
+                      </Button>
+                      <Button asChild variant="outline" className="w-full sm:w-auto">
+                        <Link to="/cart">
+                          View Cart
+                          <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+                        </Link>
+                      </Button>
+                    </div>
+
+                    {cartSugarTotalKg > 0 && (
+                      <p className="mt-3 text-sm text-muted-foreground">
+                        Sugar currently in cart: {formatNumber(cartSugarTotalKg)} KG
+                      </p>
+                    )}
                   </div>
-                  <div className="mt-4 rounded-lg border border-primary/20 bg-primary/5 p-3 text-sm">
-                    <div className="flex items-center justify-between text-foreground">
-                      <span>Total sugar</span>
-                      <span className="font-semibold">{mixTotalKg} KG</span>
-                    </div>
-                    <div className="mt-1 flex items-center justify-between text-muted-foreground">
-                      <span>1KG bags</span>
-                      <span>{mixTotalKg} bags</span>
-                    </div>
-                    <div className="mt-1 flex items-center justify-between text-foreground">
-                      <span>Estimated subtotal</span>
-                      <span className="font-semibold">${mixTotalCost.toFixed(2)}</span>
-                    </div>
-                  </div>
-                  <div className="mt-4 flex flex-col gap-3 sm:flex-row">
-                    <Button type="button" className="w-full" onClick={handleAddSugarMixToCart} disabled={mixTotalKg <= 0}>
-                      <ShoppingCart className="mr-2 h-4 w-4" />
-                      Add Sugar Mix to Cart
-                    </Button>
-                    <Button asChild variant="outline" className="w-full sm:w-auto">
-                      <Link to="/cart">
-                        View Cart
-                        <ArrowRight className="ml-2 h-4 w-4" />
-                      </Link>
-                    </Button>
+
+                  <div className="rounded-lg border border-border bg-background">
+                    <button
+                      type="button"
+                      aria-expanded={showSugarMix}
+                      aria-controls="sugar-color-mix"
+                      onClick={() => setShowSugarMix((current) => !current)}
+                      className="flex w-full items-center justify-between gap-3 rounded-lg px-4 py-3 text-left text-sm font-semibold text-foreground transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+                    >
+                      Customize Color Mix
+                      <ChevronDown
+                        className={cn(
+                          'h-4 w-4 flex-none transition-transform',
+                          showSugarMix && 'rotate-180'
+                        )}
+                        aria-hidden="true"
+                      />
+                    </button>
+                    {showSugarMix && (
+                      <div id="sugar-color-mix" className="border-t border-border p-4">
+                        <div className="flex flex-wrap gap-2">
+                          <Button
+                            type="button"
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setSugarMix(buildEqualSugarSplit(targetTotalKg))}
+                          >
+                            Equal Split
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setSugarMix(createEmptySugarMix())}
+                          >
+                            Clear Mix
+                          </Button>
+                        </div>
+                        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                          {SUGAR_COLOR_OPTIONS.map((option) => {
+                            const cartQuantity = cartSugarBreakdown[option.sku];
+                            return (
+                              <div
+                                key={option.sku}
+                                className="rounded-lg border border-border bg-muted/10 p-3"
+                              >
+                                <div className="flex items-start justify-between gap-3">
+                                  <div>
+                                    <Label
+                                      htmlFor={`sugar-mix-${option.sku}`}
+                                      className="font-semibold text-foreground"
+                                    >
+                                      {option.color}{' '}
+                                      <span className="font-normal text-muted-foreground">
+                                        ({option.flavor})
+                                      </span>
+                                    </Label>
+                                    <p className="mt-1 text-xs text-muted-foreground">
+                                      In cart: {formatNumber(cartQuantity)} KG
+                                    </p>
+                                  </div>
+                                  <Input
+                                    id={`sugar-mix-${option.sku}`}
+                                    name={`sugar_mix_${option.sku}`}
+                                    type="number"
+                                    inputMode="numeric"
+                                    min={0}
+                                    value={sugarMix[option.sku]}
+                                    onChange={(event) =>
+                                      updateColorQuantity(option.sku, Number(event.target.value))
+                                    }
+                                    className="h-10 w-24 text-right"
+                                  />
+                                </div>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    )}
                   </div>
                 </div>
-                <p className="mt-3 text-xs text-muted-foreground">
-                  Common order pattern: start from the quick preset that matches your shipment, use
-                  equal split, then adjust the color totals as needed.
-                </p>
+
+                <aside className="rounded-lg border border-border bg-muted/10 p-3">
+                  <img
+                    src={sugarProduct}
+                    alt="Premium Cotton Candy Sugar"
+                    className="aspect-[4/3] w-full rounded-lg bg-background object-cover"
+                  />
+                  <div className="mt-4 space-y-3 text-sm">
+                    <div>
+                      <p className="font-semibold text-foreground">Pricing</p>
+                      <p className="text-muted-foreground">
+                        Public {formatCurrency(NON_MEMBER_SUGAR_PRICE_PER_KG)}/KG; Plus{' '}
+                        {formatCurrency(PLUS_MEMBER_SUGAR_PRICE_PER_KG)}/KG.
+                      </p>
+                    </div>
+                    <div>
+                      <p className="font-semibold text-foreground">Color Options</p>
+                      <p className="text-muted-foreground">White, blue, orange, and red.</p>
+                    </div>
+                  </div>
+                </aside>
               </div>
             </div>
+          )}
 
-            <div className="card-elevated overflow-hidden">
-              <div className="aspect-square overflow-hidden bg-muted">
-                <img src={sticksProduct} alt="Bloomjoy branded cotton candy sticks" className="h-full w-full object-cover" />
-              </div>
-              <div className="p-6">
-                <h2 className="font-display text-xl font-semibold text-foreground">Bloomjoy Paper Sticks</h2>
-                <p className="mt-1 font-display text-2xl font-bold text-primary">
-                  ${STICKS_PRICE_PER_BOX}{' '}
-                  <span className="text-base font-normal text-muted-foreground">/ {STICKS_PIECES_PER_BOX.toLocaleString()}-piece box</span>
-                </p>
-                <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
-                  Choose Bloomjoy branded or custom paper sticks for Commercial/Full or Mini
-                  machines. Custom sticks add a ${CUSTOM_STICKS_FIRST_ORDER_PLATE_FEE}{' '}
-                  first-order plate fee.
-                </p>
-                <div className="mt-6 space-y-4">
-                  <div className="grid grid-cols-2 gap-2 rounded-xl border border-border bg-muted/30 p-2">
-                    <button
-                      type="button"
-                      onClick={() => setStickVariant('plain')}
-                      className={`rounded-lg px-3 py-2 text-sm font-semibold transition-colors ${
-                        stickVariant === 'plain' ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'
-                      }`}
-                    >
-                      Bloomjoy branded
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setStickVariant('custom')}
-                      className={`rounded-lg px-3 py-2 text-sm font-semibold transition-colors ${
-                        stickVariant === 'custom' ? 'bg-background text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'
-                      }`}
-                    >
-                      Custom sticks
-                    </button>
+          {selectedOrderMode === 'sticks' && (
+            <div className="mx-auto max-w-5xl">
+              <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_18rem]">
+                <div className="min-w-0 space-y-5">
+                  <div className="flex flex-col gap-4 border-b border-border pb-5 sm:flex-row sm:items-end sm:justify-between">
+                    <div>
+                      <p className="text-sm font-semibold uppercase tracking-[0.12em] text-primary">
+                        Bloomjoy Branded Sticks
+                      </p>
+                      <h2 className="mt-2 font-display text-3xl font-bold text-foreground">
+                        Order standard paper sticks
+                      </h2>
+                      <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+                        1-4 boxes require confirmation. 5+ boxes go straight to checkout with
+                        free shipping.
+                      </p>
+                    </div>
+                    <div className="text-left sm:text-right">
+                      <p className="font-display text-2xl font-bold text-primary">
+                        {formatCurrency(STICKS_PRICE_PER_BOX)}
+                        <span className="text-base font-normal text-muted-foreground">
+                          {' '}
+                          / box
+                        </span>
+                      </p>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {formatNumber(STICKS_PIECES_PER_BOX)} pieces per box
+                      </p>
+                    </div>
                   </div>
-                  <div className="rounded-xl border border-border bg-muted/20 p-4">
+
+                  <div className="rounded-lg border border-border bg-background p-4 sm:p-5">
                     <div className="grid gap-3 sm:grid-cols-3">
                       <div>
-                        <Label className="text-xs uppercase tracking-[0.12em] text-muted-foreground">Minimum Order</Label>
-                        <p className="mt-1 text-sm font-semibold text-foreground">1 box</p>
+                        <p className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                          Minimum
+                        </p>
+                        <p className="mt-1 font-semibold text-foreground">1 box</p>
                       </div>
                       <div>
-                        <Label className="text-xs uppercase tracking-[0.12em] text-muted-foreground">Packaging</Label>
-                        <p className="mt-1 text-sm font-semibold text-foreground">{STICKS_PIECES_PER_BOX.toLocaleString()} pieces / box</p>
+                        <p className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                          Shipping
+                        </p>
+                        <p className="mt-1 font-semibold text-foreground">5+ boxes ship free</p>
                       </div>
                       <div>
-                        <Label className="text-xs uppercase tracking-[0.12em] text-muted-foreground">Shipping</Label>
-                        <p className="mt-1 text-sm font-semibold text-foreground">5+ boxes ship free</p>
+                        <p className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                          Order Path
+                        </p>
+                        <p className="mt-1 font-semibold text-foreground">
+                          {blankSticksCheckoutEligible ? 'Direct checkout' : 'Confirmation'}
+                        </p>
                       </div>
                     </div>
-                    <p className="mt-3 text-xs text-muted-foreground">
-                      Bloomjoy branded sticks ship at $35/box to business addresses or $40/box to
-                      residential addresses for orders under {BLANK_STICKS_FREE_SHIPPING_BOX_THRESHOLD} boxes.
-                    </p>
                   </div>
-                  <div>
-                    <Label className="text-xs uppercase tracking-[0.12em] text-muted-foreground">Machine Size</Label>
-                    <RadioGroup
-                      value={stickSize}
-                      onValueChange={(value) => setStickSize(value as SelectedStickSize)}
-                      className="mt-2 gap-3"
-                    >
-                      {STICK_SIZE_OPTIONS.map((option) => (
-                        <label
-                          key={option.value}
-                          htmlFor={`stick-size-${option.value}`}
-                          className={`flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors ${
-                            stickSize === option.value ? 'border-primary bg-primary/5' : 'border-border bg-background'
-                          }`}
-                        >
-                          <RadioGroupItem id={`stick-size-${option.value}`} value={option.value} className="mt-1" />
-                          <div>
-                            <p className="font-semibold text-foreground">{option.label}</p>
-                            <p className="text-sm text-muted-foreground">{option.detail}</p>
-                          </div>
-                        </label>
-                      ))}
-                    </RadioGroup>
-                  </div>
-                  <div className="flex items-end gap-3">
+
+                  <div className="rounded-lg border border-border bg-background p-4 sm:p-5">
                     <div>
-                      <Label className="text-xs uppercase tracking-[0.12em] text-muted-foreground">Boxes</Label>
-                      <Input
-                        type="number"
-                        min={1}
-                        value={sticksBoxCount}
-                        onChange={(event) => updateStickBoxCount(Number(event.target.value))}
-                        className="mt-1 h-9 w-24 text-right"
-                      />
-                    </div>
-                    <div className="flex-1 rounded-lg border border-primary/20 bg-primary/5 px-3 py-2 text-sm">
-                      <div className="flex items-center justify-between text-foreground">
-                        <span>Stick subtotal</span>
-                        <span className="font-semibold">${(normalizedStickBoxCount * STICKS_PRICE_PER_BOX).toFixed(2)}</span>
-                      </div>
-                      <div className="mt-1 flex items-center justify-between text-muted-foreground">
-                        <span>Total pieces</span>
-                        <span>{(normalizedStickBoxCount * STICKS_PIECES_PER_BOX).toLocaleString()}</span>
-                      </div>
-                    </div>
-                  </div>
-
-                  {stickVariant === 'plain' && (
-                    <>
-                      <div>
-                        <Label className="text-xs uppercase tracking-[0.12em] text-muted-foreground">Shipping Address Type</Label>
-                        <RadioGroup
-                          value={blankAddressType}
-                          onValueChange={(value) => setBlankAddressType(value as SelectedBlankAddressType)}
-                          className="mt-2 gap-3"
-                        >
-                          {BLANK_STICKS_ADDRESS_TYPE_OPTIONS.map((option) => (
-                            <label
-                              key={option.value}
-                              htmlFor={`stick-address-${option.value}`}
-                              className={`flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors ${
-                                blankAddressType === option.value ? 'border-primary bg-primary/5' : 'border-border bg-background'
-                              }`}
-                            >
-                              <RadioGroupItem id={`stick-address-${option.value}`} value={option.value} className="mt-1" />
-                              <div>
-                                <p className="font-semibold text-foreground">{option.label}</p>
-                                <p className="text-sm text-muted-foreground">${option.shippingRatePerBox}/box for 1-4 box orders</p>
-                              </div>
-                            </label>
-                          ))}
-                        </RadioGroup>
-                      </div>
-
-                      <div className="rounded-lg border border-border bg-muted/20 p-4 text-sm">
-                        {hasBlankAddressType(blankAddressType) ? (
-                          <>
-                            <div className="flex items-center justify-between text-foreground">
-                              <span>Shipping</span>
-                              <span className="font-semibold">
-                                {formatBlankSticksShippingSummary(normalizedStickBoxCount, blankAddressType)}
-                              </span>
-                            </div>
-                            <div className="mt-1 flex items-center justify-between text-muted-foreground">
-                              <span>Address type</span>
-                              <span>{getBlankSticksAddressTypeLabel(blankAddressType)}</span>
-                            </div>
-                            <div className="mt-1 flex items-center justify-between text-muted-foreground">
-                              <span>Order path</span>
-                              <span>{blankSticksCheckoutEligible ? 'Direct checkout' : 'Procurement review'}</span>
-                            </div>
-                          </>
-                        ) : (
-                          <p className="text-muted-foreground">
-                            Select the shipping address type to see the shipping estimate and
-                            checkout path.
-                          </p>
-                        )}
-                      </div>
-                    </>
-                  )}
-
-                  {(stickVariant === 'custom' || !blankSticksCheckoutEligible) && (
-                    <div className="space-y-3 rounded-xl border border-border bg-muted/20 p-4">
-                      <p className="text-sm text-muted-foreground">
-                        {stickVariant === 'custom'
-                          ? `Upload your logo/image and we will confirm proofing, the $${CUSTOM_STICKS_FIRST_ORDER_PLATE_FEE} plate fee, production timing, and final order details.`
-                          : `Orders under ${BLANK_STICKS_FREE_SHIPPING_BOX_THRESHOLD} boxes are handled through procurement confirmation so we can verify the final shipment details before fulfillment.`}
-                      </p>
-
-                      {stickVariant === 'custom' && (
-                        <>
+                      <Label className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                        Machine Size
+                      </Label>
+                      <RadioGroup
+                        name="stick_size"
+                        value={stickSize}
+                        onValueChange={(value) => setStickSize(value as SelectedStickSize)}
+                        className="mt-2 grid gap-3 sm:grid-cols-2"
+                      >
+                        {STICK_SIZE_OPTIONS.map((option) => (
                           <label
-                            htmlFor="custom-sticks-artwork"
-                            className="flex cursor-pointer items-center justify-center gap-2 rounded-lg border border-dashed border-border bg-background px-4 py-3 text-sm font-medium text-foreground transition-colors hover:border-primary"
+                            key={option.value}
+                            htmlFor={`stick-size-${option.value}`}
+                            className={cn(
+                              'flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors',
+                              stickSize === option.value
+                                ? 'border-primary bg-primary/5'
+                                : 'border-border bg-background hover:border-primary/60'
+                            )}
                           >
-                            <Upload className="h-4 w-4" />
-                            {customArtworkFile ? `Selected: ${customArtworkFile.name}` : 'Upload logo/image'}
+                            <RadioGroupItem
+                              id={`stick-size-${option.value}`}
+                              value={option.value}
+                              className="mt-1"
+                            />
+                            <span>
+                              <span className="block font-semibold text-foreground">
+                                {option.label}
+                              </span>
+                              <span className="block text-sm text-muted-foreground">
+                                {option.detail}
+                              </span>
+                            </span>
                           </label>
-                          <Input
-                            id="custom-sticks-artwork"
-                            type="file"
-                            accept={ALLOWED_CUSTOM_STICKS_ARTWORK_TYPES.join(',')}
-                            onChange={handleCustomArtworkChange}
-                            className="hidden"
-                          />
-                          <p className="text-xs text-muted-foreground">
-                            PNG, JPG, or WEBP. Max {Math.floor(MAX_CUSTOM_STICKS_ARTWORK_SIZE_BYTES / (1024 * 1024))}MB.
-                          </p>
-                        </>
-                      )}
+                        ))}
+                      </RadioGroup>
+                    </div>
 
-                      <div className="grid gap-3 sm:grid-cols-2">
+                    <div className="mt-5 grid gap-4 md:grid-cols-[12rem_minmax(0,1fr)]">
+                      <div>
+                        <Label
+                          htmlFor="branded-sticks-boxes"
+                          className="text-xs uppercase tracking-[0.12em] text-muted-foreground"
+                        >
+                          Boxes
+                        </Label>
                         <Input
-                          placeholder="Contact name"
-                          value={sticksContactName}
-                          onChange={(event) => setSticksContactName(event.target.value)}
-                        />
-                        <Input
-                          type="email"
-                          placeholder="Email for follow-up"
-                          value={sticksContactEmail}
-                          onChange={(event) => setSticksContactEmail(event.target.value)}
+                          id="branded-sticks-boxes"
+                          name="branded_sticks_boxes"
+                          type="number"
+                          inputMode="numeric"
+                          min={1}
+                          value={sticksBoxCount}
+                          onChange={(event) => updateStickBoxCount(Number(event.target.value))}
+                          className="mt-1 h-10 w-full text-right"
                         />
                       </div>
-
-                      <Textarea
-                        value={sticksRequestNotes}
-                        onChange={(event) => setSticksRequestNotes(event.target.value)}
-                        rows={3}
-                        placeholder={
-                          stickVariant === 'custom'
-                            ? 'Optional notes (brand colors, timeline, quantity split, etc.)'
-                            : 'Optional notes (delivery window, location notes, internal PO, etc.)'
-                        }
-                      />
+                      <div className="grid gap-3 sm:grid-cols-2">
+                        <div className="rounded-lg border border-primary/20 bg-primary/5 p-3">
+                          <p className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                            Stick Subtotal
+                          </p>
+                          <p className="mt-1 text-xl font-semibold text-foreground">
+                            {formatCurrency(normalizedStickBoxCount * STICKS_PRICE_PER_BOX)}
+                          </p>
+                        </div>
+                        <div className="rounded-lg border border-border bg-muted/20 p-3">
+                          <p className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                            Total Pieces
+                          </p>
+                          <p className="mt-1 text-xl font-semibold text-foreground">
+                            {formatNumber(normalizedStickBoxCount * STICKS_PIECES_PER_BOX)}
+                          </p>
+                        </div>
+                      </div>
                     </div>
-                  )}
 
-                  {stickVariant === 'plain' ? (
+                    <div className="mt-5">
+                      <Label className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                        Delivery Location Type
+                      </Label>
+                      <RadioGroup
+                        name="delivery_location_type"
+                        value={blankAddressType}
+                        onValueChange={(value) =>
+                          setBlankAddressType(value as SelectedBlankAddressType)
+                        }
+                        className="mt-2 grid gap-3 sm:grid-cols-2"
+                      >
+                        {BLANK_STICKS_ADDRESS_TYPE_OPTIONS.map((option) => (
+                          <label
+                            key={option.value}
+                            htmlFor={`stick-address-${option.value}`}
+                            className={cn(
+                              'flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors',
+                              blankAddressType === option.value
+                                ? 'border-primary bg-primary/5'
+                                : 'border-border bg-background hover:border-primary/60'
+                            )}
+                          >
+                            <RadioGroupItem
+                              id={`stick-address-${option.value}`}
+                              value={option.value}
+                              className="mt-1"
+                            />
+                            <span>
+                              <span className="block font-semibold text-foreground">
+                                {option.label}
+                              </span>
+                              <span className="block text-sm text-muted-foreground">
+                                {formatCurrency(option.shippingRatePerBox)}/box for 1-4 boxes
+                              </span>
+                            </span>
+                          </label>
+                        ))}
+                      </RadioGroup>
+                    </div>
+
+                    <div className="mt-5 rounded-lg border border-border bg-muted/20 p-4 text-sm">
+                      {hasBlankAddressType(blankAddressType) ? (
+                        <div className="grid gap-2 sm:grid-cols-3">
+                          <div>
+                            <p className="text-muted-foreground">Shipping</p>
+                            <p className="font-semibold text-foreground">
+                              {formatBlankSticksShippingSummary(
+                                normalizedStickBoxCount,
+                                blankAddressType
+                              )}
+                            </p>
+                          </div>
+                          <div>
+                            <p className="text-muted-foreground">Location</p>
+                            <p className="font-semibold text-foreground">
+                              {getBlankSticksAddressTypeLabel(blankAddressType)}
+                            </p>
+                          </div>
+                          <div>
+                            <p className="text-muted-foreground">Next Step</p>
+                            <p className="font-semibold text-foreground">
+                              {blankSticksCheckoutEligible ? 'Checkout' : 'Procurement confirmation'}
+                            </p>
+                          </div>
+                        </div>
+                      ) : (
+                        <p className="text-muted-foreground">
+                          Select the delivery location type to see the shipping estimate and next
+                          step.
+                        </p>
+                      )}
+                    </div>
+
+                    {!blankSticksCheckoutEligible && (
+                      <div className="mt-5 space-y-3 border-t border-border pt-5">
+                        <p className="text-sm text-muted-foreground">
+                          Orders under {BLANK_STICKS_FREE_SHIPPING_BOX_THRESHOLD} boxes are
+                          confirmed first so Bloomjoy can verify final shipment details.
+                        </p>
+                        <div className="grid gap-3 sm:grid-cols-2">
+                          <div>
+                            <Label htmlFor="branded-sticks-contact-name">Contact Name</Label>
+                            <Input
+                              id="branded-sticks-contact-name"
+                              name="contact_name"
+                              autoComplete="name"
+                              placeholder="Jane Chen…"
+                              value={sticksContactName}
+                              onChange={(event) => setSticksContactName(event.target.value)}
+                              className="mt-1"
+                            />
+                          </div>
+                          <div>
+                            <Label htmlFor="branded-sticks-contact-email">Email For Follow-Up</Label>
+                            <Input
+                              id="branded-sticks-contact-email"
+                              name="email"
+                              type="email"
+                              inputMode="email"
+                              autoComplete="email"
+                              spellCheck={false}
+                              placeholder="jane@example.com…"
+                              value={sticksContactEmail}
+                              onChange={(event) => setSticksContactEmail(event.target.value)}
+                              className="mt-1"
+                            />
+                          </div>
+                        </div>
+                        <div>
+                          <Label htmlFor="branded-sticks-notes">Order Notes</Label>
+                          <Textarea
+                            id="branded-sticks-notes"
+                            name="order_notes"
+                            value={sticksRequestNotes}
+                            onChange={(event) => setSticksRequestNotes(event.target.value)}
+                            rows={3}
+                            placeholder="Delivery window, location notes, internal PO…"
+                            className="mt-1"
+                          />
+                        </div>
+                      </div>
+                    )}
+
                     <Button
-                      onClick={blankSticksCheckoutEligible ? handleStartBlankCheckout : handleSubmitBlankSticksRequest}
-                      className="w-full"
+                      type="button"
+                      onClick={
+                        blankSticksCheckoutEligible
+                          ? handleStartBlankCheckout
+                          : handleSubmitBlankSticksRequest
+                      }
+                      className="mt-5 w-full sm:w-auto"
                       disabled={submittingSticksRequest || startingBlankCheckout}
                     >
                       {blankSticksCheckoutEligible
                         ? startingBlankCheckout
-                          ? 'Redirecting...'
+                          ? 'Redirecting…'
                           : 'Checkout Bloomjoy Branded Sticks'
                         : submittingSticksRequest
-                          ? 'Submitting...'
+                          ? 'Submitting…'
                           : 'Submit Bloomjoy Branded Stick Request'}
                     </Button>
-                  ) : (
-                    <Button onClick={handleSubmitCustomSticksRequest} className="w-full" disabled={submittingSticksRequest}>
-                      {submittingSticksRequest ? 'Submitting...' : 'Submit Custom Request'}
-                    </Button>
-                  )}
-
-                  <p className="text-sm text-muted-foreground">
-                    Bloomjoy branded sticks checkout starts at {BLANK_STICKS_FREE_SHIPPING_BOX_THRESHOLD}{' '}
-                    boxes. The shared cart remains sugar-only.
-                  </p>
-
-                  {cartSugarTotalKg > 0 && (
-                    <p className="text-sm text-muted-foreground">Sugar currently in cart: {cartSugarTotalKg} KG</p>
-                  )}
+                  </div>
                 </div>
+
+                <aside className="rounded-lg border border-border bg-muted/10 p-3">
+                  <img
+                    src={sticksProduct}
+                    alt="Bloomjoy branded cotton candy sticks"
+                    className="aspect-[4/3] w-full rounded-lg bg-background object-cover"
+                  />
+                  <div className="mt-4 space-y-3 text-sm">
+                    <div>
+                      <p className="font-semibold text-foreground">Standard Size Options</p>
+                      <p className="text-muted-foreground">
+                        Commercial/Full and Mini machine sticks are available.
+                      </p>
+                    </div>
+                    <div>
+                      <p className="font-semibold text-foreground">Cart Rule</p>
+                      <p className="text-muted-foreground">
+                        The shared cart remains sugar-only; 5+ box stick orders use direct
+                        checkout.
+                      </p>
+                    </div>
+                  </div>
+                </aside>
               </div>
             </div>
-          </div>
+          )}
+
+          {selectedOrderMode === 'custom' && (
+            <div className="mx-auto max-w-5xl">
+              <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_18rem]">
+                <div className="min-w-0 space-y-5">
+                  <div className="flex flex-col gap-4 border-b border-border pb-5 sm:flex-row sm:items-end sm:justify-between">
+                    <div>
+                      <p className="text-sm font-semibold uppercase tracking-[0.12em] text-primary">
+                        Custom Sticks
+                      </p>
+                      <h2 className="mt-2 font-display text-3xl font-bold text-foreground">
+                        Request branded artwork proofing
+                      </h2>
+                      <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+                        Upload your logo/image and Bloomjoy will confirm proofing, production
+                        timing, and final order details.
+                      </p>
+                    </div>
+                    <div className="text-left sm:text-right">
+                      <p className="font-display text-2xl font-bold text-primary">
+                        {formatCurrency(STICKS_PRICE_PER_BOX)}
+                        <span className="text-base font-normal text-muted-foreground">
+                          {' '}
+                          / box
+                        </span>
+                      </p>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {formatCurrency(CUSTOM_STICKS_FIRST_ORDER_PLATE_FEE)} first-order plate fee
+                      </p>
+                    </div>
+                  </div>
+
+                  <div className="rounded-lg border border-border bg-background p-4 sm:p-5">
+                    <div className="grid gap-3 sm:grid-cols-3">
+                      <div>
+                        <p className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                          Packaging
+                        </p>
+                        <p className="mt-1 font-semibold text-foreground">
+                          {formatNumber(STICKS_PIECES_PER_BOX)} pieces / box
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                          First Order Fee
+                        </p>
+                        <p className="mt-1 font-semibold text-foreground">
+                          {formatCurrency(CUSTOM_STICKS_FIRST_ORDER_PLATE_FEE)}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                          Fulfillment
+                        </p>
+                        <p className="mt-1 font-semibold text-foreground">Proofing required</p>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="rounded-lg border border-border bg-background p-4 sm:p-5">
+                    <div>
+                      <Label className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                        Machine Size
+                      </Label>
+                      <RadioGroup
+                        name="custom_stick_size"
+                        value={stickSize}
+                        onValueChange={(value) => setStickSize(value as SelectedStickSize)}
+                        className="mt-2 grid gap-3 sm:grid-cols-2"
+                      >
+                        {STICK_SIZE_OPTIONS.map((option) => (
+                          <label
+                            key={option.value}
+                            htmlFor={`custom-stick-size-${option.value}`}
+                            className={cn(
+                              'flex cursor-pointer items-start gap-3 rounded-lg border p-3 transition-colors',
+                              stickSize === option.value
+                                ? 'border-primary bg-primary/5'
+                                : 'border-border bg-background hover:border-primary/60'
+                            )}
+                          >
+                            <RadioGroupItem
+                              id={`custom-stick-size-${option.value}`}
+                              value={option.value}
+                              className="mt-1"
+                            />
+                            <span>
+                              <span className="block font-semibold text-foreground">
+                                {option.label}
+                              </span>
+                              <span className="block text-sm text-muted-foreground">
+                                {option.detail}
+                              </span>
+                            </span>
+                          </label>
+                        ))}
+                      </RadioGroup>
+                    </div>
+
+                    <div className="mt-5 grid gap-4 md:grid-cols-[12rem_minmax(0,1fr)]">
+                      <div>
+                        <Label
+                          htmlFor="custom-sticks-boxes"
+                          className="text-xs uppercase tracking-[0.12em] text-muted-foreground"
+                        >
+                          Boxes
+                        </Label>
+                        <Input
+                          id="custom-sticks-boxes"
+                          name="custom_sticks_boxes"
+                          type="number"
+                          inputMode="numeric"
+                          min={1}
+                          value={sticksBoxCount}
+                          onChange={(event) => updateStickBoxCount(Number(event.target.value))}
+                          className="mt-1 h-10 w-full text-right"
+                        />
+                      </div>
+                      <div className="grid gap-3 sm:grid-cols-2">
+                        <div className="rounded-lg border border-primary/20 bg-primary/5 p-3">
+                          <p className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                            Stick Subtotal
+                          </p>
+                          <p className="mt-1 text-xl font-semibold text-foreground">
+                            {formatCurrency(normalizedStickBoxCount * STICKS_PRICE_PER_BOX)}
+                          </p>
+                        </div>
+                        <div className="rounded-lg border border-border bg-muted/20 p-3">
+                          <p className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                            Total Pieces
+                          </p>
+                          <p className="mt-1 text-xl font-semibold text-foreground">
+                            {formatNumber(normalizedStickBoxCount * STICKS_PIECES_PER_BOX)}
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="mt-5">
+                      <Label htmlFor="custom-sticks-artwork">Artwork</Label>
+                      <label
+                        htmlFor="custom-sticks-artwork"
+                        className="relative mt-1 flex min-h-24 cursor-pointer items-center justify-center gap-2 overflow-hidden rounded-lg border border-dashed border-border bg-muted/10 px-4 py-4 text-center text-sm font-medium text-foreground transition-colors hover:border-primary focus-within:ring-2 focus-within:ring-primary focus-within:ring-offset-2"
+                      >
+                        <Upload className="h-4 w-4" aria-hidden="true" />
+                        <span>
+                          {customArtworkFile
+                            ? `Selected: ${customArtworkFile.name}`
+                            : 'Upload logo/image'}
+                        </span>
+                        <Input
+                          id="custom-sticks-artwork"
+                          name="custom_sticks_artwork"
+                          type="file"
+                          accept={ALLOWED_CUSTOM_STICKS_ARTWORK_TYPES.join(',')}
+                          onChange={handleCustomArtworkChange}
+                          aria-describedby="custom-sticks-artwork-help"
+                          className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+                        />
+                      </label>
+                      <p id="custom-sticks-artwork-help" className="mt-2 text-xs text-muted-foreground">
+                        PNG, JPG, or WEBP. Max{' '}
+                        {Math.floor(MAX_CUSTOM_STICKS_ARTWORK_SIZE_BYTES / (1024 * 1024))}MB.
+                      </p>
+                    </div>
+
+                    <div className="mt-5 grid gap-3 sm:grid-cols-2">
+                      <div>
+                        <Label htmlFor="custom-sticks-contact-name">Contact Name</Label>
+                        <Input
+                          id="custom-sticks-contact-name"
+                          name="contact_name"
+                          autoComplete="name"
+                          placeholder="Jane Chen…"
+                          value={sticksContactName}
+                          onChange={(event) => setSticksContactName(event.target.value)}
+                          className="mt-1"
+                        />
+                      </div>
+                      <div>
+                        <Label htmlFor="custom-sticks-contact-email">Email For Follow-Up</Label>
+                        <Input
+                          id="custom-sticks-contact-email"
+                          name="email"
+                          type="email"
+                          inputMode="email"
+                          autoComplete="email"
+                          spellCheck={false}
+                          placeholder="jane@example.com…"
+                          value={sticksContactEmail}
+                          onChange={(event) => setSticksContactEmail(event.target.value)}
+                          className="mt-1"
+                        />
+                      </div>
+                    </div>
+
+                    <div className="mt-3">
+                      <Label htmlFor="custom-sticks-notes">Order Notes</Label>
+                      <Textarea
+                        id="custom-sticks-notes"
+                        name="order_notes"
+                        value={sticksRequestNotes}
+                        onChange={(event) => setSticksRequestNotes(event.target.value)}
+                        rows={3}
+                        placeholder="Brand colors, timeline, quantity split…"
+                        className="mt-1"
+                      />
+                    </div>
+
+                    <Button
+                      type="button"
+                      onClick={handleSubmitCustomSticksRequest}
+                      className="mt-5 w-full sm:w-auto"
+                      disabled={submittingSticksRequest}
+                    >
+                      {submittingSticksRequest ? 'Submitting…' : 'Submit Custom Stick Request'}
+                    </Button>
+                  </div>
+                </div>
+
+                <aside className="rounded-lg border border-border bg-muted/10 p-3">
+                  <img
+                    src={sticksProduct}
+                    alt="Custom cotton candy sticks"
+                    className="aspect-[4/3] w-full rounded-lg bg-background object-cover"
+                  />
+                  <div className="mt-4 space-y-3 text-sm">
+                    <div>
+                      <p className="font-semibold text-foreground">Proofing</p>
+                      <p className="text-muted-foreground">
+                        Bloomjoy confirms artwork, production timing, and final order details
+                        before fulfillment.
+                      </p>
+                    </div>
+                    <div>
+                      <p className="font-semibold text-foreground">Shipping</p>
+                      <p className="text-muted-foreground">
+                        1-4 boxes use estimated shipping; 5+ boxes ship free after proofing.
+                      </p>
+                    </div>
+                  </div>
+                </aside>
+              </div>
+            </div>
+          )}
         </div>
       </section>
     </Layout>


### PR DESCRIPTION
## Summary
- Refactors `/supplies` into a guided ordering surface with Sugar, Bloomjoy Branded Sticks, and Custom Sticks modes.
- Adds `?order=sugar`, `?order=sticks`, and `?order=custom` direct-link support with invalid-order fallback to Sugar.
- Moves sugar color-level controls behind `Customize Color Mix` and separates branded/custom sticks flows.

## Files changed
- `src/pages/Supplies.tsx`: mode-based supplies UI, URL state, progressive disclosure, form label/accessibility cleanup, currency formatting.
- `Docs/QA_SMOKE_TEST_CHECKLIST.md`: smoke checks for the new mode-based supplies UX.
- `Docs/CURRENT_STATUS.md`: plain-language status update for the supplies UX simplification.

## Verification commands + results
- `npm ci` - passed; npm reported 9 audit findings already present in dependency tree.
- `npm run build` - passed; Vite build and prerender completed.
- `npm test --if-present` - passed; no test script configured.
- `npm run lint --if-present` - passed with existing fast-refresh warnings in shared/generated UI/Auth files.

## Browser verification
- Checked `http://127.0.0.1:8084/supplies` default Sugar mode.
- Checked `http://127.0.0.1:8084/supplies?order=sugar`.
- Checked `http://127.0.0.1:8084/supplies?order=sticks`.
- Checked `http://127.0.0.1:8084/supplies?order=custom`.
- Confirmed invalid `?order=bad` normalizes to `?order=sugar`.
- Confirmed mode chooser updates the URL.
- Confirmed Sugar default is 400 KG, color mix disclosure opens, and Add Sugar Mix to Cart works locally.
- Confirmed branded sticks under 5 boxes shows procurement contact fields; 5 boxes switches to direct checkout CTA and hides contact fields.
- Confirmed custom sticks has its own focused request flow with upload, contact fields, and plate-fee note.

## How to test
1. From this branch, run `npm ci`.
2. Start local dev with `npm run dev`.
3. Open the printed localhost URL and visit `/supplies`.
4. Verify the chooser shows Sugar, Bloomjoy Branded Sticks, and Custom Sticks.
5. Visit `/supplies?order=sugar`, `/supplies?order=sticks`, and `/supplies?order=custom` directly and confirm the matching flow is selected.
6. In Sugar, click `Customize Color Mix`, adjust one color, then add the sugar mix to cart.
7. In Bloomjoy Branded Sticks, set boxes to `1` and confirm contact fields are visible; set boxes to `5` and confirm the CTA changes to direct checkout.
8. In Custom Sticks, confirm the artwork upload control, contact fields, box count, and `$750` first-order plate-fee note are visible.

## Rollback plan
- Revert this PR to restore the prior two-card supplies page and original smoke checklist/status docs.