### PR TITLE
Improve admin reporting access UX

### DIFF
--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -231,8 +231,12 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Machine count edits create `admin_audit_log` entries with `action=machine_inventory.upserted`
 - [ ] Non-admin user cannot access `/admin/reporting`
 - [ ] Super-admin user can access `/admin/reporting`
-- [ ] Admin can register or update a reporting machine with account, location, machine label, machine type, Sunze ID, and required reason
-- [ ] Admin can grant machine reporting access to an existing user by email and sees the entitlement in the recent access list
+- [ ] Admin reporting defaults to the Access tab with a people-first machine access matrix
+- [ ] Admin can look up an existing user by email, select multiple machines, save with a reason, and see that person’s machine count update
+- [ ] Admin can revoke one user’s machine access without removing other viewers from the same machine
+- [ ] Super-admin users show all-machine reporting access as read-only with a link to Governance & Audit
+- [ ] Machine Mapping tab flags imported holding-location machines as `Needs mapping`
+- [ ] Admin can update reporting machine mapping with account, location, machine label, machine type, Sunze ID, and required reason
 - [ ] Admin can create a weekly partner PDF schedule with recipients and sees it in active schedules
 - [ ] Admin reporting shows recent sales/refund import runs and stale/failed sync status clearly
 - [ ] Failed or stale Sunze ingest runs appear in `/admin/reporting` without changing existing sales facts

--- a/src/lib/reporting.ts
+++ b/src/lib/reporting.ts
@@ -130,6 +130,102 @@ export type AdminReportingOverview = {
   entitlements: AdminReportingEntitlement[];
 };
 
+export type AdminReportingAccessPerson = {
+  userId: string;
+  userEmail: string | null;
+  isSuperAdmin: boolean;
+  explicitMachineCount: number;
+  inheritedGrantCount: number;
+};
+
+export type AdminReportingAccessMachine = {
+  id: string;
+  accountId: string;
+  accountName: string;
+  locationId: string;
+  locationName: string;
+  machineLabel: string;
+  machineType: ReportingMachineType;
+  sunzeMachineId: string | null;
+  status: string;
+  latestSaleDate: string | null;
+  viewerCount: number;
+  viewers: Array<{
+    userId: string;
+    userEmail: string | null;
+  }>;
+};
+
+export type AdminReportingAccessGrant = {
+  id: string;
+  userId: string;
+  userEmail: string | null;
+  accountId: string | null;
+  locationId: string | null;
+  machineId: string | null;
+  accessLevel: ReportingAccessLevel;
+  grantReason: string;
+  startsAt: string;
+  expiresAt: string | null;
+  createdAt: string;
+  scopeType: 'account' | 'location' | 'machine' | 'unknown';
+};
+
+export type AdminReportingAccessMatrix = {
+  people: AdminReportingAccessPerson[];
+  machines: AdminReportingAccessMachine[];
+  grants: AdminReportingAccessGrant[];
+};
+
+type AdminReportingAccessMatrixRpc = {
+  people?: Array<{
+    userId?: string;
+    userEmail?: string | null;
+    isSuperAdmin?: boolean;
+    explicitMachineCount?: number;
+    inheritedGrantCount?: number;
+  }>;
+  machines?: Array<{
+    id?: string;
+    accountId?: string;
+    accountName?: string;
+    locationId?: string;
+    locationName?: string;
+    machineLabel?: string;
+    machineType?: ReportingMachineType;
+    sunzeMachineId?: string | null;
+    status?: string;
+    latestSaleDate?: string | null;
+    viewerCount?: number;
+    viewers?: Array<{
+      userId?: string;
+      userEmail?: string | null;
+    }>;
+  }>;
+  grants?: Array<{
+    id?: string;
+    userId?: string;
+    userEmail?: string | null;
+    accountId?: string | null;
+    locationId?: string | null;
+    machineId?: string | null;
+    accessLevel?: ReportingAccessLevel;
+    grantReason?: string;
+    startsAt?: string;
+    expiresAt?: string | null;
+    createdAt?: string;
+    scopeType?: AdminReportingAccessGrant['scopeType'];
+  }>;
+};
+
+type AdminReportingUserLookupRpc = {
+  user_id: string;
+  user_email: string | null;
+  is_super_admin: boolean | null;
+  explicit_machine_count: number | null;
+  inherited_grant_count: number | null;
+};
+
 type ReportingAccessContextRpc = {
   has_reporting_access: boolean | null;
   accessible_machine_count: number | null;
@@ -199,6 +295,11 @@ type CreateReportScheduleInput = {
   dayOfWeek: number;
   sendHourLocal: number;
   timezone: string;
+};
+
+type RevokeReportingAccessInput = {
+  entitlementId: string;
+  reason: string;
 };
 
 export const emptyReportingAccessContext: ReportingAccessContext = {
@@ -358,6 +459,95 @@ export const fetchAdminReportingOverview = async (): Promise<AdminReportingOverv
   };
 };
 
+const mapAccessMatrix = (
+  record: AdminReportingAccessMatrixRpc | null
+): AdminReportingAccessMatrix => ({
+  people: (record?.people ?? [])
+    .filter((person) => person.userId)
+    .map((person) => ({
+      userId: person.userId as string,
+      userEmail: person.userEmail ?? null,
+      isSuperAdmin: Boolean(person.isSuperAdmin),
+      explicitMachineCount: Number(person.explicitMachineCount ?? 0),
+      inheritedGrantCount: Number(person.inheritedGrantCount ?? 0),
+    })),
+  machines: (record?.machines ?? [])
+    .filter((machine) => machine.id)
+    .map((machine) => ({
+      id: machine.id as string,
+      accountId: machine.accountId ?? '',
+      accountName: machine.accountName ?? 'Unassigned account',
+      locationId: machine.locationId ?? '',
+      locationName: machine.locationName ?? 'Unassigned location',
+      machineLabel: machine.machineLabel ?? 'Unnamed machine',
+      machineType: machine.machineType ?? 'unknown',
+      sunzeMachineId: machine.sunzeMachineId ?? null,
+      status: machine.status ?? 'active',
+      latestSaleDate: machine.latestSaleDate ?? null,
+      viewerCount: Number(machine.viewerCount ?? 0),
+      viewers: (machine.viewers ?? [])
+        .filter((viewer) => viewer.userId)
+        .map((viewer) => ({
+          userId: viewer.userId as string,
+          userEmail: viewer.userEmail ?? null,
+        })),
+    })),
+  grants: (record?.grants ?? [])
+    .filter((grant) => grant.id && grant.userId)
+    .map((grant) => ({
+      id: grant.id as string,
+      userId: grant.userId as string,
+      userEmail: grant.userEmail ?? null,
+      accountId: grant.accountId ?? null,
+      locationId: grant.locationId ?? null,
+      machineId: grant.machineId ?? null,
+      accessLevel: grant.accessLevel ?? 'viewer',
+      grantReason: grant.grantReason ?? 'Sales reporting access',
+      startsAt: grant.startsAt ?? '',
+      expiresAt: grant.expiresAt ?? null,
+      createdAt: grant.createdAt ?? '',
+      scopeType: grant.scopeType ?? 'unknown',
+    })),
+});
+
+export const fetchAdminReportingAccessMatrix = async (): Promise<AdminReportingAccessMatrix> => {
+  const { data, error } = await supabaseClient.rpc('admin_get_reporting_access_matrix');
+
+  if (error) {
+    throw new Error(error.message || 'Unable to load reporting access matrix.');
+  }
+
+  return mapAccessMatrix((data as AdminReportingAccessMatrixRpc | null) ?? null);
+};
+
+export const lookupReportingUserByEmailAdmin = async (
+  userEmail: string
+): Promise<AdminReportingAccessPerson> => {
+  const { data, error } = await supabaseClient.rpc('admin_lookup_reporting_user_by_email', {
+    p_user_email: userEmail.trim(),
+  });
+
+  if (error) {
+    throw new Error(error.message || 'Unable to find reporting user.');
+  }
+
+  const record = Array.isArray(data)
+    ? ((data as AdminReportingUserLookupRpc[])[0] ?? null)
+    : ((data as AdminReportingUserLookupRpc | null) ?? null);
+
+  if (!record?.user_id) {
+    throw new Error(`No user found for ${userEmail.trim()}.`);
+  }
+
+  return {
+    userId: record.user_id,
+    userEmail: record.user_email,
+    isSuperAdmin: Boolean(record.is_super_admin),
+    explicitMachineCount: Number(record.explicit_machine_count ?? 0),
+    inheritedGrantCount: Number(record.inherited_grant_count ?? 0),
+  };
+};
+
 export const upsertReportingMachineAdmin = async (
   input: UpsertReportingMachineInput
 ): Promise<AdminReportingMachine> => {
@@ -392,6 +582,21 @@ export const grantMachineReportAccessAdmin = async (
 
   if (error || !data) {
     throw new Error(error?.message || 'Unable to grant report access.');
+  }
+
+  return data as AdminReportingEntitlement;
+};
+
+export const revokeReportingAccessAdmin = async (
+  input: RevokeReportingAccessInput
+): Promise<AdminReportingEntitlement> => {
+  const { data, error } = await supabaseClient.rpc('admin_revoke_reporting_access', {
+    p_entitlement_id: input.entitlementId,
+    p_reason: input.reason,
+  });
+
+  if (error || !data) {
+    throw new Error(error?.message || 'Unable to revoke report access.');
   }
 
   return data as AdminReportingEntitlement;

--- a/src/pages/admin/Reporting.tsx
+++ b/src/pages/admin/Reporting.tsx
@@ -1,22 +1,61 @@
-import { useMemo, useState } from 'react';
-import { BarChart3, Loader2, RefreshCw } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  AlertTriangle,
+  CalendarDays,
+  CheckCircle2,
+  Database,
+  Loader2,
+  MapPin,
+  RefreshCw,
+  Search,
+  Settings2,
+  ShieldCheck,
+  UserPlus,
+  Users,
+} from 'lucide-react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { AppLayout } from '@/components/layout/AppLayout';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
 import {
   createReportScheduleAdmin,
+  fetchAdminReportingAccessMatrix,
   fetchAdminReportingOverview,
   grantMachineReportAccessAdmin,
+  lookupReportingUserByEmailAdmin,
+  revokeReportingAccessAdmin,
+  type AdminReportingAccessGrant,
+  type AdminReportingAccessMachine,
+  type AdminReportingAccessPerson,
   type ReportingAccessLevel,
   type ReportingMachineType,
   upsertReportingMachineAdmin,
 } from '@/lib/reporting';
 import { trackEvent } from '@/lib/analytics';
+import { cn } from '@/lib/utils';
 
 const machineTypes: ReportingMachineType[] = ['commercial', 'mini', 'micro', 'unknown'];
 const accessLevels: ReportingAccessLevel[] = ['viewer', 'report_manager'];
+
+const emptyMatrix = {
+  people: [] as AdminReportingAccessPerson[],
+  machines: [] as AdminReportingAccessMachine[],
+  grants: [] as AdminReportingAccessGrant[],
+};
 
 const formatDate = (value: string | null) =>
   value
@@ -29,27 +68,93 @@ const formatDate = (value: string | null) =>
       })
     : 'n/a';
 
+const formatShortDate = (value: string | null) =>
+  value
+    ? new Date(value).toLocaleDateString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      })
+    : 'n/a';
+
 const splitEmails = (value: string) =>
   value
     .split(',')
     .map((email) => email.trim().toLowerCase())
     .filter(Boolean);
 
+const normalizeSearch = (value: string) => value.trim().toLowerCase();
+
+const isMachineGrant = (grant: AdminReportingAccessGrant) =>
+  grant.scopeType === 'machine' && Boolean(grant.machineId);
+
+const machineNeedsMapping = (machine: AdminReportingAccessMachine) =>
+  machine.accountName === 'Sunze Import Holding' ||
+  machine.locationName === 'Unmapped Sunze Machines' ||
+  machine.machineType === 'unknown';
+
+const mergePeople = (
+  matrixPeople: AdminReportingAccessPerson[],
+  localPeople: AdminReportingAccessPerson[]
+) => {
+  const byUserId = new Map<string, AdminReportingAccessPerson>();
+
+  [...localPeople, ...matrixPeople].forEach((person) => {
+    byUserId.set(person.userId, person);
+  });
+
+  return [...byUserId.values()].sort((left, right) => {
+    if (left.isSuperAdmin !== right.isSuperAdmin) {
+      return left.isSuperAdmin ? -1 : 1;
+    }
+
+    return (left.userEmail ?? left.userId).localeCompare(right.userEmail ?? right.userId);
+  });
+};
+
+const groupMachines = (machines: AdminReportingAccessMachine[]) => {
+  const groups = new Map<string, AdminReportingAccessMachine[]>();
+
+  machines.forEach((machine) => {
+    const key = `${machine.accountName}||${machine.locationName}`;
+    const current = groups.get(key) ?? [];
+    current.push(machine);
+    groups.set(key, current);
+  });
+
+  return [...groups.entries()].map(([key, values]) => {
+    const [accountName, locationName] = key.split('||');
+    return {
+      key,
+      accountName,
+      locationName,
+      machines: values,
+    };
+  });
+};
+
 export default function AdminReportingPage() {
   const queryClient = useQueryClient();
+  const [activeTab, setActiveTab] = useState('access');
+  const [peopleSearch, setPeopleSearch] = useState('');
+  const [lookupEmail, setLookupEmail] = useState('');
+  const [localPeople, setLocalPeople] = useState<AdminReportingAccessPerson[]>([]);
+  const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
+  const [selectedMachineIds, setSelectedMachineIds] = useState<Set<string>>(new Set());
+  const [accessReason, setAccessReason] = useState('');
+  const [accessLevel, setAccessLevel] = useState<ReportingAccessLevel>('viewer');
+  const [isLookingUpUser, setIsLookingUpUser] = useState(false);
+  const [isSavingAccess, setIsSavingAccess] = useState(false);
+  const [accessMachineSearch, setAccessMachineSearch] = useState('');
+  const [machineSearch, setMachineSearch] = useState('');
   const [machineForm, setMachineForm] = useState({
-    accountName: 'Bubble Planet',
-    locationName: 'Bubble Planet',
-    machineLabel: 'Bubble Planet Machine 1',
-    machineType: 'commercial' as ReportingMachineType,
-    sunzeMachineId: 'BUBBLE-PLANET-01',
-    reason: 'Initial reporting setup',
-  });
-  const [accessForm, setAccessForm] = useState({
-    userEmail: '',
-    machineId: '',
-    accessLevel: 'viewer' as ReportingAccessLevel,
-    reason: 'Weekly partner sales reporting access',
+    machineId: null as string | null,
+    accountName: '',
+    locationName: '',
+    machineLabel: '',
+    machineType: 'unknown' as ReportingMachineType,
+    sunzeMachineId: '',
+    reason: 'Machine mapping update',
   });
   const [scheduleForm, setScheduleForm] = useState({
     title: 'Bubble Planet weekly machine sales',
@@ -60,36 +165,283 @@ export default function AdminReportingPage() {
     timezone: 'America/Los_Angeles',
   });
   const [isSavingMachine, setIsSavingMachine] = useState(false);
-  const [isGrantingAccess, setIsGrantingAccess] = useState(false);
   const [isCreatingSchedule, setIsCreatingSchedule] = useState(false);
 
   const {
+    data: matrix = emptyMatrix,
+    isLoading: matrixLoading,
+    isFetching: matrixFetching,
+    error: matrixError,
+  } = useQuery({
+    queryKey: ['admin-reporting-access-matrix'],
+    queryFn: fetchAdminReportingAccessMatrix,
+    staleTime: 1000 * 30,
+  });
+
+  const {
     data: overview,
-    isLoading,
-    isFetching,
-    error,
+    isLoading: overviewLoading,
+    isFetching: overviewFetching,
+    error: overviewError,
   } = useQuery({
     queryKey: ['admin-reporting-overview'],
     queryFn: fetchAdminReportingOverview,
     staleTime: 1000 * 30,
   });
 
-  const machines = useMemo(() => overview?.machines ?? [], [overview?.machines]);
+  const people = useMemo(
+    () => mergePeople(matrix.people, localPeople),
+    [localPeople, matrix.people]
+  );
+  const machines = useMemo(() => matrix.machines, [matrix.machines]);
+  const grants = useMemo(() => matrix.grants, [matrix.grants]);
   const importRuns = useMemo(() => overview?.importRuns ?? [], [overview?.importRuns]);
   const schedules = useMemo(() => overview?.schedules ?? [], [overview?.schedules]);
-  const entitlements = useMemo(() => overview?.entitlements ?? [], [overview?.entitlements]);
+
+  const selectedPerson = people.find((person) => person.userId === selectedUserId) ?? null;
+
+  const selectedMachineGrantByMachineId = useMemo(() => {
+    const grantMap = new Map<string, AdminReportingAccessGrant>();
+
+    grants
+      .filter((grant) => grant.userId === selectedUserId && isMachineGrant(grant))
+      .forEach((grant) => {
+        if (grant.machineId) {
+          grantMap.set(grant.machineId, grant);
+        }
+      });
+
+    return grantMap;
+  }, [grants, selectedUserId]);
+
+  const originalMachineIds = useMemo(
+    () => new Set(selectedMachineGrantByMachineId.keys()),
+    [selectedMachineGrantByMachineId]
+  );
+
+  const filteredPeople = useMemo(() => {
+    const search = normalizeSearch(peopleSearch);
+
+    if (!search) {
+      return people;
+    }
+
+    return people.filter((person) =>
+      `${person.userEmail ?? ''} ${person.userId}`.toLowerCase().includes(search)
+    );
+  }, [people, peopleSearch]);
+
+  const filteredAccessMachines = useMemo(() => {
+    const search = normalizeSearch(accessMachineSearch);
+
+    if (!search) {
+      return machines;
+    }
+
+    return machines.filter((machine) =>
+      [
+        machine.machineLabel,
+        machine.sunzeMachineId ?? '',
+        machine.accountName,
+        machine.locationName,
+      ]
+        .join(' ')
+        .toLowerCase()
+        .includes(search)
+    );
+  }, [accessMachineSearch, machines]);
+
+  const filteredMappingMachines = useMemo(() => {
+    const search = normalizeSearch(machineSearch);
+
+    if (!search) {
+      return machines;
+    }
+
+    return machines.filter((machine) =>
+      [
+        machine.machineLabel,
+        machine.sunzeMachineId ?? '',
+        machine.accountName,
+        machine.locationName,
+      ]
+        .join(' ')
+        .toLowerCase()
+        .includes(search)
+    );
+  }, [machineSearch, machines]);
+
+  const groupedAccessMachines = useMemo(
+    () => groupMachines(filteredAccessMachines),
+    [filteredAccessMachines]
+  );
 
   const machineOptions = useMemo(
     () =>
       machines.map((machine) => ({
         id: machine.id,
-        label: `${machine.machine_label} (${machine.sunze_machine_id ?? 'no Sunze ID'})`,
+        label: `${machine.machineLabel} (${machine.sunzeMachineId ?? 'no Sunze ID'})`,
       })),
     [machines]
   );
 
+  const unmappedMachineCount = useMemo(
+    () => machines.filter(machineNeedsMapping).length,
+    [machines]
+  );
+
+  const addedMachineIds = useMemo(
+    () => [...selectedMachineIds].filter((machineId) => !originalMachineIds.has(machineId)),
+    [originalMachineIds, selectedMachineIds]
+  );
+
+  const removedMachineIds = useMemo(
+    () => [...originalMachineIds].filter((machineId) => !selectedMachineIds.has(machineId)),
+    [originalMachineIds, selectedMachineIds]
+  );
+
+  const hasAccessChanges = addedMachineIds.length > 0 || removedMachineIds.length > 0;
+  const isLoading = matrixLoading || overviewLoading;
+  const isFetching = matrixFetching || overviewFetching;
+
+  useEffect(() => {
+    if (!selectedUserId && people.length > 0) {
+      setSelectedUserId(people[0].userId);
+      return;
+    }
+
+    if (selectedUserId && people.length > 0 && !people.some((person) => person.userId === selectedUserId)) {
+      setSelectedUserId(people[0].userId);
+    }
+  }, [people, selectedUserId]);
+
+  useEffect(() => {
+    setSelectedMachineIds(new Set(originalMachineIds));
+    setAccessReason('');
+  }, [originalMachineIds, selectedUserId]);
+
   const refreshReporting = async () => {
-    await queryClient.invalidateQueries({ queryKey: ['admin-reporting-overview'] });
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['admin-reporting-access-matrix'] }),
+      queryClient.invalidateQueries({ queryKey: ['admin-reporting-overview'] }),
+    ]);
+  };
+
+  const toggleMachine = (machineId: string, checked: boolean) => {
+    setSelectedMachineIds((current) => {
+      const next = new Set(current);
+
+      if (checked) {
+        next.add(machineId);
+      } else {
+        next.delete(machineId);
+      }
+
+      return next;
+    });
+  };
+
+  const lookupUser = async () => {
+    if (!lookupEmail.trim()) {
+      toast.error('Enter a user email first.');
+      return;
+    }
+
+    setIsLookingUpUser(true);
+    try {
+      const person = await lookupReportingUserByEmailAdmin(lookupEmail);
+      setLocalPeople((current) => {
+        const withoutPerson = current.filter((entry) => entry.userId !== person.userId);
+        return [person, ...withoutPerson];
+      });
+      setSelectedUserId(person.userId);
+      setPeopleSearch('');
+      setLookupEmail('');
+      trackEvent('admin_reporting_user_lookup', { user_id: person.userId });
+      toast.success('User found.');
+    } catch (lookupError) {
+      toast.error(lookupError instanceof Error ? lookupError.message : 'Unable to find user.');
+    } finally {
+      setIsLookingUpUser(false);
+    }
+  };
+
+  const saveAccessChanges = async () => {
+    if (!selectedPerson) {
+      toast.error('Select a person first.');
+      return;
+    }
+
+    if (selectedPerson.isSuperAdmin) {
+      toast.error('Super-admin reporting access is managed from Governance & Audit.');
+      return;
+    }
+
+    if (!hasAccessChanges) {
+      toast.error('No access changes to save.');
+      return;
+    }
+
+    if (!accessReason.trim()) {
+      toast.error('A reason is required before saving access changes.');
+      return;
+    }
+
+    setIsSavingAccess(true);
+    try {
+      await Promise.all([
+        ...addedMachineIds.map((machineId) =>
+          grantMachineReportAccessAdmin({
+            userEmail: selectedPerson.userEmail ?? '',
+            machineId,
+            accessLevel,
+            reason: accessReason.trim(),
+          })
+        ),
+        ...removedMachineIds.map((machineId) => {
+          const grant = selectedMachineGrantByMachineId.get(machineId);
+
+          if (!grant) {
+            return Promise.resolve(null);
+          }
+
+          return revokeReportingAccessAdmin({
+            entitlementId: grant.id,
+            reason: accessReason.trim(),
+          });
+        }),
+      ]);
+
+      trackEvent('admin_reporting_access_matrix_saved', {
+        user_id: selectedPerson.userId,
+        grants_added: addedMachineIds.length,
+        grants_removed: removedMachineIds.length,
+      });
+      toast.success('Reporting access updated.');
+      await refreshReporting();
+    } catch (saveError) {
+      toast.error(saveError instanceof Error ? saveError.message : 'Unable to update access.');
+    } finally {
+      setIsSavingAccess(false);
+    }
+  };
+
+  const startMachineEdit = (machine: AdminReportingAccessMachine) => {
+    setMachineForm({
+      machineId: machine.id,
+      accountName: machine.accountName,
+      locationName: machine.locationName,
+      machineLabel: machine.machineLabel,
+      machineType: machine.machineType,
+      sunzeMachineId: machine.sunzeMachineId ?? '',
+      reason: 'Machine mapping update',
+    });
+    setActiveTab('machines');
+  };
+
+  const focusMachineAccess = (machine: AdminReportingAccessMachine) => {
+    setAccessMachineSearch(machine.machineLabel);
+    setActiveTab('access');
   };
 
   const saveMachine = async () => {
@@ -106,6 +458,7 @@ export default function AdminReportingPage() {
     setIsSavingMachine(true);
     try {
       await upsertReportingMachineAdmin({
+        machineId: machineForm.machineId,
         accountName: machineForm.accountName.trim(),
         locationName: machineForm.locationName.trim(),
         machineLabel: machineForm.machineLabel.trim(),
@@ -116,39 +469,12 @@ export default function AdminReportingPage() {
       trackEvent('admin_reporting_machine_upserted', {
         sunze_machine_id: machineForm.sunzeMachineId.trim(),
       });
-      toast.success('Reporting machine saved.');
+      toast.success('Machine mapping saved.');
       await refreshReporting();
     } catch (saveError) {
       toast.error(saveError instanceof Error ? saveError.message : 'Unable to save machine.');
     } finally {
       setIsSavingMachine(false);
-    }
-  };
-
-  const grantAccess = async () => {
-    if (!accessForm.userEmail.trim() || !accessForm.machineId || !accessForm.reason.trim()) {
-      toast.error('Email, machine, and reason are required.');
-      return;
-    }
-
-    setIsGrantingAccess(true);
-    try {
-      await grantMachineReportAccessAdmin({
-        userEmail: accessForm.userEmail.trim(),
-        machineId: accessForm.machineId,
-        accessLevel: accessForm.accessLevel,
-        reason: accessForm.reason.trim(),
-      });
-      trackEvent('admin_reporting_access_granted', {
-        machine_id: accessForm.machineId,
-        access_level: accessForm.accessLevel,
-      });
-      toast.success('Report access granted.');
-      await refreshReporting();
-    } catch (grantError) {
-      toast.error(grantError instanceof Error ? grantError.message : 'Unable to grant access.');
-    } finally {
-      setIsGrantingAccess(false);
     }
   };
 
@@ -203,8 +529,7 @@ export default function AdminReportingPage() {
                 Sales Reporting
               </h1>
               <p className="mt-2 text-sm text-muted-foreground">
-                Configure reportable machines, partner access, import status, and scheduled PDF
-                delivery.
+                Manage who can see each machine, map Sunze machines, and monitor report delivery.
               </p>
             </div>
             <Button variant="outline" onClick={refreshReporting} disabled={isFetching}>
@@ -217,13 +542,19 @@ export default function AdminReportingPage() {
             </Button>
           </div>
 
-          {error && (
+          {(matrixError || overviewError) && (
             <div className="mt-4 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
-              Unable to load reporting configuration.
+              Unable to load reporting administration data.
             </div>
           )}
 
           <div className="mt-6 grid gap-4 md:grid-cols-4">
+            <div className="card-elevated p-5">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                People
+              </p>
+              <p className="mt-2 text-2xl font-semibold text-foreground">{people.length}</p>
+            </div>
             <div className="card-elevated p-5">
               <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                 Machines
@@ -232,15 +563,9 @@ export default function AdminReportingPage() {
             </div>
             <div className="card-elevated p-5">
               <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Entitlements
+                Needs Mapping
               </p>
-              <p className="mt-2 text-2xl font-semibold text-foreground">{entitlements.length}</p>
-            </div>
-            <div className="card-elevated p-5">
-              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Schedules
-              </p>
-              <p className="mt-2 text-2xl font-semibold text-foreground">{schedules.length}</p>
+              <p className="mt-2 text-2xl font-semibold text-foreground">{unmappedMachineCount}</p>
             </div>
             <div className="card-elevated p-5">
               <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
@@ -252,403 +577,761 @@ export default function AdminReportingPage() {
             </div>
           </div>
 
-          <div className="mt-6 grid gap-6 xl:grid-cols-3">
-            <div className="rounded-xl border border-border bg-card p-5 shadow-[var(--shadow-sm)]">
-              <div className="flex items-center gap-3">
-                <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
-                  <BarChart3 className="h-5 w-5" />
-                </span>
-                <div>
-                  <h2 className="font-semibold text-foreground">Register Machine</h2>
-                  <p className="text-sm text-muted-foreground">Map a Sunze machine into reporting.</p>
-                </div>
-              </div>
-              <div className="mt-5 space-y-3">
-                <Input
-                  value={machineForm.accountName}
-                  onChange={(event) =>
-                    setMachineForm((current) => ({ ...current, accountName: event.target.value }))
-                  }
-                  placeholder="Account name"
-                />
-                <Input
-                  value={machineForm.locationName}
-                  onChange={(event) =>
-                    setMachineForm((current) => ({ ...current, locationName: event.target.value }))
-                  }
-                  placeholder="Location name"
-                />
-                <Input
-                  value={machineForm.machineLabel}
-                  onChange={(event) =>
-                    setMachineForm((current) => ({ ...current, machineLabel: event.target.value }))
-                  }
-                  placeholder="Machine label"
-                />
-                <select
-                  value={machineForm.machineType}
-                  onChange={(event) =>
-                    setMachineForm((current) => ({
-                      ...current,
-                      machineType: event.target.value as ReportingMachineType,
-                    }))
-                  }
-                  className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
-                >
-                  {machineTypes.map((machineType) => (
-                    <option key={machineType} value={machineType}>
-                      {machineType}
-                    </option>
-                  ))}
-                </select>
-                <Input
-                  value={machineForm.sunzeMachineId}
-                  onChange={(event) =>
-                    setMachineForm((current) => ({
-                      ...current,
-                      sunzeMachineId: event.target.value,
-                    }))
-                  }
-                  placeholder="Sunze machine ID"
-                />
-                <Input
-                  value={machineForm.reason}
-                  onChange={(event) =>
-                    setMachineForm((current) => ({ ...current, reason: event.target.value }))
-                  }
-                  placeholder="Required update reason"
-                />
-                <Button onClick={saveMachine} disabled={isSavingMachine}>
-                  {isSavingMachine ? (
-                    <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      Saving...
-                    </>
-                  ) : (
-                    'Save Machine'
-                  )}
-                </Button>
-              </div>
-            </div>
+          <Tabs value={activeTab} onValueChange={setActiveTab} className="mt-6">
+            <TabsList className="grid h-auto w-full grid-cols-2 gap-1 sm:inline-grid sm:w-auto sm:grid-cols-4">
+              <TabsTrigger value="access" className="gap-2">
+                <Users className="h-4 w-4" />
+                Access
+              </TabsTrigger>
+              <TabsTrigger value="machines" className="gap-2">
+                <Settings2 className="h-4 w-4" />
+                Machines
+              </TabsTrigger>
+              <TabsTrigger value="schedules" className="gap-2">
+                <CalendarDays className="h-4 w-4" />
+                Schedules
+              </TabsTrigger>
+              <TabsTrigger value="sync" className="gap-2">
+                <Database className="h-4 w-4" />
+                Sync
+              </TabsTrigger>
+            </TabsList>
 
-            <div className="rounded-xl border border-border bg-card p-5 shadow-[var(--shadow-sm)]">
-              <h2 className="font-semibold text-foreground">Grant Report Access</h2>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Give a user or partner visibility into one configured machine.
-              </p>
-              <div className="mt-5 space-y-3">
-                <Input
-                  value={accessForm.userEmail}
-                  onChange={(event) =>
-                    setAccessForm((current) => ({ ...current, userEmail: event.target.value }))
-                  }
-                  placeholder="User email"
-                />
-                <select
-                  value={accessForm.machineId}
-                  onChange={(event) =>
-                    setAccessForm((current) => ({ ...current, machineId: event.target.value }))
-                  }
-                  className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
-                >
-                  <option value="">Select machine</option>
-                  {machineOptions.map((machine) => (
-                    <option key={machine.id} value={machine.id}>
-                      {machine.label}
-                    </option>
-                  ))}
-                </select>
-                <select
-                  value={accessForm.accessLevel}
-                  onChange={(event) =>
-                    setAccessForm((current) => ({
-                      ...current,
-                      accessLevel: event.target.value as ReportingAccessLevel,
-                    }))
-                  }
-                  className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
-                >
-                  {accessLevels.map((accessLevel) => (
-                    <option key={accessLevel} value={accessLevel}>
-                      {accessLevel}
-                    </option>
-                  ))}
-                </select>
-                <Input
-                  value={accessForm.reason}
-                  onChange={(event) =>
-                    setAccessForm((current) => ({ ...current, reason: event.target.value }))
-                  }
-                  placeholder="Required grant reason"
-                />
-                <Button onClick={grantAccess} disabled={isGrantingAccess || machines.length === 0}>
-                  {isGrantingAccess ? (
-                    <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      Granting...
-                    </>
-                  ) : (
-                    'Grant Access'
-                  )}
-                </Button>
-              </div>
-            </div>
-
-            <div className="rounded-xl border border-border bg-card p-5 shadow-[var(--shadow-sm)]">
-              <h2 className="font-semibold text-foreground">Schedule Partner PDF</h2>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Create a Monday weekly PDF schedule for partner recipients.
-              </p>
-              <div className="mt-5 space-y-3">
-                <Input
-                  value={scheduleForm.title}
-                  onChange={(event) =>
-                    setScheduleForm((current) => ({ ...current, title: event.target.value }))
-                  }
-                  placeholder="Schedule title"
-                />
-                <select
-                  value={scheduleForm.machineId}
-                  onChange={(event) =>
-                    setScheduleForm((current) => ({ ...current, machineId: event.target.value }))
-                  }
-                  className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
-                >
-                  <option value="">All machines in report filter</option>
-                  {machineOptions.map((machine) => (
-                    <option key={machine.id} value={machine.id}>
-                      {machine.label}
-                    </option>
-                  ))}
-                </select>
-                <Input
-                  value={scheduleForm.recipients}
-                  onChange={(event) =>
-                    setScheduleForm((current) => ({ ...current, recipients: event.target.value }))
-                  }
-                  placeholder="partner@example.com, finance@example.com"
-                />
-                <div className="grid gap-3 sm:grid-cols-2">
-                  <Input
-                    type="number"
-                    min={0}
-                    max={6}
-                    value={scheduleForm.dayOfWeek}
-                    onChange={(event) =>
-                      setScheduleForm((current) => ({
-                        ...current,
-                        dayOfWeek: event.target.value,
-                      }))
-                    }
-                    placeholder="Day of week"
-                  />
-                  <Input
-                    type="number"
-                    min={0}
-                    max={23}
-                    value={scheduleForm.sendHourLocal}
-                    onChange={(event) =>
-                      setScheduleForm((current) => ({
-                        ...current,
-                        sendHourLocal: event.target.value,
-                      }))
-                    }
-                    placeholder="Hour"
-                  />
-                </div>
-                <Input
-                  value={scheduleForm.timezone}
-                  onChange={(event) =>
-                    setScheduleForm((current) => ({ ...current, timezone: event.target.value }))
-                  }
-                  placeholder="Timezone"
-                />
-                <Button onClick={createSchedule} disabled={isCreatingSchedule}>
-                  {isCreatingSchedule ? (
-                    <>
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      Creating...
-                    </>
-                  ) : (
-                    'Create Schedule'
-                  )}
-                </Button>
-              </div>
-            </div>
-          </div>
-
-          <div className="mt-6 grid gap-6 xl:grid-cols-2">
-            <div className="overflow-x-auto rounded-xl border border-border bg-card">
-              <div className="border-b border-border px-4 py-3">
-                <h2 className="font-semibold text-foreground">Reporting Machines</h2>
-              </div>
-              <table className="min-w-[680px] w-full">
-                <thead className="border-b border-border bg-muted/40">
-                  <tr>
-                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                      Machine
-                    </th>
-                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                      Location
-                    </th>
-                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                      Sunze ID
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {isLoading && (
-                    <tr>
-                      <td colSpan={3} className="px-4 py-10 text-center text-sm text-muted-foreground">
-                        Loading machines...
-                      </td>
-                    </tr>
-                  )}
-                  {!isLoading && machines.length === 0 && (
-                    <tr>
-                      <td colSpan={3} className="px-4 py-10 text-center text-sm text-muted-foreground">
-                        No reporting machines configured.
-                      </td>
-                    </tr>
-                  )}
-                  {machines.map((machine) => (
-                    <tr key={machine.id} className="border-b border-border/70">
-                      <td className="px-4 py-3 text-sm text-foreground">
-                        <div className="font-medium">{machine.machine_label}</div>
-                        <div className="text-xs text-muted-foreground">
-                          {machine.customer_accounts?.name ?? 'No account'}
-                        </div>
-                      </td>
-                      <td className="px-4 py-3 text-sm text-muted-foreground">
-                        {machine.reporting_locations?.name ?? 'No location'}
-                      </td>
-                      <td className="px-4 py-3 text-sm text-muted-foreground">
-                        {machine.sunze_machine_id ?? 'n/a'}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-
-            <div className="overflow-x-auto rounded-xl border border-border bg-card">
-              <div className="border-b border-border px-4 py-3">
-                <h2 className="font-semibold text-foreground">Recent Import Runs</h2>
-              </div>
-              <table className="min-w-[680px] w-full">
-                <thead className="border-b border-border bg-muted/40">
-                  <tr>
-                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                      Source
-                    </th>
-                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                      Status
-                    </th>
-                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                      Rows
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {importRuns.length === 0 ? (
-                    <tr>
-                      <td colSpan={3} className="px-4 py-10 text-center text-sm text-muted-foreground">
-                        No imports recorded yet.
-                      </td>
-                    </tr>
-                  ) : (
-                    importRuns.map((run) => (
-                      <tr key={run.id} className="border-b border-border/70">
-                        <td className="px-4 py-3 text-sm text-foreground">
-                          <div className="font-medium">{run.source}</div>
-                          <div className="text-xs text-muted-foreground">
-                            {formatDate(run.completed_at ?? run.created_at)}
-                          </div>
-                        </td>
-                        <td className="px-4 py-3 text-sm text-muted-foreground">
-                          {run.status}
-                          {run.error_message ? `: ${run.error_message}` : ''}
-                        </td>
-                        <td className="px-4 py-3 text-sm text-muted-foreground">
-                          {run.rows_imported}/{run.rows_seen}
-                        </td>
-                      </tr>
-                    ))
-                  )}
-                </tbody>
-              </table>
-            </div>
-          </div>
-
-          <div className="mt-6 grid gap-6 xl:grid-cols-2">
-            <div className="rounded-xl border border-border bg-card p-5 shadow-[var(--shadow-sm)]">
-              <h2 className="font-semibold text-foreground">Active Schedules</h2>
-              <div className="mt-4 space-y-3">
-                {schedules.length === 0 ? (
-                  <div className="rounded-lg border border-border bg-background px-4 py-8 text-center text-sm text-muted-foreground">
-                    No scheduled PDFs yet.
+            <TabsContent value="access" className="mt-6">
+              <div className="grid gap-6 xl:grid-cols-[360px_1fr]">
+                <div className="rounded-lg border border-border bg-card">
+                  <div className="border-b border-border p-4">
+                    <div className="flex items-center justify-between gap-3">
+                      <div>
+                        <h2 className="font-semibold text-foreground">People</h2>
+                        <p className="text-sm text-muted-foreground">
+                          Explicit machine grants by user.
+                        </p>
+                      </div>
+                      <Users className="h-5 w-5 text-muted-foreground" />
+                    </div>
+                    <div className="mt-4 space-y-3">
+                      <div className="relative">
+                        <Search className="pointer-events-none absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
+                        <Input
+                          value={peopleSearch}
+                          onChange={(event) => setPeopleSearch(event.target.value)}
+                          placeholder="Search people"
+                          className="pl-9"
+                        />
+                      </div>
+                      <div className="flex gap-2">
+                        <Input
+                          type="email"
+                          value={lookupEmail}
+                          onChange={(event) => setLookupEmail(event.target.value)}
+                          placeholder="Add existing user by email"
+                          onKeyDown={(event) => {
+                            if (event.key === 'Enter') {
+                              void lookupUser();
+                            }
+                          }}
+                        />
+                        <Button
+                          type="button"
+                          variant="outline"
+                          onClick={lookupUser}
+                          disabled={isLookingUpUser}
+                          aria-label="Find user"
+                        >
+                          {isLookingUpUser ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <UserPlus className="h-4 w-4" />
+                          )}
+                        </Button>
+                      </div>
+                    </div>
                   </div>
-                ) : (
-                  schedules.map((schedule) => (
-                    <div key={schedule.id} className="rounded-lg border border-border bg-background p-4">
-                      <div className="flex items-start justify-between gap-3">
+
+                  <div className="max-h-[640px] overflow-y-auto p-2">
+                    {isLoading && (
+                      <div className="p-4 text-sm text-muted-foreground">Loading access...</div>
+                    )}
+                    {!isLoading && filteredPeople.length === 0 && (
+                      <div className="p-4 text-sm text-muted-foreground">
+                        No people match this search.
+                      </div>
+                    )}
+                    {filteredPeople.map((person) => (
+                      <button
+                        key={person.userId}
+                        type="button"
+                        onClick={() => setSelectedUserId(person.userId)}
+                        className={cn(
+                          'mb-2 w-full rounded-md border border-transparent p-3 text-left transition hover:bg-muted/60',
+                          selectedUserId === person.userId
+                            ? 'border-primary/30 bg-primary/5'
+                            : 'bg-background'
+                        )}
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <p className="truncate text-sm font-medium text-foreground">
+                              {person.userEmail ?? person.userId}
+                            </p>
+                            <p className="mt-1 truncate text-xs text-muted-foreground">
+                              {person.userId}
+                            </p>
+                          </div>
+                          {person.isSuperAdmin && (
+                            <ShieldCheck className="h-4 w-4 shrink-0 text-primary" />
+                          )}
+                        </div>
+                        <div className="mt-3 flex flex-wrap gap-2">
+                          {person.isSuperAdmin ? (
+                            <Badge className="bg-primary/10 text-primary hover:bg-primary/10">
+                              Super-admin
+                            </Badge>
+                          ) : person.explicitMachineCount > 0 ? (
+                            <Badge variant="secondary">
+                              {person.explicitMachineCount} machine
+                              {person.explicitMachineCount === 1 ? '' : 's'}
+                            </Badge>
+                          ) : (
+                            <Badge variant="outline">No machine grants</Badge>
+                          )}
+                          {person.inheritedGrantCount > 0 && (
+                            <Badge variant="outline">{person.inheritedGrantCount} inherited</Badge>
+                          )}
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="rounded-lg border border-border bg-card">
+                  <div className="border-b border-border p-4">
+                    {selectedPerson ? (
+                      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
                         <div>
-                          <p className="font-semibold text-foreground">{schedule.title}</p>
+                          <div className="flex flex-wrap items-center gap-2">
+                            <h2 className="font-semibold text-foreground">
+                              {selectedPerson.userEmail ?? selectedPerson.userId}
+                            </h2>
+                            {selectedPerson.isSuperAdmin && (
+                              <Badge className="bg-primary/10 text-primary hover:bg-primary/10">
+                                All machines via super-admin
+                              </Badge>
+                            )}
+                            {!selectedPerson.isSuperAdmin &&
+                              selectedPerson.explicitMachineCount === 0 && (
+                                <Badge variant="outline">No machine grants</Badge>
+                              )}
+                          </div>
                           <p className="mt-1 text-sm text-muted-foreground">
-                            {schedule.schedule_kind}, day {schedule.send_day_of_week} at{' '}
-                            {schedule.send_hour_local}:00 {schedule.timezone}
+                            {selectedPerson.isSuperAdmin
+                              ? 'Reporting access is inherited from the super-admin role.'
+                              : `${selectedMachineIds.size} selected machine${
+                                  selectedMachineIds.size === 1 ? '' : 's'
+                                }.`}
                           </p>
                         </div>
-                        <span className="rounded-full bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">
-                          {schedule.active ? 'active' : 'paused'}
-                        </span>
+                        {selectedPerson.isSuperAdmin ? (
+                          <Button asChild variant="outline">
+                            <Link to="/admin/audit">Manage Super-Admins</Link>
+                          </Button>
+                        ) : (
+                          <div className="grid gap-3 sm:grid-cols-[180px_minmax(260px,1fr)_auto]">
+                            <div>
+                              <Label htmlFor="access-level">New grant level</Label>
+                              <select
+                                id="access-level"
+                                value={accessLevel}
+                                onChange={(event) =>
+                                  setAccessLevel(event.target.value as ReportingAccessLevel)
+                                }
+                                className="mt-1 h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                              >
+                                {accessLevels.map((level) => (
+                                  <option key={level} value={level}>
+                                    {level}
+                                  </option>
+                                ))}
+                              </select>
+                            </div>
+                            <div>
+                              <Label htmlFor="access-reason">Save reason</Label>
+                              <Input
+                                id="access-reason"
+                                value={accessReason}
+                                onChange={(event) => setAccessReason(event.target.value)}
+                                placeholder="Partner reporting access update"
+                                className="mt-1"
+                              />
+                            </div>
+                            <div className="flex items-end">
+                              <Button
+                                onClick={saveAccessChanges}
+                                disabled={isSavingAccess || !hasAccessChanges}
+                                className="w-full"
+                              >
+                                {isSavingAccess ? (
+                                  <>
+                                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                    Saving...
+                                  </>
+                                ) : (
+                                  'Save Access'
+                                )}
+                              </Button>
+                            </div>
+                          </div>
+                        )}
                       </div>
-                      <p className="mt-3 text-sm text-muted-foreground">
-                        Recipients:{' '}
-                        {schedule.report_schedule_recipients?.map((recipient) => recipient.email).join(', ') ||
-                          'none'}
+                    ) : (
+                      <div>
+                        <h2 className="font-semibold text-foreground">Select a person</h2>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                          Find an existing user by email, then assign machine visibility.
+                        </p>
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="border-b border-border p-4">
+                    <div className="relative max-w-xl">
+                      <Search className="pointer-events-none absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
+                      <Input
+                        value={accessMachineSearch}
+                        onChange={(event) => setAccessMachineSearch(event.target.value)}
+                        placeholder="Filter machines by label, Sunze ID, account, or location"
+                        className="pl-9"
+                      />
+                    </div>
+                  </div>
+
+                  <div className="max-h-[680px] overflow-y-auto p-4">
+                    {groupedAccessMachines.length === 0 ? (
+                      <div className="rounded-md border border-border bg-background px-4 py-10 text-center text-sm text-muted-foreground">
+                        No machines match this filter.
+                      </div>
+                    ) : (
+                      <div className="space-y-5">
+                        {groupedAccessMachines.map((group) => (
+                          <div key={group.key}>
+                            <div className="mb-2 flex flex-wrap items-center gap-2">
+                              <p className="text-sm font-semibold text-foreground">
+                                {group.accountName}
+                              </p>
+                              <span className="text-xs text-muted-foreground">/</span>
+                              <p className="text-sm text-muted-foreground">{group.locationName}</p>
+                            </div>
+                            <div className="overflow-hidden rounded-md border border-border">
+                              {group.machines.map((machine) => {
+                                const checked = selectedMachineIds.has(machine.id);
+                                const grant = selectedMachineGrantByMachineId.get(machine.id);
+
+                                return (
+                                  <label
+                                    key={machine.id}
+                                    className={cn(
+                                      'flex cursor-pointer items-start gap-3 border-b border-border bg-background p-3 last:border-b-0',
+                                      selectedPerson?.isSuperAdmin && 'cursor-default opacity-80'
+                                    )}
+                                  >
+                                    <Checkbox
+                                      checked={selectedPerson?.isSuperAdmin ? true : checked}
+                                      disabled={!selectedPerson || selectedPerson.isSuperAdmin}
+                                      onCheckedChange={(value) => toggleMachine(machine.id, Boolean(value))}
+                                      className="mt-1"
+                                    />
+                                    <div className="min-w-0 flex-1">
+                                      <div className="flex flex-wrap items-center gap-2">
+                                        <span className="font-medium text-foreground">
+                                          {machine.machineLabel}
+                                        </span>
+                                        {machineNeedsMapping(machine) && (
+                                          <Badge variant="outline" className="text-amber-700">
+                                            Needs mapping
+                                          </Badge>
+                                        )}
+                                        {grant && (
+                                          <Badge variant="secondary">{grant.accessLevel}</Badge>
+                                        )}
+                                      </div>
+                                      <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                                        <span>Sunze: {machine.sunzeMachineId ?? 'n/a'}</span>
+                                        <span>Latest sale: {formatShortDate(machine.latestSaleDate)}</span>
+                                        <span>
+                                          Viewers: {machine.viewerCount}
+                                        </span>
+                                      </div>
+                                    </div>
+                                  </label>
+                                );
+                              })}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </TabsContent>
+
+            <TabsContent value="machines" className="mt-6">
+              <div className="grid gap-6 xl:grid-cols-[380px_1fr]">
+                <div className="rounded-lg border border-border bg-card p-5">
+                  <div className="flex items-start gap-3">
+                    <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                      <MapPin className="h-5 w-5" />
+                    </span>
+                    <div>
+                      <h2 className="font-semibold text-foreground">Machine Mapping</h2>
+                      <p className="text-sm text-muted-foreground">
+                        Assign Sunze machines to reporting account and location names.
                       </p>
                     </div>
-                  ))
-                )}
-              </div>
-            </div>
-
-            <div className="rounded-xl border border-border bg-card p-5 shadow-[var(--shadow-sm)]">
-              <h2 className="font-semibold text-foreground">Recent Entitlements</h2>
-              <div className="mt-4 space-y-3">
-                {entitlements.length === 0 ? (
-                  <div className="rounded-lg border border-border bg-background px-4 py-8 text-center text-sm text-muted-foreground">
-                    No report entitlements granted yet.
                   </div>
-                ) : (
-                  entitlements.map((entitlement) => (
-                    <div key={entitlement.id} className="rounded-lg border border-border bg-background p-4">
-                      <div className="flex items-start justify-between gap-3">
-                        <div>
-                          <p className="font-mono text-xs text-muted-foreground">
-                            {entitlement.user_id}
-                          </p>
-                          <p className="mt-1 font-semibold text-foreground">
-                            {entitlement.reporting_machines?.machine_label ??
-                              entitlement.reporting_locations?.name ??
-                              entitlement.customer_accounts?.name ??
-                              'Scoped access'}
-                          </p>
-                          <p className="mt-1 text-sm text-muted-foreground">
-                            {entitlement.grant_reason}
-                          </p>
-                        </div>
-                        <span className="rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground">
-                          {entitlement.access_level}
-                        </span>
+                  <div className="mt-5 space-y-4">
+                    <div>
+                      <Label htmlFor="machine-account">Account</Label>
+                      <Input
+                        id="machine-account"
+                        value={machineForm.accountName}
+                        onChange={(event) =>
+                          setMachineForm((current) => ({
+                            ...current,
+                            accountName: event.target.value,
+                          }))
+                        }
+                        placeholder="Bubble Planet"
+                        className="mt-1"
+                      />
+                    </div>
+                    <div>
+                      <Label htmlFor="machine-location">Location</Label>
+                      <Input
+                        id="machine-location"
+                        value={machineForm.locationName}
+                        onChange={(event) =>
+                          setMachineForm((current) => ({
+                            ...current,
+                            locationName: event.target.value,
+                          }))
+                        }
+                        placeholder="Bubble Planet"
+                        className="mt-1"
+                      />
+                    </div>
+                    <div>
+                      <Label htmlFor="machine-label">Machine Label</Label>
+                      <Input
+                        id="machine-label"
+                        value={machineForm.machineLabel}
+                        onChange={(event) =>
+                          setMachineForm((current) => ({
+                            ...current,
+                            machineLabel: event.target.value,
+                          }))
+                        }
+                        placeholder="Bubble Planet Machine 1"
+                        className="mt-1"
+                      />
+                    </div>
+                    <div>
+                      <Label htmlFor="machine-type">Machine Type</Label>
+                      <select
+                        id="machine-type"
+                        value={machineForm.machineType}
+                        onChange={(event) =>
+                          setMachineForm((current) => ({
+                            ...current,
+                            machineType: event.target.value as ReportingMachineType,
+                          }))
+                        }
+                        className="mt-1 h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                      >
+                        {machineTypes.map((machineType) => (
+                          <option key={machineType} value={machineType}>
+                            {machineType}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <Label htmlFor="machine-sunze-id">Sunze Machine ID</Label>
+                      <Input
+                        id="machine-sunze-id"
+                        value={machineForm.sunzeMachineId}
+                        onChange={(event) =>
+                          setMachineForm((current) => ({
+                            ...current,
+                            sunzeMachineId: event.target.value,
+                          }))
+                        }
+                        placeholder="Machine code from Sunze"
+                        className="mt-1"
+                      />
+                    </div>
+                    <div>
+                      <Label htmlFor="machine-reason">Save Reason</Label>
+                      <Input
+                        id="machine-reason"
+                        value={machineForm.reason}
+                        onChange={(event) =>
+                          setMachineForm((current) => ({ ...current, reason: event.target.value }))
+                        }
+                        placeholder="Correct machine location"
+                        className="mt-1"
+                      />
+                    </div>
+                    <Button onClick={saveMachine} disabled={isSavingMachine}>
+                      {isSavingMachine ? (
+                        <>
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          Saving...
+                        </>
+                      ) : (
+                        'Save Mapping'
+                      )}
+                    </Button>
+                  </div>
+                </div>
+
+                <div className="rounded-lg border border-border bg-card">
+                  <div className="flex flex-col gap-3 border-b border-border p-4 md:flex-row md:items-center md:justify-between">
+                    <div>
+                      <h2 className="font-semibold text-foreground">Reporting Machines</h2>
+                      <p className="text-sm text-muted-foreground">
+                        Current Sunze mapping and viewer counts.
+                      </p>
+                    </div>
+                    <div className="relative md:w-80">
+                      <Search className="pointer-events-none absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
+                      <Input
+                        value={machineSearch}
+                        onChange={(event) => setMachineSearch(event.target.value)}
+                        placeholder="Search machines"
+                        className="pl-9"
+                      />
+                    </div>
+                  </div>
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Machine</TableHead>
+                        <TableHead>Location</TableHead>
+                        <TableHead>Viewers</TableHead>
+                        <TableHead>Latest Sale</TableHead>
+                        <TableHead className="text-right">Actions</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {filteredMappingMachines.length === 0 ? (
+                        <TableRow>
+                          <TableCell colSpan={5} className="py-10 text-center text-muted-foreground">
+                            No reporting machines found.
+                          </TableCell>
+                        </TableRow>
+                      ) : (
+                        filteredMappingMachines.map((machine) => (
+                          <TableRow key={machine.id}>
+                            <TableCell>
+                              <div className="font-medium text-foreground">
+                                {machine.machineLabel}
+                              </div>
+                              <div className="mt-1 text-xs text-muted-foreground">
+                                Sunze: {machine.sunzeMachineId ?? 'n/a'}
+                              </div>
+                              <div className="mt-2 flex flex-wrap gap-2">
+                                <Badge variant="secondary">{machine.machineType}</Badge>
+                                {machineNeedsMapping(machine) ? (
+                                  <Badge variant="outline" className="text-amber-700">
+                                    Needs mapping
+                                  </Badge>
+                                ) : (
+                                  <Badge className="bg-sage-light text-sage hover:bg-sage-light">
+                                    Mapped
+                                  </Badge>
+                                )}
+                              </div>
+                            </TableCell>
+                            <TableCell>
+                              <div className="text-sm text-foreground">{machine.accountName}</div>
+                              <div className="text-xs text-muted-foreground">
+                                {machine.locationName}
+                              </div>
+                            </TableCell>
+                            <TableCell>
+                              <div className="text-sm text-foreground">{machine.viewerCount}</div>
+                              <div className="mt-1 max-w-[220px] truncate text-xs text-muted-foreground">
+                                {machine.viewers.map((viewer) => viewer.userEmail ?? viewer.userId).join(', ') ||
+                                  'No explicit viewers'}
+                              </div>
+                            </TableCell>
+                            <TableCell>{formatShortDate(machine.latestSaleDate)}</TableCell>
+                            <TableCell className="text-right">
+                              <div className="flex justify-end gap-2">
+                                <Button
+                                  type="button"
+                                  variant="outline"
+                                  size="sm"
+                                  onClick={() => startMachineEdit(machine)}
+                                >
+                                  Edit
+                                </Button>
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  size="sm"
+                                  onClick={() => focusMachineAccess(machine)}
+                                >
+                                  Access
+                                </Button>
+                              </div>
+                            </TableCell>
+                          </TableRow>
+                        ))
+                      )}
+                    </TableBody>
+                  </Table>
+                </div>
+              </div>
+            </TabsContent>
+
+            <TabsContent value="schedules" className="mt-6">
+              <div className="grid gap-6 xl:grid-cols-[380px_1fr]">
+                <div className="rounded-lg border border-border bg-card p-5">
+                  <h2 className="font-semibold text-foreground">Partner PDF Schedule</h2>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    Create weekly PDF delivery for a machine filter.
+                  </p>
+                  <div className="mt-5 space-y-4">
+                    <div>
+                      <Label htmlFor="schedule-title">Title</Label>
+                      <Input
+                        id="schedule-title"
+                        value={scheduleForm.title}
+                        onChange={(event) =>
+                          setScheduleForm((current) => ({ ...current, title: event.target.value }))
+                        }
+                        className="mt-1"
+                      />
+                    </div>
+                    <div>
+                      <Label htmlFor="schedule-machine">Machine Filter</Label>
+                      <select
+                        id="schedule-machine"
+                        value={scheduleForm.machineId}
+                        onChange={(event) =>
+                          setScheduleForm((current) => ({
+                            ...current,
+                            machineId: event.target.value,
+                          }))
+                        }
+                        className="mt-1 h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                      >
+                        <option value="">All machines in report filter</option>
+                        {machineOptions.map((machine) => (
+                          <option key={machine.id} value={machine.id}>
+                            {machine.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <Label htmlFor="schedule-recipients">Recipients</Label>
+                      <Input
+                        id="schedule-recipients"
+                        value={scheduleForm.recipients}
+                        onChange={(event) =>
+                          setScheduleForm((current) => ({
+                            ...current,
+                            recipients: event.target.value,
+                          }))
+                        }
+                        placeholder="partner@example.com, finance@example.com"
+                        className="mt-1"
+                      />
+                    </div>
+                    <div className="grid gap-3 sm:grid-cols-2">
+                      <div>
+                        <Label htmlFor="schedule-day">Day</Label>
+                        <Input
+                          id="schedule-day"
+                          type="number"
+                          min={0}
+                          max={6}
+                          value={scheduleForm.dayOfWeek}
+                          onChange={(event) =>
+                            setScheduleForm((current) => ({
+                              ...current,
+                              dayOfWeek: event.target.value,
+                            }))
+                          }
+                          className="mt-1"
+                        />
+                      </div>
+                      <div>
+                        <Label htmlFor="schedule-hour">Hour</Label>
+                        <Input
+                          id="schedule-hour"
+                          type="number"
+                          min={0}
+                          max={23}
+                          value={scheduleForm.sendHourLocal}
+                          onChange={(event) =>
+                            setScheduleForm((current) => ({
+                              ...current,
+                              sendHourLocal: event.target.value,
+                            }))
+                          }
+                          className="mt-1"
+                        />
                       </div>
                     </div>
-                  ))
-                )}
+                    <div>
+                      <Label htmlFor="schedule-timezone">Timezone</Label>
+                      <Input
+                        id="schedule-timezone"
+                        value={scheduleForm.timezone}
+                        onChange={(event) =>
+                          setScheduleForm((current) => ({
+                            ...current,
+                            timezone: event.target.value,
+                          }))
+                        }
+                        className="mt-1"
+                      />
+                    </div>
+                    <Button onClick={createSchedule} disabled={isCreatingSchedule}>
+                      {isCreatingSchedule ? (
+                        <>
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          Creating...
+                        </>
+                      ) : (
+                        'Create Schedule'
+                      )}
+                    </Button>
+                  </div>
+                </div>
+
+                <div className="rounded-lg border border-border bg-card p-5">
+                  <h2 className="font-semibold text-foreground">Active Schedules</h2>
+                  <div className="mt-4 space-y-3">
+                    {schedules.length === 0 ? (
+                      <div className="rounded-md border border-border bg-background px-4 py-8 text-center text-sm text-muted-foreground">
+                        No scheduled PDFs yet.
+                      </div>
+                    ) : (
+                      schedules.map((schedule) => (
+                        <div key={schedule.id} className="rounded-md border border-border p-4">
+                          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                            <div>
+                              <p className="font-semibold text-foreground">{schedule.title}</p>
+                              <p className="mt-1 text-sm text-muted-foreground">
+                                {schedule.schedule_kind}, day {schedule.send_day_of_week} at{' '}
+                                {schedule.send_hour_local}:00 {schedule.timezone}
+                              </p>
+                            </div>
+                            <Badge variant={schedule.active ? 'default' : 'secondary'}>
+                              {schedule.active ? 'active' : 'paused'}
+                            </Badge>
+                          </div>
+                          <p className="mt-3 text-sm text-muted-foreground">
+                            Recipients:{' '}
+                            {schedule.report_schedule_recipients
+                              ?.map((recipient) => recipient.email)
+                              .join(', ') || 'none'}
+                          </p>
+                        </div>
+                      ))
+                    )}
+                  </div>
+                </div>
               </div>
-            </div>
-          </div>
+            </TabsContent>
+
+            <TabsContent value="sync" className="mt-6">
+              <div className="grid gap-6 xl:grid-cols-[320px_1fr]">
+                <div className="rounded-lg border border-border bg-card p-5">
+                  <h2 className="font-semibold text-foreground">Sunze Sync</h2>
+                  <div className="mt-5 space-y-4">
+                    <div className="flex items-start gap-3">
+                      {importRuns[0]?.status === 'completed' ? (
+                        <CheckCircle2 className="mt-0.5 h-5 w-5 text-sage" />
+                      ) : (
+                        <AlertTriangle className="mt-0.5 h-5 w-5 text-amber-600" />
+                      )}
+                      <div>
+                        <p className="text-sm font-medium text-foreground">
+                          {importRuns[0]?.status ?? 'No imports yet'}
+                        </p>
+                        <p className="text-sm text-muted-foreground">
+                          {formatDate(importRuns[0]?.completed_at ?? importRuns[0]?.created_at ?? null)}
+                        </p>
+                      </div>
+                    </div>
+                    <div className="rounded-md border border-border bg-background p-3">
+                      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        Latest rows
+                      </p>
+                      <p className="mt-1 text-2xl font-semibold text-foreground">
+                        {importRuns[0] ? `${importRuns[0].rows_imported}/${importRuns[0].rows_seen}` : '0/0'}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="rounded-lg border border-border bg-card">
+                  <div className="border-b border-border px-4 py-3">
+                    <h2 className="font-semibold text-foreground">Recent Import Runs</h2>
+                  </div>
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Source</TableHead>
+                        <TableHead>Status</TableHead>
+                        <TableHead>Rows</TableHead>
+                        <TableHead>Completed</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {importRuns.length === 0 ? (
+                        <TableRow>
+                          <TableCell colSpan={4} className="py-10 text-center text-muted-foreground">
+                            No imports recorded yet.
+                          </TableCell>
+                        </TableRow>
+                      ) : (
+                        importRuns.map((run) => (
+                          <TableRow key={run.id}>
+                            <TableCell>
+                              <div className="font-medium text-foreground">{run.source}</div>
+                              <div className="text-xs text-muted-foreground">
+                                {run.source_reference ?? run.id}
+                              </div>
+                            </TableCell>
+                            <TableCell>
+                              <Badge variant={run.status === 'completed' ? 'default' : 'outline'}>
+                                {run.status}
+                              </Badge>
+                              {run.error_message && (
+                                <p className="mt-1 text-xs text-destructive">{run.error_message}</p>
+                              )}
+                            </TableCell>
+                            <TableCell>
+                              {run.rows_imported}/{run.rows_seen}
+                            </TableCell>
+                            <TableCell>{formatDate(run.completed_at ?? run.created_at)}</TableCell>
+                          </TableRow>
+                        ))
+                      )}
+                    </TableBody>
+                  </Table>
+                </div>
+              </div>
+            </TabsContent>
+          </Tabs>
         </div>
       </section>
     </AppLayout>

--- a/supabase/migrations/202604260001_reporting_access_matrix.sql
+++ b/supabase/migrations/202604260001_reporting_access_matrix.sql
@@ -1,0 +1,480 @@
+-- Reporting access UX support: people-first access matrix, user lookup, and
+-- idempotent machine-only grants.
+
+update public.reporting_machine_entitlements
+set
+  account_id = null,
+  location_id = null
+where machine_id is not null
+  and revoked_at is null
+  and (account_id is not null or location_id is not null);
+
+drop function if exists public.admin_get_reporting_access_matrix();
+create or replace function public.admin_get_reporting_access_matrix()
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public, auth
+as $$
+declare
+  result jsonb;
+begin
+  if not public.is_super_admin(auth.uid()) then
+    raise exception 'Admin access required';
+  end if;
+
+  with active_grants as (
+    select
+      entitlement.id,
+      entitlement.user_id,
+      users.email as user_email,
+      entitlement.account_id,
+      entitlement.location_id,
+      entitlement.machine_id,
+      entitlement.access_level,
+      entitlement.grant_reason,
+      entitlement.starts_at,
+      entitlement.expires_at,
+      entitlement.created_at,
+      case
+        when entitlement.machine_id is not null then 'machine'
+        when entitlement.location_id is not null then 'location'
+        when entitlement.account_id is not null then 'account'
+        else 'unknown'
+      end as scope_type
+    from public.reporting_machine_entitlements entitlement
+    left join auth.users users on users.id = entitlement.user_id
+    where public.reporting_entitlement_is_active(
+      entitlement.starts_at,
+      entitlement.expires_at,
+      entitlement.revoked_at
+    )
+  ),
+  super_admins as (
+    select
+      role.user_id,
+      users.email as user_email
+    from public.admin_roles role
+    left join auth.users users on users.id = role.user_id
+    where role.role = 'super_admin'
+      and role.active
+      and role.revoked_at is null
+  ),
+  people_source as (
+    select
+      grant_row.user_id,
+      max(grant_row.user_email) as user_email
+    from active_grants grant_row
+    group by grant_row.user_id
+    union
+    select
+      admin_row.user_id,
+      admin_row.user_email
+    from super_admins admin_row
+  ),
+  people as (
+    select
+      person.user_id,
+      coalesce(max(person.user_email), '') as user_email,
+      exists (
+        select 1
+        from super_admins admin_row
+        where admin_row.user_id = person.user_id
+      ) as is_super_admin,
+      count(distinct grant_row.machine_id) filter (
+        where grant_row.scope_type = 'machine'
+          and grant_row.machine_id is not null
+      ) as explicit_machine_count,
+      count(grant_row.id) filter (
+        where grant_row.scope_type in ('account', 'location')
+      ) as inherited_grant_count
+    from people_source person
+    left join active_grants grant_row on grant_row.user_id = person.user_id
+    group by person.user_id
+  ),
+  machine_rows as (
+    select
+      machine.id,
+      machine.account_id,
+      account.name as account_name,
+      machine.location_id,
+      location.name as location_name,
+      machine.machine_label,
+      machine.machine_type,
+      machine.sunze_machine_id,
+      machine.status,
+      max(fact.sale_date) as latest_sale_date,
+      count(distinct grant_row.user_id) filter (
+        where grant_row.scope_type = 'machine'
+          and grant_row.machine_id = machine.id
+      ) as viewer_count,
+      coalesce(
+        jsonb_agg(
+          distinct jsonb_build_object(
+            'userId', grant_row.user_id,
+            'userEmail', grant_row.user_email
+          )
+        ) filter (
+          where grant_row.scope_type = 'machine'
+            and grant_row.machine_id = machine.id
+            and grant_row.user_id is not null
+        ),
+        '[]'::jsonb
+      ) as viewers
+    from public.reporting_machines machine
+    join public.customer_accounts account on account.id = machine.account_id
+    join public.reporting_locations location on location.id = machine.location_id
+    left join public.machine_sales_facts fact on fact.reporting_machine_id = machine.id
+    left join active_grants grant_row on grant_row.machine_id = machine.id
+    group by
+      machine.id,
+      account.name,
+      location.name
+  ),
+  grant_rows as (
+    select
+      grant_row.id,
+      grant_row.user_id,
+      grant_row.user_email,
+      grant_row.account_id,
+      grant_row.location_id,
+      grant_row.machine_id,
+      grant_row.access_level,
+      grant_row.grant_reason,
+      grant_row.starts_at,
+      grant_row.expires_at,
+      grant_row.created_at,
+      grant_row.scope_type
+    from active_grants grant_row
+  )
+  select jsonb_build_object(
+    'people',
+    coalesce(
+      (
+        select jsonb_agg(
+          jsonb_build_object(
+            'userId', people.user_id,
+            'userEmail', people.user_email,
+            'isSuperAdmin', people.is_super_admin,
+            'explicitMachineCount', people.explicit_machine_count,
+            'inheritedGrantCount', people.inherited_grant_count
+          )
+          order by people.is_super_admin desc, people.user_email
+        )
+        from people
+      ),
+      '[]'::jsonb
+    ),
+    'machines',
+    coalesce(
+      (
+        select jsonb_agg(
+          jsonb_build_object(
+            'id', machine_rows.id,
+            'accountId', machine_rows.account_id,
+            'accountName', machine_rows.account_name,
+            'locationId', machine_rows.location_id,
+            'locationName', machine_rows.location_name,
+            'machineLabel', machine_rows.machine_label,
+            'machineType', machine_rows.machine_type,
+            'sunzeMachineId', machine_rows.sunze_machine_id,
+            'status', machine_rows.status,
+            'latestSaleDate', machine_rows.latest_sale_date,
+            'viewerCount', machine_rows.viewer_count,
+            'viewers', machine_rows.viewers
+          )
+          order by machine_rows.account_name, machine_rows.location_name, machine_rows.machine_label
+        )
+        from machine_rows
+      ),
+      '[]'::jsonb
+    ),
+    'grants',
+    coalesce(
+      (
+        select jsonb_agg(
+          jsonb_build_object(
+            'id', grant_rows.id,
+            'userId', grant_rows.user_id,
+            'userEmail', grant_rows.user_email,
+            'accountId', grant_rows.account_id,
+            'locationId', grant_rows.location_id,
+            'machineId', grant_rows.machine_id,
+            'accessLevel', grant_rows.access_level,
+            'grantReason', grant_rows.grant_reason,
+            'startsAt', grant_rows.starts_at,
+            'expiresAt', grant_rows.expires_at,
+            'createdAt', grant_rows.created_at,
+            'scopeType', grant_rows.scope_type
+          )
+          order by grant_rows.created_at desc
+        )
+        from grant_rows
+      ),
+      '[]'::jsonb
+    )
+  )
+  into result;
+
+  return result;
+end;
+$$;
+
+drop function if exists public.admin_lookup_reporting_user_by_email(text);
+create or replace function public.admin_lookup_reporting_user_by_email(
+  p_user_email text
+)
+returns table (
+  user_id uuid,
+  user_email text,
+  is_super_admin boolean,
+  explicit_machine_count bigint,
+  inherited_grant_count bigint
+)
+language plpgsql
+stable
+security definer
+set search_path = public, auth
+as $$
+declare
+  normalized_email text;
+begin
+  if not public.is_super_admin(auth.uid()) then
+    raise exception 'Admin access required';
+  end if;
+
+  normalized_email := lower(trim(coalesce(p_user_email, '')));
+
+  if normalized_email = '' then
+    raise exception 'User email is required';
+  end if;
+
+  return query
+  select
+    users.id as user_id,
+    users.email::text as user_email,
+    exists (
+      select 1
+      from public.admin_roles role
+      where role.user_id = users.id
+        and role.role = 'super_admin'
+        and role.active
+        and role.revoked_at is null
+    ) as is_super_admin,
+    count(distinct entitlement.machine_id) filter (
+      where entitlement.machine_id is not null
+        and public.reporting_entitlement_is_active(
+          entitlement.starts_at,
+          entitlement.expires_at,
+          entitlement.revoked_at
+        )
+    ) as explicit_machine_count,
+    count(entitlement.id) filter (
+      where entitlement.machine_id is null
+        and (entitlement.account_id is not null or entitlement.location_id is not null)
+        and public.reporting_entitlement_is_active(
+          entitlement.starts_at,
+          entitlement.expires_at,
+          entitlement.revoked_at
+        )
+    ) as inherited_grant_count
+  from auth.users users
+  left join public.reporting_machine_entitlements entitlement
+    on entitlement.user_id = users.id
+  where lower(users.email) = normalized_email
+  group by users.id, users.email;
+end;
+$$;
+
+create or replace function public.admin_grant_machine_report_access(
+  p_user_email text,
+  p_account_id uuid,
+  p_location_id uuid,
+  p_machine_id uuid,
+  p_access_level text,
+  p_reason text
+)
+returns public.reporting_machine_entitlements
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  normalized_email text;
+  normalized_reason text;
+  normalized_access_level text;
+  target_user_id uuid;
+  machine_row public.reporting_machines;
+  location_row public.reporting_locations;
+  account_row public.customer_accounts;
+  existing_row public.reporting_machine_entitlements;
+  entitlement_row public.reporting_machine_entitlements;
+  normalized_account_id uuid;
+  normalized_location_id uuid;
+  normalized_machine_id uuid;
+begin
+  if not public.is_super_admin(auth.uid()) then
+    raise exception 'Admin access required';
+  end if;
+
+  normalized_email := lower(trim(coalesce(p_user_email, '')));
+  normalized_reason := trim(coalesce(p_reason, ''));
+  normalized_access_level := lower(coalesce(nullif(trim(p_access_level), ''), 'viewer'));
+
+  if normalized_email = '' then
+    raise exception 'User email is required';
+  end if;
+
+  if normalized_access_level not in ('viewer', 'report_manager') then
+    raise exception 'Invalid reporting access level';
+  end if;
+
+  if normalized_reason = '' then
+    raise exception 'Grant reason is required';
+  end if;
+
+  if p_account_id is null and p_location_id is null and p_machine_id is null then
+    raise exception 'A reporting scope is required';
+  end if;
+
+  select users.id
+  into target_user_id
+  from auth.users users
+  where lower(users.email) = normalized_email
+  limit 1;
+
+  if target_user_id is null then
+    raise exception 'No user found for email %', normalized_email;
+  end if;
+
+  if p_machine_id is not null then
+    select *
+    into machine_row
+    from public.reporting_machines machine
+    where machine.id = p_machine_id
+    limit 1;
+
+    if machine_row.id is null then
+      raise exception 'Reporting machine not found';
+    end if;
+
+    normalized_machine_id := machine_row.id;
+    normalized_location_id := null;
+    normalized_account_id := null;
+  elsif p_location_id is not null then
+    select *
+    into location_row
+    from public.reporting_locations location
+    where location.id = p_location_id
+    limit 1;
+
+    if location_row.id is null then
+      raise exception 'Reporting location not found';
+    end if;
+
+    normalized_machine_id := null;
+    normalized_location_id := location_row.id;
+    normalized_account_id := null;
+  else
+    select *
+    into account_row
+    from public.customer_accounts account
+    where account.id = p_account_id
+    limit 1;
+
+    if account_row.id is null then
+      raise exception 'Reporting account not found';
+    end if;
+
+    normalized_machine_id := null;
+    normalized_location_id := null;
+    normalized_account_id := account_row.id;
+  end if;
+
+  select *
+  into existing_row
+  from public.reporting_machine_entitlements entitlement
+  where entitlement.user_id = target_user_id
+    and entitlement.account_id is not distinct from normalized_account_id
+    and entitlement.location_id is not distinct from normalized_location_id
+    and entitlement.machine_id is not distinct from normalized_machine_id
+  order by entitlement.revoked_at is null desc, entitlement.updated_at desc
+  limit 1;
+
+  if existing_row.id is not null then
+    update public.reporting_machine_entitlements
+    set
+      access_level = normalized_access_level,
+      grant_reason = normalized_reason,
+      starts_at = now(),
+      expires_at = null,
+      granted_by = auth.uid(),
+      revoked_at = null,
+      revoked_by = null,
+      revoke_reason = null
+    where id = existing_row.id
+    returning * into entitlement_row;
+  else
+    insert into public.reporting_machine_entitlements (
+      user_id,
+      account_id,
+      location_id,
+      machine_id,
+      access_level,
+      grant_reason,
+      granted_by
+    )
+    values (
+      target_user_id,
+      normalized_account_id,
+      normalized_location_id,
+      normalized_machine_id,
+      normalized_access_level,
+      normalized_reason,
+      auth.uid()
+    )
+    returning * into entitlement_row;
+  end if;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    target_user_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    auth.uid(),
+    'reporting_access.granted',
+    'reporting_machine_entitlement',
+    entitlement_row.id::text,
+    target_user_id,
+    coalesce(to_jsonb(existing_row), '{}'::jsonb),
+    to_jsonb(entitlement_row),
+    jsonb_build_object(
+      'email',
+      normalized_email,
+      'reason',
+      normalized_reason,
+      'access_level',
+      normalized_access_level,
+      'scope',
+      case
+        when normalized_machine_id is not null then 'machine'
+        when normalized_location_id is not null then 'location'
+        when normalized_account_id is not null then 'account'
+        else 'unknown'
+      end
+    )
+  );
+
+  return entitlement_row;
+end;
+$$;
+
+grant execute on function public.admin_get_reporting_access_matrix() to authenticated;
+grant execute on function public.admin_lookup_reporting_user_by_email(text) to authenticated;


### PR DESCRIPTION
﻿## Summary
- Redesigns `/admin/reporting` around the person-first model: select a user, then grant/revoke machine-level reporting access in a grouped matrix.
- Splits the admin reporting area into Access, Machines, Schedules, and Sync tabs so machine mapping no longer competes with permission grants.
- Adds super-admin read-only handling, machine viewer counts, machine mapping status, and smoke checklist coverage for the new workflow.

## Files changed
- `src/pages/admin/Reporting.tsx`: new tabbed admin reporting UX, people search, access matrix, machine mapping table/form, schedules, and sync views.
- `src/lib/reporting.ts`: frontend wrappers/types for admin access matrix, user lookup, and revoke access RPCs.
- `supabase/migrations/202604260001_reporting_access_matrix.sql`: admin access matrix RPC, auth-user lookup RPC, and idempotent machine-only grant behavior.
- `Docs/QA_SMOKE_TEST_CHECKLIST.md`: updated smoke checks for the people-first access workflow.

## Verification
- `npm ci` - passed. Existing audit output remains: 10 vulnerabilities reported by npm audit.
- `npm run build` - passed with local public `VITE_*` env loaded from the repo `.env`; prerender completed.
- `npm test --if-present` - passed; no test script output.
- `npm run lint --if-present` - passed with existing fast-refresh warnings in shared UI/Auth files only.
- `npm run seo:check` - passed: 13 public routes and 17 private routes validated.
- `supabase db push --dry-run` - passed; would push only `202604260001_reporting_access_matrix.sql`.
- Browser QA - passed on Vite preview for desktop and mobile: `/` renders and logged-out `/admin/reporting` redirects to `/login` with no uncaught client errors.

## How to test
1. Apply the Supabase migration for this branch.
2. Run locally:
   ```bash
   npm ci
   npm run dev
   ```
3. Log in as a super-admin and open `/admin/reporting`.
4. On the Access tab, look up an existing Supabase Auth user by email, select several machines, enter a reason, and save. Confirm their machine count updates.
5. Select another user and grant one of the same machines. Confirm multiple viewers can share the same machine.
6. Reopen the first user, uncheck one machine, enter a reason, and save. Confirm the other user's access remains.
7. Confirm super-admin users show `All machines via super-admin` and cannot be edited from this page.
8. On the Machines tab, confirm imported holding-location machines show `Needs mapping`; edit a machine mapping and save with a reason.
9. Review the Schedules and Sync tabs to confirm schedules and recent import runs are still visible.
10. Optional portal check: log in as the granted user and confirm `/portal/reports` only exposes the machines granted to that user.

## Notes
- The migration intentionally normalizes active machine grants so `machine_id` grants do not also carry `account_id`/`location_id`. The previous mixed scope could accidentally behave like broader account/location access through the existing access predicate.
- V1 UI exposes explicit machine-level grants only. Existing inherited account/location grants are shown as read-only context.
- Open PR overlap: this branch also edits `Docs/QA_SMOKE_TEST_CHECKLIST.md`, which is touched by PRs #143, #154, and #155.
