### PR TITLE
Fix reporting chart runtime crash

### DIFF
--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -7,6 +7,7 @@
 - Write updates in plain language so non-technical readers can follow.
 
 ## Sales reporting foundation snapshot (2026-04-24)
+- Production runtime hotfix branch `agent/fix-reporting-chart-runtime` removes the forced Recharts manual chunk split that caused the app shell to crash with `Cannot access 'P' before initialization` after the reporting deployment.
 - Sales reporting is being added as a Supabase-backed extension to the existing operator app on branch `agent/sales-reporting-foundation`.
 - This slice adds account/location/machine reporting entitlements, normalized sales facts, refund adjustment facts, import run audit records, export snapshots, partner schedules, and private PDF export storage.
 - The portal now has `/portal/reports` for entitled users, with date/grain/location/machine/payment filters and on-demand PDF export.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,9 +45,8 @@ export default defineConfig(({ mode }) => ({
             return "icons";
           }
 
-          if (id.includes("node_modules/recharts/")) {
-            return "charts";
-          }
+          // Let Rollup place Recharts with its shared helpers. Forcing it into
+          // a standalone chunk creates a startup cycle with the React chunk.
         },
       },
     },


### PR DESCRIPTION
## Summary
- Removes the forced `recharts` manual chunk that created a circular production startup dependency between the chart bundle and React framework bundle.
- Adds a current-status note for the production runtime hotfix.
- Verified the production build no longer crashes on `/`, `/portal/reports`, or `/admin/reporting`.

## Files changed
- `vite.config.ts`: lets Rollup place Recharts/shared helpers instead of forcing a standalone `charts` chunk.
- `Docs/CURRENT_STATUS.md`: records the runtime hotfix context.

## Verification commands + results
- `npm ci` - passed.
- `npm run build` - passed.
- `npm test --if-present` - passed; no test script configured.
- `npm run lint --if-present` - passed with existing fast-refresh warnings only.
- `npm run seo:check` - passed.
- `git diff --check` - passed with line-ending warnings only.
- Browser smoke against `npm run preview -- --host 127.0.0.1 --port 4177` - passed for `/`, `/portal/reports`, and `/admin/reporting` with no page errors or console errors.

## How to test
1. In `C:\Repos\wt-fix-reporting-chart-runtime`, run `npm ci`.
2. Run `npm run build`.
3. Run `npm run preview -- --host 127.0.0.1 --port 4177`.
4. Open `http://127.0.0.1:4177/` and confirm the public homepage renders instead of a blank page.
5. Open `http://127.0.0.1:4177/portal/reports` and `http://127.0.0.1:4177/admin/reporting`; when logged out, both should redirect to `/login` without crashing.