### PR TITLE
Polish public CX audit findings

### DIFF
--- a/Docs/BACKLOG.md
+++ b/Docs/BACKLOG.md
@@ -87,9 +87,15 @@ Guidelines:
    - Rebalance `Start Here`, task paths, featured items, and full-library stacking.
    - Make the new document-first job aids feel curated without adding clutter.
    - Validate final desktop/mobile hierarchy with authenticated QA on `/portal/training`.
+27. **Public CX polish audit remediation**
+   - Keep Micro Machine quote-led and remove direct machine cart behavior until direct machine commerce is intentionally implemented.
+   - Make the shared cart resilient on mobile and keep checkout clearly sugar-only.
+   - Tighten public page spacing on `/machines`, `/resources`, `/plus`, and `/contact` without changing the global visual system.
+   - Improve contact form labels/input semantics, mobile icon-button labels, and product-gallery thumbnail state.
+   - Validate the remediated public routes on desktop and common mobile viewport sizes.
 
 ## P2 - Ops hardening follow-ups
-27. **Operationalize WeCom alerts + WeChat onboarding concierge** (`#110`)
+28. **Operationalize WeCom alerts + WeChat onboarding concierge** (`#110`)
    - Define referral-buddy onboarding runbook and response-time SLA.
    - Validate 1-week WeCom delivery reliability for quote/order/support alerts.
    - Capture sign-off evidence for onboarding intake + non-blocking alert failure behavior.

--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -19,6 +19,17 @@
 - Sugar still uses the 400 KG default equal split, with color-level adjustments tucked behind a "Customize Color Mix" control.
 - Bloomjoy branded sticks keep the existing under-5-box confirmation path and 5+ box direct checkout path, while custom sticks now have their own focused request flow.
 
+## Public CX polish audit (2026-04-16)
+- A public-site CX/UX/UI audit confirmed the biggest polish issues were flow clarity and mobile resilience, not a need for a redesign.
+- Micro Machine is now treated as quote-led for this remediation: `/machines/micro` should send visitors to `/contact?type=quote&interest=micro&source=/machines/micro`, keeping the shared cart sugar-only.
+- Confirmed remediation targets:
+  - Micro direct-cart behavior and cart empty-state copy
+  - cart line-item mobile overflow resilience
+  - excessive hero-to-content spacing on `/machines`, `/resources`, `/plus`, and `/contact`
+  - associated labels and input semantics on the contact form
+  - accessible names for mobile icon-only navigation controls and product-gallery thumbnails
+- This is tracked as a P1 backlog item and should stay incremental: no CMS, schema, Stripe machine-checkout, or platform change is included.
+
 ## Emergency commerce remediation snapshot (2026-04-06)
 - A production payments incident was confirmed on `2026-04-06`:
   - sugar checkout was publicly charging the Bloomjoy Plus member rate (`$8/kg`) instead of the public rate (`$10/kg`)

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -35,6 +35,8 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Mini page shows live-availability copy, `$4,000`, and no Mini waitlist form or waitlist success/error state
 - [ ] Mini page CTA opens `/contact?type=quote&interest=mini&source=/machines/mini`
 - [ ] Micro machine page shows the updated target/list price (`$2,200`)
+- [ ] Micro page primary CTA opens `/contact?type=quote&interest=micro&source=/machines/micro` and preselects `Micro Machine`
+- [ ] Micro page does not add machines to the shared cart; machine review stays quote-led
 - [ ] `/supplies` product images render professional white-background product shots without black background artifacts or awkward clipping on desktop and mobile
 - [ ] `/supplies` defaults to Sugar ordering; `/supplies?order=sugar`, `/supplies?order=sticks`, and `/supplies?order=custom` direct-load with the matching selected flow
 - [ ] Supplies order chooser switches between Sugar, Bloomjoy Branded Sticks, and Custom Sticks without showing every order flow at once
@@ -50,14 +52,20 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Bloomjoy branded sticks orders of 5+ boxes launch direct Stripe checkout with free shipping and do not use the shared cart
 - [ ] Custom sticks flow on `/supplies?order=custom` accepts logo/image upload and submits a procurement lead with artwork URL, requested box count, selected size, and `$750` first-order plate-fee note
 - [ ] Shared cart remains sugar-only and legacy stick items do not block checkout
+- [ ] Cart remains sugar-only and has no horizontal overflow on mobile viewports (`360x800`, `390x844`, `414x896`)
+- [ ] Cart line-item title, quantity controls, price, and remove action stack cleanly on mobile
 - [ ] Plus page: pricing and boundaries are visible and clear
 - [ ] Resources page shows Bloomjoy Plus teaser content for locked downloads (procedure docs, daily checklists, frequent updates)
+- [ ] `/machines`, `/resources`, `/plus`, and `/contact` show primary content without excessive dead space on desktop and mobile
 - [ ] Footer legal links open `/privacy`, `/terms`, and `/billing-cancellation`
 - [ ] Footer support links navigate to valid Resources anchors (`/resources#faq` and `/resources#support-boundaries`)
 - [ ] Billing & cancellation page explains Stripe portal cancellation path and end-of-period effect
 - [ ] Contact/Quote form submits (and confirmation is shown)
+- [ ] Contact form labels are clickable, and all visible fields have associated labels
 - [ ] Quote flow preserves machine context (for example, Commercial CTA preselects "Machine of Interest" on `/contact`)
 - [ ] Mini quote CTA preselects `Mini Machine` on `/contact` and submits as a normal quote lead (not a waitlist)
+- [ ] Mobile icon-only cart/menu controls have accessible names
+- [ ] Product-gallery thumbnail buttons are keyboard operable and announce selected image state
 - [ ] Contact/Quote submission creates a `lead_submissions` row in Supabase with expected type/email
 - [ ] Quote submissions send internal notification email with full request summary (name/email/source/type/message)
 - [ ] Quote submissions send a WeCom internal alert to configured `WECOM_ALERT_TO_USERIDS` recipients

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -230,7 +230,11 @@ export function AppLayout({ children }: AppLayoutProps) {
             <div className="md:hidden">
               <Sheet>
                 <SheetTrigger asChild>
-                  <button className="flex h-11 w-11 items-center justify-center rounded-xl border border-border bg-background text-muted-foreground transition-colors hover:text-foreground">
+                  <button
+                    type="button"
+                    className="flex h-11 w-11 items-center justify-center rounded-xl border border-border bg-background text-muted-foreground transition-colors hover:text-foreground"
+                    aria-label="Open operator navigation menu"
+                  >
                     <Menu className="h-5 w-5" />
                   </button>
                 </SheetTrigger>

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -26,6 +26,8 @@ export function Navbar() {
   const operatorAppUrl = getCanonicalUrlForSurface('app', '/portal', '', '', window.location);
   const operatorLoginUrl = getCanonicalUrlForSurface('app', '/login', '', '', window.location);
   const adminAppUrl = getCanonicalUrlForSurface('app', '/admin', '', '', window.location);
+  const cartLabel =
+    itemCount > 0 ? `View cart with ${itemCount} item${itemCount === 1 ? '' : 's'}` : 'View cart';
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-border/50 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/80">
@@ -58,7 +60,11 @@ export function Navbar() {
 
         {/* Desktop Actions */}
         <div className="hidden items-center gap-3 md:flex">
-          <Link to="/cart" className="relative p-2 text-muted-foreground hover:text-foreground">
+          <Link
+            to="/cart"
+            className="relative p-2 text-muted-foreground hover:text-foreground"
+            aria-label={cartLabel}
+          >
             <ShoppingCart className="h-5 w-5" />
             {itemCount > 0 && (
               <span className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-foreground">
@@ -93,7 +99,11 @@ export function Navbar() {
 
         {/* Mobile Menu Button */}
         <div className="flex items-center gap-3 md:hidden">
-          <Link to="/cart" className="relative p-2 text-muted-foreground hover:text-foreground">
+          <Link
+            to="/cart"
+            className="relative p-2 text-muted-foreground hover:text-foreground"
+            aria-label={cartLabel}
+          >
             <ShoppingCart className="h-5 w-5" />
             {itemCount > 0 && (
               <span className="absolute -right-1 -top-1 flex h-5 w-5 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-foreground">
@@ -102,8 +112,12 @@ export function Navbar() {
             )}
           </Link>
           <button
+            type="button"
             onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
             className="p-2 text-muted-foreground hover:text-foreground"
+            aria-label={mobileMenuOpen ? 'Close navigation menu' : 'Open navigation menu'}
+            aria-controls="mobile-navigation-menu"
+            aria-expanded={mobileMenuOpen}
           >
             {mobileMenuOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
           </button>
@@ -112,7 +126,7 @@ export function Navbar() {
 
       {/* Mobile Menu */}
       {mobileMenuOpen && (
-        <div className="border-t border-border bg-background md:hidden">
+        <div id="mobile-navigation-menu" className="border-t border-border bg-background md:hidden">
           <div className="container-page py-4">
             <div className="flex flex-col gap-2">
               {navLinks.map((link) => (

--- a/src/components/products/ProductImageGallery.tsx
+++ b/src/components/products/ProductImageGallery.tsx
@@ -24,6 +24,7 @@ export function ProductImageGallery({ images, className }: ProductImageGalleryPr
         <img
           src={images[activeIndex].src}
           alt={images[activeIndex].alt}
+          decoding="async"
           className="h-full w-full object-contain p-3"
         />
       </div>
@@ -34,12 +35,20 @@ export function ProductImageGallery({ images, className }: ProductImageGalleryPr
               key={image.src}
               type="button"
               onClick={() => setActiveIndex(index)}
+              aria-label={`View image ${index + 1}: ${image.alt}`}
+              aria-current={index === activeIndex ? 'true' : undefined}
               className={cn(
-                'aspect-square overflow-hidden rounded-md border bg-muted transition',
+                'aspect-square overflow-hidden rounded-md border bg-muted transition-colors',
                 index === activeIndex ? 'border-primary ring-1 ring-primary/30' : 'border-border hover:border-primary/40'
               )}
             >
-              <img src={image.src} alt={image.alt} className="h-full w-full object-contain p-1" />
+              <img
+                src={image.src}
+                alt={image.alt}
+                loading="lazy"
+                decoding="async"
+                className="h-full w-full object-contain p-1"
+              />
             </button>
           ))}
         </div>

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -89,7 +89,8 @@ export default function CartPage() {
                 Your cart is empty
               </h1>
               <p className="mt-2 text-muted-foreground">
-                Add some supplies or machines to get started.
+                Checkout is available for sugar supplies. Machines are reviewed through the
+                quote process.
               </p>
               <div className="mt-8 flex flex-wrap justify-center gap-4">
                 <Link to="/supplies">
@@ -117,22 +118,26 @@ export default function CartPage() {
             <div className="lg:col-span-2">
               <div className="divide-y divide-border rounded-xl border border-border bg-card">
                 {items.map((item) => (
-                  <div key={item.sku} className="flex items-center gap-4 p-4">
+                  <div
+                    key={item.sku}
+                    className="grid gap-4 p-4 sm:grid-cols-[auto_minmax(0,1fr)_auto_auto_auto] sm:items-center"
+                  >
                     <div className="flex h-16 w-16 items-center justify-center rounded-lg bg-muted">
                       <ShoppingBag className="h-8 w-8 text-muted-foreground/50" />
                     </div>
-                    <div className="flex-1">
-                      <h3 className="font-semibold text-foreground">{item.name}</h3>
+                    <div className="min-w-0">
+                      <h3 className="break-words font-semibold text-foreground">{item.name}</h3>
                       <p className="text-sm text-muted-foreground">
                         ${getDisplayUnitPrice(item.sku, item.price).toFixed(2)} each
                       </p>
                     </div>
-                    <div className="flex items-center gap-2 rounded-lg border border-border p-1">
+                    <div className="flex w-full flex-wrap items-center gap-2 rounded-lg border border-border p-1 sm:w-auto sm:flex-nowrap">
                       <Button
                         variant="ghost"
                         size="icon"
                         className="h-8 w-8"
                         onClick={() => updateQuantity(item.sku, item.quantity - 1)}
+                        aria-label={`Decrease quantity for ${item.name}`}
                       >
                         <Minus className="h-4 w-4" />
                       </Button>
@@ -142,11 +147,15 @@ export default function CartPage() {
                         size="icon"
                         className="h-8 w-8"
                         onClick={() => updateQuantity(item.sku, item.quantity + 1)}
+                        aria-label={`Increase quantity for ${item.name}`}
                       >
                         <Plus className="h-4 w-4" />
                       </Button>
                       <Input
+                        aria-label={`Quantity for ${item.name}`}
+                        name={`quantity-${item.sku}`}
                         type="number"
+                        inputMode="numeric"
                         min={0}
                         value={item.quantity}
                         onChange={(event) => {
@@ -156,10 +165,10 @@ export default function CartPage() {
                             Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0
                           );
                         }}
-                        className="h-8 w-20 text-right"
+                        className="h-8 min-w-0 flex-1 text-right sm:w-20 sm:flex-none"
                       />
                     </div>
-                    <p className="w-20 text-right font-semibold text-foreground">
+                    <p className="text-right font-semibold text-foreground sm:w-20">
                       ${(
                         getDisplayUnitPrice(item.sku, item.price) * item.quantity
                       ).toFixed(2)}
@@ -169,6 +178,7 @@ export default function CartPage() {
                       size="icon"
                       className="text-muted-foreground hover:text-destructive"
                       onClick={() => removeItem(item.sku)}
+                      aria-label={`Remove ${item.name} from cart`}
                     >
                       <Trash2 className="h-4 w-4" />
                     </Button>
@@ -252,7 +262,7 @@ export default function CartPage() {
                   onClick={handleCheckout}
                   disabled={isCheckingOut}
                 >
-                  {isCheckingOut ? 'Redirecting...' : 'Checkout'}
+                  {isCheckingOut ? 'Redirecting…' : 'Checkout'}
                   <ArrowRight className="ml-2 h-4 w-4" />
                 </Button>
                 <p className="mt-3 text-center text-xs text-muted-foreground">

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Mail, MapPin, Phone } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
@@ -80,7 +79,7 @@ export default function ContactPage() {
 
   return (
     <Layout>
-      <section className="bg-gradient-to-b from-cream to-background section-padding">
+      <section className="bg-gradient-to-b from-cream to-background py-12 sm:py-14 lg:py-16">
         <div className="container-page">
           <div className="mx-auto max-w-2xl text-center">
             <h1 className="font-display text-4xl font-bold text-foreground">Contact Us</h1>
@@ -91,7 +90,7 @@ export default function ContactPage() {
         </div>
       </section>
 
-      <section className="section-padding">
+      <section className="py-10 sm:py-12 lg:py-16">
         <div className="container-page">
           <div className="mx-auto max-w-2xl">
             <div className="card-elevated p-8">
@@ -100,6 +99,7 @@ export default function ContactPage() {
                   <label htmlFor="website">Website</label>
                   <Input
                     id="website"
+                    name="website"
                     value={formData.website}
                     onChange={(e) => setFormData({ ...formData, website: e.target.value })}
                     tabIndex={-1}
@@ -108,17 +108,57 @@ export default function ContactPage() {
                 </div>
                 <div className="grid gap-4 sm:grid-cols-2">
                   <div>
-                    <label className="block text-sm font-medium text-foreground">Name</label>
-                    <Input value={formData.name} onChange={(e) => setFormData({ ...formData, name: e.target.value })} required className="mt-1" />
+                    <label
+                      htmlFor="contact-name"
+                      className="block text-sm font-medium text-foreground"
+                    >
+                      Name
+                    </label>
+                    <Input
+                      id="contact-name"
+                      name="name"
+                      value={formData.name}
+                      onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                      autoComplete="name"
+                      required
+                      className="mt-1"
+                    />
                   </div>
                   <div>
-                    <label className="block text-sm font-medium text-foreground">Email</label>
-                    <Input type="email" value={formData.email} onChange={(e) => setFormData({ ...formData, email: e.target.value })} required className="mt-1" />
+                    <label
+                      htmlFor="contact-email"
+                      className="block text-sm font-medium text-foreground"
+                    >
+                      Email
+                    </label>
+                    <Input
+                      id="contact-email"
+                      name="email"
+                      type="email"
+                      inputMode="email"
+                      value={formData.email}
+                      onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+                      autoComplete="email"
+                      spellCheck={false}
+                      required
+                      className="mt-1"
+                    />
                   </div>
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-foreground">Inquiry Type</label>
-                  <select value={formData.type} onChange={(e) => setFormData({ ...formData, type: e.target.value })} className="mt-1 w-full rounded-lg border border-input bg-background px-3 py-2 text-sm">
+                  <label
+                    htmlFor="contact-type"
+                    className="block text-sm font-medium text-foreground"
+                  >
+                    Inquiry Type
+                  </label>
+                  <select
+                    id="contact-type"
+                    name="type"
+                    value={formData.type}
+                    onChange={(e) => setFormData({ ...formData, type: e.target.value })}
+                    className="mt-1 w-full rounded-lg border border-input bg-background px-3 py-2 text-sm"
+                  >
                     <option value="quote">Request a Quote</option>
                     <option value="demo">Demo Request</option>
                     <option value="procurement">Procurement Questions</option>
@@ -127,10 +167,15 @@ export default function ContactPage() {
                 </div>
                 {formData.type === 'quote' && (
                   <div>
-                    <label className="block text-sm font-medium text-foreground">
+                    <label
+                      htmlFor="contact-interest"
+                      className="block text-sm font-medium text-foreground"
+                    >
                       Machine of Interest
                     </label>
                     <select
+                      id="contact-interest"
+                      name="interest"
                       value={formData.interest}
                       onChange={(e) => setFormData({ ...formData, interest: e.target.value })}
                       className="mt-1 w-full rounded-lg border border-input bg-background px-3 py-2 text-sm"
@@ -145,11 +190,24 @@ export default function ContactPage() {
                   </div>
                 )}
                 <div>
-                  <label className="block text-sm font-medium text-foreground">Message</label>
-                  <Textarea value={formData.message} onChange={(e) => setFormData({ ...formData, message: e.target.value })} rows={5} required className="mt-1" />
+                  <label
+                    htmlFor="contact-message"
+                    className="block text-sm font-medium text-foreground"
+                  >
+                    Message
+                  </label>
+                  <Textarea
+                    id="contact-message"
+                    name="message"
+                    value={formData.message}
+                    onChange={(e) => setFormData({ ...formData, message: e.target.value })}
+                    rows={5}
+                    required
+                    className="mt-1"
+                  />
                 </div>
                 <Button type="submit" variant="hero" size="lg" className="w-full" disabled={submitting}>
-                  {submitting ? 'Sending...' : 'Send Message'}
+                  {submitting ? 'Sending…' : 'Send Message'}
                 </Button>
               </form>
             </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -105,12 +105,14 @@ export default function HomePage() {
               <Link
                 key={product.title}
                 to={product.href}
-                className="group card-elevated overflow-hidden transition-all hover:-translate-y-1"
+                className="group card-elevated overflow-hidden transition-[box-shadow,transform] duration-200 hover:-translate-y-1"
               >
                 <div className="aspect-square overflow-hidden bg-muted">
                   <img
                     src={product.image}
                     alt={product.title}
+                    loading="lazy"
+                    decoding="async"
                     className="h-full w-full object-contain p-3 transition-transform duration-300 group-hover:scale-105"
                   />
                 </div>

--- a/src/pages/Plus.tsx
+++ b/src/pages/Plus.tsx
@@ -80,7 +80,7 @@ export default function PlusPage() {
   return (
     <Layout>
       {/* Hero */}
-      <section className="bg-gradient-to-b from-cream to-background section-padding">
+      <section className="bg-gradient-to-b from-cream to-background py-12 sm:py-14 lg:py-16">
         <div className="container-page">
           <div className="mx-auto max-w-3xl text-center">
             <span className="rounded-full bg-primary/10 px-4 py-1.5 text-sm font-semibold text-primary">
@@ -97,7 +97,7 @@ export default function PlusPage() {
       </section>
 
       {/* Pricing Card */}
-      <section className="section-padding">
+      <section className="py-10 sm:py-12 lg:py-16">
         <div className="container-page">
           <div className="mx-auto max-w-2xl">
             <div className="card-elevated overflow-hidden">
@@ -142,7 +142,7 @@ export default function PlusPage() {
                   disabled={isStartingCheckout}
                 >
                   {isStartingCheckout
-                    ? 'Redirecting...'
+                    ? 'Redirecting…'
                     : user
                       ? 'Start Membership'
                       : 'Log In to Start Membership'}
@@ -167,7 +167,7 @@ export default function PlusPage() {
       </section>
 
       {/* Support Boundaries */}
-      <section className="bg-muted/50 section-padding">
+      <section className="bg-muted/50 py-10 sm:py-12 lg:py-16">
         <div className="container-page">
           <div className="mx-auto max-w-3xl">
             <h2 className="text-center font-display text-2xl font-bold text-foreground">
@@ -239,7 +239,7 @@ export default function PlusPage() {
       </section>
 
       {/* CTA */}
-      <section className="section-padding">
+      <section className="py-10 sm:py-12 lg:py-16">
         <div className="container-page text-center">
           <h2 className="font-display text-2xl font-bold text-foreground">
             Questions about Plus?

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -46,7 +46,7 @@ export default function ProductsPage() {
   return (
     <Layout>
       {/* Hero */}
-      <section className="bg-gradient-to-b from-cream to-background section-padding">
+      <section className="bg-gradient-to-b from-cream to-background py-12 sm:py-14 lg:py-16">
         <div className="container-page text-center">
           <h1 className="font-display text-4xl font-bold text-foreground sm:text-5xl">
             Machines
@@ -58,7 +58,7 @@ export default function ProductsPage() {
       </section>
 
       {/* Machines */}
-      <section className="section-padding">
+      <section className="py-10 sm:py-12 lg:py-16">
         <div className="container-page">
           <h2 className="font-display text-2xl font-bold text-foreground">Machines</h2>
           <div className="mt-8 grid gap-8 md:grid-cols-3">
@@ -66,12 +66,14 @@ export default function ProductsPage() {
               <Link
                 key={product.sku}
                 to={product.href}
-                className="group card-elevated overflow-hidden transition-all hover:-translate-y-1"
+                className="group card-elevated overflow-hidden transition-[box-shadow,transform] duration-200 hover:-translate-y-1"
               >
                 <div className="aspect-square overflow-hidden bg-muted">
                   <img
                     src={product.image}
                     alt={product.name}
+                    loading="lazy"
+                    decoding="async"
                     className="h-full w-full object-contain p-3 transition-transform duration-300 group-hover:scale-105"
                   />
                 </div>
@@ -104,7 +106,7 @@ export default function ProductsPage() {
       </section>
 
       {/* Supplies Callout */}
-      <section className="bg-muted/50 section-padding">
+      <section className="bg-muted/50 py-10 sm:py-12 lg:py-16">
         <div className="container-page">
           <div className="card-elevated flex flex-col items-center gap-6 p-8 text-center md:flex-row md:text-left">
             <div className="flex-1">

--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -38,13 +38,13 @@ export default function ResourcesPage() {
 
   return (
     <Layout>
-      <section className="bg-gradient-to-b from-cream to-background section-padding">
+      <section className="bg-gradient-to-b from-cream to-background py-12 sm:py-14 lg:py-16">
         <div className="container-page text-center">
           <h1 className="font-display text-4xl font-bold text-foreground">Resources</h1>
           <p className="mt-4 text-lg text-muted-foreground">FAQs, guides, and what to expect.</p>
         </div>
       </section>
-      <section id="faq" className="section-padding scroll-mt-24">
+      <section id="faq" className="scroll-mt-24 py-10 sm:py-12 lg:py-16">
         <div className="container-page">
           <div className="mx-auto max-w-2xl">
             <h2 className="font-display text-2xl font-bold text-foreground">Frequently Asked Questions</h2>
@@ -59,7 +59,7 @@ export default function ResourcesPage() {
           </div>
         </div>
       </section>
-      <section className="section-padding border-y border-border bg-muted/20">
+      <section className="border-y border-border bg-muted/20 py-10 sm:py-12 lg:py-16">
         <div className="container-page">
           <div className="mx-auto max-w-4xl">
             <div className="flex flex-col gap-3 text-center">

--- a/src/pages/products/Micro.tsx
+++ b/src/pages/products/Micro.tsx
@@ -1,13 +1,11 @@
 import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { Check, AlertCircle, ShoppingCart } from 'lucide-react';
+import { AlertCircle, ArrowRight, Check } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Layout } from '@/components/layout/Layout';
 import { ProductImageGallery } from '@/components/products/ProductImageGallery';
 import { trackEvent } from '@/lib/analytics';
-import { useCart } from '@/lib/cart';
 import { MACHINE_NAMES } from '@/lib/machineNames';
-import { toast } from 'sonner';
 import microMain from '@/assets/real/micro-main.webp';
 import microGallery1 from '@/assets/real/micro-gallery-1.webp';
 import microGallery2 from '@/assets/real/micro-gallery-2.webp';
@@ -25,21 +23,12 @@ const microImages = [
 ];
 
 export default function MicroPage() {
-  const { addItem } = useCart();
-
   useEffect(() => {
     trackEvent('view_product_micro');
   }, []);
 
-  const handleBuyNow = () => {
-    trackEvent('click_buy_micro');
-    addItem({
-      sku: 'micro',
-      name: `Bloomjoy Sweets ${MACHINE_NAMES.micro}`,
-      price: 2200,
-      type: 'machine',
-    });
-    toast.success('Micro added to cart!');
+  const handleQuoteRequest = () => {
+    trackEvent('click_quote_micro');
   };
 
   return (
@@ -77,10 +66,15 @@ export default function MicroPage() {
               </p>
 
               <div className="mt-8 space-y-4">
-                <Button variant="hero" size="xl" className="w-full" onClick={handleBuyNow}>
-                  <ShoppingCart className="mr-2 h-5 w-5" />
-                  Add to Cart
-                </Button>
+                <Link
+                  to="/contact?type=quote&interest=micro&source=/machines/micro"
+                  onClick={handleQuoteRequest}
+                >
+                  <Button variant="hero" size="xl" className="w-full">
+                    Request a Quote
+                    <ArrowRight className="ml-2 h-5 w-5" />
+                  </Button>
+                </Link>
                 <Link to="/supplies">
                   <Button variant="hero-outline" size="lg" className="w-full">
                     Reorder Sugar

--- a/src/pages/products/Micro.tsx
+++ b/src/pages/products/Micro.tsx
@@ -66,20 +66,20 @@ export default function MicroPage() {
               </p>
 
               <div className="mt-8 space-y-4">
-                <Link
-                  to="/contact?type=quote&interest=micro&source=/machines/micro"
-                  onClick={handleQuoteRequest}
-                >
-                  <Button variant="hero" size="xl" className="w-full">
+                <Button asChild variant="hero" size="xl" className="w-full">
+                  <Link
+                    to="/contact?type=quote&interest=micro&source=/machines/micro"
+                    onClick={handleQuoteRequest}
+                  >
                     Request a Quote
                     <ArrowRight className="ml-2 h-5 w-5" />
-                  </Button>
-                </Link>
-                <Link to="/supplies">
-                  <Button variant="hero-outline" size="lg" className="w-full">
+                  </Link>
+                </Button>
+                <Button asChild variant="hero-outline" size="lg" className="w-full">
+                  <Link to="/supplies">
                     Reorder Sugar
-                  </Button>
-                </Link>
+                  </Link>
+                </Button>
               </div>
 
               {/* Features */}


### PR DESCRIPTION
## Summary
- Makes Micro Machine quote-led by replacing direct cart behavior with a quote CTA that preserves machine interest/source context.
- Improves public CX polish across cart mobile resilience, contact form semantics, nav/gallery accessible labels, and targeted page spacing.
- Documents the audit snapshot, P1 backlog item, and QA acceptance checks in repo docs.

## Files changed
- Public product/cart/contact pages: Micro CTA flow, sugar-only cart copy, responsive cart rows, contact form labels/input semantics.
- Public layout/gallery components: mobile nav/cart accessible names, app-shell menu label, product-gallery thumbnail labels/current state.
- Public marketing pages: targeted spacing reductions on `/machines`, `/resources`, `/plus`, and `/contact`; explicit transitions/lazy image loading on touched cards.
- Docs: `Docs/CURRENT_STATUS.md`, `Docs/BACKLOG.md`, `Docs/QA_SMOKE_TEST_CHECKLIST.md`.

## Verification commands + results
- `npm ci` - passed; npm reported existing audit advisories (9 vulnerabilities: 4 moderate, 5 high).
- `npm run build` - passed; Vite build completed and prerendered public/private route HTML.
- `npm test --if-present` - passed with no test output; no test script appears to be defined.
- `npm run lint --if-present` - passed with existing fast-refresh warnings in shared UI/auth files only.
- Browser QA on localhost with Playwright temp spec - passed 7/7 checks:
  - desktop `1440x1000` route load and no horizontal overflow for `/`, `/machines`, `/machines/micro`, `/supplies?order=sugar`, `/plus`, `/resources`, `/contact?type=quote&interest=micro&source=/machines/micro`, `/cart`
  - mobile `360x800`, `390x844`, `414x896` route load and no horizontal overflow for the same routes
  - Micro quote CTA preselects `Micro Machine`
  - contact visible fields have associated labels
  - mobile cart/menu controls have accessible names
  - product-gallery thumbnails are keyboard operable and expose selected state
  - legacy machine cart item does not overflow mobile cart

## How to test
1. In the worktree, run `npm ci`.
2. Start local dev with client-safe env values present, for example:
   `VITE_SUPABASE_URL=https://example.supabase.co VITE_SUPABASE_ANON_KEY=placeholder npm run dev -- --host 127.0.0.1 --port 8082`
3. Open `http://127.0.0.1:8082`.
4. Check these key URLs:
   - `/machines/micro` - primary CTA is `Request a Quote`, not `Add to Cart`.
   - `/contact?type=quote&interest=micro&source=/machines/micro` - `Machine of Interest` is preselected as `Micro Machine`.
   - `/cart` - empty-state copy keeps checkout sugar-only and points machines to quote/review.
   - `/machines`, `/resources`, `/plus`, `/contact` - primary content appears without excessive hero-to-content dead space on desktop and mobile.
   - `/supplies?order=sugar` - sugar ordering still supports cart/checkout initiation.
5. On mobile widths `360x800`, `390x844`, and `414x896`, open/close the mobile nav and confirm cart/routes do not horizontally scroll.