### PR TITLE
Implement autonomous marketing foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,8 @@ VITE_USE_GIS_BUTTON=false
 # Optional local-dev-only QA override for admin access (comma-separated emails).
 # Ignored outside local development mode.
 VITE_DEV_ADMIN_EMAILS=
+# Optional client-safe GA4 measurement ID for marketing attribution and page views.
+VITE_GA4_MEASUREMENT_ID=
 
 # Server-only values (Supabase Edge Functions / backend only)
 # WARNING: Never prefix these with VITE_.

--- a/Docs/AUTONOMOUS_MARKETING_AGENCY.md
+++ b/Docs/AUTONOMOUS_MARKETING_AGENCY.md
@@ -1,0 +1,82 @@
+# Autonomous Marketing Agency
+
+Purpose: define the v1 hands-off marketing operating system for Bloomjoy. This is an implementation contract for agents, not a campaign brainstorm.
+
+## Strategy
+
+- Primary KPI: qualified machine quote leads.
+- First revenue path: machine quote pipeline.
+- Follow-on revenue path: Bloomjoy Plus, sugar, and sticks.
+- Channel mix: owned-first. Prioritize the website, SEO, opt-in email, LinkedIn, YouTube/short-form repurposing, and lightweight social distribution.
+- Monthly budget cap: under `$500` until attribution and lead scoring show reliable signal.
+- Email policy: opt-in only. No cold campaigns in v1.
+
+## Agent Roles
+
+- CMO Orchestrator: owns the weekly scorecard, content calendar, budget cap, and escalation log.
+- Growth Intelligence: reviews Supabase leads/orders, Stripe, GA4/Search Console, GitHub issues/PRs, and the Bloomjoy events repo for next actions.
+- Content + SEO: ships machine-buyer pages, resource updates, FAQs, case studies, comparison content, and Plus/support content.
+- Lifecycle Email: uses Resend Audience/Broadcast only for opted-in contacts after sender, unsubscribe, and seed-list checks pass.
+- Social Repurposing: turns approved owned content and anonymized event lessons into LinkedIn posts, short-form scripts, and captions.
+- Compliance + QA: blocks unsupported claims, franchise-era language, unapproved client/logo use, missing unsubscribe paths, and 24/7 Bloomjoy support promises.
+
+## Guardrails
+
+- Do not introduce a paid marketing platform without a decision entry in `Docs/DECISIONS.md`.
+- Do not use client/event names, logos, or identifiable event details in public content unless written permission is documented.
+- Do not auto-send one-to-one Gmail replies. Existing Bloomjoy Gmail automation may draft but not send external replies.
+- Do not send marketing email to contacts unless `lead_submissions.marketing_consent = true` or another explicit opt-in source is documented.
+- Do not spend paid media budget until UTM capture, lead scoring, and the weekly scorecard are working.
+- Paid search/social tests are capped at `$300/month` inside the overall `$500/month` v1 cap.
+
+## Attribution And Lead Scoring
+
+Website quote submissions now capture:
+
+- Source page and stored attribution (`utm_*`, click IDs, first/latest landing page, first/latest external referrer).
+- Machine interest, buyer segment, purchase timeline, budget/procurement status, Plus interest, and marketing consent.
+- Qualification grade:
+  - `A`: use case, timeline, budget/procurement signal, and contact quality are all present.
+  - `B`: three of the four signals are present.
+  - `C`: fewer than three signals are present.
+
+Contact quality means a valid name/email plus a company/venue, or a consumer/home buyer segment.
+
+## Weekly Cadence
+
+1. Run the marketing scorecard:
+
+```bash
+npm run marketing:scorecard -- --days 7
+```
+
+2. Review:
+   - qualified quote leads by grade
+   - machine interest and buyer segment mix
+   - UTM source/campaign performance
+   - Plus-interest leads
+   - supply orders and Plus activations
+
+3. Ship one owned-first improvement:
+   - one SEO/resource/page update
+   - one opt-in email/nurture improvement
+   - one conversion experiment or landing-page cleanup
+
+4. Repurpose only approved owned content into social posts.
+
+## Email QA
+
+Before any Resend Broadcast goes live:
+
+- Confirm the contact segment is opt-in only.
+- Send to an internal seed list first.
+- Verify unsubscribe handling.
+- Verify sender domain and reply-to.
+- Confirm no unsupported claims, unapproved client names, or unapproved logos are present.
+
+## Compliance References
+
+- FTC CAN-SPAM guide: https://www.ftc.gov/node/81459
+- FTC endorsement guidance: https://www.ftc.gov/business-guidance/resources/ftcs-endorsement-guides
+- Google helpful content guidance: https://developers.google.com/search/docs/fundamentals/creating-helpful-content
+- Resend Audiences/Broadcasts docs: https://resend.com/docs/dashboard/audiences/introduction

--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -6,6 +6,14 @@
 - First priority is to **stabilize the POC** and align it to the MVP routing + docs workflow.
 - Write updates in plain language so non-technical readers can follow.
 
+## Autonomous marketing foundation (2026-04-23)
+- Added the v1 autonomous marketing operating contract in `Docs/AUTONOMOUS_MARKETING_AGENCY.md`.
+- Website quote submissions now capture campaign attribution, buyer segment, purchase timeline, budget/procurement status, Plus interest, and opt-in marketing consent.
+- Lead intake now stores a server-computed qualification grade (`A`, `B`, or `C`) so the weekly KPI can focus on qualified machine quote leads instead of raw form count.
+- Optional GA4 page-view tracking is wired through the client-safe `VITE_GA4_MEASUREMENT_ID` env var.
+- Added `npm run marketing:scorecard` for the weekly CMO/orchestrator scorecard across leads, orders, and Plus activations.
+- GitHub issue `#99` for the dedicated Resend account is closed; docs should treat Resend as an ongoing secret/sender-health dependency rather than an open P0 blocker.
+
 ## Mini launch update (2026-04-09)
 - Mini is now live on the public site as a sales-led machine offer at `$4,000`.
 - Public Mini demand no longer goes to a waitlist form:
@@ -64,7 +72,6 @@
   - confirm whether the Bloomjoy Alerts app enforces an IP allowlist or trusted network restriction in WeCom
   - update the WeCom app policy so Supabase Edge Function traffic can send messages successfully
   - re-run the live `$0` order smoke test and confirm `wecom_alert_sent_at` populates in `public.orders`
-- Unblock and complete issue `#99` (dedicated Resend account for `bloomjoysweets.com`) so production auth and transactional email ownership can move off the currently blocked setup.
 
 ## Operator app surface split (2026-03-22)
 - Authenticated operator routes now have a dedicated application shell and canonical host instead of inheriting the public sales navbar/footer.
@@ -302,7 +309,7 @@ Execution order is based on launch risk and dependency overlap.
 
 ## Environments
 - Local: `npm run dev` on a PR branch/worktree
-- Production: `main` deployed to `www.bloomjoyusa.com` / `app.bloomjoyusa.com`; remaining commerce follow-up is limited to WeCom alert delivery policy and dedicated Resend ownership
+- Production: `main` deployed to `www.bloomjoyusa.com` / `app.bloomjoyusa.com`; remaining commerce follow-up is limited to WeCom alert delivery policy plus normal Resend sender/secret health
 
 ## How to test on localhost (simple steps)
 1) In the project folder, run `npm ci`

--- a/Docs/DECISIONS.md
+++ b/Docs/DECISIONS.md
@@ -1,5 +1,22 @@
 # Decisions
 
+## 2026-04-23 - Autonomous marketing foundation
+Bloomjoy will run v1 autonomous marketing as an owned-first, opt-in-only system optimized for qualified machine quote leads.
+
+**Canonical choices**
+- Primary KPI: qualified machine quote leads.
+- Channel priority: website/SEO, conversion improvements, opt-in email, LinkedIn, YouTube/short-form repurposing, and lightweight social distribution.
+- Monthly budget cap: under `$500`; paid tests are deferred until attribution and scorecard reporting work.
+- Email policy: opt-in only for marketing campaigns; no cold outreach in v1.
+- Resend may be used for marketing only through Audience/Broadcast workflows with unsubscribe handling; do not add another email platform for v1.
+- One-to-one Gmail lead/vendor replies remain draft-only under the existing Bloomjoy Gmail automation workflow.
+
+**Implementation notes**
+- Quote submissions capture campaign attribution, buyer segment, purchase timeline, budget/procurement status, Plus interest, marketing consent, and a server-computed `A`/`B`/`C` lead grade.
+- GA4 page-view tracking is optional through `VITE_GA4_MEASUREMENT_ID`; do not place analytics or ad-platform secrets in `VITE_` variables.
+- Weekly reporting runs through `npm run marketing:scorecard`.
+- Public content may use anonymized event learnings, but client names/logos require documented permission before publication.
+
 ## 2026-04-14 - Training-only operator access grants
 Bloomjoy now supports a narrow operator access tier for staff who need training without becoming paid Bloomjoy Plus members.
 

--- a/Docs/LOCAL_DEV.md
+++ b/Docs/LOCAL_DEV.md
@@ -19,6 +19,8 @@
      - `VITE_USE_GIS_BUTTON=true` (optional; if omitted, app uses redirect-based Google sign-in)
    - Optional local QA-only admin override:
      - `VITE_DEV_ADMIN_EMAILS=ethtri@gmail.com` (comma-separated list; applies only in local dev mode)
+   - Optional marketing analytics:
+     - `VITE_GA4_MEASUREMENT_ID` (client-safe GA4 measurement ID; leave blank for local dev if not testing analytics)
 3) Install deps:
    - `npm ci`
 4) Start dev server (from your worktree folder, e.g. `C:\Repos\wt-<task>`):
@@ -161,6 +163,22 @@ To use all login methods in local dev:
   Board: https://github.com/users/ethtri/projects/2
 - Keep repo docs light: `Docs/CURRENT_STATUS.md` is a short, plain-language snapshot.
 - If you keep personal notes, store them locally and do not commit them.
+
+## Autonomous marketing scorecard
+Use this for the weekly CMO/orchestrator readout after the marketing attribution migration is applied.
+
+1) Ensure local env includes:
+   - `SUPABASE_URL` or `VITE_SUPABASE_URL`
+   - `SUPABASE_SERVICE_ROLE_KEY`
+2) Run:
+   - `npm run marketing:scorecard -- --days 7`
+3) Optional JSON output for agent tooling:
+   - `npm run marketing:scorecard -- --days 7 --format json`
+
+Notes:
+- The scorecard is read-only.
+- It reports qualified quote leads, marketing opt-ins, Plus-interest leads, orders, Plus activations, and UTM/source breakdowns.
+- Marketing email sends remain opt-in only; use `Docs/AUTONOMOUS_MARKETING_AGENCY.md` before creating campaigns.
 
 
 ## Asset access (local-only)

--- a/Docs/PRODUCTION_RUNBOOK.md
+++ b/Docs/PRODUCTION_RUNBOOK.md
@@ -18,6 +18,7 @@ Set the following values before launch.
 |---|---|---|---|---|
 | `VITE_SUPABASE_URL` | Frontend (public) | SPA Supabase client | Supabase project settings | Technical owner |
 | `VITE_SUPABASE_ANON_KEY` | Frontend (public) | SPA Supabase client | Supabase project API keys | Technical owner |
+| `VITE_GA4_MEASUREMENT_ID` | Frontend (public, optional) | GA4 page-view tracking | Google Analytics property | Marketing owner |
 | `STRIPE_SECRET_KEY` | Server-only | Stripe Edge Functions | Stripe Dashboard > Developers > API keys | Billing owner |
 | `STRIPE_SUGAR_MEMBER_PRICE_ID` | Server-only | `stripe-sugar-checkout` | Stripe member sugar price (`$8/kg`) | Billing owner |
 | `STRIPE_SUGAR_NON_MEMBER_PRICE_ID` | Server-only | `stripe-sugar-checkout` | Stripe public sugar price (`$10/kg`) | Billing owner |
@@ -38,6 +39,7 @@ Set the following values before launch.
 
 Security rule:
 - Never place secrets in `VITE_` variables.
+- GA4 measurement IDs are client-safe identifiers, but ad-platform secrets, API keys, or service-role credentials are never client-safe.
 
 ## 3) Pre-launch checklist (T-24h)
 - [ ] Launch freeze announced (no unrelated merges to `main` during launch window).

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -64,6 +64,10 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Contact form labels are clickable, and all visible fields have associated labels
 - [ ] Quote flow preserves machine context (for example, Commercial CTA preselects "Machine of Interest" on `/contact`)
 - [ ] Mini quote CTA preselects `Mini Machine` on `/contact` and submits as a normal quote lead (not a waitlist)
+- [ ] Contact/Quote form captures company/venue, buyer segment, timeline, budget/procurement status, Plus interest, and opt-in marketing consent
+- [ ] Contact/Quote submission with UTM parameters stores attribution in `lead_submissions.attribution`
+- [ ] Contact/Quote submission stores `qualification_grade` as `A`, `B`, or `C` based on use case, timeline, budget/procurement, and contact-quality signals
+- [ ] Marketing consent stays opt-in only; unchecked submissions persist `marketing_consent=false`
 - [ ] Mobile icon-only cart/menu controls have accessible names
 - [ ] Product-gallery thumbnail buttons are keyboard operable and announce selected image state
 - [ ] Contact/Quote submission creates a `lead_submissions` row in Supabase with expected type/email

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "training:dedupe-catalog": "node scripts/dedupe-training-catalog.mjs",
     "training:sync-guides": "node scripts/sync-training-guides.mjs",
     "training:upload-docs": "node scripts/upload-training-documents.mjs",
+    "marketing:scorecard": "node scripts/marketing-scorecard.mjs",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/scripts/marketing-scorecard.mjs
+++ b/scripts/marketing-scorecard.mjs
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createClient } from '@supabase/supabase-js';
+
+const DEFAULTS = {
+  days: 7,
+  envFiles: ['.env', '.env.local'],
+  format: 'markdown',
+};
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+function parseArgs(argv) {
+  const parsed = { ...DEFAULTS, envFiles: [] };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (arg === '--days' && next) {
+      const days = Number(next);
+      if (Number.isFinite(days) && days > 0) {
+        parsed.days = days;
+      }
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--env-file' && next) {
+      parsed.envFiles.push(next);
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--format' && next) {
+      parsed.format = next === 'json' ? 'json' : 'markdown';
+      index += 1;
+      continue;
+    }
+  }
+
+  if (parsed.envFiles.length === 0) {
+    parsed.envFiles = [...DEFAULTS.envFiles];
+  }
+
+  return parsed;
+}
+
+function parseEnvFile(contents) {
+  const result = {};
+
+  for (const rawLine of contents.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) {
+      continue;
+    }
+
+    const eqIndex = line.indexOf('=');
+    if (eqIndex <= 0) {
+      continue;
+    }
+
+    const key = line.slice(0, eqIndex).trim();
+    let value = line.slice(eqIndex + 1).trim();
+
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    result[key] = value;
+  }
+
+  return result;
+}
+
+function loadEnvFiles(envFiles) {
+  const merged = {};
+  const loadedFiles = [];
+
+  for (const envFile of envFiles) {
+    const absolutePath = path.resolve(repoRoot, envFile);
+    if (!fs.existsSync(absolutePath)) {
+      continue;
+    }
+
+    Object.assign(merged, parseEnvFile(fs.readFileSync(absolutePath, 'utf8')));
+    loadedFiles.push(envFile);
+  }
+
+  return {
+    env: {
+      ...merged,
+      ...process.env,
+    },
+    loadedFiles,
+  };
+}
+
+function countBy(rows, mapper) {
+  return rows.reduce((acc, row) => {
+    const key = mapper(row) || 'unknown';
+    acc[key] = (acc[key] ?? 0) + 1;
+    return acc;
+  }, {});
+}
+
+function sumCents(rows) {
+  return rows.reduce((total, row) => {
+    const amount = Number(row.amount_total);
+    return total + (Number.isFinite(amount) ? amount : 0);
+  }, 0);
+}
+
+function formatUsd(cents) {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function toSortedEntries(record) {
+  return Object.entries(record).sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+}
+
+async function fetchRows(client, table, select, cutoffIso) {
+  const { data, error } = await client
+    .from(table)
+    .select(select)
+    .gte('created_at', cutoffIso)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    throw new Error(`${table}: ${error.message}`);
+  }
+
+  return data ?? [];
+}
+
+function buildActionQueue({ leads, orders, subscriptions }) {
+  const actions = [];
+  const qualifiedLeads = leads.filter((lead) => ['A', 'B'].includes(lead.qualification_grade));
+  const quoteLeads = leads.filter((lead) => lead.submission_type === 'quote');
+  const optIns = leads.filter((lead) => lead.marketing_consent);
+
+  if (qualifiedLeads.length === 0) {
+    actions.push('Prioritize one machine-buyer SEO/CRO improvement before adding social volume.');
+  }
+
+  if (quoteLeads.length > 0 && optIns.length === 0) {
+    actions.push('Review contact form consent copy and lead magnet offer; quote demand is not converting into nurture permission.');
+  }
+
+  if (orders.length > 0 && subscriptions.length === 0) {
+    actions.push('Add a Plus follow-up to post-purchase owned channels for recent supply buyers.');
+  }
+
+  if (actions.length === 0) {
+    actions.push('Continue the weekly owned-first cadence: one SEO asset, one email/nurture improvement, and one conversion experiment.');
+  }
+
+  return actions;
+}
+
+function buildScorecard({ days, cutoffIso, leads, orders, subscriptions }) {
+  const quoteLeads = leads.filter((lead) => lead.submission_type === 'quote');
+  const qualifiedA = quoteLeads.filter((lead) => lead.qualification_grade === 'A');
+  const qualifiedB = quoteLeads.filter((lead) => lead.qualification_grade === 'B');
+  const optIns = leads.filter((lead) => lead.marketing_consent);
+  const plusInterest = leads.filter((lead) => lead.plus_interest);
+  const completedOrders = orders.filter((order) => order.status === 'paid' || order.status === 'complete');
+  const activeSubscriptions = subscriptions.filter((subscription) =>
+    ['active', 'trialing'].includes(subscription.status)
+  );
+
+  return {
+    generated_at: new Date().toISOString(),
+    window_days: days,
+    cutoff_iso: cutoffIso,
+    metrics: {
+      total_leads: leads.length,
+      quote_leads: quoteLeads.length,
+      qualified_quote_leads_a: qualifiedA.length,
+      qualified_quote_leads_b: qualifiedB.length,
+      qualified_quote_leads_a_or_b: qualifiedA.length + qualifiedB.length,
+      marketing_opt_ins: optIns.length,
+      plus_interest_leads: plusInterest.length,
+      orders: orders.length,
+      completed_orders: completedOrders.length,
+      order_revenue: sumCents(completedOrders.length ? completedOrders : orders),
+      plus_activations: activeSubscriptions.length,
+    },
+    breakdowns: {
+      leads_by_machine: countBy(quoteLeads, (lead) => lead.machine_interest),
+      leads_by_segment: countBy(quoteLeads, (lead) => lead.audience_segment),
+      leads_by_grade: countBy(quoteLeads, (lead) => lead.qualification_grade),
+      leads_by_utm_source: countBy(leads, (lead) => lead.attribution?.utm_source),
+      leads_by_utm_campaign: countBy(leads, (lead) => lead.attribution?.utm_campaign),
+      orders_by_type: countBy(orders, (order) => order.order_type),
+    },
+    autonomous_action_queue: buildActionQueue({ leads, orders, subscriptions }),
+  };
+}
+
+function renderBreakdown(title, record) {
+  const entries = toSortedEntries(record);
+  if (entries.length === 0) {
+    return [`### ${title}`, '- none'];
+  }
+
+  return [
+    `### ${title}`,
+    ...entries.map(([key, count]) => `- ${key}: ${count}`),
+  ];
+}
+
+function renderMarkdown(scorecard) {
+  const metrics = scorecard.metrics;
+  return [
+    '# Bloomjoy Autonomous Marketing Scorecard',
+    '',
+    `Generated: ${scorecard.generated_at}`,
+    `Window: last ${scorecard.window_days} days since ${scorecard.cutoff_iso}`,
+    '',
+    '## KPI Summary',
+    `- Qualified quote leads (A/B): ${metrics.qualified_quote_leads_a_or_b}`,
+    `- A-grade quote leads: ${metrics.qualified_quote_leads_a}`,
+    `- Total quote leads: ${metrics.quote_leads}`,
+    `- Marketing opt-ins: ${metrics.marketing_opt_ins}`,
+    `- Plus-interest leads: ${metrics.plus_interest_leads}`,
+    `- Orders: ${metrics.orders}`,
+    `- Completed-order revenue: ${formatUsd(metrics.order_revenue)}`,
+    `- Plus activations: ${metrics.plus_activations}`,
+    '',
+    ...renderBreakdown('Quote Leads By Grade', scorecard.breakdowns.leads_by_grade),
+    '',
+    ...renderBreakdown('Quote Leads By Machine', scorecard.breakdowns.leads_by_machine),
+    '',
+    ...renderBreakdown('Quote Leads By Segment', scorecard.breakdowns.leads_by_segment),
+    '',
+    ...renderBreakdown('Leads By UTM Source', scorecard.breakdowns.leads_by_utm_source),
+    '',
+    ...renderBreakdown('Leads By UTM Campaign', scorecard.breakdowns.leads_by_utm_campaign),
+    '',
+    ...renderBreakdown('Orders By Type', scorecard.breakdowns.orders_by_type),
+    '',
+    '## Autonomous Action Queue',
+    ...scorecard.autonomous_action_queue.map((action) => `- ${action}`),
+  ].join('\n');
+}
+
+async function run() {
+  const args = parseArgs(process.argv.slice(2));
+  const { env, loadedFiles } = loadEnvFiles(args.envFiles);
+  const supabaseUrl = env.SUPABASE_URL || env.VITE_SUPABASE_URL;
+  const serviceRoleKey = env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    console.error('Missing SUPABASE_URL/VITE_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY.');
+    console.error('This command reads aggregate marketing data and requires service-role access.');
+    process.exit(1);
+  }
+
+  const cutoffIso = new Date(Date.now() - args.days * 24 * 60 * 60 * 1000).toISOString();
+  const client = createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      persistSession: false,
+    },
+  });
+
+  const [leads, orders, subscriptions] = await Promise.all([
+    fetchRows(
+      client,
+      'lead_submissions',
+      'created_at, submission_type, source_page, machine_interest, audience_segment, purchase_timeline, budget_status, plus_interest, marketing_consent, qualification_grade, attribution',
+      cutoffIso
+    ),
+    fetchRows(
+      client,
+      'orders',
+      'created_at, order_type, amount_total, pricing_tier, status',
+      cutoffIso
+    ),
+    fetchRows(
+      client,
+      'subscriptions',
+      'created_at, status',
+      cutoffIso
+    ),
+  ]);
+
+  const scorecard = buildScorecard({ days: args.days, cutoffIso, leads, orders, subscriptions });
+
+  if (args.format === 'json') {
+    console.log(JSON.stringify(scorecard, null, 2));
+    return;
+  }
+
+  if (loadedFiles.length > 0) {
+    console.error(`Loaded env files: ${loadedFiles.join(', ')}`);
+  }
+  console.log(renderMarkdown(scorecard));
+}
+
+run().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/src/components/seo/RouteSeoManager.tsx
+++ b/src/components/seo/RouteSeoManager.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import type { AppSurface } from "@/lib/appSurface";
 import { getCanonicalOriginForSurface } from "@/lib/appSurface";
+import { trackPageView } from "@/lib/analytics";
 
 type RouteSeo = {
   title: string;
@@ -346,6 +347,8 @@ export const RouteSeoManager = () => {
     } else {
       removeStructuredData();
     }
+
+    trackPageView(`${pathname}${location.search}`, seo.title);
   }, [location]);
 
   return null;

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,5 +1,4 @@
-// Analytics event tracking stub (PostHog/GA4 style)
-// Replace with actual implementation when ready
+import { appConfig } from '@/lib/config';
 
 type EventName =
   | 'view_home'
@@ -35,6 +34,9 @@ type EventName =
   | 'add_to_cart'
   | 'remove_from_cart'
   | 'view_cart'
+  | 'submit_lead_form'
+  | 'lead_qualification_assigned'
+  | 'marketing_attribution_captured'
   | 'admin_support_request_updated'
   | 'admin_order_fulfillment_updated'
   | 'admin_machine_inventory_updated'
@@ -49,15 +51,18 @@ interface EventProperties {
 
 type PosthogClient = {
   capture: (name: EventName, properties?: EventProperties) => void;
-  identify: (userId: string, traits?: Record<string, unknown>) => void;
+  identify?: (userId: string, traits?: Record<string, unknown>) => void;
 };
 
-type GtagClient = (command: "event", name: EventName, params?: EventProperties) => void;
+type GtagClient = (...args: unknown[]) => void;
 
 type AnalyticsWindow = Window & {
+  dataLayer?: unknown[];
   posthog?: PosthogClient;
   gtag?: GtagClient;
 };
+
+let ga4Initialized = false;
 
 const getAnalyticsWindow = (): AnalyticsWindow | undefined => {
   if (typeof window === 'undefined') {
@@ -67,19 +72,67 @@ const getAnalyticsWindow = (): AnalyticsWindow | undefined => {
   return window as AnalyticsWindow;
 };
 
+export function initAnalytics(): void {
+  const measurementId = appConfig.ga4MeasurementId;
+  const analyticsWindow = getAnalyticsWindow();
+
+  if (!measurementId || !analyticsWindow || ga4Initialized) {
+    return;
+  }
+
+  analyticsWindow.dataLayer = analyticsWindow.dataLayer ?? [];
+  analyticsWindow.gtag =
+    analyticsWindow.gtag ??
+    function gtag(...args: unknown[]) {
+      analyticsWindow.dataLayer?.push(args);
+    };
+
+  if (!document.getElementById('bloomjoy-ga4')) {
+    const script = document.createElement('script');
+    script.id = 'bloomjoy-ga4';
+    script.async = true;
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(
+      measurementId
+    )}`;
+    document.head.appendChild(script);
+  }
+
+  analyticsWindow.gtag('js', new Date());
+  analyticsWindow.gtag('config', measurementId, {
+    anonymize_ip: true,
+    send_page_view: false,
+  });
+  ga4Initialized = true;
+}
+
+export function trackPageView(path: string, title?: string): void {
+  const analyticsWindow = getAnalyticsWindow();
+
+  if (analyticsWindow?.posthog) {
+    analyticsWindow.posthog.capture('$pageview' as EventName, {
+      path,
+      title,
+    });
+  }
+
+  if (analyticsWindow?.gtag && appConfig.ga4MeasurementId) {
+    analyticsWindow.gtag('event', 'page_view', {
+      page_path: path,
+      page_title: title,
+    });
+  }
+}
+
 export function trackEvent(name: EventName, properties?: EventProperties): void {
-  // Development logging
   if (import.meta.env.DEV) {
     console.log('[Analytics]', name, properties);
   }
 
-  // PostHog stub
   const analyticsWindow = getAnalyticsWindow();
   if (analyticsWindow?.posthog) {
     analyticsWindow.posthog.capture(name, properties);
   }
 
-  // GA4 stub
   if (analyticsWindow?.gtag) {
     analyticsWindow.gtag('event', name, properties);
   }
@@ -91,7 +144,7 @@ export function identifyUser(userId: string, traits?: Record<string, unknown>): 
   }
 
   const analyticsWindow = getAnalyticsWindow();
-  if (analyticsWindow?.posthog) {
+  if (analyticsWindow?.posthog?.identify) {
     analyticsWindow.posthog.identify(userId, traits);
   }
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -20,11 +20,17 @@ const readRequiredClientEnv = (key: RequiredClientEnvKey): string => {
 export interface AppConfig {
   supabaseUrl: string;
   supabaseAnonKey: string;
+  ga4MeasurementId: string | null;
   isDev: boolean;
 }
 
 export const appConfig: AppConfig = {
   supabaseUrl: readRequiredClientEnv('VITE_SUPABASE_URL'),
   supabaseAnonKey: readRequiredClientEnv('VITE_SUPABASE_ANON_KEY'),
+  ga4MeasurementId:
+    typeof import.meta.env.VITE_GA4_MEASUREMENT_ID === 'string' &&
+    import.meta.env.VITE_GA4_MEASUREMENT_ID.trim().length > 0
+      ? import.meta.env.VITE_GA4_MEASUREMENT_ID.trim()
+      : null,
   isDev: import.meta.env.DEV,
 };

--- a/src/lib/leadSubmissions.ts
+++ b/src/lib/leadSubmissions.ts
@@ -1,14 +1,50 @@
 import { invokeEdgeFunction } from '@/lib/edgeFunctions';
+import { trackEvent } from '@/lib/analytics';
+import {
+  buildLeadAttributionPayload,
+  type MarketingAttribution,
+} from '@/lib/marketingAttribution';
 
 type LeadSubmissionType = 'quote' | 'demo' | 'procurement' | 'general';
+export type LeadAudienceSegment =
+  | 'commercial_operator'
+  | 'event_operator'
+  | 'venue_or_procurement'
+  | 'consumer_home_buyer'
+  | 'not_sure';
+export type LeadPurchaseTimeline =
+  | 'now_30_days'
+  | 'one_to_three_months'
+  | 'three_to_six_months'
+  | 'six_plus_months'
+  | 'not_sure';
+export type LeadBudgetStatus =
+  | 'budget_approved'
+  | 'procurement_started'
+  | 'evaluating_budget'
+  | 'no_budget_yet'
+  | 'not_sure';
+type LeadQualificationGrade = 'A' | 'B' | 'C';
 
 type CreateLeadSubmissionInput = {
   submissionType: LeadSubmissionType;
   name: string;
   email: string;
   message: string;
+  companyName?: string;
   machineInterest?: string;
+  audienceSegment?: LeadAudienceSegment;
+  purchaseTimeline?: LeadPurchaseTimeline;
+  budgetStatus?: LeadBudgetStatus;
+  plusInterest?: boolean;
+  marketingConsent?: boolean;
   sourcePage?: string;
+  attribution?: MarketingAttribution;
+};
+
+type LeadSubmissionResponse = {
+  error?: string;
+  qualificationGrade?: LeadQualificationGrade;
 };
 
 export const createLeadSubmission = async ({
@@ -16,23 +52,58 @@ export const createLeadSubmission = async ({
   name,
   email,
   message,
+  companyName,
   machineInterest,
+  audienceSegment,
+  purchaseTimeline,
+  budgetStatus,
+  plusInterest = false,
+  marketingConsent = false,
   sourcePage = '/contact',
+  attribution,
 }: CreateLeadSubmissionInput) => {
-  const data = await invokeEdgeFunction<{ error?: string }>(
+  const leadAttribution = attribution ?? buildLeadAttributionPayload(sourcePage);
+  const data = await invokeEdgeFunction<LeadSubmissionResponse>(
     'lead-submission-intake',
     {
       submissionType,
       name,
       email,
       message,
+      companyName,
       machineInterest,
+      audienceSegment,
+      purchaseTimeline,
+      budgetStatus,
+      plusInterest,
+      marketingConsent,
       sourcePage,
+      attribution: leadAttribution,
       clientSubmissionId: crypto.randomUUID(),
     }
   );
 
   if (data?.error) {
     throw new Error(data.error);
+  }
+
+  trackEvent('submit_lead_form', {
+    submission_type: submissionType,
+    source_page: sourcePage,
+    machine_interest: machineInterest,
+    audience_segment: audienceSegment,
+    purchase_timeline: purchaseTimeline,
+    budget_status: budgetStatus,
+    plus_interest: plusInterest,
+    marketing_consent: marketingConsent,
+  });
+
+  if (data?.qualificationGrade) {
+    trackEvent('lead_qualification_assigned', {
+      submission_type: submissionType,
+      qualification_grade: data.qualificationGrade,
+      machine_interest: machineInterest,
+      audience_segment: audienceSegment,
+    });
   }
 };

--- a/src/lib/marketingAttribution.ts
+++ b/src/lib/marketingAttribution.ts
@@ -1,0 +1,147 @@
+const STORAGE_KEY = 'bloomjoy.marketing_attribution.v1';
+
+const campaignParamKeys = [
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_content',
+  'utm_term',
+  'gclid',
+  'gbraid',
+  'wbraid',
+  'fbclid',
+] as const;
+
+export type CampaignParamKey = (typeof campaignParamKeys)[number];
+
+export type MarketingAttribution = Partial<Record<CampaignParamKey, string>> & {
+  first_landing_page?: string;
+  latest_page?: string;
+  first_referrer?: string;
+  latest_referrer?: string;
+  first_seen_at?: string;
+  latest_seen_at?: string;
+  source_page?: string;
+};
+
+const readCurrentPage = () => {
+  if (typeof window === 'undefined') {
+    return '/';
+  }
+
+  return `${window.location.pathname}${window.location.search}`;
+};
+
+const safeParse = (value: string | null): MarketingAttribution | null => {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(value) as MarketingAttribution;
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+const readStoredAttribution = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    return safeParse(window.localStorage.getItem(STORAGE_KEY));
+  } catch {
+    return null;
+  }
+};
+
+const writeStoredAttribution = (attribution: MarketingAttribution) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(attribution));
+  } catch {
+    // Private browsing or storage policy failures should not block lead capture.
+  }
+};
+
+const getExternalReferrer = () => {
+  if (typeof document === 'undefined' || typeof window === 'undefined') {
+    return '';
+  }
+
+  if (!document.referrer) {
+    return '';
+  }
+
+  try {
+    const referrerUrl = new URL(document.referrer);
+    return referrerUrl.origin === window.location.origin ? '' : document.referrer;
+  } catch {
+    return document.referrer;
+  }
+};
+
+const readCampaignParams = (search: string) => {
+  const params = new URLSearchParams(search);
+  const campaign: Partial<Record<CampaignParamKey, string>> = {};
+
+  for (const key of campaignParamKeys) {
+    const value = params.get(key)?.trim();
+    if (value) {
+      campaign[key] = value.slice(0, 200);
+    }
+  }
+
+  return campaign;
+};
+
+export const captureMarketingAttribution = (): MarketingAttribution | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const existing = readStoredAttribution();
+  const campaign = readCampaignParams(window.location.search);
+  const hasCampaignParams = Object.keys(campaign).length > 0;
+
+  if (!hasCampaignParams && existing) {
+    const refreshed = {
+      ...existing,
+      latest_page: readCurrentPage(),
+      latest_seen_at: new Date().toISOString(),
+    };
+    writeStoredAttribution(refreshed);
+    return refreshed;
+  }
+
+  const now = new Date().toISOString();
+  const referrer = getExternalReferrer();
+  const attribution: MarketingAttribution = {
+    ...existing,
+    ...campaign,
+    first_landing_page: existing?.first_landing_page ?? readCurrentPage(),
+    latest_page: readCurrentPage(),
+    first_referrer: existing?.first_referrer ?? (referrer || undefined),
+    latest_referrer: referrer || existing?.latest_referrer,
+    first_seen_at: existing?.first_seen_at ?? now,
+    latest_seen_at: now,
+  };
+
+  writeStoredAttribution(attribution);
+  return attribution;
+};
+
+export const getStoredMarketingAttribution = (): MarketingAttribution | null =>
+  readStoredAttribution();
+
+export const buildLeadAttributionPayload = (sourcePage: string): MarketingAttribution => ({
+  ...(getStoredMarketingAttribution() ?? captureMarketingAttribution() ?? {}),
+  latest_page: readCurrentPage(),
+  source_page: sourcePage,
+  latest_seen_at: new Date().toISOString(),
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,12 @@
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
+import { initAnalytics, trackEvent } from "@/lib/analytics";
+import { captureMarketingAttribution } from "@/lib/marketingAttribution";
+
+initAnalytics();
+if (captureMarketingAttribution()) {
+  trackEvent('marketing_attribution_captured');
+}
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -5,7 +5,12 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Layout } from '@/components/layout/Layout';
 import { toast } from 'sonner';
-import { createLeadSubmission } from '@/lib/leadSubmissions';
+import {
+  createLeadSubmission,
+  type LeadAudienceSegment,
+  type LeadBudgetStatus,
+  type LeadPurchaseTimeline,
+} from '@/lib/leadSubmissions';
 import { MACHINE_INTEREST_OPTIONS, normalizeMachineInterest } from '@/lib/machineNames';
 
 const validInquiryTypes = new Set(['quote', 'demo', 'procurement', 'general']);
@@ -13,6 +18,30 @@ const validInquiryTypes = new Set(['quote', 'demo', 'procurement', 'general']);
 const machineInterestOptions = [
   ...MACHINE_INTEREST_OPTIONS,
   'Not sure yet',
+];
+
+const audienceSegmentOptions: Array<{ value: LeadAudienceSegment; label: string }> = [
+  { value: 'commercial_operator', label: 'Commercial operator / venue' },
+  { value: 'event_operator', label: 'Events, fairs, or pop-ups' },
+  { value: 'venue_or_procurement', label: 'Procurement / facilities team' },
+  { value: 'consumer_home_buyer', label: 'Home / gift buyer' },
+  { value: 'not_sure', label: 'Not sure yet' },
+];
+
+const purchaseTimelineOptions: Array<{ value: LeadPurchaseTimeline; label: string }> = [
+  { value: 'now_30_days', label: 'Now / next 30 days' },
+  { value: 'one_to_three_months', label: '1-3 months' },
+  { value: 'three_to_six_months', label: '3-6 months' },
+  { value: 'six_plus_months', label: '6+ months' },
+  { value: 'not_sure', label: 'Not sure yet' },
+];
+
+const budgetStatusOptions: Array<{ value: LeadBudgetStatus; label: string }> = [
+  { value: 'budget_approved', label: 'Budget approved' },
+  { value: 'procurement_started', label: 'Procurement started' },
+  { value: 'evaluating_budget', label: 'Evaluating budget' },
+  { value: 'no_budget_yet', label: 'No budget yet' },
+  { value: 'not_sure', label: 'Not sure yet' },
 ];
 
 export default function ContactPage() {
@@ -25,26 +54,41 @@ export default function ContactPage() {
   const [formData, setFormData] = useState({
     name: '',
     email: '',
+    companyName: '',
     type: initialType,
     interest: initialInterest,
+    audienceSegment: 'not_sure' as LeadAudienceSegment,
+    purchaseTimeline: 'not_sure' as LeadPurchaseTimeline,
+    budgetStatus: 'not_sure' as LeadBudgetStatus,
+    plusInterest: false,
+    marketingConsent: false,
     message: '',
     website: '',
   });
   const [submitting, setSubmitting] = useState(false);
+
+  const resetForm = () =>
+    setFormData({
+      name: '',
+      email: '',
+      companyName: '',
+      type: initialType,
+      interest: initialInterest,
+      audienceSegment: 'not_sure',
+      purchaseTimeline: 'not_sure',
+      budgetStatus: 'not_sure',
+      plusInterest: false,
+      marketingConsent: false,
+      message: '',
+      website: '',
+    });
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
     if (formData.website.trim()) {
       toast.success('Message sent! We\'ll be in touch soon.');
-      setFormData({
-        name: '',
-        email: '',
-        type: initialType,
-        interest: initialInterest,
-        message: '',
-        website: '',
-      });
+      resetForm();
       return;
     }
 
@@ -57,18 +101,17 @@ export default function ContactPage() {
         name: formData.name.trim(),
         email: formData.email.trim().toLowerCase(),
         message: cleanedMessage,
+        companyName: formData.companyName.trim() || undefined,
         machineInterest: formData.type === 'quote' ? formData.interest.trim() : undefined,
+        audienceSegment: formData.type === 'quote' ? formData.audienceSegment : undefined,
+        purchaseTimeline: formData.type === 'quote' ? formData.purchaseTimeline : undefined,
+        budgetStatus: formData.type === 'quote' ? formData.budgetStatus : undefined,
+        plusInterest: formData.plusInterest,
+        marketingConsent: formData.marketingConsent,
         sourcePage: querySource?.trim() || '/contact',
       });
       toast.success('Message sent! We\'ll be in touch soon.');
-      setFormData({
-        name: '',
-        email: '',
-        type: initialType,
-        interest: initialInterest,
-        message: '',
-        website: '',
-      });
+      resetForm();
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unable to send message.';
       toast.error(message);
@@ -144,6 +187,22 @@ export default function ContactPage() {
                       className="mt-1"
                     />
                   </div>
+                  <div className="sm:col-span-2">
+                    <label
+                      htmlFor="contact-company"
+                      className="block text-sm font-medium text-foreground"
+                    >
+                      Company / Venue
+                    </label>
+                    <Input
+                      id="contact-company"
+                      name="company"
+                      value={formData.companyName}
+                      onChange={(e) => setFormData({ ...formData, companyName: e.target.value })}
+                      autoComplete="organization"
+                      className="mt-1"
+                    />
+                  </div>
                 </div>
                 <div>
                   <label
@@ -166,27 +225,107 @@ export default function ContactPage() {
                   </select>
                 </div>
                 {formData.type === 'quote' && (
-                  <div>
-                    <label
-                      htmlFor="contact-interest"
-                      className="block text-sm font-medium text-foreground"
-                    >
-                      Machine of Interest
-                    </label>
-                    <select
-                      id="contact-interest"
-                      name="interest"
-                      value={formData.interest}
-                      onChange={(e) => setFormData({ ...formData, interest: e.target.value })}
-                      className="mt-1 w-full rounded-lg border border-input bg-background px-3 py-2 text-sm"
-                    >
-                      <option value="">Select a machine (optional)</option>
-                      {machineInterestOptions.map((option) => (
-                        <option key={option} value={option}>
-                          {option}
-                        </option>
-                      ))}
-                    </select>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <div>
+                      <label
+                        htmlFor="contact-interest"
+                        className="block text-sm font-medium text-foreground"
+                      >
+                        Machine of Interest
+                      </label>
+                      <select
+                        id="contact-interest"
+                        name="interest"
+                        value={formData.interest}
+                        onChange={(e) => setFormData({ ...formData, interest: e.target.value })}
+                        className="mt-1 w-full rounded-lg border border-input bg-background px-3 py-2 text-sm"
+                      >
+                        <option value="">Select a machine (optional)</option>
+                        {machineInterestOptions.map((option) => (
+                          <option key={option} value={option}>
+                            {option}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <label
+                        htmlFor="contact-segment"
+                        className="block text-sm font-medium text-foreground"
+                      >
+                        Best Fit
+                      </label>
+                      <select
+                        id="contact-segment"
+                        name="audienceSegment"
+                        value={formData.audienceSegment}
+                        onChange={(e) =>
+                          setFormData({
+                            ...formData,
+                            audienceSegment: e.target.value as LeadAudienceSegment,
+                          })
+                        }
+                        className="mt-1 w-full rounded-lg border border-input bg-background px-3 py-2 text-sm"
+                      >
+                        {audienceSegmentOptions.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <label
+                        htmlFor="contact-timeline"
+                        className="block text-sm font-medium text-foreground"
+                      >
+                        Timeline
+                      </label>
+                      <select
+                        id="contact-timeline"
+                        name="purchaseTimeline"
+                        value={formData.purchaseTimeline}
+                        onChange={(e) =>
+                          setFormData({
+                            ...formData,
+                            purchaseTimeline: e.target.value as LeadPurchaseTimeline,
+                          })
+                        }
+                        className="mt-1 w-full rounded-lg border border-input bg-background px-3 py-2 text-sm"
+                      >
+                        {purchaseTimelineOptions.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <label
+                        htmlFor="contact-budget"
+                        className="block text-sm font-medium text-foreground"
+                      >
+                        Budget / Procurement
+                      </label>
+                      <select
+                        id="contact-budget"
+                        name="budgetStatus"
+                        value={formData.budgetStatus}
+                        onChange={(e) =>
+                          setFormData({
+                            ...formData,
+                            budgetStatus: e.target.value as LeadBudgetStatus,
+                          })
+                        }
+                        className="mt-1 w-full rounded-lg border border-input bg-background px-3 py-2 text-sm"
+                      >
+                        {budgetStatusOptions.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
                   </div>
                 )}
                 <div>
@@ -206,8 +345,32 @@ export default function ContactPage() {
                     className="mt-1"
                   />
                 </div>
+                <div className="space-y-3 rounded-lg border border-border bg-muted/20 p-4">
+                  <label className="flex gap-3 text-sm text-muted-foreground">
+                    <input
+                      type="checkbox"
+                      checked={formData.plusInterest}
+                      onChange={(e) =>
+                        setFormData({ ...formData, plusInterest: e.target.checked })
+                      }
+                      className="mt-1 h-4 w-4 rounded border-input"
+                    />
+                    <span>I'm interested in Bloomjoy Plus onboarding, training, and support.</span>
+                  </label>
+                  <label className="flex gap-3 text-sm text-muted-foreground">
+                    <input
+                      type="checkbox"
+                      checked={formData.marketingConsent}
+                      onChange={(e) =>
+                        setFormData({ ...formData, marketingConsent: e.target.checked })
+                      }
+                      className="mt-1 h-4 w-4 rounded border-input"
+                    />
+                    <span>Send me occasional Bloomjoy product, training, and supply updates.</span>
+                  </label>
+                </div>
                 <Button type="submit" variant="hero" size="lg" className="w-full" disabled={submitting}>
-                  {submitting ? 'Sending…' : 'Send Message'}
+                  {submitting ? 'Sending...' : 'Send Message'}
                 </Button>
               </form>
             </div>

--- a/supabase/functions/lead-submission-intake/index.ts
+++ b/supabase/functions/lead-submission-intake/index.ts
@@ -11,6 +11,45 @@ export const config = {
 const supabaseUrl = Deno.env.get("SUPABASE_URL");
 const supabaseServiceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
 const validSubmissionTypes = new Set(["quote", "demo", "procurement", "general"]);
+const validAudienceSegments = new Set([
+  "commercial_operator",
+  "event_operator",
+  "venue_or_procurement",
+  "consumer_home_buyer",
+  "not_sure",
+]);
+const validPurchaseTimelines = new Set([
+  "now_30_days",
+  "one_to_three_months",
+  "three_to_six_months",
+  "six_plus_months",
+  "not_sure",
+]);
+const validBudgetStatuses = new Set([
+  "budget_approved",
+  "procurement_started",
+  "evaluating_budget",
+  "no_budget_yet",
+  "not_sure",
+]);
+const attributionKeys = new Set([
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+  "gclid",
+  "gbraid",
+  "wbraid",
+  "fbclid",
+  "first_landing_page",
+  "latest_page",
+  "source_page",
+  "first_referrer",
+  "latest_referrer",
+  "first_seen_at",
+  "latest_seen_at",
+]);
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/i;
 const uuidPattern =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -31,7 +70,90 @@ const supabase = supabaseUrl && supabaseServiceRoleKey
     })
   : null;
 
-const sanitizeText = (value: unknown) => (typeof value === "string" ? value.trim() : "");
+const sanitizeText = (value: unknown, maxLength = 2000) =>
+  typeof value === "string" ? value.trim().slice(0, maxLength) : "";
+
+const sanitizeEnum = (value: unknown, allowed: Set<string>) => {
+  const cleaned = sanitizeText(value, 100);
+  return allowed.has(cleaned) ? cleaned : null;
+};
+
+const sanitizeBoolean = (value: unknown) => value === true;
+
+const sanitizeAttribution = (value: unknown): Record<string, string> => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+
+  const result: Record<string, string> = {};
+  for (const [key, rawValue] of Object.entries(value)) {
+    if (!attributionKeys.has(key) || typeof rawValue !== "string") {
+      continue;
+    }
+
+    const cleaned = rawValue.trim().slice(0, 300);
+    if (cleaned) {
+      result[key] = cleaned;
+    }
+  }
+
+  return result;
+};
+
+const hasSpecificValue = (value: string | null | undefined) =>
+  Boolean(value && value !== "not_sure");
+
+const scoreLead = ({
+  submissionType,
+  machineInterest,
+  audienceSegment,
+  purchaseTimeline,
+  budgetStatus,
+  name,
+  email,
+  companyName,
+}: {
+  submissionType: string;
+  machineInterest: string;
+  audienceSegment: string | null;
+  purchaseTimeline: string | null;
+  budgetStatus: string | null;
+  name: string;
+  email: string;
+  companyName: string;
+}) => {
+  const hasUseCase =
+    submissionType === "quote" &&
+    (Boolean(machineInterest) || hasSpecificValue(audienceSegment));
+  const hasTimeline =
+    purchaseTimeline === "now_30_days" ||
+    purchaseTimeline === "one_to_three_months" ||
+    purchaseTimeline === "three_to_six_months";
+  const hasBudgetOrProcurement =
+    budgetStatus === "budget_approved" ||
+    budgetStatus === "procurement_started" ||
+    budgetStatus === "evaluating_budget";
+  const hasContactQuality =
+    Boolean(name && email) &&
+    (Boolean(companyName) || audienceSegment === "consumer_home_buyer");
+  const matchedSignals = [
+    hasUseCase,
+    hasTimeline,
+    hasBudgetOrProcurement,
+    hasContactQuality,
+  ].filter(Boolean).length;
+
+  return {
+    grade: matchedSignals === 4 ? "A" : matchedSignals >= 3 ? "B" : "C",
+    signals: {
+      has_use_case: hasUseCase,
+      has_timeline: hasTimeline,
+      has_budget_or_procurement: hasBudgetOrProcurement,
+      has_contact_quality: hasContactQuality,
+      matched_signal_count: matchedSignals,
+    },
+  };
+};
 
 const claimDispatch = async (
   eventKey: string,
@@ -100,11 +222,18 @@ serve(async (req) => {
     const body = await req.json();
 
     const submissionType = sanitizeText(body?.submissionType).toLowerCase();
-    const name = sanitizeText(body?.name);
+    const name = sanitizeText(body?.name, 200);
     const email = sanitizeText(body?.email).toLowerCase();
-    const sourcePage = sanitizeText(body?.sourcePage) || "/contact";
+    const sourcePage = sanitizeText(body?.sourcePage, 300) || "/contact";
     const message = sanitizeText(body?.message);
-    const machineInterest = sanitizeText(body?.machineInterest);
+    const companyName = sanitizeText(body?.companyName, 200);
+    const machineInterest = sanitizeText(body?.machineInterest, 100);
+    const audienceSegment = sanitizeEnum(body?.audienceSegment, validAudienceSegments);
+    const purchaseTimeline = sanitizeEnum(body?.purchaseTimeline, validPurchaseTimelines);
+    const budgetStatus = sanitizeEnum(body?.budgetStatus, validBudgetStatuses);
+    const plusInterest = sanitizeBoolean(body?.plusInterest);
+    const marketingConsent = sanitizeBoolean(body?.marketingConsent);
+    const attribution = sanitizeAttribution(body?.attribution);
     const clientSubmissionId = sanitizeText(body?.clientSubmissionId).toLowerCase();
 
     if (!validSubmissionTypes.has(submissionType)) {
@@ -152,8 +281,19 @@ serve(async (req) => {
         ? `Machine of interest: ${machineInterest}\n\n${message}`
         : message;
 
+    const leadScore = scoreLead({
+      submissionType,
+      machineInterest,
+      audienceSegment,
+      purchaseTimeline,
+      budgetStatus,
+      name,
+      email,
+      companyName,
+    });
+
     const selectedColumns =
-      "id, submission_type, name, email, source_page, message, created_at, internal_notification_sent_at";
+      "id, submission_type, name, email, source_page, message, machine_interest, audience_segment, purchase_timeline, budget_status, plus_interest, marketing_consent, qualification_grade, qualification_signals, attribution, created_at, internal_notification_sent_at";
 
     const { data: insertedLead, error: insertError } = await supabase
       .from("lead_submissions")
@@ -161,8 +301,19 @@ serve(async (req) => {
         submission_type: submissionType,
         name,
         email,
+        company_name: companyName || null,
         message: normalizedMessage,
         source_page: sourcePage,
+        machine_interest: machineInterest || null,
+        audience_segment: audienceSegment,
+        purchase_timeline: purchaseTimeline,
+        budget_status: budgetStatus,
+        plus_interest: plusInterest,
+        marketing_consent: marketingConsent,
+        marketing_consent_at: marketingConsent ? new Date().toISOString() : null,
+        attribution,
+        qualification_grade: leadScore.grade,
+        qualification_signals: leadScore.signals,
         client_submission_id: clientSubmissionId,
       })
       .select(selectedColumns)
@@ -214,9 +365,17 @@ serve(async (req) => {
       `Submission ID: ${leadSubmission.id}`,
       `Submitted At (UTC): ${leadSubmission.created_at}`,
       `Inquiry Type: ${leadSubmission.submission_type}`,
+      `Qualification Grade: ${leadSubmission.qualification_grade ?? "n/a"}`,
       `Name: ${leadSubmission.name}`,
       `Email: ${leadSubmission.email}`,
       `Source Page: ${leadSubmission.source_page}`,
+      `Machine Interest: ${leadSubmission.machine_interest ?? "n/a"}`,
+      `Audience Segment: ${leadSubmission.audience_segment ?? "n/a"}`,
+      `Timeline: ${leadSubmission.purchase_timeline ?? "n/a"}`,
+      `Budget / Procurement: ${leadSubmission.budget_status ?? "n/a"}`,
+      `Plus Interest: ${leadSubmission.plus_interest ? "yes" : "no"}`,
+      `Marketing Consent: ${leadSubmission.marketing_consent ? "yes" : "no"}`,
+      `Attribution: ${JSON.stringify(leadSubmission.attribution ?? {})}`,
       "",
       "Message:",
       leadSubmission.message,
@@ -239,9 +398,16 @@ serve(async (req) => {
         `Submission ID: ${leadSubmission.id}`,
         `Submitted At (UTC): ${leadSubmission.created_at}`,
         `Inquiry Type: ${leadSubmission.submission_type}`,
+        `Qualification Grade: ${leadSubmission.qualification_grade ?? "n/a"}`,
         `Name: ${leadSubmission.name}`,
         `Email: ${leadSubmission.email}`,
         `Source Page: ${leadSubmission.source_page}`,
+        `Machine Interest: ${leadSubmission.machine_interest ?? "n/a"}`,
+        `Audience Segment: ${leadSubmission.audience_segment ?? "n/a"}`,
+        `Timeline: ${leadSubmission.purchase_timeline ?? "n/a"}`,
+        `Budget / Procurement: ${leadSubmission.budget_status ?? "n/a"}`,
+        `Plus Interest: ${leadSubmission.plus_interest ? "yes" : "no"}`,
+        `Marketing Consent: ${leadSubmission.marketing_consent ? "yes" : "no"}`,
         "Message:",
         leadSubmission.message,
       ],
@@ -255,10 +421,11 @@ serve(async (req) => {
       markDispatchSent(eventKey, {
         submission_type: leadSubmission.submission_type,
         source_page: leadSubmission.source_page,
+        qualification_grade: leadSubmission.qualification_grade,
       }),
     ]);
 
-    return new Response(JSON.stringify({ ok: true }), {
+    return new Response(JSON.stringify({ ok: true, qualificationGrade: leadScore.grade }), {
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });
   } catch (error) {

--- a/supabase/migrations/202604230001_marketing_attribution_lead_scoring.sql
+++ b/supabase/migrations/202604230001_marketing_attribution_lead_scoring.sql
@@ -1,0 +1,98 @@
+-- Autonomous marketing foundation: attribution, consent, and quote qualification.
+
+alter table public.lead_submissions
+  add column if not exists company_name text,
+  add column if not exists machine_interest text,
+  add column if not exists audience_segment text,
+  add column if not exists purchase_timeline text,
+  add column if not exists budget_status text,
+  add column if not exists plus_interest boolean not null default false,
+  add column if not exists marketing_consent boolean not null default false,
+  add column if not exists marketing_consent_at timestamptz,
+  add column if not exists attribution jsonb not null default '{}'::jsonb,
+  add column if not exists qualification_grade text not null default 'C',
+  add column if not exists qualification_signals jsonb not null default '{}'::jsonb;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'lead_submissions_audience_segment_check'
+      and conrelid = 'public.lead_submissions'::regclass
+  ) then
+    alter table public.lead_submissions
+      add constraint lead_submissions_audience_segment_check
+      check (
+        audience_segment is null
+        or audience_segment in (
+          'commercial_operator',
+          'event_operator',
+          'venue_or_procurement',
+          'consumer_home_buyer',
+          'not_sure'
+        )
+      );
+  end if;
+
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'lead_submissions_purchase_timeline_check'
+      and conrelid = 'public.lead_submissions'::regclass
+  ) then
+    alter table public.lead_submissions
+      add constraint lead_submissions_purchase_timeline_check
+      check (
+        purchase_timeline is null
+        or purchase_timeline in (
+          'now_30_days',
+          'one_to_three_months',
+          'three_to_six_months',
+          'six_plus_months',
+          'not_sure'
+        )
+      );
+  end if;
+
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'lead_submissions_budget_status_check'
+      and conrelid = 'public.lead_submissions'::regclass
+  ) then
+    alter table public.lead_submissions
+      add constraint lead_submissions_budget_status_check
+      check (
+        budget_status is null
+        or budget_status in (
+          'budget_approved',
+          'procurement_started',
+          'evaluating_budget',
+          'no_budget_yet',
+          'not_sure'
+        )
+      );
+  end if;
+
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'lead_submissions_qualification_grade_check'
+      and conrelid = 'public.lead_submissions'::regclass
+  ) then
+    alter table public.lead_submissions
+      add constraint lead_submissions_qualification_grade_check
+      check (qualification_grade in ('A', 'B', 'C'));
+  end if;
+end $$;
+
+create index if not exists lead_submissions_qualification_created_at_idx
+  on public.lead_submissions (qualification_grade, created_at desc);
+
+create index if not exists lead_submissions_marketing_consent_created_at_idx
+  on public.lead_submissions (marketing_consent, created_at desc);
+
+create index if not exists lead_submissions_machine_interest_created_at_idx
+  on public.lead_submissions (machine_interest, created_at desc)
+  where machine_interest is not null;


### PR DESCRIPTION
## Summary
- Adds the v1 autonomous marketing operating contract and decision record for owned-first, opt-in-only marketing.
- Captures UTM/referrer attribution plus quote qualification fields on contact submissions and stores server-computed A/B/C lead grades.
- Adds optional GA4 page-view tracking and a read-only weekly marketing scorecard command.

## Files changed
- Marketing/docs: `Docs/AUTONOMOUS_MARKETING_AGENCY.md`, decision/status/runbook/local-dev/QA updates, `.env.example`.
- Website/client: contact form qualification fields, attribution storage, analytics initialization, page-view tracking.
- Backend/data: lead intake function persistence/scoring plus Supabase migration for attribution, consent, and qualification columns.
- Ops tooling: `npm run marketing:scorecard`.

## Verification commands + results
- `npm ci` - passed; npm reported existing audit findings (4 moderate, 5 high) but exited successfully.
- `npm run build` - passed.
- `npm test --if-present` - passed; no test script is present.
- `npm run lint --if-present` - passed with existing fast-refresh warnings only.
- `npm run seo:check` - passed.
- `node --check scripts/marketing-scorecard.mjs` - passed.

## How to test
1. From this branch/worktree, run `npm ci`.
2. Apply `supabase/migrations/202604230001_marketing_attribution_lead_scoring.sql` to the target Supabase environment before deploying the updated `lead-submission-intake` function.
3. Run `npm run dev` and open the local URL, usually `http://localhost:8080`.
4. Open `http://localhost:8080/contact?type=quote&interest=mini&source=/machines/mini&utm_source=qa&utm_medium=manual&utm_campaign=autonomous-marketing-foundation`.
5. Submit a quote with company/venue, buyer segment, timeline, budget/procurement, Plus interest, and marketing consent values.
6. Confirm the `lead_submissions` row includes `machine_interest`, `audience_segment`, `purchase_timeline`, `budget_status`, `plus_interest`, `marketing_consent`, `attribution`, and `qualification_grade`.
7. If `SUPABASE_SERVICE_ROLE_KEY` is available locally, run `npm run marketing:scorecard -- --days 7`.

## Overlap / coordination notes
- Open PR #143 touches lead intake, contact submissions, package scripts, docs, and production runbooks. Rebase/retest after either PR merges.
- Open PR #154 touches SEO routing/page-view-adjacent files and docs. Rebase/retest after either PR merges.
- Older docs PRs #112 and #151 also touch `Docs/CURRENT_STATUS.md` / `Docs/DECISIONS.md`.