### PR TITLE
Add admin access and partnership reporting setup

### DIFF
--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -11,7 +11,12 @@
 - Sales reporting is being added as a Supabase-backed extension to the existing operator app on branch `agent/sales-reporting-foundation`.
 - This slice adds account/location/machine reporting entitlements, normalized sales facts, refund adjustment facts, import run audit records, export snapshots, partner schedules, and private PDF export storage.
 - The portal now has `/portal/reports` for entitled users, with date/grain/location/machine/payment filters and on-demand PDF export.
-- Admins now have `/admin/reporting` for reporting machine setup, machine-level access grants, import status visibility, and scheduled partner PDF configuration.
+- Admin access and reporting operations are being split into clearer surfaces:
+  - `/admin/access` is the single admin place for users, Plus grants, global roles, audit history, and explicit machine-level reporting access.
+  - `/admin/partnerships` is the setup area for partners, partnerships, machine assignments, machine-level tax rates, and financial rules.
+  - `/admin/reporting` is focused on report schedules, import/sync status, freshness, and export archive visibility.
+- Reporting visibility remains machine-level only for V1. Partnerships are for financial reporting and grouping, not permission inheritance.
+- Tax rates are configured directly on machines with effective dates, not on partnerships.
 - Manual CSV import helpers and sample files are available before production sync is enabled.
 - Sunze browser automation is now implemented as a scheduled GitHub Actions Playwright worker that exports the Orders workbook with the safe `Last 3 Days` preset, deletes the raw workbook after parsing, and sends normalized rows to the locked `sunze-sales-ingest` Edge Function.
 - `Docs/SUNZE_SALES_DISCOVERY.md` records the validated Sunze routes, export headers, payment/status mappings, and remaining open questions without storing credentials or raw order data.

--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -17,6 +17,7 @@
   - `/admin/reporting` is focused on report schedules, import/sync status, freshness, and export archive visibility.
 - Reporting visibility remains machine-level only for V1. Partnerships are for financial reporting and grouping, not permission inheritance.
 - Tax rates are configured directly on machines with effective dates, not on partnerships.
+- The Bubble Planet workbook baseline uses Sunze order amount as gross sales, subtracts machine tax plus a configured `$0.40` paid-order fee before the 60/40 split, counts no-pay orders as `$0`, and reports completed Monday-Sunday weeks.
 - Manual CSV import helpers and sample files are available before production sync is enabled.
 - Sunze browser automation is now implemented as a scheduled GitHub Actions Playwright worker that exports the Orders workbook with the safe `Last 3 Days` preset, deletes the raw workbook after parsing, and sends normalized rows to the locked `sunze-sales-ingest` Edge Function.
 - `Docs/SUNZE_SALES_DISCOVERY.md` records the validated Sunze routes, export headers, payment/status mappings, and remaining open questions without storing credentials or raw order data.

--- a/Docs/DECISIONS.md
+++ b/Docs/DECISIONS.md
@@ -27,6 +27,25 @@ Bloomjoy sales reporting will use account/location/machine entitlements that are
 - Keeping sales facts and refund adjustments separate preserves source auditability while allowing gross/net calculations.
 - This keeps browser automation separate from database authority while still allowing daily imports, idempotent writes, and clear failure auditing.
 
+## 2026-04-25 - Admin access and partnership reporting split
+Admin permission work and partnership financial setup are separate concerns.
+
+**Canonical admin surfaces**
+- `/admin/access` is the single admin place for users, Plus grants, super-admin roles, audit history, and explicit machine-level reporting visibility.
+- `/admin/reporting` is for reporting operations: schedules, import/sync status, stale-data warnings, and export archive visibility.
+- `/admin/partnerships` is for partner setup, partnership agreements, machine assignments, machine tax rates, and financial rules.
+
+**Canonical partnership model**
+- Reporting visibility remains machine-level only for V1. Partnerships do not grant inherited user access yet.
+- Partnerships group machines for financial reporting, partner report setup, and payout calculations.
+- Tax rates are configured on machines through effective-dated machine tax-rate records, not on partnerships.
+- Partner report calculations resolve the active machine tax rate by machine and sale date before applying partnership financial rules.
+
+**Why this choice**
+- Admins think about permissions person-first, while partnership setup is about financial reporting and contractual grouping.
+- Keeping user access machine-level avoids hidden permission inheritance while the reporting feature is still new.
+- Machine-level tax rates reflect real operating differences and keep tax changes auditable over time.
+
 ## 2026-04-14 - Training-only operator access grants
 Bloomjoy now supports a narrow operator access tier for staff who need training without becoming paid Bloomjoy Plus members.
 

--- a/Docs/DECISIONS.md
+++ b/Docs/DECISIONS.md
@@ -40,6 +40,8 @@ Admin permission work and partnership financial setup are separate concerns.
 - Partnerships group machines for financial reporting, partner report setup, and payout calculations.
 - Tax rates are configured on machines through effective-dated machine tax-rate records, not on partnerships.
 - Partner report calculations resolve the active machine tax rate by machine and sale date before applying partnership financial rules.
+- Bubble Planet workbook parity uses Sunze `Order amount` as gross sales, subtracts machine-rate tax plus configured paid-order fees before the split, counts no-pay orders as orders with `$0` sales and `$0` fees, and defaults to a 60% Fever / 40% partner-style split when configured that way.
+- Weekly partner previews must use the partnership's configured week-ending day. Bubble Planet-style weekly reporting is Monday-Sunday with a Sunday week-ending date.
 
 **Why this choice**
 - Admins think about permissions person-first, while partnership setup is about financial reporting and contractual grouping.

--- a/Docs/LOCAL_DEV.md
+++ b/Docs/LOCAL_DEV.md
@@ -39,6 +39,7 @@
    - Training experience upgrade migration: `supabase/migrations/202603190001_training_experience_upgrade.sql`
    - Sales reporting foundation migration: `supabase/migrations/202604240001_sales_reporting_foundation.sql`
    - Sales reporting daily automation helpers: `supabase/migrations/202604250001_sales_reporting_daily_automation.sql`
+   - Partner reporting foundation: `supabase/migrations/202604260002_partner_reporting_foundation.sql`
 2) Seed data (optional for local dev): `supabase/seed/20260122_training_seed.sql`
 3) Populate Vimeo fields after account setup:
    - `provider_video_id`

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -232,20 +232,22 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Admin Access > Users machine count edits require update reason and persist in `customer_machine_inventory`
 - [ ] Machine count edits create `admin_audit_log` entries with `action=machine_inventory.upserted`
 - [ ] Admin Access > Reporting Access uses a people-first explicit machine access matrix
-- [ ] Admin Access > Reporting Access can look up an existing user by email, select multiple machines, save with a reason, and update that person's machine grants
+- [ ] Admin Access > Reporting Access can look up an existing user by email, select multiple machines, save with a reason, and update that person's machine grants in one transactional save
 - [ ] Admin Access > Reporting Access can revoke one user's machine access without removing other viewers from the same machine
 - [ ] Super-admin users show all-machine reporting access as read-only in Admin Access
-- [ ] Admin Access > Global Roles can grant and revoke super-admin role with reason metadata
+- [ ] Admin Access > Global Roles can grant and revoke super-admin role with required reason metadata
 - [ ] Admin Access > Audit supports filtering and shows role + operational actions
 - [ ] Non-admin user cannot access `/admin/partnerships`
 - [ ] Super-admin user can access `/admin/partnerships`
 - [ ] Admin Partnerships can create/edit partner and partnership records
+- [ ] Admin Partnerships > Parties can attach partners to partnerships with role, optional share percentage, report-recipient flag, and required reason
 - [ ] Admin Partnerships > Machine Assignments can update Sunze machine mapping with account, location, machine label, machine type, Sunze ID, and required reason
 - [ ] Admin Partnerships > Machine Assignments can assign machines to partnerships with effective dates and rejects overlapping active assignments
 - [ ] Admin Partnerships > Machine Tax Rates configures tax rates at the machine level with effective dates and rejects overlapping active tax rates
 - [ ] Admin Partnerships > Financial Rules can configure net split, gross split, per-order fee, and per-stick cost rules with effective dates
 - [ ] Admin Partnerships shows warnings for missing machine tax rate, missing partnership assignment, missing financial rule, and overlapping active assignments
-- [ ] Admin Partnerships > Weekly Preview uses machine-level tax rates and shows gross, orders, sticks, fees, costs, net, split base, and partner/Fever/Bloomjoy shares
+- [ ] Admin Partnerships > Weekly Preview enforces the partnership week-ending day and uses the previous completed Monday-Sunday week for Bubble Planet-style reporting
+- [ ] Admin Partnerships > Weekly Preview matches the Bubble Planet workbook math: Sunze order amount as gross, machine tax plus configured paid-order fee before split, no-pay orders counted as `$0`, and 60/40 split when configured
 - [ ] Non-admin user cannot access `/admin/reporting`
 - [ ] Super-admin user can access `/admin/reporting`
 - [ ] Admin can create a weekly partner PDF schedule with recipients and sees it in active schedules

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -216,32 +216,39 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Admin orders detail panel shows billing/shipping address snapshots, pricing tier, unit price, receipt link, and notification statuses
 - [ ] Admin orders detail panel shows sugar color quantities for sugar orders and box/size/address metadata for Bloomjoy branded stick orders
 - [ ] Admin fulfillment updates create `admin_audit_log` entries with `action=order.fulfillment_updated`
-- [ ] Non-admin user cannot access `/admin/accounts`
-- [ ] Super-admin user can access `/admin/accounts`
-- [ ] Admin account search returns rows by email/user ID and shows membership/order/support summary data
+- [ ] Non-admin user cannot access `/admin/access`
+- [ ] Super-admin user can access `/admin/access`
+- [ ] `/admin/accounts` redirects to `/admin/access?tab=users`
+- [ ] `/admin/audit` redirects to `/admin/access?tab=audit`
+- [ ] Admin Access > Users search returns rows by email/user ID and shows membership/order/support summary data
 - [ ] Admin account search can find an existing Supabase Auth user by email even if they do not have orders yet
-- [ ] Admin Accounts shows paid subscription status separately from free Plus grant status
+- [ ] Admin Access > Users shows paid subscription status separately from free Plus grant status
 - [ ] Super-admin cannot grant free Plus access without a future expiry date and grant reason
 - [ ] Super-admin cannot grant free Plus access while the account has an active paid Stripe subscription that is not scheduled to cancel
 - [ ] Super-admin can grant or extend free Plus access and the customer can reach Plus-only portal pages without a paid Stripe subscription
 - [ ] Super-admin can revoke free Plus access with a required reason and the customer is blocked from Plus-only portal pages after access is revoked
 - [ ] Free Plus grant, extension, and revoke actions create `admin_audit_log` entries with `entity_type=plus_access_grant`
 - [ ] Grant-only customers see waived Plus access on `/portal/account` and are not offered the Stripe billing portal unless they also have a paid subscription
-- [ ] Admin machine count edits require update reason and persist in `customer_machine_inventory`
+- [ ] Admin Access > Users machine count edits require update reason and persist in `customer_machine_inventory`
 - [ ] Machine count edits create `admin_audit_log` entries with `action=machine_inventory.upserted`
+- [ ] Admin Access > Reporting Access uses a people-first explicit machine access matrix
+- [ ] Admin Access > Reporting Access can look up an existing user by email, select multiple machines, save with a reason, and update that person's machine grants
+- [ ] Admin Access > Reporting Access can revoke one user's machine access without removing other viewers from the same machine
+- [ ] Super-admin users show all-machine reporting access as read-only in Admin Access
+- [ ] Admin Access > Global Roles can grant and revoke super-admin role with reason metadata
+- [ ] Admin Access > Audit supports filtering and shows role + operational actions
+- [ ] Non-admin user cannot access `/admin/partnerships`
+- [ ] Super-admin user can access `/admin/partnerships`
+- [ ] Admin Partnerships can create/edit partner and partnership records
+- [ ] Admin Partnerships > Machine Assignments can update Sunze machine mapping with account, location, machine label, machine type, Sunze ID, and required reason
+- [ ] Admin Partnerships > Machine Assignments can assign machines to partnerships with effective dates and rejects overlapping active assignments
+- [ ] Admin Partnerships > Machine Tax Rates configures tax rates at the machine level with effective dates and rejects overlapping active tax rates
+- [ ] Admin Partnerships > Financial Rules can configure net split, gross split, per-order fee, and per-stick cost rules with effective dates
+- [ ] Admin Partnerships shows warnings for missing machine tax rate, missing partnership assignment, missing financial rule, and overlapping active assignments
+- [ ] Admin Partnerships > Weekly Preview uses machine-level tax rates and shows gross, orders, sticks, fees, costs, net, split base, and partner/Fever/Bloomjoy shares
 - [ ] Non-admin user cannot access `/admin/reporting`
 - [ ] Super-admin user can access `/admin/reporting`
-- [ ] Admin reporting defaults to the Access tab with a people-first machine access matrix
-- [ ] Admin can look up an existing user by email, select multiple machines, save with a reason, and see that person’s machine count update
-- [ ] Admin can revoke one user’s machine access without removing other viewers from the same machine
-- [ ] Super-admin users show all-machine reporting access as read-only with a link to Governance & Audit
-- [ ] Machine Mapping tab flags imported holding-location machines as `Needs mapping`
-- [ ] Admin can update reporting machine mapping with account, location, machine label, machine type, Sunze ID, and required reason
 - [ ] Admin can create a weekly partner PDF schedule with recipients and sees it in active schedules
-- [ ] Admin reporting shows recent sales/refund import runs and stale/failed sync status clearly
+- [ ] Admin reporting shows report export archive, recent sales/refund import runs, and stale/failed sync status clearly
 - [ ] Failed or stale Sunze ingest runs appear in `/admin/reporting` without changing existing sales facts
-- [ ] Non-admin user cannot access `/admin/audit`
-- [ ] Super-admin user can access `/admin/audit`
-- [ ] Super-admin can grant and revoke super-admin role with reason metadata
-- [ ] Audit log view supports filtering and shows role + operational actions (support, orders, machine inventory)
 - [ ] Signed-in super-admin can reach `/admin` from visible navigation without typing the URL manually

--- a/scripts/prerender-public-routes.mjs
+++ b/scripts/prerender-public-routes.mjs
@@ -133,6 +133,8 @@ const privateRoutes = [
   { path: "/admin/orders", canonicalOrigin: APP_ORIGIN, title: "Bloomjoy Operator App" },
   { path: "/admin/support", canonicalOrigin: APP_ORIGIN, title: "Bloomjoy Operator App" },
   { path: "/admin/accounts", canonicalOrigin: APP_ORIGIN, title: "Bloomjoy Operator App" },
+  { path: "/admin/access", canonicalOrigin: APP_ORIGIN, title: "Bloomjoy Operator App" },
+  { path: "/admin/partnerships", canonicalOrigin: APP_ORIGIN, title: "Bloomjoy Operator App" },
   { path: "/admin/reporting", canonicalOrigin: APP_ORIGIN, title: "Bloomjoy Operator App" },
   { path: "/admin/audit", canonicalOrigin: APP_ORIGIN, title: "Bloomjoy Operator App" },
 ];

--- a/scripts/seo-regression-check.mjs
+++ b/scripts/seo-regression-check.mjs
@@ -49,6 +49,8 @@ const privateRoutes = [
   { path: "/admin/orders", canonicalOrigin: APP_CANONICAL_HOST, title: "Bloomjoy Operator App" },
   { path: "/admin/support", canonicalOrigin: APP_CANONICAL_HOST, title: "Bloomjoy Operator App" },
   { path: "/admin/accounts", canonicalOrigin: APP_CANONICAL_HOST, title: "Bloomjoy Operator App" },
+  { path: "/admin/access", canonicalOrigin: APP_CANONICAL_HOST, title: "Bloomjoy Operator App" },
+  { path: "/admin/partnerships", canonicalOrigin: APP_CANONICAL_HOST, title: "Bloomjoy Operator App" },
   { path: "/admin/reporting", canonicalOrigin: APP_CANONICAL_HOST, title: "Bloomjoy Operator App" },
   { path: "/admin/audit", canonicalOrigin: APP_CANONICAL_HOST, title: "Bloomjoy Operator App" },
 ];

--- a/scripts/sunze/sample-sunze-orders.json
+++ b/scripts/sunze/sample-sunze-orders.json
@@ -14,7 +14,7 @@
   "rows": [
     [
       "sample-order-001",
-      "Sample product",
+      "Flower dream-2",
       "Sample merchant",
       "BUBBLE-PLANET-01",
       "Bubble Planet Seattle",
@@ -26,7 +26,7 @@
     ],
     [
       "sample-order-002",
-      "Sample product",
+      "Color Bloom-1,Rainbow Coral-1",
       "Sample merchant",
       "BUBBLE-PLANET-01",
       "Bubble Planet Seattle",

--- a/scripts/sunze/sunze-orders.mjs
+++ b/scripts/sunze/sunze-orders.mjs
@@ -29,6 +29,26 @@ const normalizeHeader = (value) => toText(value).replace(/\s+/g, ' ');
 
 const normalizeSourceLabel = (value) => toText(value).replace(/\s+/g, ' ');
 
+export const parseTradeItemQuantity = (value) => {
+  const source = normalizeSourceLabel(value);
+
+  if (!source) {
+    return 0;
+  }
+
+  return source.split(',').reduce((total, segment) => {
+    const trimmed = segment.trim();
+    if (!trimmed) {
+      return total;
+    }
+
+    const quantityMatch = trimmed.match(/-(\d+)\s*$/);
+    const quantity = quantityMatch ? Number(quantityMatch[1]) : 1;
+
+    return total + (Number.isSafeInteger(quantity) && quantity > 0 ? quantity : 1);
+  }, 0);
+};
+
 const parseCents = (value, columnName, rowNumber) => {
   if (value === null || value === undefined || value === '') {
     return 0;
@@ -131,6 +151,7 @@ export const parseSunzeOrderRows = (rows) => {
       const rowNumber = index + 2;
       const cell = (header) => row[headerIndexes[header]];
       const sourceOrderNumber = toText(cell('Order number'));
+      const tradeName = normalizeSourceLabel(cell('Trade name'));
       const machineCode = toText(cell('Machine code'));
       const machineName = toText(cell('Machine name'));
       const paymentTimeIso = parsePaymentTime(cell('Payment time'), rowNumber);
@@ -150,6 +171,8 @@ export const parseSunzeOrderRows = (rows) => {
 
       return {
         sourceOrderNumber,
+        tradeName,
+        itemQuantity: parseTradeItemQuantity(tradeName),
         machineCode,
         machineName,
         orderAmountCents: parseCents(cell('Order amount'), 'Order amount', rowNumber),

--- a/scripts/sunze/validate-sunze-orders-parser.mjs
+++ b/scripts/sunze/validate-sunze-orders-parser.mjs
@@ -92,6 +92,10 @@ try {
   assert.equal(parsed[2].paymentMethod, 'other');
   assert.equal(parsed[0].orderAmountCents, 1000);
   assert.equal(parsed[2].orderAmountCents, 0);
+  assert.equal(parsed[0].tradeName, 'Flower dream-2');
+  assert.equal(parsed[0].itemQuantity, 2);
+  assert.equal(parsed[1].itemQuantity, 2);
+  assert.equal(parsed[2].itemQuantity, 1);
 
   console.log(
     JSON.stringify(

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,8 +39,8 @@ const PortalReports = lazy(() => import("./pages/portal/Reports"));
 const AdminDashboard = lazy(() => import("./pages/admin/Dashboard"));
 const AdminOrders = lazy(() => import("./pages/admin/Orders"));
 const AdminSupport = lazy(() => import("./pages/admin/Support"));
-const AdminAccounts = lazy(() => import("./pages/admin/Accounts"));
-const AdminAudit = lazy(() => import("./pages/admin/Audit"));
+const AdminAccess = lazy(() => import("./pages/admin/Access"));
+const AdminPartnerships = lazy(() => import("./pages/admin/Partnerships"));
 const AdminReporting = lazy(() => import("./pages/admin/Reporting"));
 const NotFound = lazy(() => import("./pages/NotFound"));
 
@@ -103,9 +103,17 @@ const App = () => (
                     <Route path="/admin" element={<AdminDashboard />} />
                     <Route path="/admin/orders" element={<AdminOrders />} />
                     <Route path="/admin/support" element={<AdminSupport />} />
-                    <Route path="/admin/accounts" element={<AdminAccounts />} />
+                    <Route path="/admin/access" element={<AdminAccess />} />
+                    <Route
+                      path="/admin/accounts"
+                      element={<Navigate to="/admin/access?tab=users" replace />}
+                    />
+                    <Route path="/admin/partnerships" element={<AdminPartnerships />} />
                     <Route path="/admin/reporting" element={<AdminReporting />} />
-                    <Route path="/admin/audit" element={<AdminAudit />} />
+                    <Route
+                      path="/admin/audit"
+                      element={<Navigate to="/admin/access?tab=audit" replace />}
+                    />
                   </Route>
                 </Route>
                 <Route path="*" element={<NotFound />} />

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -51,19 +51,19 @@ const adminDestinations = [
     description: 'Support triage, concierge intake, and request routing.',
   },
   {
-    href: '/admin/accounts',
-    label: 'Admin accounts',
-    description: 'Memberships, machine counts, and account-level review.',
+    href: '/admin/access',
+    label: 'Admin access',
+    description: 'Users, Plus grants, global roles, reporting access, and audit history.',
+  },
+  {
+    href: '/admin/partnerships',
+    label: 'Admin partnerships',
+    description: 'Partners, partnership setup, machine assignments, tax rates, and rules.',
   },
   {
     href: '/admin/reporting',
     label: 'Admin reporting',
-    description: 'Reporting machines, entitlements, imports, and partner report schedules.',
-  },
-  {
-    href: '/admin/audit',
-    label: 'Admin audit log',
-    description: 'Sensitive action history and role change visibility.',
+    description: 'Report schedules, exports, and sync status.',
   },
 ];
 

--- a/src/lib/partnershipReporting.ts
+++ b/src/lib/partnershipReporting.ts
@@ -51,6 +51,19 @@ export type ReportingMachinePartnershipAssignment = {
   notes: string | null;
 };
 
+export type ReportingPartnershipParty = {
+  id: string;
+  partnership_id: string;
+  partnership_name: string;
+  partner_id: string;
+  partner_name: string;
+  party_role: string;
+  share_basis_points: number | null;
+  is_report_recipient: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
 export type ReportingMachineTaxRate = {
   id: string;
   machine_id: string;
@@ -97,6 +110,7 @@ export type PartnershipReportingSetup = {
   partnerships: ReportingPartnership[];
   machines: PartnershipSetupMachine[];
   assignments: ReportingMachinePartnershipAssignment[];
+  parties: ReportingPartnershipParty[];
   taxRates: ReportingMachineTaxRate[];
   financialRules: ReportingPartnershipFinancialRule[];
   warnings: PartnershipSetupWarning[];
@@ -104,6 +118,8 @@ export type PartnershipReportingSetup = {
 
 export type PartnerWeeklyReportPreview = {
   partnershipId: string;
+  partnershipName?: string;
+  reportingWeekEndDay?: number;
   weekEndingDate: string;
   weekStartDate: string;
   summary: {
@@ -170,6 +186,16 @@ export type UpsertMachineAssignmentInput = {
   reason: string;
 };
 
+export type UpsertPartnershipPartyInput = {
+  partyId?: string | null;
+  partnershipId: string;
+  partnerId: string;
+  partyRole: string;
+  shareBasisPoints?: number | null;
+  isReportRecipient: boolean;
+  reason: string;
+};
+
 export type UpsertMachineTaxRateInput = {
   taxRateId?: string | null;
   machineId: string;
@@ -207,6 +233,7 @@ const emptySetup: PartnershipReportingSetup = {
   partnerships: [],
   machines: [],
   assignments: [],
+  parties: [],
   taxRates: [],
   financialRules: [],
   warnings: [],
@@ -288,6 +315,26 @@ export const upsertReportingMachineAssignmentAdmin = async (
   }
 
   return data as ReportingMachinePartnershipAssignment;
+};
+
+export const upsertReportingPartnershipPartyAdmin = async (
+  input: UpsertPartnershipPartyInput
+) => {
+  const { data, error } = await supabaseClient.rpc('admin_upsert_reporting_partnership_party', {
+    p_party_id: input.partyId ?? null,
+    p_partnership_id: input.partnershipId,
+    p_partner_id: input.partnerId,
+    p_party_role: input.partyRole,
+    p_share_basis_points: input.shareBasisPoints ?? null,
+    p_is_report_recipient: input.isReportRecipient,
+    p_reason: input.reason,
+  });
+
+  if (error || !data) {
+    throw new Error(error?.message || 'Unable to save partnership party.');
+  }
+
+  return data as ReportingPartnershipParty;
 };
 
 export const upsertReportingMachineTaxRateAdmin = async (input: UpsertMachineTaxRateInput) => {

--- a/src/lib/partnershipReporting.ts
+++ b/src/lib/partnershipReporting.ts
@@ -1,0 +1,355 @@
+import { supabaseClient } from '@/lib/supabaseClient';
+import type { ReportingMachineType } from '@/lib/reporting';
+
+export type ReportingPartner = {
+  id: string;
+  name: string;
+  partner_type: string;
+  primary_contact_name: string | null;
+  primary_contact_email: string | null;
+  status: 'active' | 'archived';
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ReportingPartnership = {
+  id: string;
+  name: string;
+  partnership_type: string;
+  reporting_week_end_day: number;
+  timezone: string;
+  effective_start_date: string;
+  effective_end_date: string | null;
+  status: 'draft' | 'active' | 'archived';
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type PartnershipSetupMachine = {
+  id: string;
+  machine_label: string;
+  machine_type: ReportingMachineType;
+  sunze_machine_id: string | null;
+  status: string;
+  account_name: string;
+  location_name: string;
+  latest_sale_date: string | null;
+};
+
+export type ReportingMachinePartnershipAssignment = {
+  id: string;
+  machine_id: string;
+  machine_label: string;
+  partnership_id: string;
+  partnership_name: string;
+  assignment_role: string;
+  effective_start_date: string;
+  effective_end_date: string | null;
+  status: 'active' | 'archived';
+  notes: string | null;
+};
+
+export type ReportingMachineTaxRate = {
+  id: string;
+  machine_id: string;
+  machine_label: string;
+  tax_rate_percent: number;
+  effective_start_date: string;
+  effective_end_date: string | null;
+  status: 'active' | 'archived';
+  notes: string | null;
+};
+
+export type ReportingPartnershipFinancialRule = {
+  id: string;
+  partnership_id: string;
+  partnership_name: string;
+  calculation_model: string;
+  split_base: string;
+  fee_amount_cents: number;
+  fee_basis: string;
+  cost_amount_cents: number;
+  cost_basis: string;
+  deduction_timing: string;
+  gross_to_net_method: string;
+  fever_share_basis_points: number;
+  partner_share_basis_points: number;
+  bloomjoy_share_basis_points: number;
+  effective_start_date: string;
+  effective_end_date: string | null;
+  status: 'draft' | 'active' | 'archived';
+  notes: string | null;
+};
+
+export type PartnershipSetupWarning = {
+  warningType: string;
+  machineId?: string;
+  machineLabel?: string;
+  partnershipId?: string;
+  partnershipName?: string;
+  message: string;
+};
+
+export type PartnershipReportingSetup = {
+  partners: ReportingPartner[];
+  partnerships: ReportingPartnership[];
+  machines: PartnershipSetupMachine[];
+  assignments: ReportingMachinePartnershipAssignment[];
+  taxRates: ReportingMachineTaxRate[];
+  financialRules: ReportingPartnershipFinancialRule[];
+  warnings: PartnershipSetupWarning[];
+};
+
+export type PartnerWeeklyReportPreview = {
+  partnershipId: string;
+  weekEndingDate: string;
+  weekStartDate: string;
+  summary: {
+    order_count?: number;
+    item_quantity?: number;
+    gross_sales_cents?: number;
+    tax_cents?: number;
+    fee_cents?: number;
+    cost_cents?: number;
+    net_sales_cents?: number;
+    split_base_cents?: number;
+    fever_profit_cents?: number;
+    partner_profit_cents?: number;
+    bloomjoy_profit_cents?: number;
+  };
+  machines: Array<{
+    reporting_machine_id: string;
+    machine_label: string;
+    order_count: number;
+    item_quantity: number;
+    gross_sales_cents: number;
+    tax_cents: number;
+    fee_cents: number;
+    cost_cents: number;
+    net_sales_cents: number;
+    split_base_cents: number;
+  }>;
+  warnings: PartnershipSetupWarning[];
+};
+
+export type UpsertPartnerInput = {
+  partnerId?: string | null;
+  name: string;
+  partnerType: string;
+  primaryContactName?: string | null;
+  primaryContactEmail?: string | null;
+  status: string;
+  notes?: string | null;
+  reason: string;
+};
+
+export type UpsertPartnershipInput = {
+  partnershipId?: string | null;
+  name: string;
+  partnershipType: string;
+  reportingWeekEndDay: number;
+  timezone: string;
+  effectiveStartDate: string;
+  effectiveEndDate?: string | null;
+  status: string;
+  notes?: string | null;
+  reason: string;
+};
+
+export type UpsertMachineAssignmentInput = {
+  assignmentId?: string | null;
+  machineId: string;
+  partnershipId: string;
+  assignmentRole: string;
+  effectiveStartDate: string;
+  effectiveEndDate?: string | null;
+  status: string;
+  notes?: string | null;
+  reason: string;
+};
+
+export type UpsertMachineTaxRateInput = {
+  taxRateId?: string | null;
+  machineId: string;
+  taxRatePercent: number;
+  effectiveStartDate: string;
+  effectiveEndDate?: string | null;
+  status: string;
+  notes?: string | null;
+  reason: string;
+};
+
+export type UpsertFinancialRuleInput = {
+  ruleId?: string | null;
+  partnershipId: string;
+  calculationModel: string;
+  splitBase: string;
+  feeAmountCents: number;
+  feeBasis: string;
+  costAmountCents: number;
+  costBasis: string;
+  deductionTiming: string;
+  grossToNetMethod: string;
+  feverShareBasisPoints: number;
+  partnerShareBasisPoints: number;
+  bloomjoyShareBasisPoints: number;
+  effectiveStartDate: string;
+  effectiveEndDate?: string | null;
+  status: string;
+  notes?: string | null;
+  reason: string;
+};
+
+const emptySetup: PartnershipReportingSetup = {
+  partners: [],
+  partnerships: [],
+  machines: [],
+  assignments: [],
+  taxRates: [],
+  financialRules: [],
+  warnings: [],
+};
+
+export const fetchPartnershipReportingSetup = async (): Promise<PartnershipReportingSetup> => {
+  const { data, error } = await supabaseClient.rpc('admin_get_partnership_reporting_setup');
+
+  if (error) {
+    throw new Error(error.message || 'Unable to load partnership reporting setup.');
+  }
+
+  return {
+    ...emptySetup,
+    ...((data as Partial<PartnershipReportingSetup> | null) ?? {}),
+  };
+};
+
+export const upsertReportingPartnerAdmin = async (input: UpsertPartnerInput) => {
+  const { data, error } = await supabaseClient.rpc('admin_upsert_reporting_partner', {
+    p_partner_id: input.partnerId ?? null,
+    p_name: input.name,
+    p_partner_type: input.partnerType,
+    p_primary_contact_name: input.primaryContactName ?? null,
+    p_primary_contact_email: input.primaryContactEmail ?? null,
+    p_status: input.status,
+    p_notes: input.notes ?? null,
+    p_reason: input.reason,
+  });
+
+  if (error || !data) {
+    throw new Error(error?.message || 'Unable to save partner.');
+  }
+
+  return data as ReportingPartner;
+};
+
+export const upsertReportingPartnershipAdmin = async (input: UpsertPartnershipInput) => {
+  const { data, error } = await supabaseClient.rpc('admin_upsert_reporting_partnership', {
+    p_partnership_id: input.partnershipId ?? null,
+    p_name: input.name,
+    p_partnership_type: input.partnershipType,
+    p_reporting_week_end_day: input.reportingWeekEndDay,
+    p_timezone: input.timezone,
+    p_effective_start_date: input.effectiveStartDate,
+    p_effective_end_date: input.effectiveEndDate || null,
+    p_status: input.status,
+    p_notes: input.notes ?? null,
+    p_reason: input.reason,
+  });
+
+  if (error || !data) {
+    throw new Error(error?.message || 'Unable to save partnership.');
+  }
+
+  return data as ReportingPartnership;
+};
+
+export const upsertReportingMachineAssignmentAdmin = async (
+  input: UpsertMachineAssignmentInput
+) => {
+  const { data, error } = await supabaseClient.rpc(
+    'admin_upsert_reporting_machine_assignment',
+    {
+      p_assignment_id: input.assignmentId ?? null,
+      p_machine_id: input.machineId,
+      p_partnership_id: input.partnershipId,
+      p_assignment_role: input.assignmentRole,
+      p_effective_start_date: input.effectiveStartDate,
+      p_effective_end_date: input.effectiveEndDate || null,
+      p_status: input.status,
+      p_notes: input.notes ?? null,
+      p_reason: input.reason,
+    }
+  );
+
+  if (error || !data) {
+    throw new Error(error?.message || 'Unable to save machine assignment.');
+  }
+
+  return data as ReportingMachinePartnershipAssignment;
+};
+
+export const upsertReportingMachineTaxRateAdmin = async (input: UpsertMachineTaxRateInput) => {
+  const { data, error } = await supabaseClient.rpc('admin_upsert_reporting_machine_tax_rate', {
+    p_tax_rate_id: input.taxRateId ?? null,
+    p_machine_id: input.machineId,
+    p_tax_rate_percent: input.taxRatePercent,
+    p_effective_start_date: input.effectiveStartDate,
+    p_effective_end_date: input.effectiveEndDate || null,
+    p_status: input.status,
+    p_notes: input.notes ?? null,
+    p_reason: input.reason,
+  });
+
+  if (error || !data) {
+    throw new Error(error?.message || 'Unable to save machine tax rate.');
+  }
+
+  return data as ReportingMachineTaxRate;
+};
+
+export const upsertReportingFinancialRuleAdmin = async (input: UpsertFinancialRuleInput) => {
+  const { data, error } = await supabaseClient.rpc('admin_upsert_reporting_financial_rule', {
+    p_rule_id: input.ruleId ?? null,
+    p_partnership_id: input.partnershipId,
+    p_calculation_model: input.calculationModel,
+    p_split_base: input.splitBase,
+    p_fee_amount_cents: input.feeAmountCents,
+    p_fee_basis: input.feeBasis,
+    p_cost_amount_cents: input.costAmountCents,
+    p_cost_basis: input.costBasis,
+    p_deduction_timing: input.deductionTiming,
+    p_gross_to_net_method: input.grossToNetMethod,
+    p_fever_share_basis_points: input.feverShareBasisPoints,
+    p_partner_share_basis_points: input.partnerShareBasisPoints,
+    p_bloomjoy_share_basis_points: input.bloomjoyShareBasisPoints,
+    p_effective_start_date: input.effectiveStartDate,
+    p_effective_end_date: input.effectiveEndDate || null,
+    p_status: input.status,
+    p_notes: input.notes ?? null,
+    p_reason: input.reason,
+  });
+
+  if (error || !data) {
+    throw new Error(error?.message || 'Unable to save financial rule.');
+  }
+
+  return data as ReportingPartnershipFinancialRule;
+};
+
+export const previewPartnerWeeklyReportAdmin = async (
+  partnershipId: string,
+  weekEndingDate: string
+): Promise<PartnerWeeklyReportPreview> => {
+  const { data, error } = await supabaseClient.rpc('admin_preview_partner_weekly_report', {
+    p_partnership_id: partnershipId,
+    p_week_ending_date: weekEndingDate,
+  });
+
+  if (error) {
+    throw new Error(error.message || 'Unable to preview partner report.');
+  }
+
+  return data as PartnerWeeklyReportPreview;
+};

--- a/src/lib/reporting.ts
+++ b/src/lib/reporting.ts
@@ -315,6 +315,13 @@ type RevokeReportingAccessInput = {
   reason: string;
 };
 
+type SetUserMachineReportingAccessInput = {
+  userEmail: string;
+  machineIds: string[];
+  accessLevel: ReportingAccessLevel;
+  reason: string;
+};
+
 export const emptyReportingAccessContext: ReportingAccessContext = {
   hasReportingAccess: false,
   accessibleMachineCount: 0,
@@ -624,6 +631,33 @@ export const revokeReportingAccessAdmin = async (
   }
 
   return data as AdminReportingEntitlement;
+};
+
+export const setUserMachineReportingAccessAdmin = async (
+  input: SetUserMachineReportingAccessInput
+): Promise<{
+  userId: string;
+  machineCount: number;
+  addedCount: number;
+  revokedCount: number;
+}> => {
+  const { data, error } = await supabaseClient.rpc('admin_set_user_machine_reporting_access', {
+    p_user_email: input.userEmail,
+    p_machine_ids: input.machineIds,
+    p_access_level: input.accessLevel,
+    p_reason: input.reason,
+  });
+
+  if (error || !data) {
+    throw new Error(error?.message || 'Unable to save report access.');
+  }
+
+  return data as {
+    userId: string;
+    machineCount: number;
+    addedCount: number;
+    revokedCount: number;
+  };
 };
 
 export const createReportScheduleAdmin = async (

--- a/src/lib/reporting.ts
+++ b/src/lib/reporting.ts
@@ -106,6 +106,18 @@ export type AdminReportSchedule = {
   }>;
 };
 
+export type AdminReportViewSnapshot = {
+  id: string;
+  title: string;
+  filters: Record<string, unknown>;
+  summary: Record<string, unknown>;
+  export_storage_path: string | null;
+  export_status: 'pending' | 'ready' | 'failed';
+  error_message: string | null;
+  created_at: string;
+  created_by: string | null;
+};
+
 export type AdminReportingEntitlement = {
   id: string;
   user_id: string;
@@ -127,6 +139,7 @@ export type AdminReportingOverview = {
   machines: AdminReportingMachine[];
   importRuns: AdminReportingImportRun[];
   schedules: AdminReportSchedule[];
+  snapshots: AdminReportViewSnapshot[];
   entitlements: AdminReportingEntitlement[];
 };
 
@@ -422,7 +435,8 @@ export const exportSalesReportPdf = async (
   );
 
 export const fetchAdminReportingOverview = async (): Promise<AdminReportingOverview> => {
-  const [machinesResult, runsResult, schedulesResult, entitlementsResult] = await Promise.all([
+  const [machinesResult, runsResult, schedulesResult, snapshotsResult, entitlementsResult] =
+    await Promise.all([
     supabaseClient
       .from('reporting_machines')
       .select('*, reporting_locations(name, timezone), customer_accounts(name)')
@@ -438,6 +452,11 @@ export const fetchAdminReportingOverview = async (): Promise<AdminReportingOverv
       .order('created_at', { ascending: false })
       .limit(10),
     supabaseClient
+      .from('report_view_snapshots')
+      .select('*')
+      .order('created_at', { ascending: false })
+      .limit(10),
+    supabaseClient
       .from('reporting_machine_entitlements')
       .select('*, reporting_machines(machine_label), reporting_locations(name), customer_accounts(name)')
       .order('created_at', { ascending: false })
@@ -445,7 +464,11 @@ export const fetchAdminReportingOverview = async (): Promise<AdminReportingOverv
   ]);
 
   const firstError =
-    machinesResult.error || runsResult.error || schedulesResult.error || entitlementsResult.error;
+    machinesResult.error ||
+    runsResult.error ||
+    schedulesResult.error ||
+    snapshotsResult.error ||
+    entitlementsResult.error;
 
   if (firstError) {
     throw new Error(firstError.message || 'Unable to load reporting admin overview.');
@@ -455,6 +478,7 @@ export const fetchAdminReportingOverview = async (): Promise<AdminReportingOverv
     machines: (machinesResult.data ?? []) as AdminReportingMachine[],
     importRuns: (runsResult.data ?? []) as AdminReportingImportRun[],
     schedules: (schedulesResult.data ?? []) as AdminReportSchedule[],
+    snapshots: (snapshotsResult.data ?? []) as AdminReportViewSnapshot[],
     entitlements: (entitlementsResult.data ?? []) as AdminReportingEntitlement[],
   };
 };

--- a/src/pages/admin/Access.tsx
+++ b/src/pages/admin/Access.tsx
@@ -1,0 +1,1235 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Loader2,
+  RefreshCw,
+  Search,
+  ShieldCheck,
+  UserPlus,
+} from 'lucide-react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { AppLayout } from '@/components/layout/AppLayout';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  fetchAdminAccountSummaries,
+  fetchMachineInventoryForAccount,
+  grantPlusAccessAdmin,
+  revokePlusAccessAdmin,
+  type AdminAccountSummary,
+  type MachineType,
+  upsertMachineInventoryAdmin,
+} from '@/lib/adminAccounts';
+import {
+  fetchAdminAuditLog,
+  fetchAdminRoles,
+  grantSuperAdminByEmail,
+  revokeSuperAdmin,
+  type AdminAuditLogRecord,
+  type AdminRoleRecord,
+} from '@/lib/adminGovernance';
+import {
+  fetchAdminReportingAccessMatrix,
+  grantMachineReportAccessAdmin,
+  lookupReportingUserByEmailAdmin,
+  revokeReportingAccessAdmin,
+  type AdminReportingAccessGrant,
+  type AdminReportingAccessMachine,
+  type AdminReportingAccessPerson,
+  type ReportingAccessLevel,
+} from '@/lib/reporting';
+import { trackEvent } from '@/lib/analytics';
+import { cn } from '@/lib/utils';
+
+const tabs = ['users', 'reporting-access', 'global-roles', 'audit'];
+const machineTypeMeta: Array<{ key: MachineType; label: string }> = [
+  { key: 'commercial', label: 'Commercial' },
+  { key: 'mini', label: 'Mini' },
+  { key: 'micro', label: 'Micro' },
+];
+const emptyQuantities: Record<MachineType, number> = { commercial: 0, mini: 0, micro: 0 };
+const accessLevels: ReportingAccessLevel[] = ['viewer', 'report_manager'];
+
+const formatDate = (value: string | null) =>
+  value
+    ? new Date(value).toLocaleString(undefined, {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      })
+    : 'n/a';
+
+const formatDateInput = (date: Date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const getPresetExpiryDate = (days: number) => {
+  const date = new Date();
+  date.setDate(date.getDate() + days);
+  return formatDateInput(date);
+};
+
+const parseExpiryDateEndOfDay = (value: string): Date | null => {
+  const [year, month, day] = value.split('-').map((part) => Number(part));
+  if (!year || !month || !day) return null;
+  const date = new Date(year, month - 1, day, 23, 59, 59, 999);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+const normalizeSearch = (value: string) => value.trim().toLowerCase();
+
+const formatAccessSource = (account: AdminAccountSummary) => {
+  switch (account.plus_access_source) {
+    case 'paid_subscription':
+      return 'Paid Plus';
+    case 'free_grant':
+      return 'Free Plus grant';
+    case 'admin':
+      return 'Super-admin override';
+    default:
+      return 'No Plus access';
+  }
+};
+
+const formatFreeGrant = (account: AdminAccountSummary) => {
+  if (!account.plus_grant_id) return 'none';
+  const expiry = formatDate(account.plus_grant_expires_at);
+  return account.plus_grant_active ? `active until ${expiry}` : `expired ${expiry}`;
+};
+
+const isMachineGrant = (grant: AdminReportingAccessGrant) =>
+  grant.scopeType === 'machine' && Boolean(grant.machineId);
+
+const mergePeople = (
+  matrixPeople: AdminReportingAccessPerson[],
+  localPeople: AdminReportingAccessPerson[]
+) => {
+  const byUserId = new Map<string, AdminReportingAccessPerson>();
+  [...localPeople, ...matrixPeople].forEach((person) => byUserId.set(person.userId, person));
+  return [...byUserId.values()].sort((left, right) => {
+    if (left.isSuperAdmin !== right.isSuperAdmin) return left.isSuperAdmin ? -1 : 1;
+    return (left.userEmail ?? left.userId).localeCompare(right.userEmail ?? right.userId);
+  });
+};
+
+const groupMachines = (machines: AdminReportingAccessMachine[]) => {
+  const groups = new Map<string, AdminReportingAccessMachine[]>();
+  machines.forEach((machine) => {
+    const key = `${machine.accountName}||${machine.locationName}`;
+    groups.set(key, [...(groups.get(key) ?? []), machine]);
+  });
+
+  return [...groups.entries()].map(([key, values]) => {
+    const [accountName, locationName] = key.split('||');
+    return { key, accountName, locationName, machines: values };
+  });
+};
+
+const uniqueValues = (items: string[]) => [...new Set(items)].sort((a, b) => a.localeCompare(b));
+
+const roleSort = (a: AdminRoleRecord, b: AdminRoleRecord) => {
+  if (a.active !== b.active) return a.active ? -1 : 1;
+  return new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime();
+};
+
+export default function AdminAccessPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab = tabs.includes(searchParams.get('tab') ?? '')
+    ? (searchParams.get('tab') as string)
+    : 'users';
+
+  const setActiveTab = (value: string) => {
+    setSearchParams({ tab: value }, { replace: true });
+  };
+
+  return (
+    <AppLayout>
+      <section className="section-padding">
+        <div className="container-page">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                Admin
+              </p>
+              <h1 className="mt-2 font-display text-3xl font-bold text-foreground">
+                Access
+              </h1>
+              <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+                Manage users, Plus access, global roles, and explicit machine-level reporting
+                visibility from one place.
+              </p>
+            </div>
+          </div>
+
+          <Tabs value={activeTab} onValueChange={setActiveTab} className="mt-6">
+            <TabsList className="h-auto flex-wrap justify-start">
+              <TabsTrigger value="users">Users</TabsTrigger>
+              <TabsTrigger value="reporting-access">Reporting Access</TabsTrigger>
+              <TabsTrigger value="global-roles">Global Roles</TabsTrigger>
+              <TabsTrigger value="audit">Audit</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="users" className="mt-6">
+              <UsersTab />
+            </TabsContent>
+            <TabsContent value="reporting-access" className="mt-6">
+              <ReportingAccessTab />
+            </TabsContent>
+            <TabsContent value="global-roles" className="mt-6">
+              <GlobalRolesTab />
+            </TabsContent>
+            <TabsContent value="audit" className="mt-6">
+              <AuditTab />
+            </TabsContent>
+          </Tabs>
+        </div>
+      </section>
+    </AppLayout>
+  );
+}
+
+function UsersTab() {
+  const queryClient = useQueryClient();
+  const [search, setSearch] = useState('');
+  const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
+  const [quantities, setQuantities] = useState<Record<MachineType, number>>(emptyQuantities);
+  const [updateReason, setUpdateReason] = useState('');
+  const [grantExpiryDate, setGrantExpiryDate] = useState(() => getPresetExpiryDate(90));
+  const [grantReason, setGrantReason] = useState('');
+  const [revokeReason, setRevokeReason] = useState('');
+  const [isSavingInventory, setIsSavingInventory] = useState(false);
+  const [isSavingGrant, setIsSavingGrant] = useState(false);
+  const [isRevokingGrant, setIsRevokingGrant] = useState(false);
+
+  const {
+    data: accounts = [],
+    isLoading,
+    isFetching,
+    error,
+  } = useQuery({
+    queryKey: ['admin-account-summaries', search],
+    queryFn: () => fetchAdminAccountSummaries(search),
+    staleTime: 1000 * 30,
+  });
+
+  useEffect(() => {
+    if (!selectedUserId && accounts.length > 0) {
+      setSelectedUserId(accounts[0].user_id);
+      return;
+    }
+    if (selectedUserId && !accounts.find((account) => account.user_id === selectedUserId)) {
+      setSelectedUserId(accounts[0]?.user_id ?? null);
+    }
+  }, [accounts, selectedUserId]);
+
+  const selectedAccount = accounts.find((account) => account.user_id === selectedUserId) ?? null;
+  const paidSubscriptionBlocksGrant = Boolean(
+    selectedAccount?.paid_subscription_active && !selectedAccount.membership_cancel_at_period_end
+  );
+
+  const {
+    data: machineInventory = [],
+    isFetching: inventoryFetching,
+    error: inventoryError,
+  } = useQuery({
+    queryKey: ['admin-account-machine-inventory', selectedUserId],
+    queryFn: () => fetchMachineInventoryForAccount(selectedUserId as string),
+    enabled: Boolean(selectedUserId),
+    staleTime: 1000 * 30,
+  });
+
+  useEffect(() => {
+    const nextQuantities = { ...emptyQuantities };
+    machineInventory.forEach((entry) => {
+      nextQuantities[entry.machine_type] = entry.quantity;
+    });
+    setQuantities(nextQuantities);
+    setUpdateReason('');
+    setGrantReason('');
+    setRevokeReason('');
+    setGrantExpiryDate(getPresetExpiryDate(90));
+  }, [machineInventory, selectedUserId]);
+
+  const refreshAccounts = async () => {
+    await queryClient.invalidateQueries({ queryKey: ['admin-account-summaries'] });
+    if (selectedUserId) {
+      await queryClient.invalidateQueries({
+        queryKey: ['admin-account-machine-inventory', selectedUserId],
+      });
+    }
+  };
+
+  const updateQuantity = (machineType: MachineType, value: string) => {
+    const parsed = Number(value);
+    const nextValue = Number.isFinite(parsed) ? Math.max(0, Math.floor(parsed)) : 0;
+    setQuantities((prev) => ({ ...prev, [machineType]: nextValue }));
+  };
+
+  const saveMachineCounts = async () => {
+    if (!selectedAccount) return;
+    if (!updateReason.trim()) {
+      toast.error('Update reason is required.');
+      return;
+    }
+
+    setIsSavingInventory(true);
+    try {
+      for (const type of machineTypeMeta) {
+        await upsertMachineInventoryAdmin({
+          customerUserId: selectedAccount.user_id,
+          machineType: type.key,
+          quantity: quantities[type.key],
+          updatedReason: updateReason.trim(),
+        });
+      }
+      trackEvent('admin_machine_inventory_updated', {
+        user_id: selectedAccount.user_id,
+        total_machine_count: quantities.commercial + quantities.mini + quantities.micro,
+      });
+      toast.success('Machine counts updated.');
+      setUpdateReason('');
+      await refreshAccounts();
+    } catch (saveError) {
+      toast.error(saveError instanceof Error ? saveError.message : 'Unable to update counts.');
+    } finally {
+      setIsSavingInventory(false);
+    }
+  };
+
+  const savePlusGrant = async () => {
+    if (!selectedAccount) return;
+    if (paidSubscriptionBlocksGrant) {
+      toast.error('Cancel or schedule cancellation for the paid Stripe subscription first.');
+      return;
+    }
+    if (!grantReason.trim()) {
+      toast.error('Grant reason is required.');
+      return;
+    }
+    const expiry = parseExpiryDateEndOfDay(grantExpiryDate);
+    if (!expiry || expiry <= new Date()) {
+      toast.error('Grant expiry must be a future date.');
+      return;
+    }
+
+    setIsSavingGrant(true);
+    try {
+      await grantPlusAccessAdmin({
+        customerUserId: selectedAccount.user_id,
+        expiresAt: expiry.toISOString(),
+        reason: grantReason.trim(),
+      });
+      toast.success(selectedAccount.plus_grant_id ? 'Free Plus access updated.' : 'Free Plus access granted.');
+      setGrantReason('');
+      await refreshAccounts();
+    } catch (grantError) {
+      toast.error(grantError instanceof Error ? grantError.message : 'Unable to grant Plus access.');
+    } finally {
+      setIsSavingGrant(false);
+    }
+  };
+
+  const revokePlusGrant = async () => {
+    if (!selectedAccount?.plus_grant_id) return;
+    if (!revokeReason.trim()) {
+      toast.error('Revoke reason is required.');
+      return;
+    }
+
+    setIsRevokingGrant(true);
+    try {
+      await revokePlusAccessAdmin({
+        grantId: selectedAccount.plus_grant_id,
+        reason: revokeReason.trim(),
+      });
+      toast.success('Free Plus access revoked.');
+      setRevokeReason('');
+      await refreshAccounts();
+    } catch (revokeError) {
+      toast.error(revokeError instanceof Error ? revokeError.message : 'Unable to revoke Plus access.');
+    } finally {
+      setIsRevokingGrant(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="relative sm:max-w-md sm:flex-1">
+          <Search className="pointer-events-none absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+          <Input
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Search by account email or user ID"
+            className="pl-9"
+          />
+        </div>
+        <Button variant="outline" onClick={refreshAccounts} disabled={isFetching}>
+          {isFetching ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-2 h-4 w-4" />}
+          Refresh
+        </Button>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+          Unable to load account summaries.
+        </div>
+      )}
+
+      <div className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr]">
+        <div className="overflow-hidden rounded-lg border border-border bg-card">
+          <table className="w-full">
+            <thead className="border-b border-border bg-muted/40">
+              <tr>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">User</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">Plus Access</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">Orders</th>
+                <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">Machines</th>
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading && (
+                <tr>
+                  <td colSpan={4} className="px-4 py-10 text-center text-sm text-muted-foreground">
+                    Loading users...
+                  </td>
+                </tr>
+              )}
+              {!isLoading && accounts.length === 0 && (
+                <tr>
+                  <td colSpan={4} className="px-4 py-10 text-center text-sm text-muted-foreground">
+                    No users found.
+                  </td>
+                </tr>
+              )}
+              {!isLoading &&
+                accounts.map((account) => (
+                  <tr
+                    key={account.user_id}
+                    className={cn(
+                      'cursor-pointer border-b border-border/70 transition-colors hover:bg-muted/40',
+                      account.user_id === selectedUserId && 'bg-muted/50'
+                    )}
+                    onClick={() => setSelectedUserId(account.user_id)}
+                  >
+                    <td className="px-4 py-3 align-top">
+                      <div className="text-sm font-medium text-foreground">
+                        {account.customer_email || 'No email on file'}
+                      </div>
+                      <div className="mt-1 text-xs text-muted-foreground">{account.user_id}</div>
+                    </td>
+                    <td className="px-4 py-3 text-sm">
+                      <div className="font-medium text-foreground">{formatAccessSource(account)}</div>
+                      <div className="mt-1 text-xs text-muted-foreground">{formatFreeGrant(account)}</div>
+                    </td>
+                    <td className="px-4 py-3 text-sm text-foreground">{account.total_orders}</td>
+                    <td className="px-4 py-3 text-sm text-foreground">{account.total_machine_count}</td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="rounded-lg border border-border bg-card p-5">
+          {!selectedAccount ? (
+            <div className="text-sm text-muted-foreground">Select a user to manage account access.</div>
+          ) : (
+            <div className="space-y-5">
+              <div>
+                <h2 className="font-semibold text-foreground">
+                  {selectedAccount.customer_email || selectedAccount.user_id}
+                </h2>
+                <p className="mt-1 text-xs text-muted-foreground">{selectedAccount.user_id}</p>
+              </div>
+
+              <div className="grid gap-2 rounded-md border border-border bg-muted/20 p-3 text-sm">
+                <div className="flex justify-between gap-3">
+                  <span className="text-muted-foreground">Paid subscription</span>
+                  <span className="font-medium text-foreground">{selectedAccount.membership_status ?? 'none'}</span>
+                </div>
+                <div className="flex justify-between gap-3">
+                  <span className="text-muted-foreground">Effective Plus access</span>
+                  <span className="font-medium text-foreground">{formatAccessSource(selectedAccount)}</span>
+                </div>
+                <div className="flex justify-between gap-3">
+                  <span className="text-muted-foreground">Last order</span>
+                  <span className="text-foreground">{formatDate(selectedAccount.last_order_at)}</span>
+                </div>
+              </div>
+
+              <div className="rounded-md border border-border p-3">
+                <h3 className="text-sm font-semibold text-foreground">Free Plus Access</h3>
+                {paidSubscriptionBlocksGrant && (
+                  <div className="mt-3 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+                    This user has an active paid Stripe subscription.
+                  </div>
+                )}
+                <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                  <div>
+                    <Label htmlFor="grant-expiry">Grant expiry</Label>
+                    <Input
+                      id="grant-expiry"
+                      type="date"
+                      value={grantExpiryDate}
+                      onChange={(event) => setGrantExpiryDate(event.target.value)}
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="grant-reason">Grant reason</Label>
+                    <Input
+                      id="grant-reason"
+                      value={grantReason}
+                      onChange={(event) => setGrantReason(event.target.value)}
+                      placeholder="Required reason"
+                    />
+                  </div>
+                </div>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {[30, 90, 180, 365].map((days) => (
+                    <Button
+                      key={days}
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setGrantExpiryDate(getPresetExpiryDate(days))}
+                    >
+                      {days === 365 ? '1 year' : `${days} days`}
+                    </Button>
+                  ))}
+                  <Button onClick={savePlusGrant} disabled={isSavingGrant || paidSubscriptionBlocksGrant}>
+                    {isSavingGrant ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                    {selectedAccount.plus_grant_id ? 'Extend Free Plus' : 'Grant Free Plus'}
+                  </Button>
+                </div>
+
+                {selectedAccount.plus_grant_id && (
+                  <div className="mt-4 border-t border-border/70 pt-3">
+                    <Label htmlFor="revoke-plus">Revoke reason</Label>
+                    <div className="mt-1 flex flex-col gap-2 sm:flex-row">
+                      <Input
+                        id="revoke-plus"
+                        value={revokeReason}
+                        onChange={(event) => setRevokeReason(event.target.value)}
+                        placeholder="Required reason"
+                      />
+                      <Button variant="outline" onClick={revokePlusGrant} disabled={isRevokingGrant}>
+                        {isRevokingGrant ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                        Revoke
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <div className="rounded-md border border-border p-3">
+                <h3 className="text-sm font-semibold text-foreground">Customer Machine Counts</h3>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Count records are customer context only. They do not grant reporting access.
+                </p>
+                {inventoryError && (
+                  <div className="mt-3 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+                    Unable to load machine inventory.
+                  </div>
+                )}
+                <div className="mt-3 grid gap-3 sm:grid-cols-3">
+                  {machineTypeMeta.map((machineType) => (
+                    <div key={machineType.key}>
+                      <Label htmlFor={`count-${machineType.key}`}>{machineType.label}</Label>
+                      <Input
+                        id={`count-${machineType.key}`}
+                        type="number"
+                        min={0}
+                        value={quantities[machineType.key]}
+                        onChange={(event) => updateQuantity(machineType.key, event.target.value)}
+                        disabled={inventoryFetching}
+                      />
+                    </div>
+                  ))}
+                </div>
+                <div className="mt-3">
+                  <Label htmlFor="machine-count-reason">Update reason</Label>
+                  <Input
+                    id="machine-count-reason"
+                    value={updateReason}
+                    onChange={(event) => setUpdateReason(event.target.value)}
+                    placeholder="Required reason for count changes"
+                  />
+                </div>
+                <Button className="mt-3" onClick={saveMachineCounts} disabled={isSavingInventory || inventoryFetching}>
+                  {isSavingInventory ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                  Save Machine Counts
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ReportingAccessTab() {
+  const queryClient = useQueryClient();
+  const [peopleSearch, setPeopleSearch] = useState('');
+  const [lookupEmail, setLookupEmail] = useState('');
+  const [localPeople, setLocalPeople] = useState<AdminReportingAccessPerson[]>([]);
+  const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
+  const [selectedMachineIds, setSelectedMachineIds] = useState<Set<string>>(new Set());
+  const [accessReason, setAccessReason] = useState('');
+  const [accessLevel, setAccessLevel] = useState<ReportingAccessLevel>('viewer');
+  const [isLookingUpUser, setIsLookingUpUser] = useState(false);
+  const [isSavingAccess, setIsSavingAccess] = useState(false);
+  const [machineSearch, setMachineSearch] = useState('');
+
+  const {
+    data: matrix = { people: [], machines: [], grants: [] },
+    isLoading,
+    isFetching,
+    error,
+  } = useQuery({
+    queryKey: ['admin-reporting-access-matrix'],
+    queryFn: fetchAdminReportingAccessMatrix,
+    staleTime: 1000 * 30,
+  });
+
+  const people = useMemo(() => mergePeople(matrix.people, localPeople), [localPeople, matrix.people]);
+  const selectedPerson = people.find((person) => person.userId === selectedUserId) ?? null;
+
+  const selectedMachineGrantByMachineId = useMemo(() => {
+    const grantMap = new Map<string, AdminReportingAccessGrant>();
+    matrix.grants
+      .filter((grant) => grant.userId === selectedUserId && isMachineGrant(grant))
+      .forEach((grant) => {
+        if (grant.machineId) grantMap.set(grant.machineId, grant);
+      });
+    return grantMap;
+  }, [matrix.grants, selectedUserId]);
+
+  const originalMachineIds = useMemo(
+    () => new Set(selectedMachineGrantByMachineId.keys()),
+    [selectedMachineGrantByMachineId]
+  );
+
+  useEffect(() => {
+    if (!selectedUserId && people.length > 0) {
+      setSelectedUserId(people[0].userId);
+    }
+  }, [people, selectedUserId]);
+
+  useEffect(() => {
+    setSelectedMachineIds(new Set(originalMachineIds));
+    setAccessReason('');
+  }, [originalMachineIds, selectedUserId]);
+
+  const filteredPeople = useMemo(() => {
+    const search = normalizeSearch(peopleSearch);
+    if (!search) return people;
+    return people.filter((person) =>
+      `${person.userEmail ?? ''} ${person.userId}`.toLowerCase().includes(search)
+    );
+  }, [people, peopleSearch]);
+
+  const filteredMachines = useMemo(() => {
+    const search = normalizeSearch(machineSearch);
+    if (!search) return matrix.machines;
+    return matrix.machines.filter((machine) =>
+      [machine.machineLabel, machine.sunzeMachineId ?? '', machine.accountName, machine.locationName]
+        .join(' ')
+        .toLowerCase()
+        .includes(search)
+    );
+  }, [machineSearch, matrix.machines]);
+
+  const groupedMachines = useMemo(() => groupMachines(filteredMachines), [filteredMachines]);
+  const addedMachineIds = [...selectedMachineIds].filter((id) => !originalMachineIds.has(id));
+  const removedMachineIds = [...originalMachineIds].filter((id) => !selectedMachineIds.has(id));
+  const hasAccessChanges = addedMachineIds.length > 0 || removedMachineIds.length > 0;
+
+  const lookupUser = async () => {
+    if (!lookupEmail.trim()) {
+      toast.error('User email is required.');
+      return;
+    }
+
+    setIsLookingUpUser(true);
+    try {
+      const person = await lookupReportingUserByEmailAdmin(lookupEmail);
+      setLocalPeople((current) => mergePeople([person], current));
+      setSelectedUserId(person.userId);
+      setLookupEmail('');
+      toast.success('User loaded.');
+    } catch (lookupError) {
+      toast.error(lookupError instanceof Error ? lookupError.message : 'Unable to find user.');
+    } finally {
+      setIsLookingUpUser(false);
+    }
+  };
+
+  const toggleMachine = (machineId: string, checked: boolean) => {
+    setSelectedMachineIds((current) => {
+      const next = new Set(current);
+      if (checked) next.add(machineId);
+      else next.delete(machineId);
+      return next;
+    });
+  };
+
+  const saveAccessChanges = async () => {
+    if (!selectedPerson?.userEmail) {
+      toast.error('Select a user with an email before saving.');
+      return;
+    }
+    if (selectedPerson.isSuperAdmin) {
+      toast.error('Super-admin reporting access is managed from Global Roles.');
+      return;
+    }
+    if (!hasAccessChanges) {
+      toast.info('No reporting access changes to save.');
+      return;
+    }
+    if (!accessReason.trim()) {
+      toast.error('Reason is required.');
+      return;
+    }
+
+    setIsSavingAccess(true);
+    try {
+      await Promise.all([
+        ...addedMachineIds.map((machineId) =>
+          grantMachineReportAccessAdmin({
+            userEmail: selectedPerson.userEmail as string,
+            machineId,
+            accessLevel,
+            reason: accessReason.trim(),
+          })
+        ),
+        ...removedMachineIds.map((machineId) => {
+          const grant = selectedMachineGrantByMachineId.get(machineId);
+          if (!grant) return Promise.resolve(null);
+          return revokeReportingAccessAdmin({
+            entitlementId: grant.id,
+            reason: accessReason.trim(),
+          });
+        }),
+      ]);
+
+      trackEvent('admin_reporting_access_matrix_saved', {
+        user_id: selectedPerson.userId,
+        added_count: addedMachineIds.length,
+        removed_count: removedMachineIds.length,
+      });
+      toast.success('Reporting access saved.');
+      setAccessReason('');
+      await queryClient.invalidateQueries({ queryKey: ['admin-reporting-access-matrix'] });
+    } catch (saveError) {
+      toast.error(saveError instanceof Error ? saveError.message : 'Unable to save reporting access.');
+    } finally {
+      setIsSavingAccess(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-border bg-card p-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end">
+          <div className="flex-1">
+            <Label htmlFor="reporting-user-email">Add existing user by email</Label>
+            <Input
+              id="reporting-user-email"
+              type="email"
+              value={lookupEmail}
+              onChange={(event) => setLookupEmail(event.target.value)}
+              placeholder="adam@example.com"
+            />
+          </div>
+          <Button onClick={lookupUser} disabled={isLookingUpUser}>
+            {isLookingUpUser ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <UserPlus className="mr-2 h-4 w-4" />}
+            Load User
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => queryClient.invalidateQueries({ queryKey: ['admin-reporting-access-matrix'] })}
+            disabled={isFetching}
+          >
+            {isFetching ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-2 h-4 w-4" />}
+            Refresh
+          </Button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+          Unable to load reporting access.
+        </div>
+      )}
+
+      <div className="grid gap-6 xl:grid-cols-[0.42fr_0.58fr]">
+        <div className="rounded-lg border border-border bg-card">
+          <div className="border-b border-border p-4">
+            <Label htmlFor="people-search">People</Label>
+            <Input
+              id="people-search"
+              value={peopleSearch}
+              onChange={(event) => setPeopleSearch(event.target.value)}
+              placeholder="Search people"
+            />
+          </div>
+          <div className="max-h-[680px] overflow-y-auto">
+            {isLoading && <div className="p-4 text-sm text-muted-foreground">Loading people...</div>}
+            {!isLoading && filteredPeople.length === 0 && (
+              <div className="p-4 text-sm text-muted-foreground">Load a user by email to manage access.</div>
+            )}
+            {filteredPeople.map((person) => (
+              <button
+                key={person.userId}
+                type="button"
+                onClick={() => setSelectedUserId(person.userId)}
+                className={cn(
+                  'block w-full border-b border-border/70 p-4 text-left transition hover:bg-muted/40',
+                  selectedUserId === person.userId && 'bg-muted/50'
+                )}
+              >
+                <div className="font-medium text-foreground">{person.userEmail ?? person.userId}</div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {person.isSuperAdmin && <Badge variant="secondary">Super-admin</Badge>}
+                  <Badge variant="outline">{person.explicitMachineCount} machine grants</Badge>
+                  {!person.isSuperAdmin && person.explicitMachineCount === 0 && (
+                    <Badge variant="destructive">No machine grants</Badge>
+                  )}
+                </div>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-border bg-card">
+          {!selectedPerson ? (
+            <div className="p-6 text-sm text-muted-foreground">Select a user to manage machine access.</div>
+          ) : (
+            <div className="space-y-4 p-4">
+              <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+                <div>
+                  <h2 className="font-semibold text-foreground">
+                    {selectedPerson.userEmail ?? selectedPerson.userId}
+                  </h2>
+                  <p className="mt-1 text-xs text-muted-foreground">{selectedPerson.userId}</p>
+                  {selectedPerson.isSuperAdmin && (
+                    <Badge className="mt-2" variant="secondary">
+                      All machines via super-admin
+                    </Badge>
+                  )}
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Badge variant="outline">{selectedMachineIds.size} selected</Badge>
+                  <Badge variant={hasAccessChanges ? 'default' : 'outline'}>
+                    +{addedMachineIds.length} / -{removedMachineIds.length}
+                  </Badge>
+                </div>
+              </div>
+
+              {selectedPerson.isSuperAdmin ? (
+                <div className="rounded-md border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
+                  Super-admins have implicit reporting access to all machines. Use the Global Roles
+                  tab to grant or revoke that global role.
+                </div>
+              ) : (
+                <>
+                  <div className="grid gap-3 md:grid-cols-[0.5fr_1fr_auto]">
+                    <div>
+                      <Label htmlFor="access-level">New grant level</Label>
+                      <select
+                        id="access-level"
+                        value={accessLevel}
+                        onChange={(event) => setAccessLevel(event.target.value as ReportingAccessLevel)}
+                        className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                      >
+                        {accessLevels.map((level) => (
+                          <option key={level} value={level}>
+                            {level === 'report_manager' ? 'Report manager' : 'Viewer'}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <Label htmlFor="access-reason">Reason</Label>
+                      <Input
+                        id="access-reason"
+                        value={accessReason}
+                        onChange={(event) => setAccessReason(event.target.value)}
+                        placeholder="Required reason for access changes"
+                      />
+                    </div>
+                    <div className="flex items-end">
+                      <Button onClick={saveAccessChanges} disabled={isSavingAccess || !hasAccessChanges}>
+                        {isSavingAccess ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <CheckCircle2 className="mr-2 h-4 w-4" />}
+                        Save Access
+                      </Button>
+                    </div>
+                  </div>
+
+                  <div>
+                    <Label htmlFor="machine-search">Machines</Label>
+                    <Input
+                      id="machine-search"
+                      value={machineSearch}
+                      onChange={(event) => setMachineSearch(event.target.value)}
+                      placeholder="Filter by label, Sunze ID, account, or location"
+                    />
+                  </div>
+
+                  <div className="max-h-[520px] overflow-y-auto rounded-md border border-border">
+                    {groupedMachines.length === 0 ? (
+                      <div className="p-4 text-sm text-muted-foreground">No machines found.</div>
+                    ) : (
+                      groupedMachines.map((group) => (
+                        <div key={group.key} className="border-b border-border last:border-b-0">
+                          <div className="bg-muted/40 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                            {group.accountName} / {group.locationName}
+                          </div>
+                          {group.machines.map((machine) => (
+                            <label
+                              key={machine.id}
+                              className="flex cursor-pointer items-start gap-3 border-b border-border/60 p-3 last:border-b-0"
+                            >
+                              <Checkbox
+                                checked={selectedMachineIds.has(machine.id)}
+                                onCheckedChange={(checked) => toggleMachine(machine.id, Boolean(checked))}
+                              />
+                              <div className="min-w-0 flex-1">
+                                <div className="font-medium text-foreground">{machine.machineLabel}</div>
+                                <div className="mt-1 text-xs text-muted-foreground">
+                                  Sunze: {machine.sunzeMachineId ?? 'n/a'} / Viewers: {machine.viewerCount}
+                                </div>
+                              </div>
+                            </label>
+                          ))}
+                        </div>
+                      ))
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function GlobalRolesTab() {
+  const queryClient = useQueryClient();
+  const [grantEmail, setGrantEmail] = useState('');
+  const [grantReason, setGrantReason] = useState('');
+  const [revokeReasons, setRevokeReasons] = useState<Record<string, string>>({});
+  const [isGranting, setIsGranting] = useState(false);
+  const [revokingUserId, setRevokingUserId] = useState<string | null>(null);
+
+  const {
+    data: roles = [],
+    isLoading,
+    isFetching,
+    error,
+  } = useQuery({
+    queryKey: ['admin-governance-roles'],
+    queryFn: fetchAdminRoles,
+    staleTime: 1000 * 30,
+  });
+
+  const sortedRoles = useMemo(() => [...roles].sort(roleSort), [roles]);
+
+  const refreshRoles = () => queryClient.invalidateQueries({ queryKey: ['admin-governance-roles'] });
+
+  const handleGrant = async () => {
+    if (!grantEmail.trim()) {
+      toast.error('Email is required.');
+      return;
+    }
+
+    setIsGranting(true);
+    try {
+      await grantSuperAdminByEmail(grantEmail.trim(), grantReason.trim());
+      trackEvent('admin_role_granted', { target_email: grantEmail.trim() });
+      toast.success('Super-admin role granted.');
+      setGrantEmail('');
+      setGrantReason('');
+      await refreshRoles();
+    } catch (grantError) {
+      toast.error(grantError instanceof Error ? grantError.message : 'Unable to grant role.');
+    } finally {
+      setIsGranting(false);
+    }
+  };
+
+  const handleRevoke = async (role: AdminRoleRecord) => {
+    const reason = revokeReasons[role.user_id]?.trim();
+    if (!reason) {
+      toast.error('Revoke reason is required.');
+      return;
+    }
+
+    setRevokingUserId(role.user_id);
+    try {
+      await revokeSuperAdmin(role.user_id, reason);
+      trackEvent('admin_role_revoked', { target_user_id: role.user_id });
+      toast.success('Super-admin role revoked.');
+      setRevokeReasons((prev) => ({ ...prev, [role.user_id]: '' }));
+      await refreshRoles();
+    } catch (revokeError) {
+      toast.error(revokeError instanceof Error ? revokeError.message : 'Unable to revoke role.');
+    } finally {
+      setRevokingUserId(null);
+    }
+  };
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[0.8fr_1.2fr]">
+      <div className="rounded-lg border border-border bg-card p-5">
+        <h2 className="font-semibold text-foreground">Grant Super-Admin</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Super-admin is global access across admin and reporting surfaces.
+        </p>
+        <div className="mt-4 space-y-3">
+          <div>
+            <Label htmlFor="super-admin-email">Email</Label>
+            <Input
+              id="super-admin-email"
+              type="email"
+              value={grantEmail}
+              onChange={(event) => setGrantEmail(event.target.value)}
+              placeholder="admin@company.com"
+            />
+          </div>
+          <div>
+            <Label htmlFor="super-admin-reason">Grant reason</Label>
+            <Input
+              id="super-admin-reason"
+              value={grantReason}
+              onChange={(event) => setGrantReason(event.target.value)}
+              placeholder="Why this user needs global access"
+            />
+          </div>
+          <Button onClick={handleGrant} disabled={isGranting}>
+            {isGranting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <ShieldCheck className="mr-2 h-4 w-4" />}
+            Grant Super-Admin
+          </Button>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-border bg-card p-5">
+        <div className="flex items-center justify-between gap-3">
+          <h2 className="font-semibold text-foreground">Current Global Roles</h2>
+          <Button variant="outline" size="sm" onClick={refreshRoles} disabled={isFetching}>
+            {isFetching ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-2 h-4 w-4" />}
+            Refresh
+          </Button>
+        </div>
+        {error && (
+          <div className="mt-3 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+            Unable to load roles.
+          </div>
+        )}
+        <div className="mt-4 space-y-3">
+          {isLoading && <div className="text-sm text-muted-foreground">Loading roles...</div>}
+          {!isLoading && sortedRoles.length === 0 && (
+            <div className="text-sm text-muted-foreground">No super-admin roles found.</div>
+          )}
+          {sortedRoles.map((role) => (
+            <div key={role.id} className="rounded-md border border-border p-3">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <div className="font-medium text-foreground">{role.user_email ?? role.user_id}</div>
+                  <div className="mt-1 text-xs text-muted-foreground">{role.user_id}</div>
+                </div>
+                <Badge variant={role.active ? 'default' : 'outline'}>{role.active ? 'active' : 'revoked'}</Badge>
+              </div>
+              <div className="mt-2 text-xs text-muted-foreground">Granted: {formatDate(role.granted_at)}</div>
+              {role.active && (
+                <div className="mt-3 flex flex-col gap-2 sm:flex-row">
+                  <Input
+                    value={revokeReasons[role.user_id] ?? ''}
+                    onChange={(event) =>
+                      setRevokeReasons((prev) => ({ ...prev, [role.user_id]: event.target.value }))
+                    }
+                    placeholder="Required revoke reason"
+                  />
+                  <Button
+                    variant="outline"
+                    onClick={() => handleRevoke(role)}
+                    disabled={revokingUserId === role.user_id}
+                  >
+                    {revokingUserId === role.user_id ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                    Revoke
+                  </Button>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AuditTab() {
+  const [auditSearch, setAuditSearch] = useState('');
+  const [auditActionFilter, setAuditActionFilter] = useState('all');
+  const [auditEntityFilter, setAuditEntityFilter] = useState('all');
+  const [selectedLogId, setSelectedLogId] = useState<string | null>(null);
+
+  const {
+    data: auditLog = [],
+    isLoading,
+    isFetching,
+    error,
+  } = useQuery({
+    queryKey: ['admin-governance-audit', auditSearch, auditActionFilter, auditEntityFilter],
+    queryFn: () =>
+      fetchAdminAuditLog({
+        search: auditSearch,
+        action: auditActionFilter === 'all' ? undefined : auditActionFilter,
+        entityType: auditEntityFilter === 'all' ? undefined : auditEntityFilter,
+        limit: 250,
+      }),
+    staleTime: 1000 * 20,
+  });
+
+  const selectedLog = auditLog.find((entry) => entry.id === selectedLogId) ?? null;
+  const actionOptions = useMemo(() => uniqueValues(auditLog.map((entry) => entry.action)), [auditLog]);
+  const entityOptions = useMemo(
+    () => uniqueValues(auditLog.map((entry) => entry.entity_type)),
+    [auditLog]
+  );
+
+  return (
+    <div className="grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
+      <div className="rounded-lg border border-border bg-card">
+        <div className="space-y-3 border-b border-border p-4">
+          <div className="grid gap-3 md:grid-cols-3">
+            <Input
+              value={auditSearch}
+              onChange={(event) => setAuditSearch(event.target.value)}
+              placeholder="Search audit log"
+            />
+            <select
+              value={auditActionFilter}
+              onChange={(event) => setAuditActionFilter(event.target.value)}
+              className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+            >
+              <option value="all">All actions</option>
+              {actionOptions.map((action) => (
+                <option key={action} value={action}>
+                  {action}
+                </option>
+              ))}
+            </select>
+            <select
+              value={auditEntityFilter}
+              onChange={(event) => setAuditEntityFilter(event.target.value)}
+              className="h-10 rounded-md border border-input bg-background px-3 text-sm"
+            >
+              <option value="all">All entities</option>
+              {entityOptions.map((entity) => (
+                <option key={entity} value={entity}>
+                  {entity}
+                </option>
+              ))}
+            </select>
+          </div>
+          {isFetching && <div className="text-xs text-muted-foreground">Refreshing audit log...</div>}
+        </div>
+
+        {error && (
+          <div className="m-4 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+            Unable to load audit log.
+          </div>
+        )}
+
+        <div className="max-h-[640px] overflow-y-auto">
+          {isLoading && <div className="p-4 text-sm text-muted-foreground">Loading audit log...</div>}
+          {!isLoading && auditLog.length === 0 && (
+            <div className="p-4 text-sm text-muted-foreground">No audit entries found.</div>
+          )}
+          {auditLog.map((entry) => (
+            <button
+              key={entry.id}
+              type="button"
+              onClick={() => setSelectedLogId(entry.id)}
+              className={cn(
+                'block w-full border-b border-border/70 p-4 text-left transition hover:bg-muted/40',
+                selectedLogId === entry.id && 'bg-muted/50'
+              )}
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="outline">{entry.action}</Badge>
+                <span className="text-sm font-medium text-foreground">{entry.entity_type}</span>
+              </div>
+              <div className="mt-2 text-xs text-muted-foreground">
+                {formatDate(entry.created_at)} / actor: {entry.actor_email ?? entry.actor_user_id ?? 'system'}
+              </div>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-border bg-card p-5">
+        {!selectedLog ? (
+          <div className="flex items-start gap-3 text-sm text-muted-foreground">
+            <AlertTriangle className="mt-0.5 h-4 w-4" />
+            Select an audit row to inspect before/after details.
+          </div>
+        ) : (
+          <AuditDetails entry={selectedLog} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function AuditDetails({ entry }: { entry: AdminAuditLogRecord }) {
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="font-semibold text-foreground">{entry.action}</h2>
+        <p className="mt-1 text-xs text-muted-foreground">{formatDate(entry.created_at)}</p>
+      </div>
+      <div className="grid gap-2 text-sm">
+        <div>
+          <span className="text-muted-foreground">Entity: </span>
+          <span className="text-foreground">{entry.entity_type}</span>
+        </div>
+        <div>
+          <span className="text-muted-foreground">Actor: </span>
+          <span className="text-foreground">{entry.actor_email ?? entry.actor_user_id ?? 'system'}</span>
+        </div>
+        <div>
+          <span className="text-muted-foreground">Target: </span>
+          <span className="text-foreground">{entry.target_email ?? entry.target_user_id ?? 'n/a'}</span>
+        </div>
+      </div>
+      {(['before', 'after', 'meta'] as const).map((key) => (
+        <div key={key}>
+          <Label>{key}</Label>
+          <Textarea
+            readOnly
+            value={JSON.stringify(entry[key] ?? {}, null, 2)}
+            className="mt-1 min-h-36 font-mono text-xs"
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/admin/Access.tsx
+++ b/src/pages/admin/Access.tsx
@@ -38,9 +38,8 @@ import {
 } from '@/lib/adminGovernance';
 import {
   fetchAdminReportingAccessMatrix,
-  grantMachineReportAccessAdmin,
   lookupReportingUserByEmailAdmin,
-  revokeReportingAccessAdmin,
+  setUserMachineReportingAccessAdmin,
   type AdminReportingAccessGrant,
   type AdminReportingAccessMachine,
   type AdminReportingAccessPerson,
@@ -707,24 +706,12 @@ function ReportingAccessTab() {
 
     setIsSavingAccess(true);
     try {
-      await Promise.all([
-        ...addedMachineIds.map((machineId) =>
-          grantMachineReportAccessAdmin({
-            userEmail: selectedPerson.userEmail as string,
-            machineId,
-            accessLevel,
-            reason: accessReason.trim(),
-          })
-        ),
-        ...removedMachineIds.map((machineId) => {
-          const grant = selectedMachineGrantByMachineId.get(machineId);
-          if (!grant) return Promise.resolve(null);
-          return revokeReportingAccessAdmin({
-            entitlementId: grant.id,
-            reason: accessReason.trim(),
-          });
-        }),
-      ]);
+      await setUserMachineReportingAccessAdmin({
+        userEmail: selectedPerson.userEmail as string,
+        machineIds: [...selectedMachineIds],
+        accessLevel,
+        reason: accessReason.trim(),
+      });
 
       trackEvent('admin_reporting_access_matrix_saved', {
         user_id: selectedPerson.userId,
@@ -956,6 +943,10 @@ function GlobalRolesTab() {
   const handleGrant = async () => {
     if (!grantEmail.trim()) {
       toast.error('Email is required.');
+      return;
+    }
+    if (!grantReason.trim()) {
+      toast.error('Grant reason is required.');
       return;
     }
 

--- a/src/pages/admin/Dashboard.tsx
+++ b/src/pages/admin/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { BarChart3, ShieldCheck, ShoppingBag, LifeBuoy, Users, ClipboardList } from 'lucide-react';
+import { BarChart3, Handshake, ShieldCheck, ShoppingBag, LifeBuoy, Users } from 'lucide-react';
 import { AppLayout } from '@/components/layout/AppLayout';
 import { Button } from '@/components/ui/button';
 
@@ -17,22 +17,22 @@ const adminModules = [
     href: '/admin/support',
   },
   {
-    title: 'Accounts',
-    description: 'Review memberships, machine counts, and account activity.',
+    title: 'Access',
+    description: 'Manage users, Plus grants, global roles, machine reporting access, and audit.',
     icon: Users,
-    href: '/admin/accounts',
+    href: '/admin/access',
+  },
+  {
+    title: 'Partnerships',
+    description: 'Configure partners, machine assignments, machine tax rates, and financial rules.',
+    icon: Handshake,
+    href: '/admin/partnerships',
   },
   {
     title: 'Reporting',
-    description: 'Configure reportable machines, user entitlements, imports, and scheduled PDFs.',
+    description: 'Monitor schedules, report exports, and sales sync status.',
     icon: BarChart3,
     href: '/admin/reporting',
-  },
-  {
-    title: 'Audit Log',
-    description: 'Track sensitive admin actions and role changes.',
-    icon: ClipboardList,
-    href: '/admin/audit',
   },
 ];
 
@@ -58,8 +58,8 @@ export default function AdminDashboardPage() {
       <section className="section-padding">
         <div className="container-page">
           <div className="rounded-xl border border-sage/30 bg-sage-light px-4 py-3 text-sm text-sage">
-            Admin workspace is active. Use the modules below for orders, support, accounts, and
-            governance operations.
+            Admin workspace is active. Use the modules below for orders, support, access,
+            partnerships, and reporting operations.
           </div>
 
           <div className="mt-6 grid gap-4 md:grid-cols-2">

--- a/src/pages/admin/Partnerships.tsx
+++ b/src/pages/admin/Partnerships.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import {
   AlertTriangle,
@@ -12,6 +12,7 @@ import { toast } from 'sonner';
 import { AppLayout } from '@/components/layout/AppLayout';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -23,12 +24,14 @@ import {
   upsertReportingMachineAssignmentAdmin,
   upsertReportingMachineTaxRateAdmin,
   upsertReportingPartnerAdmin,
+  upsertReportingPartnershipPartyAdmin,
   upsertReportingPartnershipAdmin,
   type PartnerWeeklyReportPreview,
   type PartnershipReportingSetup,
   type ReportingMachinePartnershipAssignment,
   type ReportingMachineTaxRate,
   type ReportingPartner,
+  type ReportingPartnershipParty,
   type ReportingPartnership,
   type ReportingPartnershipFinancialRule,
 } from '@/lib/partnershipReporting';
@@ -37,7 +40,25 @@ import {
   upsertReportingMachineAdmin,
 } from '@/lib/reporting';
 
-const today = () => new Date().toISOString().slice(0, 10);
+const toDateInputValue = (date: Date) => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const today = () => toDateInputValue(new Date());
+
+const getLastCompletedWeekEndingDate = (weekEndDay: number) => {
+  const date = new Date();
+  const currentDay = date.getDay();
+  let daysBack = (currentDay - weekEndDay + 7) % 7;
+  if (daysBack === 0) daysBack = 7;
+  date.setDate(date.getDate() - daysBack);
+  return toDateInputValue(date);
+};
+
+const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
 const centsFromDollars = (value: string) => Math.round((Number(value) || 0) * 100);
 const dollarsFromCents = (value: number) => (Number(value ?? 0) / 100).toFixed(2);
@@ -63,6 +84,15 @@ const partnerTypes = [
 const partnershipTypes = ['venue', 'event', 'platform', 'revenue_share', 'internal', 'other'];
 const statuses = ['active', 'archived'];
 const partnershipStatuses = ['draft', 'active', 'archived'];
+const partyRoles = [
+  'venue_partner',
+  'event_partner',
+  'platform_partner',
+  'revenue_share_recipient',
+  'operator',
+  'internal',
+  'other',
+];
 const assignmentRoles = ['primary_reporting', 'venue', 'event', 'platform', 'internal'];
 const machineTypes: ReportingMachineType[] = ['commercial', 'mini', 'micro', 'unknown'];
 const calculationModels = [
@@ -75,6 +105,7 @@ const calculationModels = [
 const splitBases = ['gross_sales', 'net_sales', 'contribution_after_costs'];
 const feeBases = ['none', 'per_order', 'per_stick', 'per_transaction'];
 const costBases = ['none', 'per_stick', 'per_order', 'percentage_of_sales'];
+const deductionTimings = ['before_split', 'after_split', 'reporting_only'];
 const grossToNetMethods = [
   'machine_tax_plus_configured_fees',
   'imported_tax_plus_configured_fees',
@@ -127,6 +158,16 @@ const emptyAssignmentForm = {
   reason: 'Machine partnership assignment update',
 };
 
+const emptyPartyForm = {
+  partyId: null as string | null,
+  partnershipId: '',
+  partnerId: '',
+  partyRole: 'revenue_share_recipient',
+  sharePercent: '',
+  isReportRecipient: false,
+  reason: 'Partnership party update',
+};
+
 const emptyTaxForm = {
   taxRateId: null as string | null,
   machineId: '',
@@ -167,6 +208,7 @@ export default function AdminPartnershipsPage() {
       partnerships: [],
       machines: [],
       assignments: [],
+      parties: [],
       taxRates: [],
       financialRules: [],
       warnings: [],
@@ -235,6 +277,7 @@ export default function AdminPartnershipsPage() {
             <TabsList className="h-auto flex-wrap justify-start">
               <TabsTrigger value="partners">Partners</TabsTrigger>
               <TabsTrigger value="partnerships">Partnerships</TabsTrigger>
+              <TabsTrigger value="parties">Parties</TabsTrigger>
               <TabsTrigger value="machines">Machine Assignments</TabsTrigger>
               <TabsTrigger value="tax">Machine Tax Rates</TabsTrigger>
               <TabsTrigger value="rules">Financial Rules</TabsTrigger>
@@ -251,6 +294,9 @@ export default function AdminPartnershipsPage() {
                 </TabsContent>
                 <TabsContent value="partnerships" className="mt-6">
                   <PartnershipsTab setup={setup} onRefresh={refresh} />
+                </TabsContent>
+                <TabsContent value="parties" className="mt-6">
+                  <PartiesTab setup={setup} onRefresh={refresh} />
                 </TabsContent>
                 <TabsContent value="machines" className="mt-6">
                   <MachineAssignmentsTab setup={setup} onRefresh={refresh} />
@@ -555,6 +601,160 @@ function PartnershipsTab({
               <div className="flex items-center gap-2">
                 <Badge variant={partnership.status === 'active' ? 'default' : 'outline'}>{partnership.status}</Badge>
                 <Button variant="outline" size="sm" onClick={() => editPartnership(partnership)}>
+                  Edit
+                </Button>
+              </div>
+            </Row>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PartiesTab({
+  setup,
+  onRefresh,
+}: {
+  setup: PartnershipReportingSetup;
+  onRefresh: () => Promise<unknown>;
+}) {
+  const [form, setForm] = useState(emptyPartyForm);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const editParty = (party: ReportingPartnershipParty) => {
+    setForm({
+      partyId: party.id,
+      partnershipId: party.partnership_id,
+      partnerId: party.partner_id,
+      partyRole: party.party_role,
+      sharePercent: party.share_basis_points
+        ? percentFromBasisPoints(party.share_basis_points)
+        : '',
+      isReportRecipient: party.is_report_recipient,
+      reason: 'Partnership party update',
+    });
+  };
+
+  const saveParty = async () => {
+    if (!form.partnershipId || !form.partnerId || !form.reason.trim()) {
+      toast.error('Partnership, partner, and reason are required.');
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      await upsertReportingPartnershipPartyAdmin({
+        partyId: form.partyId,
+        partnershipId: form.partnershipId,
+        partnerId: form.partnerId,
+        partyRole: form.partyRole,
+        shareBasisPoints: form.sharePercent.trim()
+          ? basisPointsFromPercent(form.sharePercent)
+          : null,
+        isReportRecipient: form.isReportRecipient,
+        reason: form.reason,
+      });
+      toast.success(form.partyId ? 'Partnership party updated.' : 'Partnership party added.');
+      setForm(emptyPartyForm);
+      await onRefresh();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Unable to save partnership party.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[0.75fr_1.25fr]">
+      <div className="rounded-lg border border-border bg-card p-5">
+        <h2 className="font-semibold text-foreground">
+          {form.partyId ? 'Edit Partnership Party' : 'Add Partnership Party'}
+        </h2>
+        <div className="mt-4 space-y-3">
+          <PartnershipSelect
+            setup={setup}
+            value={form.partnershipId}
+            onChange={(partnershipId) => setForm({ ...form, partnershipId })}
+            id="party-partnership"
+          />
+          <PartnerSelect
+            setup={setup}
+            value={form.partnerId}
+            onChange={(partnerId) => setForm({ ...form, partnerId })}
+            id="party-partner"
+          />
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <Label htmlFor="party-role">Role</Label>
+              <FieldSelect
+                id="party-role"
+                value={form.partyRole}
+                onChange={(partyRole) => setForm({ ...form, partyRole })}
+                options={partyRoles}
+              />
+            </div>
+            <div>
+              <Label htmlFor="party-share">Share %</Label>
+              <Input
+                id="party-share"
+                type="number"
+                step="0.01"
+                min={0}
+                max={100}
+                value={form.sharePercent}
+                onChange={(event) => setForm({ ...form, sharePercent: event.target.value })}
+              />
+            </div>
+          </div>
+          <label className="flex items-center gap-2 rounded-md border border-border p-3 text-sm">
+            <Checkbox
+              checked={form.isReportRecipient}
+              onCheckedChange={(checked) =>
+                setForm({ ...form, isReportRecipient: Boolean(checked) })
+              }
+            />
+            Report recipient
+          </label>
+          <div>
+            <Label htmlFor="party-reason">Reason</Label>
+            <Input
+              id="party-reason"
+              value={form.reason}
+              onChange={(event) => setForm({ ...form, reason: event.target.value })}
+            />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button onClick={saveParty} disabled={isSaving}>
+              {isSaving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <CheckCircle2 className="mr-2 h-4 w-4" />}
+              Save Party
+            </Button>
+            {form.partyId && (
+              <Button variant="outline" onClick={() => setForm(emptyPartyForm)}>
+                New Party
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-border bg-card">
+        <ListHeader title="Partnership Parties" count={setup.parties.length} />
+        {setup.parties.length === 0 ? (
+          <EmptyRow text="No partnership parties configured." />
+        ) : (
+          setup.parties.map((party) => (
+            <Row key={party.id}>
+              <div>
+                <div className="font-medium text-foreground">{party.partner_name}</div>
+                <div className="mt-1 text-xs text-muted-foreground">
+                  {party.partnership_name} / {party.party_role.replaceAll('_', ' ')} / share{' '}
+                  {party.share_basis_points ? percentFromBasisPoints(party.share_basis_points) : 'n/a'}%
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                {party.is_report_recipient && <Badge variant="secondary">Recipient</Badge>}
+                <Button variant="outline" size="sm" onClick={() => editParty(party)}>
                   Edit
                 </Button>
               </div>
@@ -1002,9 +1202,15 @@ function FinancialRulesTab({
               <FieldSelect id="cost-basis" value={form.costBasis} onChange={(value) => setForm({ ...form, costBasis: value })} options={costBases} />
             </div>
           </div>
-          <div>
-            <Label htmlFor="gross-to-net-method">Gross-to-net method</Label>
-            <FieldSelect id="gross-to-net-method" value={form.grossToNetMethod} onChange={(value) => setForm({ ...form, grossToNetMethod: value })} options={grossToNetMethods} />
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <Label htmlFor="gross-to-net-method">Gross-to-net method</Label>
+              <FieldSelect id="gross-to-net-method" value={form.grossToNetMethod} onChange={(value) => setForm({ ...form, grossToNetMethod: value })} options={grossToNetMethods} />
+            </div>
+            <div>
+              <Label htmlFor="deduction-timing">Cost deduction timing</Label>
+              <FieldSelect id="deduction-timing" value={form.deductionTiming} onChange={(value) => setForm({ ...form, deductionTiming: value })} options={deductionTimings} />
+            </div>
           </div>
           <div className="grid gap-3 sm:grid-cols-3">
             <div>
@@ -1083,7 +1289,7 @@ function FinancialRulesTab({
 
 function WeeklyPreviewTab({ setup }: { setup: PartnershipReportingSetup }) {
   const [partnershipId, setPartnershipId] = useState(setup.partnerships[0]?.id ?? '');
-  const [weekEndingDate, setWeekEndingDate] = useState(today());
+  const [weekEndingDate, setWeekEndingDate] = useState(() => getLastCompletedWeekEndingDate(0));
   const [preview, setPreview] = useState<PartnerWeeklyReportPreview | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -1091,10 +1297,36 @@ function WeeklyPreviewTab({ setup }: { setup: PartnershipReportingSetup }) {
     () => setup.partnerships.find((partnership) => partnership.id === partnershipId),
     [partnershipId, setup.partnerships]
   );
+  const firstPartnershipId = setup.partnerships[0]?.id ?? '';
+  const selectedPartnershipId = selectedPartnership?.id;
+  const selectedWeekEndDay = selectedPartnership?.reporting_week_end_day;
+
+  useEffect(() => {
+    if (!partnershipId && firstPartnershipId) {
+      setPartnershipId(firstPartnershipId);
+    }
+  }, [firstPartnershipId, partnershipId]);
+
+  useEffect(() => {
+    if (!selectedPartnershipId || selectedWeekEndDay === undefined) return;
+    setWeekEndingDate(getLastCompletedWeekEndingDate(selectedWeekEndDay));
+    setPreview(null);
+  }, [selectedPartnershipId, selectedWeekEndDay]);
 
   const loadPreview = async () => {
     if (!partnershipId || !weekEndingDate) {
       toast.error('Partnership and week ending date are required.');
+      return;
+    }
+
+    if (
+      selectedPartnership &&
+      new Date(`${weekEndingDate}T00:00:00`).getDay() !==
+        selectedPartnership.reporting_week_end_day
+    ) {
+      toast.error(
+        `Week ending date must be a ${dayNames[selectedPartnership.reporting_week_end_day]}.`
+      );
       return;
     }
 
@@ -1118,6 +1350,11 @@ function WeeklyPreviewTab({ setup }: { setup: PartnershipReportingSetup }) {
           <div>
             <Label htmlFor="week-ending">Week ending</Label>
             <Input id="week-ending" type="date" value={weekEndingDate} onChange={(event) => setWeekEndingDate(event.target.value)} />
+            {selectedPartnership && (
+              <div className="mt-1 text-xs text-muted-foreground">
+                Week ends {dayNames[selectedPartnership.reporting_week_end_day]}
+              </div>
+            )}
           </div>
           <Button onClick={loadPreview} disabled={isLoading}>
             {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-2 h-4 w-4" />}
@@ -1245,6 +1482,37 @@ function MachineSelect({
         {setup.machines.map((machine) => (
           <option key={machine.id} value={machine.id}>
             {machine.machine_label} / {machine.account_name} / {machine.location_name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function PartnerSelect({
+  setup,
+  value,
+  onChange,
+  id,
+}: {
+  setup: PartnershipReportingSetup;
+  value: string;
+  onChange: (partnerId: string) => void;
+  id: string;
+}) {
+  return (
+    <div>
+      <Label htmlFor={id}>Partner</Label>
+      <select
+        id={id}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+      >
+        <option value="">Select partner</option>
+        {setup.partners.map((partner) => (
+          <option key={partner.id} value={partner.id}>
+            {partner.name}
           </option>
         ))}
       </select>

--- a/src/pages/admin/Partnerships.tsx
+++ b/src/pages/admin/Partnerships.tsx
@@ -1,0 +1,1314 @@
+import { useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Loader2,
+  RefreshCw,
+  Settings2,
+} from 'lucide-react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { AppLayout } from '@/components/layout/AppLayout';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  fetchPartnershipReportingSetup,
+  previewPartnerWeeklyReportAdmin,
+  upsertReportingFinancialRuleAdmin,
+  upsertReportingMachineAssignmentAdmin,
+  upsertReportingMachineTaxRateAdmin,
+  upsertReportingPartnerAdmin,
+  upsertReportingPartnershipAdmin,
+  type PartnerWeeklyReportPreview,
+  type PartnershipReportingSetup,
+  type ReportingMachinePartnershipAssignment,
+  type ReportingMachineTaxRate,
+  type ReportingPartner,
+  type ReportingPartnership,
+  type ReportingPartnershipFinancialRule,
+} from '@/lib/partnershipReporting';
+import {
+  type ReportingMachineType,
+  upsertReportingMachineAdmin,
+} from '@/lib/reporting';
+
+const today = () => new Date().toISOString().slice(0, 10);
+
+const centsFromDollars = (value: string) => Math.round((Number(value) || 0) * 100);
+const dollarsFromCents = (value: number) => (Number(value ?? 0) / 100).toFixed(2);
+const basisPointsFromPercent = (value: string) => Math.round((Number(value) || 0) * 100);
+const percentFromBasisPoints = (value: number) => (Number(value ?? 0) / 100).toFixed(2);
+
+const formatMoney = (cents: number | undefined) =>
+  new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency: 'USD',
+  }).format(Number(cents ?? 0) / 100);
+
+const formatDate = (value: string | null | undefined) => value || 'open-ended';
+
+const partnerTypes = [
+  'venue',
+  'event_operator',
+  'platform_partner',
+  'revenue_share_partner',
+  'internal',
+  'other',
+];
+const partnershipTypes = ['venue', 'event', 'platform', 'revenue_share', 'internal', 'other'];
+const statuses = ['active', 'archived'];
+const partnershipStatuses = ['draft', 'active', 'archived'];
+const assignmentRoles = ['primary_reporting', 'venue', 'event', 'platform', 'internal'];
+const machineTypes: ReportingMachineType[] = ['commercial', 'mini', 'micro', 'unknown'];
+const calculationModels = [
+  'gross_split',
+  'net_split',
+  'contribution_split',
+  'fixed_fee_plus_split',
+  'internal_only',
+];
+const splitBases = ['gross_sales', 'net_sales', 'contribution_after_costs'];
+const feeBases = ['none', 'per_order', 'per_stick', 'per_transaction'];
+const costBases = ['none', 'per_stick', 'per_order', 'percentage_of_sales'];
+const grossToNetMethods = [
+  'machine_tax_plus_configured_fees',
+  'imported_tax_plus_configured_fees',
+  'configured_fees_only',
+];
+
+const emptyPartnerForm = {
+  partnerId: null as string | null,
+  name: '',
+  partnerType: 'revenue_share_partner',
+  primaryContactName: '',
+  primaryContactEmail: '',
+  status: 'active',
+  notes: '',
+  reason: 'Partner setup update',
+};
+
+const emptyPartnershipForm = {
+  partnershipId: null as string | null,
+  name: '',
+  partnershipType: 'revenue_share',
+  reportingWeekEndDay: '0',
+  timezone: 'America/Los_Angeles',
+  effectiveStartDate: today(),
+  effectiveEndDate: '',
+  status: 'draft',
+  notes: '',
+  reason: 'Partnership setup update',
+};
+
+const emptyMachineForm = {
+  machineId: null as string | null,
+  accountName: '',
+  locationName: '',
+  machineLabel: '',
+  machineType: 'unknown' as ReportingMachineType,
+  sunzeMachineId: '',
+  reason: 'Machine mapping update',
+};
+
+const emptyAssignmentForm = {
+  assignmentId: null as string | null,
+  machineId: '',
+  partnershipId: '',
+  assignmentRole: 'primary_reporting',
+  effectiveStartDate: today(),
+  effectiveEndDate: '',
+  status: 'active',
+  notes: '',
+  reason: 'Machine partnership assignment update',
+};
+
+const emptyTaxForm = {
+  taxRateId: null as string | null,
+  machineId: '',
+  taxRatePercent: '',
+  effectiveStartDate: today(),
+  effectiveEndDate: '',
+  status: 'active',
+  notes: '',
+  reason: 'Machine tax rate update',
+};
+
+const emptyRuleForm = {
+  ruleId: null as string | null,
+  partnershipId: '',
+  calculationModel: 'net_split',
+  splitBase: 'net_sales',
+  feeAmountDollars: '0.40',
+  feeBasis: 'per_order',
+  costAmountDollars: '0.00',
+  costBasis: 'none',
+  deductionTiming: 'before_split',
+  grossToNetMethod: 'machine_tax_plus_configured_fees',
+  feverSharePercent: '60',
+  partnerSharePercent: '40',
+  bloomjoySharePercent: '0',
+  effectiveStartDate: today(),
+  effectiveEndDate: '',
+  status: 'draft',
+  notes: '',
+  reason: 'Financial rule update',
+};
+
+export default function AdminPartnershipsPage() {
+  const queryClient = useQueryClient();
+  const {
+    data: setup = {
+      partners: [],
+      partnerships: [],
+      machines: [],
+      assignments: [],
+      taxRates: [],
+      financialRules: [],
+      warnings: [],
+    },
+    isLoading,
+    isFetching,
+    error,
+  } = useQuery({
+    queryKey: ['admin-partnership-reporting-setup'],
+    queryFn: fetchPartnershipReportingSetup,
+    staleTime: 1000 * 30,
+  });
+
+  const refresh = () =>
+    queryClient.invalidateQueries({ queryKey: ['admin-partnership-reporting-setup'] });
+
+  return (
+    <AppLayout>
+      <section className="section-padding">
+        <div className="container-page">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                Admin
+              </p>
+              <h1 className="mt-2 font-display text-3xl font-bold text-foreground">
+                Partnerships
+              </h1>
+              <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+                Configure partners, partnership agreements, machine assignments, machine-level tax
+                rates, and financial rules for partner reporting.
+              </p>
+            </div>
+            <Button variant="outline" onClick={refresh} disabled={isFetching}>
+              {isFetching ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-2 h-4 w-4" />}
+              Refresh
+            </Button>
+          </div>
+
+          {error && (
+            <div className="mt-4 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+              Unable to load partnership setup.
+            </div>
+          )}
+
+          {setup.warnings.length > 0 && (
+            <div className="mt-6 rounded-lg border border-amber-300 bg-amber-50 p-4 text-amber-950">
+              <div className="flex items-start gap-3">
+                <AlertTriangle className="mt-0.5 h-5 w-5" />
+                <div>
+                  <h2 className="font-semibold">Setup warnings</h2>
+                  <div className="mt-2 grid gap-1 text-sm">
+                    {setup.warnings.slice(0, 8).map((warning, index) => (
+                      <div key={`${warning.warningType}-${index}`}>{warning.message}</div>
+                    ))}
+                    {setup.warnings.length > 8 && (
+                      <div>{setup.warnings.length - 8} more warnings hidden.</div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          <Tabs defaultValue="partners" className="mt-6">
+            <TabsList className="h-auto flex-wrap justify-start">
+              <TabsTrigger value="partners">Partners</TabsTrigger>
+              <TabsTrigger value="partnerships">Partnerships</TabsTrigger>
+              <TabsTrigger value="machines">Machine Assignments</TabsTrigger>
+              <TabsTrigger value="tax">Machine Tax Rates</TabsTrigger>
+              <TabsTrigger value="rules">Financial Rules</TabsTrigger>
+              <TabsTrigger value="preview">Weekly Preview</TabsTrigger>
+            </TabsList>
+            {isLoading ? (
+              <div className="mt-6 rounded-lg border border-border bg-card p-6 text-sm text-muted-foreground">
+                Loading partnership setup...
+              </div>
+            ) : (
+              <>
+                <TabsContent value="partners" className="mt-6">
+                  <PartnersTab setup={setup} onRefresh={refresh} />
+                </TabsContent>
+                <TabsContent value="partnerships" className="mt-6">
+                  <PartnershipsTab setup={setup} onRefresh={refresh} />
+                </TabsContent>
+                <TabsContent value="machines" className="mt-6">
+                  <MachineAssignmentsTab setup={setup} onRefresh={refresh} />
+                </TabsContent>
+                <TabsContent value="tax" className="mt-6">
+                  <MachineTaxTab setup={setup} onRefresh={refresh} />
+                </TabsContent>
+                <TabsContent value="rules" className="mt-6">
+                  <FinancialRulesTab setup={setup} onRefresh={refresh} />
+                </TabsContent>
+                <TabsContent value="preview" className="mt-6">
+                  <WeeklyPreviewTab setup={setup} />
+                </TabsContent>
+              </>
+            )}
+          </Tabs>
+        </div>
+      </section>
+    </AppLayout>
+  );
+}
+
+function FieldSelect({
+  id,
+  value,
+  onChange,
+  options,
+}: {
+  id: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: string[];
+}) {
+  return (
+    <select
+      id={id}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+    >
+      {options.map((option) => (
+        <option key={option} value={option}>
+          {option.replaceAll('_', ' ')}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+function PartnersTab({
+  setup,
+  onRefresh,
+}: {
+  setup: PartnershipReportingSetup;
+  onRefresh: () => Promise<unknown>;
+}) {
+  const [form, setForm] = useState(emptyPartnerForm);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const editPartner = (partner: ReportingPartner) => {
+    setForm({
+      partnerId: partner.id,
+      name: partner.name,
+      partnerType: partner.partner_type,
+      primaryContactName: partner.primary_contact_name ?? '',
+      primaryContactEmail: partner.primary_contact_email ?? '',
+      status: partner.status,
+      notes: partner.notes ?? '',
+      reason: 'Partner setup update',
+    });
+  };
+
+  const savePartner = async () => {
+    if (!form.name.trim() || !form.reason.trim()) {
+      toast.error('Partner name and reason are required.');
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      await upsertReportingPartnerAdmin(form);
+      toast.success(form.partnerId ? 'Partner updated.' : 'Partner created.');
+      setForm(emptyPartnerForm);
+      await onRefresh();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Unable to save partner.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[0.75fr_1.25fr]">
+      <div className="rounded-lg border border-border bg-card p-5">
+        <h2 className="font-semibold text-foreground">
+          {form.partnerId ? 'Edit Partner' : 'Create Partner'}
+        </h2>
+        <div className="mt-4 space-y-3">
+          <div>
+            <Label htmlFor="partner-name">Partner name</Label>
+            <Input id="partner-name" value={form.name} onChange={(event) => setForm({ ...form, name: event.target.value })} />
+          </div>
+          <div>
+            <Label htmlFor="partner-type">Partner type</Label>
+            <FieldSelect id="partner-type" value={form.partnerType} onChange={(value) => setForm({ ...form, partnerType: value })} options={partnerTypes} />
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <Label htmlFor="partner-contact-name">Primary contact</Label>
+              <Input id="partner-contact-name" value={form.primaryContactName} onChange={(event) => setForm({ ...form, primaryContactName: event.target.value })} />
+            </div>
+            <div>
+              <Label htmlFor="partner-contact-email">Contact email</Label>
+              <Input id="partner-contact-email" type="email" value={form.primaryContactEmail} onChange={(event) => setForm({ ...form, primaryContactEmail: event.target.value })} />
+            </div>
+          </div>
+          <div>
+            <Label htmlFor="partner-status">Status</Label>
+            <FieldSelect id="partner-status" value={form.status} onChange={(value) => setForm({ ...form, status: value })} options={statuses} />
+          </div>
+          <div>
+            <Label htmlFor="partner-notes">Notes</Label>
+            <Textarea id="partner-notes" value={form.notes} onChange={(event) => setForm({ ...form, notes: event.target.value })} />
+          </div>
+          <div>
+            <Label htmlFor="partner-reason">Reason</Label>
+            <Input id="partner-reason" value={form.reason} onChange={(event) => setForm({ ...form, reason: event.target.value })} />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button onClick={savePartner} disabled={isSaving}>
+              {isSaving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <CheckCircle2 className="mr-2 h-4 w-4" />}
+              Save Partner
+            </Button>
+            {form.partnerId && (
+              <Button variant="outline" onClick={() => setForm(emptyPartnerForm)}>
+                New Partner
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-border bg-card">
+        <ListHeader title="Partners" count={setup.partners.length} />
+        {setup.partners.length === 0 ? (
+          <EmptyRow text="No partner records yet." />
+        ) : (
+          setup.partners.map((partner) => (
+            <Row key={partner.id}>
+              <div>
+                <div className="font-medium text-foreground">{partner.name}</div>
+                <div className="mt-1 text-xs text-muted-foreground">
+                  {partner.partner_type.replaceAll('_', ' ')} / {partner.primary_contact_email ?? 'no contact email'}
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <Badge variant={partner.status === 'active' ? 'default' : 'outline'}>{partner.status}</Badge>
+                <Button variant="outline" size="sm" onClick={() => editPartner(partner)}>
+                  Edit
+                </Button>
+              </div>
+            </Row>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PartnershipsTab({
+  setup,
+  onRefresh,
+}: {
+  setup: PartnershipReportingSetup;
+  onRefresh: () => Promise<unknown>;
+}) {
+  const [form, setForm] = useState(emptyPartnershipForm);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const editPartnership = (partnership: ReportingPartnership) => {
+    setForm({
+      partnershipId: partnership.id,
+      name: partnership.name,
+      partnershipType: partnership.partnership_type,
+      reportingWeekEndDay: String(partnership.reporting_week_end_day),
+      timezone: partnership.timezone,
+      effectiveStartDate: partnership.effective_start_date,
+      effectiveEndDate: partnership.effective_end_date ?? '',
+      status: partnership.status,
+      notes: partnership.notes ?? '',
+      reason: 'Partnership setup update',
+    });
+  };
+
+  const savePartnership = async () => {
+    if (!form.name.trim() || !form.effectiveStartDate || !form.reason.trim()) {
+      toast.error('Partnership name, effective start date, and reason are required.');
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      await upsertReportingPartnershipAdmin({
+        ...form,
+        reportingWeekEndDay: Number(form.reportingWeekEndDay),
+      });
+      toast.success(form.partnershipId ? 'Partnership updated.' : 'Partnership created.');
+      setForm(emptyPartnershipForm);
+      await onRefresh();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Unable to save partnership.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[0.75fr_1.25fr]">
+      <div className="rounded-lg border border-border bg-card p-5">
+        <h2 className="font-semibold text-foreground">
+          {form.partnershipId ? 'Edit Partnership' : 'Create Partnership'}
+        </h2>
+        <div className="mt-4 space-y-3">
+          <div>
+            <Label htmlFor="partnership-name">Partnership name</Label>
+            <Input id="partnership-name" value={form.name} onChange={(event) => setForm({ ...form, name: event.target.value })} placeholder="Bubble Planet Seattle" />
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <Label htmlFor="partnership-type">Type</Label>
+              <FieldSelect id="partnership-type" value={form.partnershipType} onChange={(value) => setForm({ ...form, partnershipType: value })} options={partnershipTypes} />
+            </div>
+            <div>
+              <Label htmlFor="partnership-week-end">Week ends</Label>
+              <select
+                id="partnership-week-end"
+                value={form.reportingWeekEndDay}
+                onChange={(event) => setForm({ ...form, reportingWeekEndDay: event.target.value })}
+                className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+              >
+                <option value="0">Sunday</option>
+                <option value="1">Monday</option>
+                <option value="2">Tuesday</option>
+                <option value="3">Wednesday</option>
+                <option value="4">Thursday</option>
+                <option value="5">Friday</option>
+                <option value="6">Saturday</option>
+              </select>
+            </div>
+          </div>
+          <div>
+            <Label htmlFor="partnership-timezone">Timezone</Label>
+            <Input id="partnership-timezone" value={form.timezone} onChange={(event) => setForm({ ...form, timezone: event.target.value })} />
+          </div>
+          <DateWindowFields
+            startId="partnership-start"
+            endId="partnership-end"
+            startValue={form.effectiveStartDate}
+            endValue={form.effectiveEndDate}
+            onStartChange={(value) => setForm({ ...form, effectiveStartDate: value })}
+            onEndChange={(value) => setForm({ ...form, effectiveEndDate: value })}
+          />
+          <div>
+            <Label htmlFor="partnership-status">Status</Label>
+            <FieldSelect id="partnership-status" value={form.status} onChange={(value) => setForm({ ...form, status: value })} options={partnershipStatuses} />
+          </div>
+          <div>
+            <Label htmlFor="partnership-notes">Notes</Label>
+            <Textarea id="partnership-notes" value={form.notes} onChange={(event) => setForm({ ...form, notes: event.target.value })} />
+          </div>
+          <div>
+            <Label htmlFor="partnership-reason">Reason</Label>
+            <Input id="partnership-reason" value={form.reason} onChange={(event) => setForm({ ...form, reason: event.target.value })} />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button onClick={savePartnership} disabled={isSaving}>
+              {isSaving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <CheckCircle2 className="mr-2 h-4 w-4" />}
+              Save Partnership
+            </Button>
+            {form.partnershipId && (
+              <Button variant="outline" onClick={() => setForm(emptyPartnershipForm)}>
+                New Partnership
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-border bg-card">
+        <ListHeader title="Partnerships" count={setup.partnerships.length} />
+        {setup.partnerships.length === 0 ? (
+          <EmptyRow text="No partnerships yet." />
+        ) : (
+          setup.partnerships.map((partnership) => (
+            <Row key={partnership.id}>
+              <div>
+                <div className="font-medium text-foreground">{partnership.name}</div>
+                <div className="mt-1 text-xs text-muted-foreground">
+                  {partnership.partnership_type.replaceAll('_', ' ')} / {formatDate(partnership.effective_start_date)} to {formatDate(partnership.effective_end_date)}
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <Badge variant={partnership.status === 'active' ? 'default' : 'outline'}>{partnership.status}</Badge>
+                <Button variant="outline" size="sm" onClick={() => editPartnership(partnership)}>
+                  Edit
+                </Button>
+              </div>
+            </Row>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+function MachineAssignmentsTab({
+  setup,
+  onRefresh,
+}: {
+  setup: PartnershipReportingSetup;
+  onRefresh: () => Promise<unknown>;
+}) {
+  const [machineForm, setMachineForm] = useState(emptyMachineForm);
+  const [assignmentForm, setAssignmentForm] = useState(emptyAssignmentForm);
+  const [isSavingMachine, setIsSavingMachine] = useState(false);
+  const [isSavingAssignment, setIsSavingAssignment] = useState(false);
+
+  const editMachine = (machine: PartnershipReportingSetup['machines'][number]) => {
+    setMachineForm({
+      machineId: machine.id,
+      accountName: machine.account_name,
+      locationName: machine.location_name,
+      machineLabel: machine.machine_label,
+      machineType: machine.machine_type,
+      sunzeMachineId: machine.sunze_machine_id ?? '',
+      reason: 'Machine mapping update',
+    });
+  };
+
+  const editAssignment = (assignment: ReportingMachinePartnershipAssignment) => {
+    setAssignmentForm({
+      assignmentId: assignment.id,
+      machineId: assignment.machine_id,
+      partnershipId: assignment.partnership_id,
+      assignmentRole: assignment.assignment_role,
+      effectiveStartDate: assignment.effective_start_date,
+      effectiveEndDate: assignment.effective_end_date ?? '',
+      status: assignment.status,
+      notes: assignment.notes ?? '',
+      reason: 'Machine partnership assignment update',
+    });
+  };
+
+  const saveMachine = async () => {
+    if (!machineForm.accountName.trim() || !machineForm.locationName.trim() || !machineForm.machineLabel.trim() || !machineForm.reason.trim()) {
+      toast.error('Account, location, machine label, and reason are required.');
+      return;
+    }
+
+    setIsSavingMachine(true);
+    try {
+      await upsertReportingMachineAdmin(machineForm);
+      toast.success(machineForm.machineId ? 'Machine mapping updated.' : 'Machine mapping created.');
+      setMachineForm(emptyMachineForm);
+      await onRefresh();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Unable to save machine mapping.');
+    } finally {
+      setIsSavingMachine(false);
+    }
+  };
+
+  const saveAssignment = async () => {
+    if (!assignmentForm.machineId || !assignmentForm.partnershipId || !assignmentForm.effectiveStartDate || !assignmentForm.reason.trim()) {
+      toast.error('Machine, partnership, effective start date, and reason are required.');
+      return;
+    }
+
+    setIsSavingAssignment(true);
+    try {
+      await upsertReportingMachineAssignmentAdmin(assignmentForm);
+      toast.success(assignmentForm.assignmentId ? 'Assignment updated.' : 'Assignment created.');
+      setAssignmentForm(emptyAssignmentForm);
+      await onRefresh();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Unable to save assignment.');
+    } finally {
+      setIsSavingAssignment(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-6 lg:grid-cols-2">
+        <div className="rounded-lg border border-border bg-card p-5">
+          <h2 className="font-semibold text-foreground">Machine Mapping</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Assign imported Sunze machines to real reporting account/location names before
+            partnership reporting uses them.
+          </p>
+          <div className="mt-4 space-y-3">
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div>
+                <Label htmlFor="machine-account">Account</Label>
+                <Input id="machine-account" value={machineForm.accountName} onChange={(event) => setMachineForm({ ...machineForm, accountName: event.target.value })} />
+              </div>
+              <div>
+                <Label htmlFor="machine-location">Location</Label>
+                <Input id="machine-location" value={machineForm.locationName} onChange={(event) => setMachineForm({ ...machineForm, locationName: event.target.value })} />
+              </div>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div>
+                <Label htmlFor="machine-label">Machine label</Label>
+                <Input id="machine-label" value={machineForm.machineLabel} onChange={(event) => setMachineForm({ ...machineForm, machineLabel: event.target.value })} />
+              </div>
+              <div>
+                <Label htmlFor="machine-type">Machine type</Label>
+                <FieldSelect id="machine-type" value={machineForm.machineType} onChange={(value) => setMachineForm({ ...machineForm, machineType: value as ReportingMachineType })} options={machineTypes} />
+              </div>
+            </div>
+            <div>
+              <Label htmlFor="sunze-id">Sunze ID</Label>
+              <Input id="sunze-id" value={machineForm.sunzeMachineId} onChange={(event) => setMachineForm({ ...machineForm, sunzeMachineId: event.target.value })} />
+            </div>
+            <div>
+              <Label htmlFor="machine-reason">Reason</Label>
+              <Input id="machine-reason" value={machineForm.reason} onChange={(event) => setMachineForm({ ...machineForm, reason: event.target.value })} />
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button onClick={saveMachine} disabled={isSavingMachine}>
+                {isSavingMachine ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Settings2 className="mr-2 h-4 w-4" />}
+                Save Machine Mapping
+              </Button>
+              {machineForm.machineId && (
+                <Button variant="outline" onClick={() => setMachineForm(emptyMachineForm)}>
+                  New Mapping
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-border bg-card p-5">
+          <h2 className="font-semibold text-foreground">Partnership Assignment</h2>
+          <div className="mt-4 space-y-3">
+            <MachineSelect setup={setup} value={assignmentForm.machineId} onChange={(machineId) => setAssignmentForm({ ...assignmentForm, machineId })} id="assignment-machine" />
+            <PartnershipSelect setup={setup} value={assignmentForm.partnershipId} onChange={(partnershipId) => setAssignmentForm({ ...assignmentForm, partnershipId })} id="assignment-partnership" />
+            <div>
+              <Label htmlFor="assignment-role">Assignment role</Label>
+              <FieldSelect id="assignment-role" value={assignmentForm.assignmentRole} onChange={(value) => setAssignmentForm({ ...assignmentForm, assignmentRole: value })} options={assignmentRoles} />
+            </div>
+            <DateWindowFields
+              startId="assignment-start"
+              endId="assignment-end"
+              startValue={assignmentForm.effectiveStartDate}
+              endValue={assignmentForm.effectiveEndDate}
+              onStartChange={(value) => setAssignmentForm({ ...assignmentForm, effectiveStartDate: value })}
+              onEndChange={(value) => setAssignmentForm({ ...assignmentForm, effectiveEndDate: value })}
+            />
+            <div>
+              <Label htmlFor="assignment-status">Status</Label>
+              <FieldSelect id="assignment-status" value={assignmentForm.status} onChange={(value) => setAssignmentForm({ ...assignmentForm, status: value })} options={statuses} />
+            </div>
+            <div>
+              <Label htmlFor="assignment-notes">Notes</Label>
+              <Textarea id="assignment-notes" value={assignmentForm.notes} onChange={(event) => setAssignmentForm({ ...assignmentForm, notes: event.target.value })} />
+            </div>
+            <div>
+              <Label htmlFor="assignment-reason">Reason</Label>
+              <Input id="assignment-reason" value={assignmentForm.reason} onChange={(event) => setAssignmentForm({ ...assignmentForm, reason: event.target.value })} />
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button onClick={saveAssignment} disabled={isSavingAssignment}>
+                {isSavingAssignment ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <CheckCircle2 className="mr-2 h-4 w-4" />}
+                Save Assignment
+              </Button>
+              {assignmentForm.assignmentId && (
+                <Button variant="outline" onClick={() => setAssignmentForm(emptyAssignmentForm)}>
+                  New Assignment
+                </Button>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-2">
+        <div className="rounded-lg border border-border bg-card">
+          <ListHeader title="Mapped Machines" count={setup.machines.length} />
+          {setup.machines.map((machine) => (
+            <Row key={machine.id}>
+              <div>
+                <div className="font-medium text-foreground">{machine.machine_label}</div>
+                <div className="mt-1 text-xs text-muted-foreground">
+                  {machine.account_name} / {machine.location_name} / Sunze: {machine.sunze_machine_id ?? 'n/a'}
+                </div>
+              </div>
+              <Button variant="outline" size="sm" onClick={() => editMachine(machine)}>
+                Edit
+              </Button>
+            </Row>
+          ))}
+        </div>
+        <div className="rounded-lg border border-border bg-card">
+          <ListHeader title="Partnership Assignments" count={setup.assignments.length} />
+          {setup.assignments.length === 0 ? (
+            <EmptyRow text="No machine partnership assignments yet." />
+          ) : (
+            setup.assignments.map((assignment) => (
+              <Row key={assignment.id}>
+                <div>
+                  <div className="font-medium text-foreground">{assignment.machine_label}</div>
+                  <div className="mt-1 text-xs text-muted-foreground">
+                    {assignment.partnership_name} / {assignment.assignment_role.replaceAll('_', ' ')} / {formatDate(assignment.effective_start_date)} to {formatDate(assignment.effective_end_date)}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Badge variant={assignment.status === 'active' ? 'default' : 'outline'}>{assignment.status}</Badge>
+                  <Button variant="outline" size="sm" onClick={() => editAssignment(assignment)}>
+                    Edit
+                  </Button>
+                </div>
+              </Row>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MachineTaxTab({
+  setup,
+  onRefresh,
+}: {
+  setup: PartnershipReportingSetup;
+  onRefresh: () => Promise<unknown>;
+}) {
+  const [form, setForm] = useState(emptyTaxForm);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const editTaxRate = (taxRate: ReportingMachineTaxRate) => {
+    setForm({
+      taxRateId: taxRate.id,
+      machineId: taxRate.machine_id,
+      taxRatePercent: String(taxRate.tax_rate_percent),
+      effectiveStartDate: taxRate.effective_start_date,
+      effectiveEndDate: taxRate.effective_end_date ?? '',
+      status: taxRate.status,
+      notes: taxRate.notes ?? '',
+      reason: 'Machine tax rate update',
+    });
+  };
+
+  const saveTaxRate = async () => {
+    if (!form.machineId || !form.taxRatePercent || !form.effectiveStartDate || !form.reason.trim()) {
+      toast.error('Machine, tax rate, effective start date, and reason are required.');
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      await upsertReportingMachineTaxRateAdmin({
+        ...form,
+        taxRatePercent: Number(form.taxRatePercent),
+      });
+      toast.success(form.taxRateId ? 'Machine tax rate updated.' : 'Machine tax rate created.');
+      setForm(emptyTaxForm);
+      await onRefresh();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Unable to save tax rate.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[0.75fr_1.25fr]">
+      <div className="rounded-lg border border-border bg-card p-5">
+        <h2 className="font-semibold text-foreground">
+          {form.taxRateId ? 'Edit Machine Tax Rate' : 'Create Machine Tax Rate'}
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Tax rates are configured at the machine level with effective dates. They are not
+          partnership-level settings.
+        </p>
+        <div className="mt-4 space-y-3">
+          <MachineSelect setup={setup} value={form.machineId} onChange={(machineId) => setForm({ ...form, machineId })} id="tax-machine" />
+          <div>
+            <Label htmlFor="tax-rate">Tax rate percent</Label>
+            <Input id="tax-rate" type="number" step="0.0001" min={0} max={100} value={form.taxRatePercent} onChange={(event) => setForm({ ...form, taxRatePercent: event.target.value })} placeholder="7.25" />
+          </div>
+          <DateWindowFields
+            startId="tax-start"
+            endId="tax-end"
+            startValue={form.effectiveStartDate}
+            endValue={form.effectiveEndDate}
+            onStartChange={(value) => setForm({ ...form, effectiveStartDate: value })}
+            onEndChange={(value) => setForm({ ...form, effectiveEndDate: value })}
+          />
+          <div>
+            <Label htmlFor="tax-status">Status</Label>
+            <FieldSelect id="tax-status" value={form.status} onChange={(value) => setForm({ ...form, status: value })} options={statuses} />
+          </div>
+          <div>
+            <Label htmlFor="tax-notes">Notes</Label>
+            <Textarea id="tax-notes" value={form.notes} onChange={(event) => setForm({ ...form, notes: event.target.value })} />
+          </div>
+          <div>
+            <Label htmlFor="tax-reason">Reason</Label>
+            <Input id="tax-reason" value={form.reason} onChange={(event) => setForm({ ...form, reason: event.target.value })} />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button onClick={saveTaxRate} disabled={isSaving}>
+              {isSaving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <CheckCircle2 className="mr-2 h-4 w-4" />}
+              Save Machine Tax Rate
+            </Button>
+            {form.taxRateId && (
+              <Button variant="outline" onClick={() => setForm(emptyTaxForm)}>
+                New Tax Rate
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-border bg-card">
+        <ListHeader title="Machine Tax Rates" count={setup.taxRates.length} />
+        {setup.taxRates.length === 0 ? (
+          <EmptyRow text="No machine tax rates configured." />
+        ) : (
+          setup.taxRates.map((taxRate) => (
+            <Row key={taxRate.id}>
+              <div>
+                <div className="font-medium text-foreground">{taxRate.machine_label}</div>
+                <div className="mt-1 text-xs text-muted-foreground">
+                  {Number(taxRate.tax_rate_percent).toFixed(4)}% / {formatDate(taxRate.effective_start_date)} to {formatDate(taxRate.effective_end_date)}
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <Badge variant={taxRate.status === 'active' ? 'default' : 'outline'}>{taxRate.status}</Badge>
+                <Button variant="outline" size="sm" onClick={() => editTaxRate(taxRate)}>
+                  Edit
+                </Button>
+              </div>
+            </Row>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+function FinancialRulesTab({
+  setup,
+  onRefresh,
+}: {
+  setup: PartnershipReportingSetup;
+  onRefresh: () => Promise<unknown>;
+}) {
+  const [form, setForm] = useState(emptyRuleForm);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const editRule = (rule: ReportingPartnershipFinancialRule) => {
+    setForm({
+      ruleId: rule.id,
+      partnershipId: rule.partnership_id,
+      calculationModel: rule.calculation_model,
+      splitBase: rule.split_base,
+      feeAmountDollars: dollarsFromCents(rule.fee_amount_cents),
+      feeBasis: rule.fee_basis,
+      costAmountDollars: dollarsFromCents(rule.cost_amount_cents),
+      costBasis: rule.cost_basis,
+      deductionTiming: rule.deduction_timing,
+      grossToNetMethod: rule.gross_to_net_method,
+      feverSharePercent: percentFromBasisPoints(rule.fever_share_basis_points),
+      partnerSharePercent: percentFromBasisPoints(rule.partner_share_basis_points),
+      bloomjoySharePercent: percentFromBasisPoints(rule.bloomjoy_share_basis_points),
+      effectiveStartDate: rule.effective_start_date,
+      effectiveEndDate: rule.effective_end_date ?? '',
+      status: rule.status,
+      notes: rule.notes ?? '',
+      reason: 'Financial rule update',
+    });
+  };
+
+  const saveRule = async () => {
+    if (!form.partnershipId || !form.effectiveStartDate || !form.reason.trim()) {
+      toast.error('Partnership, effective start date, and reason are required.');
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      await upsertReportingFinancialRuleAdmin({
+        ...form,
+        feeAmountCents: centsFromDollars(form.feeAmountDollars),
+        costAmountCents: centsFromDollars(form.costAmountDollars),
+        feverShareBasisPoints: basisPointsFromPercent(form.feverSharePercent),
+        partnerShareBasisPoints: basisPointsFromPercent(form.partnerSharePercent),
+        bloomjoyShareBasisPoints: basisPointsFromPercent(form.bloomjoySharePercent),
+      });
+      toast.success(form.ruleId ? 'Financial rule updated.' : 'Financial rule created.');
+      setForm(emptyRuleForm);
+      await onRefresh();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Unable to save financial rule.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="grid gap-6 xl:grid-cols-[0.8fr_1.2fr]">
+      <div className="rounded-lg border border-border bg-card p-5">
+        <h2 className="font-semibold text-foreground">
+          {form.ruleId ? 'Edit Financial Rule' : 'Create Financial Rule'}
+        </h2>
+        <div className="mt-4 space-y-3">
+          <PartnershipSelect setup={setup} value={form.partnershipId} onChange={(partnershipId) => setForm({ ...form, partnershipId })} id="rule-partnership" />
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <Label htmlFor="calculation-model">Calculation model</Label>
+              <FieldSelect id="calculation-model" value={form.calculationModel} onChange={(value) => setForm({ ...form, calculationModel: value })} options={calculationModels} />
+            </div>
+            <div>
+              <Label htmlFor="split-base">Split base</Label>
+              <FieldSelect id="split-base" value={form.splitBase} onChange={(value) => setForm({ ...form, splitBase: value })} options={splitBases} />
+            </div>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <Label htmlFor="fee-amount">Fee amount</Label>
+              <Input id="fee-amount" type="number" step="0.01" value={form.feeAmountDollars} onChange={(event) => setForm({ ...form, feeAmountDollars: event.target.value })} />
+            </div>
+            <div>
+              <Label htmlFor="fee-basis">Fee basis</Label>
+              <FieldSelect id="fee-basis" value={form.feeBasis} onChange={(value) => setForm({ ...form, feeBasis: value })} options={feeBases} />
+            </div>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <Label htmlFor="cost-amount">Cost amount</Label>
+              <Input id="cost-amount" type="number" step="0.01" value={form.costAmountDollars} onChange={(event) => setForm({ ...form, costAmountDollars: event.target.value })} />
+            </div>
+            <div>
+              <Label htmlFor="cost-basis">Cost basis</Label>
+              <FieldSelect id="cost-basis" value={form.costBasis} onChange={(value) => setForm({ ...form, costBasis: value })} options={costBases} />
+            </div>
+          </div>
+          <div>
+            <Label htmlFor="gross-to-net-method">Gross-to-net method</Label>
+            <FieldSelect id="gross-to-net-method" value={form.grossToNetMethod} onChange={(value) => setForm({ ...form, grossToNetMethod: value })} options={grossToNetMethods} />
+          </div>
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div>
+              <Label htmlFor="fever-share">Fever %</Label>
+              <Input id="fever-share" type="number" step="0.01" value={form.feverSharePercent} onChange={(event) => setForm({ ...form, feverSharePercent: event.target.value })} />
+            </div>
+            <div>
+              <Label htmlFor="partner-share">Partner %</Label>
+              <Input id="partner-share" type="number" step="0.01" value={form.partnerSharePercent} onChange={(event) => setForm({ ...form, partnerSharePercent: event.target.value })} />
+            </div>
+            <div>
+              <Label htmlFor="bloomjoy-share">Bloomjoy %</Label>
+              <Input id="bloomjoy-share" type="number" step="0.01" value={form.bloomjoySharePercent} onChange={(event) => setForm({ ...form, bloomjoySharePercent: event.target.value })} />
+            </div>
+          </div>
+          <DateWindowFields
+            startId="rule-start"
+            endId="rule-end"
+            startValue={form.effectiveStartDate}
+            endValue={form.effectiveEndDate}
+            onStartChange={(value) => setForm({ ...form, effectiveStartDate: value })}
+            onEndChange={(value) => setForm({ ...form, effectiveEndDate: value })}
+          />
+          <div>
+            <Label htmlFor="rule-status">Status</Label>
+            <FieldSelect id="rule-status" value={form.status} onChange={(value) => setForm({ ...form, status: value })} options={partnershipStatuses} />
+          </div>
+          <div>
+            <Label htmlFor="rule-notes">Notes</Label>
+            <Textarea id="rule-notes" value={form.notes} onChange={(event) => setForm({ ...form, notes: event.target.value })} />
+          </div>
+          <div>
+            <Label htmlFor="rule-reason">Reason</Label>
+            <Input id="rule-reason" value={form.reason} onChange={(event) => setForm({ ...form, reason: event.target.value })} />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button onClick={saveRule} disabled={isSaving}>
+              {isSaving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <CheckCircle2 className="mr-2 h-4 w-4" />}
+              Save Financial Rule
+            </Button>
+            {form.ruleId && (
+              <Button variant="outline" onClick={() => setForm(emptyRuleForm)}>
+                New Rule
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-border bg-card">
+        <ListHeader title="Financial Rules" count={setup.financialRules.length} />
+        {setup.financialRules.length === 0 ? (
+          <EmptyRow text="No financial rules configured." />
+        ) : (
+          setup.financialRules.map((rule) => (
+            <Row key={rule.id}>
+              <div>
+                <div className="font-medium text-foreground">{rule.partnership_name}</div>
+                <div className="mt-1 text-xs text-muted-foreground">
+                  {rule.calculation_model.replaceAll('_', ' ')} / fee {formatMoney(rule.fee_amount_cents)} {rule.fee_basis.replaceAll('_', ' ')} / shares {percentFromBasisPoints(rule.fever_share_basis_points)}% + {percentFromBasisPoints(rule.partner_share_basis_points)}%
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                <Badge variant={rule.status === 'active' ? 'default' : 'outline'}>{rule.status}</Badge>
+                <Button variant="outline" size="sm" onClick={() => editRule(rule)}>
+                  Edit
+                </Button>
+              </div>
+            </Row>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+function WeeklyPreviewTab({ setup }: { setup: PartnershipReportingSetup }) {
+  const [partnershipId, setPartnershipId] = useState(setup.partnerships[0]?.id ?? '');
+  const [weekEndingDate, setWeekEndingDate] = useState(today());
+  const [preview, setPreview] = useState<PartnerWeeklyReportPreview | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const selectedPartnership = useMemo(
+    () => setup.partnerships.find((partnership) => partnership.id === partnershipId),
+    [partnershipId, setup.partnerships]
+  );
+
+  const loadPreview = async () => {
+    if (!partnershipId || !weekEndingDate) {
+      toast.error('Partnership and week ending date are required.');
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const nextPreview = await previewPartnerWeeklyReportAdmin(partnershipId, weekEndingDate);
+      setPreview(nextPreview);
+      toast.success('Weekly report preview loaded.');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Unable to preview report.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-lg border border-border bg-card p-5">
+        <div className="grid gap-3 md:grid-cols-[1fr_0.5fr_auto] md:items-end">
+          <PartnershipSelect setup={setup} value={partnershipId} onChange={setPartnershipId} id="preview-partnership" />
+          <div>
+            <Label htmlFor="week-ending">Week ending</Label>
+            <Input id="week-ending" type="date" value={weekEndingDate} onChange={(event) => setWeekEndingDate(event.target.value)} />
+          </div>
+          <Button onClick={loadPreview} disabled={isLoading}>
+            {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-2 h-4 w-4" />}
+            Preview
+          </Button>
+        </div>
+      </div>
+
+      {preview && (
+        <div className="space-y-6">
+          <div className="rounded-lg border border-border bg-card p-5">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <h2 className="font-semibold text-foreground">
+                  {selectedPartnership?.name ?? 'Partnership'} weekly preview
+                </h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {preview.weekStartDate} through {preview.weekEndingDate}
+                </p>
+              </div>
+              <Badge variant={preview.warnings.length ? 'destructive' : 'default'}>
+                {preview.warnings.length ? `${preview.warnings.length} warnings` : 'Ready'}
+              </Badge>
+            </div>
+            <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+              <Metric label="Orders" value={String(preview.summary.order_count ?? 0)} />
+              <Metric label="Sticks/items" value={String(preview.summary.item_quantity ?? 0)} />
+              <Metric label="Gross sales" value={formatMoney(preview.summary.gross_sales_cents)} />
+              <Metric label="Machine taxes" value={formatMoney(preview.summary.tax_cents)} />
+              <Metric label="Fees" value={formatMoney(preview.summary.fee_cents)} />
+              <Metric label="Costs" value={formatMoney(preview.summary.cost_cents)} />
+              <Metric label="Net sales" value={formatMoney(preview.summary.net_sales_cents)} />
+              <Metric label="Split base" value={formatMoney(preview.summary.split_base_cents)} />
+              <Metric label="Fever profit" value={formatMoney(preview.summary.fever_profit_cents)} />
+              <Metric label="Partner profit" value={formatMoney(preview.summary.partner_profit_cents)} />
+              <Metric label="Bloomjoy profit" value={formatMoney(preview.summary.bloomjoy_profit_cents)} />
+            </div>
+          </div>
+
+          {preview.warnings.length > 0 && (
+            <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 text-sm text-amber-950">
+              {preview.warnings.map((warning, index) => (
+                <div key={`${warning.warningType}-${index}`}>{warning.message}</div>
+              ))}
+            </div>
+          )}
+
+          <div className="rounded-lg border border-border bg-card">
+            <ListHeader title="Sales by Machine" count={preview.machines.length} />
+            {preview.machines.length === 0 ? (
+              <EmptyRow text="No sales found for this partnership and week." />
+            ) : (
+              preview.machines.map((machine) => (
+                <Row key={machine.reporting_machine_id}>
+                  <div>
+                    <div className="font-medium text-foreground">{machine.machine_label}</div>
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      {machine.order_count} orders / {machine.item_quantity} sticks/items
+                    </div>
+                  </div>
+                  <div className="text-right text-sm">
+                    <div className="font-medium text-foreground">{formatMoney(machine.gross_sales_cents)}</div>
+                    <div className="text-xs text-muted-foreground">Net {formatMoney(machine.net_sales_cents)}</div>
+                  </div>
+                </Row>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DateWindowFields({
+  startId,
+  endId,
+  startValue,
+  endValue,
+  onStartChange,
+  onEndChange,
+}: {
+  startId: string;
+  endId: string;
+  startValue: string;
+  endValue: string;
+  onStartChange: (value: string) => void;
+  onEndChange: (value: string) => void;
+}) {
+  return (
+    <div className="grid gap-3 sm:grid-cols-2">
+      <div>
+        <Label htmlFor={startId}>Effective start</Label>
+        <Input id={startId} type="date" value={startValue} onChange={(event) => onStartChange(event.target.value)} />
+      </div>
+      <div>
+        <Label htmlFor={endId}>Effective end</Label>
+        <Input id={endId} type="date" value={endValue} onChange={(event) => onEndChange(event.target.value)} />
+      </div>
+    </div>
+  );
+}
+
+function MachineSelect({
+  setup,
+  value,
+  onChange,
+  id,
+}: {
+  setup: PartnershipReportingSetup;
+  value: string;
+  onChange: (machineId: string) => void;
+  id: string;
+}) {
+  return (
+    <div>
+      <Label htmlFor={id}>Machine</Label>
+      <select
+        id={id}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+      >
+        <option value="">Select machine</option>
+        {setup.machines.map((machine) => (
+          <option key={machine.id} value={machine.id}>
+            {machine.machine_label} / {machine.account_name} / {machine.location_name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function PartnershipSelect({
+  setup,
+  value,
+  onChange,
+  id,
+}: {
+  setup: PartnershipReportingSetup;
+  value: string;
+  onChange: (partnershipId: string) => void;
+  id: string;
+}) {
+  return (
+    <div>
+      <Label htmlFor={id}>Partnership</Label>
+      <select
+        id={id}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+      >
+        <option value="">Select partnership</option>
+        {setup.partnerships.map((partnership) => (
+          <option key={partnership.id} value={partnership.id}>
+            {partnership.name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+function ListHeader({ title, count }: { title: string; count: number }) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-b border-border p-4">
+      <h2 className="font-semibold text-foreground">{title}</h2>
+      <Badge variant="outline">{count}</Badge>
+    </div>
+  );
+}
+
+function EmptyRow({ text }: { text: string }) {
+  return <div className="p-4 text-sm text-muted-foreground">{text}</div>;
+}
+
+function Row({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex flex-col gap-3 border-b border-border/70 p-4 last:border-b-0 sm:flex-row sm:items-center sm:justify-between">
+      {children}
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-border bg-muted/20 p-3">
+      <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{label}</div>
+      <div className="mt-1 text-lg font-semibold text-foreground">{value}</div>
+    </div>
+  );
+}

--- a/src/pages/admin/Reporting.tsx
+++ b/src/pages/admin/Reporting.tsx
@@ -1,61 +1,35 @@
-import { useEffect, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
 import {
   AlertTriangle,
   CalendarDays,
   CheckCircle2,
   Database,
   Loader2,
-  MapPin,
   RefreshCw,
-  Search,
-  Settings2,
-  ShieldCheck,
-  UserPlus,
-  Users,
 } from 'lucide-react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { AppLayout } from '@/components/layout/AppLayout';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/table';
-import {
   createReportScheduleAdmin,
-  fetchAdminReportingAccessMatrix,
   fetchAdminReportingOverview,
-  grantMachineReportAccessAdmin,
-  lookupReportingUserByEmailAdmin,
-  revokeReportingAccessAdmin,
-  type AdminReportingAccessGrant,
-  type AdminReportingAccessMachine,
-  type AdminReportingAccessPerson,
-  type ReportingAccessLevel,
-  type ReportingMachineType,
-  upsertReportingMachineAdmin,
+  type AdminReportSchedule,
+  type AdminReportViewSnapshot,
+  type AdminReportingImportRun,
 } from '@/lib/reporting';
 import { trackEvent } from '@/lib/analytics';
-import { cn } from '@/lib/utils';
 
-const machineTypes: ReportingMachineType[] = ['commercial', 'mini', 'micro', 'unknown'];
-const accessLevels: ReportingAccessLevel[] = ['viewer', 'report_manager'];
-
-const emptyMatrix = {
-  people: [] as AdminReportingAccessPerson[],
-  machines: [] as AdminReportingAccessMachine[],
-  grants: [] as AdminReportingAccessGrant[],
-};
+const splitEmails = (value: string) =>
+  value
+    .split(',')
+    .map((email) => email.trim().toLowerCase())
+    .filter(Boolean);
 
 const formatDate = (value: string | null) =>
   value
@@ -68,94 +42,14 @@ const formatDate = (value: string | null) =>
       })
     : 'n/a';
 
-const formatShortDate = (value: string | null) =>
-  value
-    ? new Date(value).toLocaleDateString(undefined, {
-        month: 'short',
-        day: 'numeric',
-        year: 'numeric',
-      })
-    : 'n/a';
-
-const splitEmails = (value: string) =>
-  value
-    .split(',')
-    .map((email) => email.trim().toLowerCase())
-    .filter(Boolean);
-
-const normalizeSearch = (value: string) => value.trim().toLowerCase();
-
-const isMachineGrant = (grant: AdminReportingAccessGrant) =>
-  grant.scopeType === 'machine' && Boolean(grant.machineId);
-
-const machineNeedsMapping = (machine: AdminReportingAccessMachine) =>
-  machine.accountName === 'Sunze Import Holding' ||
-  machine.locationName === 'Unmapped Sunze Machines' ||
-  machine.machineType === 'unknown';
-
-const mergePeople = (
-  matrixPeople: AdminReportingAccessPerson[],
-  localPeople: AdminReportingAccessPerson[]
-) => {
-  const byUserId = new Map<string, AdminReportingAccessPerson>();
-
-  [...localPeople, ...matrixPeople].forEach((person) => {
-    byUserId.set(person.userId, person);
-  });
-
-  return [...byUserId.values()].sort((left, right) => {
-    if (left.isSuperAdmin !== right.isSuperAdmin) {
-      return left.isSuperAdmin ? -1 : 1;
-    }
-
-    return (left.userEmail ?? left.userId).localeCompare(right.userEmail ?? right.userId);
-  });
-};
-
-const groupMachines = (machines: AdminReportingAccessMachine[]) => {
-  const groups = new Map<string, AdminReportingAccessMachine[]>();
-
-  machines.forEach((machine) => {
-    const key = `${machine.accountName}||${machine.locationName}`;
-    const current = groups.get(key) ?? [];
-    current.push(machine);
-    groups.set(key, current);
-  });
-
-  return [...groups.entries()].map(([key, values]) => {
-    const [accountName, locationName] = key.split('||');
-    return {
-      key,
-      accountName,
-      locationName,
-      machines: values,
-    };
-  });
+const formatStatusVariant = (status: string) => {
+  if (status === 'completed' || status === 'ready') return 'default';
+  if (status === 'failed') return 'destructive';
+  return 'outline';
 };
 
 export default function AdminReportingPage() {
   const queryClient = useQueryClient();
-  const [activeTab, setActiveTab] = useState('access');
-  const [peopleSearch, setPeopleSearch] = useState('');
-  const [lookupEmail, setLookupEmail] = useState('');
-  const [localPeople, setLocalPeople] = useState<AdminReportingAccessPerson[]>([]);
-  const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
-  const [selectedMachineIds, setSelectedMachineIds] = useState<Set<string>>(new Set());
-  const [accessReason, setAccessReason] = useState('');
-  const [accessLevel, setAccessLevel] = useState<ReportingAccessLevel>('viewer');
-  const [isLookingUpUser, setIsLookingUpUser] = useState(false);
-  const [isSavingAccess, setIsSavingAccess] = useState(false);
-  const [accessMachineSearch, setAccessMachineSearch] = useState('');
-  const [machineSearch, setMachineSearch] = useState('');
-  const [machineForm, setMachineForm] = useState({
-    machineId: null as string | null,
-    accountName: '',
-    locationName: '',
-    machineLabel: '',
-    machineType: 'unknown' as ReportingMachineType,
-    sunzeMachineId: '',
-    reason: 'Machine mapping update',
-  });
   const [scheduleForm, setScheduleForm] = useState({
     title: 'Bubble Planet weekly machine sales',
     machineId: '',
@@ -164,324 +58,39 @@ export default function AdminReportingPage() {
     sendHourLocal: '9',
     timezone: 'America/Los_Angeles',
   });
-  const [isSavingMachine, setIsSavingMachine] = useState(false);
   const [isCreatingSchedule, setIsCreatingSchedule] = useState(false);
 
   const {
-    data: matrix = emptyMatrix,
-    isLoading: matrixLoading,
-    isFetching: matrixFetching,
-    error: matrixError,
-  } = useQuery({
-    queryKey: ['admin-reporting-access-matrix'],
-    queryFn: fetchAdminReportingAccessMatrix,
-    staleTime: 1000 * 30,
-  });
-
-  const {
     data: overview,
-    isLoading: overviewLoading,
-    isFetching: overviewFetching,
-    error: overviewError,
+    isLoading,
+    isFetching,
+    error,
   } = useQuery({
     queryKey: ['admin-reporting-overview'],
     queryFn: fetchAdminReportingOverview,
     staleTime: 1000 * 30,
   });
 
-  const people = useMemo(
-    () => mergePeople(matrix.people, localPeople),
-    [localPeople, matrix.people]
-  );
-  const machines = useMemo(() => matrix.machines, [matrix.machines]);
-  const grants = useMemo(() => matrix.grants, [matrix.grants]);
+  const machines = useMemo(() => overview?.machines ?? [], [overview?.machines]);
   const importRuns = useMemo(() => overview?.importRuns ?? [], [overview?.importRuns]);
   const schedules = useMemo(() => overview?.schedules ?? [], [overview?.schedules]);
+  const snapshots = useMemo(() => overview?.snapshots ?? [], [overview?.snapshots]);
+  const latestRun = importRuns[0] ?? null;
+  const latestCompletedRun =
+    importRuns.find((run) => run.status === 'completed' && run.completed_at) ?? null;
 
-  const selectedPerson = people.find((person) => person.userId === selectedUserId) ?? null;
-
-  const selectedMachineGrantByMachineId = useMemo(() => {
-    const grantMap = new Map<string, AdminReportingAccessGrant>();
-
-    grants
-      .filter((grant) => grant.userId === selectedUserId && isMachineGrant(grant))
-      .forEach((grant) => {
-        if (grant.machineId) {
-          grantMap.set(grant.machineId, grant);
-        }
-      });
-
-    return grantMap;
-  }, [grants, selectedUserId]);
-
-  const originalMachineIds = useMemo(
-    () => new Set(selectedMachineGrantByMachineId.keys()),
-    [selectedMachineGrantByMachineId]
-  );
-
-  const filteredPeople = useMemo(() => {
-    const search = normalizeSearch(peopleSearch);
-
-    if (!search) {
-      return people;
-    }
-
-    return people.filter((person) =>
-      `${person.userEmail ?? ''} ${person.userId}`.toLowerCase().includes(search)
-    );
-  }, [people, peopleSearch]);
-
-  const filteredAccessMachines = useMemo(() => {
-    const search = normalizeSearch(accessMachineSearch);
-
-    if (!search) {
-      return machines;
-    }
-
-    return machines.filter((machine) =>
-      [
-        machine.machineLabel,
-        machine.sunzeMachineId ?? '',
-        machine.accountName,
-        machine.locationName,
-      ]
-        .join(' ')
-        .toLowerCase()
-        .includes(search)
-    );
-  }, [accessMachineSearch, machines]);
-
-  const filteredMappingMachines = useMemo(() => {
-    const search = normalizeSearch(machineSearch);
-
-    if (!search) {
-      return machines;
-    }
-
-    return machines.filter((machine) =>
-      [
-        machine.machineLabel,
-        machine.sunzeMachineId ?? '',
-        machine.accountName,
-        machine.locationName,
-      ]
-        .join(' ')
-        .toLowerCase()
-        .includes(search)
-    );
-  }, [machineSearch, machines]);
-
-  const groupedAccessMachines = useMemo(
-    () => groupMachines(filteredAccessMachines),
-    [filteredAccessMachines]
-  );
-
-  const machineOptions = useMemo(
-    () =>
-      machines.map((machine) => ({
-        id: machine.id,
-        label: `${machine.machineLabel} (${machine.sunzeMachineId ?? 'no Sunze ID'})`,
-      })),
-    [machines]
-  );
-
-  const unmappedMachineCount = useMemo(
-    () => machines.filter(machineNeedsMapping).length,
-    [machines]
-  );
-
-  const addedMachineIds = useMemo(
-    () => [...selectedMachineIds].filter((machineId) => !originalMachineIds.has(machineId)),
-    [originalMachineIds, selectedMachineIds]
-  );
-
-  const removedMachineIds = useMemo(
-    () => [...originalMachineIds].filter((machineId) => !selectedMachineIds.has(machineId)),
-    [originalMachineIds, selectedMachineIds]
-  );
-
-  const hasAccessChanges = addedMachineIds.length > 0 || removedMachineIds.length > 0;
-  const isLoading = matrixLoading || overviewLoading;
-  const isFetching = matrixFetching || overviewFetching;
-
-  useEffect(() => {
-    if (!selectedUserId && people.length > 0) {
-      setSelectedUserId(people[0].userId);
-      return;
-    }
-
-    if (selectedUserId && people.length > 0 && !people.some((person) => person.userId === selectedUserId)) {
-      setSelectedUserId(people[0].userId);
-    }
-  }, [people, selectedUserId]);
-
-  useEffect(() => {
-    setSelectedMachineIds(new Set(originalMachineIds));
-    setAccessReason('');
-  }, [originalMachineIds, selectedUserId]);
-
-  const refreshReporting = async () => {
-    await Promise.all([
-      queryClient.invalidateQueries({ queryKey: ['admin-reporting-access-matrix'] }),
-      queryClient.invalidateQueries({ queryKey: ['admin-reporting-overview'] }),
-    ]);
-  };
-
-  const toggleMachine = (machineId: string, checked: boolean) => {
-    setSelectedMachineIds((current) => {
-      const next = new Set(current);
-
-      if (checked) {
-        next.add(machineId);
-      } else {
-        next.delete(machineId);
-      }
-
-      return next;
-    });
-  };
-
-  const lookupUser = async () => {
-    if (!lookupEmail.trim()) {
-      toast.error('Enter a user email first.');
-      return;
-    }
-
-    setIsLookingUpUser(true);
-    try {
-      const person = await lookupReportingUserByEmailAdmin(lookupEmail);
-      setLocalPeople((current) => {
-        const withoutPerson = current.filter((entry) => entry.userId !== person.userId);
-        return [person, ...withoutPerson];
-      });
-      setSelectedUserId(person.userId);
-      setPeopleSearch('');
-      setLookupEmail('');
-      trackEvent('admin_reporting_user_lookup', { user_id: person.userId });
-      toast.success('User found.');
-    } catch (lookupError) {
-      toast.error(lookupError instanceof Error ? lookupError.message : 'Unable to find user.');
-    } finally {
-      setIsLookingUpUser(false);
-    }
-  };
-
-  const saveAccessChanges = async () => {
-    if (!selectedPerson) {
-      toast.error('Select a person first.');
-      return;
-    }
-
-    if (selectedPerson.isSuperAdmin) {
-      toast.error('Super-admin reporting access is managed from Governance & Audit.');
-      return;
-    }
-
-    if (!hasAccessChanges) {
-      toast.error('No access changes to save.');
-      return;
-    }
-
-    if (!accessReason.trim()) {
-      toast.error('A reason is required before saving access changes.');
-      return;
-    }
-
-    setIsSavingAccess(true);
-    try {
-      await Promise.all([
-        ...addedMachineIds.map((machineId) =>
-          grantMachineReportAccessAdmin({
-            userEmail: selectedPerson.userEmail ?? '',
-            machineId,
-            accessLevel,
-            reason: accessReason.trim(),
-          })
-        ),
-        ...removedMachineIds.map((machineId) => {
-          const grant = selectedMachineGrantByMachineId.get(machineId);
-
-          if (!grant) {
-            return Promise.resolve(null);
-          }
-
-          return revokeReportingAccessAdmin({
-            entitlementId: grant.id,
-            reason: accessReason.trim(),
-          });
-        }),
-      ]);
-
-      trackEvent('admin_reporting_access_matrix_saved', {
-        user_id: selectedPerson.userId,
-        grants_added: addedMachineIds.length,
-        grants_removed: removedMachineIds.length,
-      });
-      toast.success('Reporting access updated.');
-      await refreshReporting();
-    } catch (saveError) {
-      toast.error(saveError instanceof Error ? saveError.message : 'Unable to update access.');
-    } finally {
-      setIsSavingAccess(false);
-    }
-  };
-
-  const startMachineEdit = (machine: AdminReportingAccessMachine) => {
-    setMachineForm({
-      machineId: machine.id,
-      accountName: machine.accountName,
-      locationName: machine.locationName,
-      machineLabel: machine.machineLabel,
-      machineType: machine.machineType,
-      sunzeMachineId: machine.sunzeMachineId ?? '',
-      reason: 'Machine mapping update',
-    });
-    setActiveTab('machines');
-  };
-
-  const focusMachineAccess = (machine: AdminReportingAccessMachine) => {
-    setAccessMachineSearch(machine.machineLabel);
-    setActiveTab('access');
-  };
-
-  const saveMachine = async () => {
-    if (!machineForm.accountName.trim() || !machineForm.locationName.trim()) {
-      toast.error('Account and location are required.');
-      return;
-    }
-
-    if (!machineForm.machineLabel.trim() || !machineForm.reason.trim()) {
-      toast.error('Machine label and reason are required.');
-      return;
-    }
-
-    setIsSavingMachine(true);
-    try {
-      await upsertReportingMachineAdmin({
-        machineId: machineForm.machineId,
-        accountName: machineForm.accountName.trim(),
-        locationName: machineForm.locationName.trim(),
-        machineLabel: machineForm.machineLabel.trim(),
-        machineType: machineForm.machineType,
-        sunzeMachineId: machineForm.sunzeMachineId.trim() || null,
-        reason: machineForm.reason.trim(),
-      });
-      trackEvent('admin_reporting_machine_upserted', {
-        sunze_machine_id: machineForm.sunzeMachineId.trim(),
-      });
-      toast.success('Machine mapping saved.');
-      await refreshReporting();
-    } catch (saveError) {
-      toast.error(saveError instanceof Error ? saveError.message : 'Unable to save machine.');
-    } finally {
-      setIsSavingMachine(false);
-    }
-  };
+  const refresh = () =>
+    queryClient.invalidateQueries({ queryKey: ['admin-reporting-overview'] });
 
   const createSchedule = async () => {
-    const recipientEmails = splitEmails(scheduleForm.recipients);
-    if (!scheduleForm.title.trim() || recipientEmails.length === 0) {
-      toast.error('Schedule title and at least one recipient are required.');
+    if (!scheduleForm.title.trim()) {
+      toast.error('Schedule title is required.');
+      return;
+    }
+
+    const recipients = splitEmails(scheduleForm.recipients);
+    if (recipients.length === 0) {
+      toast.error('At least one recipient is required.');
       return;
     }
 
@@ -491,22 +100,29 @@ export default function AdminReportingPage() {
         title: scheduleForm.title.trim(),
         filters: {
           title: scheduleForm.title.trim(),
-          datePreset: 'previous_week',
+          machineIds: scheduleForm.machineId ? [scheduleForm.machineId] : undefined,
           grain: 'week',
-          machineIds: scheduleForm.machineId ? [scheduleForm.machineId] : [],
-          paymentMethods: [],
         },
-        recipientEmails,
+        recipientEmails: recipients,
         dayOfWeek: Number(scheduleForm.dayOfWeek),
         sendHourLocal: Number(scheduleForm.sendHourLocal),
         timezone: scheduleForm.timezone,
       });
+
       trackEvent('admin_report_schedule_created', {
         title: scheduleForm.title.trim(),
-        recipient_count: recipientEmails.length,
+        recipient_count: recipients.length,
       });
       toast.success('Report schedule created.');
-      await refreshReporting();
+      setScheduleForm({
+        title: 'Bubble Planet weekly machine sales',
+        machineId: '',
+        recipients: '',
+        dayOfWeek: '1',
+        sendHourLocal: '9',
+        timezone: 'America/Los_Angeles',
+      });
+      await refresh();
     } catch (scheduleError) {
       toast.error(
         scheduleError instanceof Error ? scheduleError.message : 'Unable to create schedule.'
@@ -526,814 +142,348 @@ export default function AdminReportingPage() {
                 Admin
               </p>
               <h1 className="mt-2 font-display text-3xl font-bold text-foreground">
-                Sales Reporting
+                Reporting Operations
               </h1>
-              <p className="mt-2 text-sm text-muted-foreground">
-                Manage who can see each machine, map Sunze machines, and monitor report delivery.
+              <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+                Monitor Sunze sync health, scheduled deliveries, and report exports. User access
+                lives in Admin Access; machine and partnership setup lives in Admin Partnerships.
               </p>
             </div>
-            <Button variant="outline" onClick={refreshReporting} disabled={isFetching}>
-              {isFetching ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              ) : (
-                <RefreshCw className="mr-2 h-4 w-4" />
-              )}
+            <Button variant="outline" onClick={refresh} disabled={isFetching}>
+              {isFetching ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-2 h-4 w-4" />}
               Refresh
             </Button>
           </div>
 
-          {(matrixError || overviewError) && (
+          {error && (
             <div className="mt-4 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
-              Unable to load reporting administration data.
+              Unable to load reporting overview.
             </div>
           )}
 
-          <div className="mt-6 grid gap-4 md:grid-cols-4">
-            <div className="card-elevated p-5">
-              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                People
-              </p>
-              <p className="mt-2 text-2xl font-semibold text-foreground">{people.length}</p>
-            </div>
-            <div className="card-elevated p-5">
-              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Machines
-              </p>
-              <p className="mt-2 text-2xl font-semibold text-foreground">{machines.length}</p>
-            </div>
-            <div className="card-elevated p-5">
-              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Needs Mapping
-              </p>
-              <p className="mt-2 text-2xl font-semibold text-foreground">{unmappedMachineCount}</p>
-            </div>
-            <div className="card-elevated p-5">
-              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Last Import
-              </p>
-              <p className="mt-2 text-sm font-semibold text-foreground">
-                {formatDate(importRuns[0]?.completed_at ?? importRuns[0]?.created_at ?? null)}
-              </p>
-            </div>
+          <div className="mt-6 grid gap-4 md:grid-cols-3">
+            <StatusCard
+              icon={<Database className="h-5 w-5" />}
+              label="Latest Sunze Run"
+              value={latestRun ? latestRun.status : 'none'}
+              detail={latestRun ? formatDate(latestRun.completed_at ?? latestRun.created_at) : 'No imports yet'}
+              status={latestRun?.status}
+            />
+            <StatusCard
+              icon={<CheckCircle2 className="h-5 w-5" />}
+              label="Last Completed Import"
+              value={latestCompletedRun ? `${latestCompletedRun.rows_imported} rows` : 'none'}
+              detail={latestCompletedRun ? formatDate(latestCompletedRun.completed_at) : 'No successful imports yet'}
+              status={latestCompletedRun ? 'completed' : 'pending'}
+            />
+            <StatusCard
+              icon={<CalendarDays className="h-5 w-5" />}
+              label="Active Schedules"
+              value={String(schedules.filter((schedule) => schedule.active).length)}
+              detail={`${snapshots.length} recent export snapshots`}
+              status="completed"
+            />
           </div>
 
-          <Tabs value={activeTab} onValueChange={setActiveTab} className="mt-6">
-            <TabsList className="grid h-auto w-full grid-cols-2 gap-1 sm:inline-grid sm:w-auto sm:grid-cols-4">
-              <TabsTrigger value="access" className="gap-2">
-                <Users className="h-4 w-4" />
-                Access
-              </TabsTrigger>
-              <TabsTrigger value="machines" className="gap-2">
-                <Settings2 className="h-4 w-4" />
-                Machines
-              </TabsTrigger>
-              <TabsTrigger value="schedules" className="gap-2">
-                <CalendarDays className="h-4 w-4" />
-                Schedules
-              </TabsTrigger>
-              <TabsTrigger value="sync" className="gap-2">
-                <Database className="h-4 w-4" />
-                Sync
-              </TabsTrigger>
+          <Tabs defaultValue="schedules" className="mt-6">
+            <TabsList className="h-auto flex-wrap justify-start">
+              <TabsTrigger value="schedules">Schedules</TabsTrigger>
+              <TabsTrigger value="sync">Sync</TabsTrigger>
+              <TabsTrigger value="exports">Exports</TabsTrigger>
             </TabsList>
-
-            <TabsContent value="access" className="mt-6">
-              <div className="grid gap-6 xl:grid-cols-[360px_1fr]">
-                <div className="rounded-lg border border-border bg-card">
-                  <div className="border-b border-border p-4">
-                    <div className="flex items-center justify-between gap-3">
-                      <div>
-                        <h2 className="font-semibold text-foreground">People</h2>
-                        <p className="text-sm text-muted-foreground">
-                          Explicit machine grants by user.
-                        </p>
-                      </div>
-                      <Users className="h-5 w-5 text-muted-foreground" />
-                    </div>
-                    <div className="mt-4 space-y-3">
-                      <div className="relative">
-                        <Search className="pointer-events-none absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
-                        <Input
-                          value={peopleSearch}
-                          onChange={(event) => setPeopleSearch(event.target.value)}
-                          placeholder="Search people"
-                          className="pl-9"
-                        />
-                      </div>
-                      <div className="flex gap-2">
-                        <Input
-                          type="email"
-                          value={lookupEmail}
-                          onChange={(event) => setLookupEmail(event.target.value)}
-                          placeholder="Add existing user by email"
-                          onKeyDown={(event) => {
-                            if (event.key === 'Enter') {
-                              void lookupUser();
-                            }
-                          }}
-                        />
-                        <Button
-                          type="button"
-                          variant="outline"
-                          onClick={lookupUser}
-                          disabled={isLookingUpUser}
-                          aria-label="Find user"
-                        >
-                          {isLookingUpUser ? (
-                            <Loader2 className="h-4 w-4 animate-spin" />
-                          ) : (
-                            <UserPlus className="h-4 w-4" />
-                          )}
-                        </Button>
-                      </div>
-                    </div>
-                  </div>
-
-                  <div className="max-h-[640px] overflow-y-auto p-2">
-                    {isLoading && (
-                      <div className="p-4 text-sm text-muted-foreground">Loading access...</div>
-                    )}
-                    {!isLoading && filteredPeople.length === 0 && (
-                      <div className="p-4 text-sm text-muted-foreground">
-                        No people match this search.
-                      </div>
-                    )}
-                    {filteredPeople.map((person) => (
-                      <button
-                        key={person.userId}
-                        type="button"
-                        onClick={() => setSelectedUserId(person.userId)}
-                        className={cn(
-                          'mb-2 w-full rounded-md border border-transparent p-3 text-left transition hover:bg-muted/60',
-                          selectedUserId === person.userId
-                            ? 'border-primary/30 bg-primary/5'
-                            : 'bg-background'
-                        )}
-                      >
-                        <div className="flex items-start justify-between gap-3">
-                          <div className="min-w-0">
-                            <p className="truncate text-sm font-medium text-foreground">
-                              {person.userEmail ?? person.userId}
-                            </p>
-                            <p className="mt-1 truncate text-xs text-muted-foreground">
-                              {person.userId}
-                            </p>
-                          </div>
-                          {person.isSuperAdmin && (
-                            <ShieldCheck className="h-4 w-4 shrink-0 text-primary" />
-                          )}
-                        </div>
-                        <div className="mt-3 flex flex-wrap gap-2">
-                          {person.isSuperAdmin ? (
-                            <Badge className="bg-primary/10 text-primary hover:bg-primary/10">
-                              Super-admin
-                            </Badge>
-                          ) : person.explicitMachineCount > 0 ? (
-                            <Badge variant="secondary">
-                              {person.explicitMachineCount} machine
-                              {person.explicitMachineCount === 1 ? '' : 's'}
-                            </Badge>
-                          ) : (
-                            <Badge variant="outline">No machine grants</Badge>
-                          )}
-                          {person.inheritedGrantCount > 0 && (
-                            <Badge variant="outline">{person.inheritedGrantCount} inherited</Badge>
-                          )}
-                        </div>
-                      </button>
-                    ))}
-                  </div>
-                </div>
-
-                <div className="rounded-lg border border-border bg-card">
-                  <div className="border-b border-border p-4">
-                    {selectedPerson ? (
-                      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-                        <div>
-                          <div className="flex flex-wrap items-center gap-2">
-                            <h2 className="font-semibold text-foreground">
-                              {selectedPerson.userEmail ?? selectedPerson.userId}
-                            </h2>
-                            {selectedPerson.isSuperAdmin && (
-                              <Badge className="bg-primary/10 text-primary hover:bg-primary/10">
-                                All machines via super-admin
-                              </Badge>
-                            )}
-                            {!selectedPerson.isSuperAdmin &&
-                              selectedPerson.explicitMachineCount === 0 && (
-                                <Badge variant="outline">No machine grants</Badge>
-                              )}
-                          </div>
-                          <p className="mt-1 text-sm text-muted-foreground">
-                            {selectedPerson.isSuperAdmin
-                              ? 'Reporting access is inherited from the super-admin role.'
-                              : `${selectedMachineIds.size} selected machine${
-                                  selectedMachineIds.size === 1 ? '' : 's'
-                                }.`}
-                          </p>
-                        </div>
-                        {selectedPerson.isSuperAdmin ? (
-                          <Button asChild variant="outline">
-                            <Link to="/admin/audit">Manage Super-Admins</Link>
-                          </Button>
-                        ) : (
-                          <div className="grid gap-3 sm:grid-cols-[180px_minmax(260px,1fr)_auto]">
-                            <div>
-                              <Label htmlFor="access-level">New grant level</Label>
-                              <select
-                                id="access-level"
-                                value={accessLevel}
-                                onChange={(event) =>
-                                  setAccessLevel(event.target.value as ReportingAccessLevel)
-                                }
-                                className="mt-1 h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
-                              >
-                                {accessLevels.map((level) => (
-                                  <option key={level} value={level}>
-                                    {level}
-                                  </option>
-                                ))}
-                              </select>
-                            </div>
-                            <div>
-                              <Label htmlFor="access-reason">Save reason</Label>
-                              <Input
-                                id="access-reason"
-                                value={accessReason}
-                                onChange={(event) => setAccessReason(event.target.value)}
-                                placeholder="Partner reporting access update"
-                                className="mt-1"
-                              />
-                            </div>
-                            <div className="flex items-end">
-                              <Button
-                                onClick={saveAccessChanges}
-                                disabled={isSavingAccess || !hasAccessChanges}
-                                className="w-full"
-                              >
-                                {isSavingAccess ? (
-                                  <>
-                                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                                    Saving...
-                                  </>
-                                ) : (
-                                  'Save Access'
-                                )}
-                              </Button>
-                            </div>
-                          </div>
-                        )}
-                      </div>
-                    ) : (
-                      <div>
-                        <h2 className="font-semibold text-foreground">Select a person</h2>
-                        <p className="mt-1 text-sm text-muted-foreground">
-                          Find an existing user by email, then assign machine visibility.
-                        </p>
-                      </div>
-                    )}
-                  </div>
-
-                  <div className="border-b border-border p-4">
-                    <div className="relative max-w-xl">
-                      <Search className="pointer-events-none absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
-                      <Input
-                        value={accessMachineSearch}
-                        onChange={(event) => setAccessMachineSearch(event.target.value)}
-                        placeholder="Filter machines by label, Sunze ID, account, or location"
-                        className="pl-9"
-                      />
-                    </div>
-                  </div>
-
-                  <div className="max-h-[680px] overflow-y-auto p-4">
-                    {groupedAccessMachines.length === 0 ? (
-                      <div className="rounded-md border border-border bg-background px-4 py-10 text-center text-sm text-muted-foreground">
-                        No machines match this filter.
-                      </div>
-                    ) : (
-                      <div className="space-y-5">
-                        {groupedAccessMachines.map((group) => (
-                          <div key={group.key}>
-                            <div className="mb-2 flex flex-wrap items-center gap-2">
-                              <p className="text-sm font-semibold text-foreground">
-                                {group.accountName}
-                              </p>
-                              <span className="text-xs text-muted-foreground">/</span>
-                              <p className="text-sm text-muted-foreground">{group.locationName}</p>
-                            </div>
-                            <div className="overflow-hidden rounded-md border border-border">
-                              {group.machines.map((machine) => {
-                                const checked = selectedMachineIds.has(machine.id);
-                                const grant = selectedMachineGrantByMachineId.get(machine.id);
-
-                                return (
-                                  <label
-                                    key={machine.id}
-                                    className={cn(
-                                      'flex cursor-pointer items-start gap-3 border-b border-border bg-background p-3 last:border-b-0',
-                                      selectedPerson?.isSuperAdmin && 'cursor-default opacity-80'
-                                    )}
-                                  >
-                                    <Checkbox
-                                      checked={selectedPerson?.isSuperAdmin ? true : checked}
-                                      disabled={!selectedPerson || selectedPerson.isSuperAdmin}
-                                      onCheckedChange={(value) => toggleMachine(machine.id, Boolean(value))}
-                                      className="mt-1"
-                                    />
-                                    <div className="min-w-0 flex-1">
-                                      <div className="flex flex-wrap items-center gap-2">
-                                        <span className="font-medium text-foreground">
-                                          {machine.machineLabel}
-                                        </span>
-                                        {machineNeedsMapping(machine) && (
-                                          <Badge variant="outline" className="text-amber-700">
-                                            Needs mapping
-                                          </Badge>
-                                        )}
-                                        {grant && (
-                                          <Badge variant="secondary">{grant.accessLevel}</Badge>
-                                        )}
-                                      </div>
-                                      <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
-                                        <span>Sunze: {machine.sunzeMachineId ?? 'n/a'}</span>
-                                        <span>Latest sale: {formatShortDate(machine.latestSaleDate)}</span>
-                                        <span>
-                                          Viewers: {machine.viewerCount}
-                                        </span>
-                                      </div>
-                                    </div>
-                                  </label>
-                                );
-                              })}
-                            </div>
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </TabsContent>
-
-            <TabsContent value="machines" className="mt-6">
-              <div className="grid gap-6 xl:grid-cols-[380px_1fr]">
-                <div className="rounded-lg border border-border bg-card p-5">
-                  <div className="flex items-start gap-3">
-                    <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
-                      <MapPin className="h-5 w-5" />
-                    </span>
-                    <div>
-                      <h2 className="font-semibold text-foreground">Machine Mapping</h2>
-                      <p className="text-sm text-muted-foreground">
-                        Assign Sunze machines to reporting account and location names.
-                      </p>
-                    </div>
-                  </div>
-                  <div className="mt-5 space-y-4">
-                    <div>
-                      <Label htmlFor="machine-account">Account</Label>
-                      <Input
-                        id="machine-account"
-                        value={machineForm.accountName}
-                        onChange={(event) =>
-                          setMachineForm((current) => ({
-                            ...current,
-                            accountName: event.target.value,
-                          }))
-                        }
-                        placeholder="Bubble Planet"
-                        className="mt-1"
-                      />
-                    </div>
-                    <div>
-                      <Label htmlFor="machine-location">Location</Label>
-                      <Input
-                        id="machine-location"
-                        value={machineForm.locationName}
-                        onChange={(event) =>
-                          setMachineForm((current) => ({
-                            ...current,
-                            locationName: event.target.value,
-                          }))
-                        }
-                        placeholder="Bubble Planet"
-                        className="mt-1"
-                      />
-                    </div>
-                    <div>
-                      <Label htmlFor="machine-label">Machine Label</Label>
-                      <Input
-                        id="machine-label"
-                        value={machineForm.machineLabel}
-                        onChange={(event) =>
-                          setMachineForm((current) => ({
-                            ...current,
-                            machineLabel: event.target.value,
-                          }))
-                        }
-                        placeholder="Bubble Planet Machine 1"
-                        className="mt-1"
-                      />
-                    </div>
-                    <div>
-                      <Label htmlFor="machine-type">Machine Type</Label>
-                      <select
-                        id="machine-type"
-                        value={machineForm.machineType}
-                        onChange={(event) =>
-                          setMachineForm((current) => ({
-                            ...current,
-                            machineType: event.target.value as ReportingMachineType,
-                          }))
-                        }
-                        className="mt-1 h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
-                      >
-                        {machineTypes.map((machineType) => (
-                          <option key={machineType} value={machineType}>
-                            {machineType}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-                    <div>
-                      <Label htmlFor="machine-sunze-id">Sunze Machine ID</Label>
-                      <Input
-                        id="machine-sunze-id"
-                        value={machineForm.sunzeMachineId}
-                        onChange={(event) =>
-                          setMachineForm((current) => ({
-                            ...current,
-                            sunzeMachineId: event.target.value,
-                          }))
-                        }
-                        placeholder="Machine code from Sunze"
-                        className="mt-1"
-                      />
-                    </div>
-                    <div>
-                      <Label htmlFor="machine-reason">Save Reason</Label>
-                      <Input
-                        id="machine-reason"
-                        value={machineForm.reason}
-                        onChange={(event) =>
-                          setMachineForm((current) => ({ ...current, reason: event.target.value }))
-                        }
-                        placeholder="Correct machine location"
-                        className="mt-1"
-                      />
-                    </div>
-                    <Button onClick={saveMachine} disabled={isSavingMachine}>
-                      {isSavingMachine ? (
-                        <>
-                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                          Saving...
-                        </>
-                      ) : (
-                        'Save Mapping'
-                      )}
-                    </Button>
-                  </div>
-                </div>
-
-                <div className="rounded-lg border border-border bg-card">
-                  <div className="flex flex-col gap-3 border-b border-border p-4 md:flex-row md:items-center md:justify-between">
-                    <div>
-                      <h2 className="font-semibold text-foreground">Reporting Machines</h2>
-                      <p className="text-sm text-muted-foreground">
-                        Current Sunze mapping and viewer counts.
-                      </p>
-                    </div>
-                    <div className="relative md:w-80">
-                      <Search className="pointer-events-none absolute left-3 top-2.5 h-4 w-4 text-muted-foreground" />
-                      <Input
-                        value={machineSearch}
-                        onChange={(event) => setMachineSearch(event.target.value)}
-                        placeholder="Search machines"
-                        className="pl-9"
-                      />
-                    </div>
-                  </div>
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead>Machine</TableHead>
-                        <TableHead>Location</TableHead>
-                        <TableHead>Viewers</TableHead>
-                        <TableHead>Latest Sale</TableHead>
-                        <TableHead className="text-right">Actions</TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {filteredMappingMachines.length === 0 ? (
-                        <TableRow>
-                          <TableCell colSpan={5} className="py-10 text-center text-muted-foreground">
-                            No reporting machines found.
-                          </TableCell>
-                        </TableRow>
-                      ) : (
-                        filteredMappingMachines.map((machine) => (
-                          <TableRow key={machine.id}>
-                            <TableCell>
-                              <div className="font-medium text-foreground">
-                                {machine.machineLabel}
-                              </div>
-                              <div className="mt-1 text-xs text-muted-foreground">
-                                Sunze: {machine.sunzeMachineId ?? 'n/a'}
-                              </div>
-                              <div className="mt-2 flex flex-wrap gap-2">
-                                <Badge variant="secondary">{machine.machineType}</Badge>
-                                {machineNeedsMapping(machine) ? (
-                                  <Badge variant="outline" className="text-amber-700">
-                                    Needs mapping
-                                  </Badge>
-                                ) : (
-                                  <Badge className="bg-sage-light text-sage hover:bg-sage-light">
-                                    Mapped
-                                  </Badge>
-                                )}
-                              </div>
-                            </TableCell>
-                            <TableCell>
-                              <div className="text-sm text-foreground">{machine.accountName}</div>
-                              <div className="text-xs text-muted-foreground">
-                                {machine.locationName}
-                              </div>
-                            </TableCell>
-                            <TableCell>
-                              <div className="text-sm text-foreground">{machine.viewerCount}</div>
-                              <div className="mt-1 max-w-[220px] truncate text-xs text-muted-foreground">
-                                {machine.viewers.map((viewer) => viewer.userEmail ?? viewer.userId).join(', ') ||
-                                  'No explicit viewers'}
-                              </div>
-                            </TableCell>
-                            <TableCell>{formatShortDate(machine.latestSaleDate)}</TableCell>
-                            <TableCell className="text-right">
-                              <div className="flex justify-end gap-2">
-                                <Button
-                                  type="button"
-                                  variant="outline"
-                                  size="sm"
-                                  onClick={() => startMachineEdit(machine)}
-                                >
-                                  Edit
-                                </Button>
-                                <Button
-                                  type="button"
-                                  variant="ghost"
-                                  size="sm"
-                                  onClick={() => focusMachineAccess(machine)}
-                                >
-                                  Access
-                                </Button>
-                              </div>
-                            </TableCell>
-                          </TableRow>
-                        ))
-                      )}
-                    </TableBody>
-                  </Table>
-                </div>
-              </div>
-            </TabsContent>
-
             <TabsContent value="schedules" className="mt-6">
-              <div className="grid gap-6 xl:grid-cols-[380px_1fr]">
-                <div className="rounded-lg border border-border bg-card p-5">
-                  <h2 className="font-semibold text-foreground">Partner PDF Schedule</h2>
-                  <p className="mt-1 text-sm text-muted-foreground">
-                    Create weekly PDF delivery for a machine filter.
-                  </p>
-                  <div className="mt-5 space-y-4">
-                    <div>
-                      <Label htmlFor="schedule-title">Title</Label>
-                      <Input
-                        id="schedule-title"
-                        value={scheduleForm.title}
-                        onChange={(event) =>
-                          setScheduleForm((current) => ({ ...current, title: event.target.value }))
-                        }
-                        className="mt-1"
-                      />
-                    </div>
-                    <div>
-                      <Label htmlFor="schedule-machine">Machine Filter</Label>
-                      <select
-                        id="schedule-machine"
-                        value={scheduleForm.machineId}
-                        onChange={(event) =>
-                          setScheduleForm((current) => ({
-                            ...current,
-                            machineId: event.target.value,
-                          }))
-                        }
-                        className="mt-1 h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
-                      >
-                        <option value="">All machines in report filter</option>
-                        {machineOptions.map((machine) => (
-                          <option key={machine.id} value={machine.id}>
-                            {machine.label}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-                    <div>
-                      <Label htmlFor="schedule-recipients">Recipients</Label>
-                      <Input
-                        id="schedule-recipients"
-                        value={scheduleForm.recipients}
-                        onChange={(event) =>
-                          setScheduleForm((current) => ({
-                            ...current,
-                            recipients: event.target.value,
-                          }))
-                        }
-                        placeholder="partner@example.com, finance@example.com"
-                        className="mt-1"
-                      />
-                    </div>
-                    <div className="grid gap-3 sm:grid-cols-2">
-                      <div>
-                        <Label htmlFor="schedule-day">Day</Label>
-                        <Input
-                          id="schedule-day"
-                          type="number"
-                          min={0}
-                          max={6}
-                          value={scheduleForm.dayOfWeek}
-                          onChange={(event) =>
-                            setScheduleForm((current) => ({
-                              ...current,
-                              dayOfWeek: event.target.value,
-                            }))
-                          }
-                          className="mt-1"
-                        />
-                      </div>
-                      <div>
-                        <Label htmlFor="schedule-hour">Hour</Label>
-                        <Input
-                          id="schedule-hour"
-                          type="number"
-                          min={0}
-                          max={23}
-                          value={scheduleForm.sendHourLocal}
-                          onChange={(event) =>
-                            setScheduleForm((current) => ({
-                              ...current,
-                              sendHourLocal: event.target.value,
-                            }))
-                          }
-                          className="mt-1"
-                        />
-                      </div>
-                    </div>
-                    <div>
-                      <Label htmlFor="schedule-timezone">Timezone</Label>
-                      <Input
-                        id="schedule-timezone"
-                        value={scheduleForm.timezone}
-                        onChange={(event) =>
-                          setScheduleForm((current) => ({
-                            ...current,
-                            timezone: event.target.value,
-                          }))
-                        }
-                        className="mt-1"
-                      />
-                    </div>
-                    <Button onClick={createSchedule} disabled={isCreatingSchedule}>
-                      {isCreatingSchedule ? (
-                        <>
-                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                          Creating...
-                        </>
-                      ) : (
-                        'Create Schedule'
-                      )}
-                    </Button>
-                  </div>
-                </div>
-
-                <div className="rounded-lg border border-border bg-card p-5">
-                  <h2 className="font-semibold text-foreground">Active Schedules</h2>
-                  <div className="mt-4 space-y-3">
-                    {schedules.length === 0 ? (
-                      <div className="rounded-md border border-border bg-background px-4 py-8 text-center text-sm text-muted-foreground">
-                        No scheduled PDFs yet.
-                      </div>
-                    ) : (
-                      schedules.map((schedule) => (
-                        <div key={schedule.id} className="rounded-md border border-border p-4">
-                          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                            <div>
-                              <p className="font-semibold text-foreground">{schedule.title}</p>
-                              <p className="mt-1 text-sm text-muted-foreground">
-                                {schedule.schedule_kind}, day {schedule.send_day_of_week} at{' '}
-                                {schedule.send_hour_local}:00 {schedule.timezone}
-                              </p>
-                            </div>
-                            <Badge variant={schedule.active ? 'default' : 'secondary'}>
-                              {schedule.active ? 'active' : 'paused'}
-                            </Badge>
-                          </div>
-                          <p className="mt-3 text-sm text-muted-foreground">
-                            Recipients:{' '}
-                            {schedule.report_schedule_recipients
-                              ?.map((recipient) => recipient.email)
-                              .join(', ') || 'none'}
-                          </p>
-                        </div>
-                      ))
-                    )}
-                  </div>
-                </div>
-              </div>
+              {isLoading ? (
+                <LoadingCard />
+              ) : (
+                <SchedulesTab
+                  machines={machines}
+                  schedules={schedules}
+                  scheduleForm={scheduleForm}
+                  setScheduleForm={setScheduleForm}
+                  isCreatingSchedule={isCreatingSchedule}
+                  createSchedule={createSchedule}
+                />
+              )}
             </TabsContent>
-
             <TabsContent value="sync" className="mt-6">
-              <div className="grid gap-6 xl:grid-cols-[320px_1fr]">
-                <div className="rounded-lg border border-border bg-card p-5">
-                  <h2 className="font-semibold text-foreground">Sunze Sync</h2>
-                  <div className="mt-5 space-y-4">
-                    <div className="flex items-start gap-3">
-                      {importRuns[0]?.status === 'completed' ? (
-                        <CheckCircle2 className="mt-0.5 h-5 w-5 text-sage" />
-                      ) : (
-                        <AlertTriangle className="mt-0.5 h-5 w-5 text-amber-600" />
-                      )}
-                      <div>
-                        <p className="text-sm font-medium text-foreground">
-                          {importRuns[0]?.status ?? 'No imports yet'}
-                        </p>
-                        <p className="text-sm text-muted-foreground">
-                          {formatDate(importRuns[0]?.completed_at ?? importRuns[0]?.created_at ?? null)}
-                        </p>
-                      </div>
-                    </div>
-                    <div className="rounded-md border border-border bg-background p-3">
-                      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                        Latest rows
-                      </p>
-                      <p className="mt-1 text-2xl font-semibold text-foreground">
-                        {importRuns[0] ? `${importRuns[0].rows_imported}/${importRuns[0].rows_seen}` : '0/0'}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-
-                <div className="rounded-lg border border-border bg-card">
-                  <div className="border-b border-border px-4 py-3">
-                    <h2 className="font-semibold text-foreground">Recent Import Runs</h2>
-                  </div>
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead>Source</TableHead>
-                        <TableHead>Status</TableHead>
-                        <TableHead>Rows</TableHead>
-                        <TableHead>Completed</TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {importRuns.length === 0 ? (
-                        <TableRow>
-                          <TableCell colSpan={4} className="py-10 text-center text-muted-foreground">
-                            No imports recorded yet.
-                          </TableCell>
-                        </TableRow>
-                      ) : (
-                        importRuns.map((run) => (
-                          <TableRow key={run.id}>
-                            <TableCell>
-                              <div className="font-medium text-foreground">{run.source}</div>
-                              <div className="text-xs text-muted-foreground">
-                                {run.source_reference ?? run.id}
-                              </div>
-                            </TableCell>
-                            <TableCell>
-                              <Badge variant={run.status === 'completed' ? 'default' : 'outline'}>
-                                {run.status}
-                              </Badge>
-                              {run.error_message && (
-                                <p className="mt-1 text-xs text-destructive">{run.error_message}</p>
-                              )}
-                            </TableCell>
-                            <TableCell>
-                              {run.rows_imported}/{run.rows_seen}
-                            </TableCell>
-                            <TableCell>{formatDate(run.completed_at ?? run.created_at)}</TableCell>
-                          </TableRow>
-                        ))
-                      )}
-                    </TableBody>
-                  </Table>
-                </div>
-              </div>
+              {isLoading ? <LoadingCard /> : <SyncTab importRuns={importRuns} />}
+            </TabsContent>
+            <TabsContent value="exports" className="mt-6">
+              {isLoading ? <LoadingCard /> : <ExportsTab snapshots={snapshots} />}
             </TabsContent>
           </Tabs>
         </div>
       </section>
     </AppLayout>
+  );
+}
+
+function StatusCard({
+  icon,
+  label,
+  value,
+  detail,
+  status,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: string;
+  detail: string;
+  status?: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-primary">{icon}</span>
+        {status && <Badge variant={formatStatusVariant(status)}>{status}</Badge>}
+      </div>
+      <div className="mt-4 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      <div className="mt-1 text-xl font-semibold text-foreground">{value}</div>
+      <div className="mt-1 text-sm text-muted-foreground">{detail}</div>
+    </div>
+  );
+}
+
+function LoadingCard() {
+  return (
+    <div className="rounded-lg border border-border bg-card p-6 text-sm text-muted-foreground">
+      Loading reporting operations...
+    </div>
+  );
+}
+
+function SchedulesTab({
+  machines,
+  schedules,
+  scheduleForm,
+  setScheduleForm,
+  isCreatingSchedule,
+  createSchedule,
+}: {
+  machines: Array<{ id: string; machine_label: string; sunze_machine_id: string | null }>;
+  schedules: AdminReportSchedule[];
+  scheduleForm: {
+    title: string;
+    machineId: string;
+    recipients: string;
+    dayOfWeek: string;
+    sendHourLocal: string;
+    timezone: string;
+  };
+  setScheduleForm: (value: {
+    title: string;
+    machineId: string;
+    recipients: string;
+    dayOfWeek: string;
+    sendHourLocal: string;
+    timezone: string;
+  }) => void;
+  isCreatingSchedule: boolean;
+  createSchedule: () => void;
+}) {
+  return (
+    <div className="grid gap-6 lg:grid-cols-[0.8fr_1.2fr]">
+      <div className="rounded-lg border border-border bg-card p-5">
+        <h2 className="font-semibold text-foreground">Create Scheduled Delivery</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Scheduled PDFs use report filters and email recipients. Partner-specific financial
+          reports will be driven by the Partnerships setup once approved.
+        </p>
+        <div className="mt-4 space-y-3">
+          <div>
+            <Label htmlFor="schedule-title">Title</Label>
+            <Input
+              id="schedule-title"
+              value={scheduleForm.title}
+              onChange={(event) => setScheduleForm({ ...scheduleForm, title: event.target.value })}
+            />
+          </div>
+          <div>
+            <Label htmlFor="schedule-machine">Optional machine filter</Label>
+            <select
+              id="schedule-machine"
+              value={scheduleForm.machineId}
+              onChange={(event) => setScheduleForm({ ...scheduleForm, machineId: event.target.value })}
+              className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+            >
+              <option value="">All accessible machines in filter</option>
+              {machines.map((machine) => (
+                <option key={machine.id} value={machine.id}>
+                  {machine.machine_label} / {machine.sunze_machine_id ?? 'no Sunze ID'}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <Label htmlFor="schedule-recipients">Recipients</Label>
+            <Input
+              id="schedule-recipients"
+              value={scheduleForm.recipients}
+              onChange={(event) =>
+                setScheduleForm({ ...scheduleForm, recipients: event.target.value })
+              }
+              placeholder="partner@example.com, finance@example.com"
+            />
+          </div>
+          <div className="grid gap-3 sm:grid-cols-3">
+            <div>
+              <Label htmlFor="schedule-day">Send day</Label>
+              <select
+                id="schedule-day"
+                value={scheduleForm.dayOfWeek}
+                onChange={(event) =>
+                  setScheduleForm({ ...scheduleForm, dayOfWeek: event.target.value })
+                }
+                className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+              >
+                <option value="1">Monday</option>
+                <option value="2">Tuesday</option>
+                <option value="3">Wednesday</option>
+                <option value="4">Thursday</option>
+                <option value="5">Friday</option>
+              </select>
+            </div>
+            <div>
+              <Label htmlFor="schedule-hour">Hour</Label>
+              <Input
+                id="schedule-hour"
+                type="number"
+                min={0}
+                max={23}
+                value={scheduleForm.sendHourLocal}
+                onChange={(event) =>
+                  setScheduleForm({ ...scheduleForm, sendHourLocal: event.target.value })
+                }
+              />
+            </div>
+            <div>
+              <Label htmlFor="schedule-timezone">Timezone</Label>
+              <Input
+                id="schedule-timezone"
+                value={scheduleForm.timezone}
+                onChange={(event) =>
+                  setScheduleForm({ ...scheduleForm, timezone: event.target.value })
+                }
+              />
+            </div>
+          </div>
+          <Button onClick={createSchedule} disabled={isCreatingSchedule}>
+            {isCreatingSchedule ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <CalendarDays className="mr-2 h-4 w-4" />}
+            Create Schedule
+          </Button>
+        </div>
+      </div>
+
+      <div className="rounded-lg border border-border bg-card">
+        <ListHeader title="Active Schedules" count={schedules.length} />
+        {schedules.length === 0 ? (
+          <EmptyRow text="No schedules configured." />
+        ) : (
+          schedules.map((schedule) => (
+            <Row key={schedule.id}>
+              <div>
+                <div className="font-medium text-foreground">{schedule.title}</div>
+                <div className="mt-1 text-xs text-muted-foreground">
+                  Day {schedule.send_day_of_week} at {schedule.send_hour_local}:00 / {schedule.timezone}
+                </div>
+                <div className="mt-1 text-xs text-muted-foreground">
+                  Recipients:{' '}
+                  {schedule.report_schedule_recipients
+                    ?.filter((recipient) => recipient.active)
+                    .map((recipient) => recipient.email)
+                    .join(', ') || 'none'}
+                </div>
+              </div>
+              <Badge variant={schedule.active ? 'default' : 'outline'}>
+                {schedule.active ? 'active' : 'inactive'}
+              </Badge>
+            </Row>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SyncTab({ importRuns }: { importRuns: AdminReportingImportRun[] }) {
+  return (
+    <div className="rounded-lg border border-border bg-card">
+      <ListHeader title="Recent Import Runs" count={importRuns.length} />
+      {importRuns.length === 0 ? (
+        <EmptyRow text="No sales import runs found." />
+      ) : (
+        importRuns.map((run) => (
+          <Row key={run.id}>
+            <div>
+              <div className="font-medium text-foreground">{run.source}</div>
+              <div className="mt-1 text-xs text-muted-foreground">
+                {run.source_reference ?? 'no source reference'} / started {formatDate(run.started_at)}
+              </div>
+              {run.error_message && (
+                <div className="mt-2 flex items-start gap-2 text-xs text-destructive">
+                  <AlertTriangle className="mt-0.5 h-3.5 w-3.5" />
+                  {run.error_message}
+                </div>
+              )}
+            </div>
+            <div className="text-right text-sm">
+              <Badge variant={formatStatusVariant(run.status)}>{run.status}</Badge>
+              <div className="mt-2 text-xs text-muted-foreground">
+                seen {run.rows_seen} / imported {run.rows_imported} / skipped {run.rows_skipped}
+              </div>
+            </div>
+          </Row>
+        ))
+      )}
+    </div>
+  );
+}
+
+function ExportsTab({ snapshots }: { snapshots: AdminReportViewSnapshot[] }) {
+  return (
+    <div className="rounded-lg border border-border bg-card">
+      <ListHeader title="Recent Export Snapshots" count={snapshots.length} />
+      {snapshots.length === 0 ? (
+        <EmptyRow text="No report exports found." />
+      ) : (
+        snapshots.map((snapshot) => (
+          <Row key={snapshot.id}>
+            <div>
+              <div className="font-medium text-foreground">{snapshot.title}</div>
+              <div className="mt-1 text-xs text-muted-foreground">
+                Created {formatDate(snapshot.created_at)} / {snapshot.export_storage_path ?? 'no file yet'}
+              </div>
+              {snapshot.error_message && (
+                <div className="mt-2 text-xs text-destructive">{snapshot.error_message}</div>
+              )}
+            </div>
+            <Badge variant={formatStatusVariant(snapshot.export_status)}>{snapshot.export_status}</Badge>
+          </Row>
+        ))
+      )}
+    </div>
+  );
+}
+
+function ListHeader({ title, count }: { title: string; count: number }) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-b border-border p-4">
+      <h2 className="font-semibold text-foreground">{title}</h2>
+      <Badge variant="outline">{count}</Badge>
+    </div>
+  );
+}
+
+function EmptyRow({ text }: { text: string }) {
+  return <div className="p-4 text-sm text-muted-foreground">{text}</div>;
+}
+
+function Row({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex flex-col gap-3 border-b border-border/70 p-4 last:border-b-0 sm:flex-row sm:items-center sm:justify-between">
+      {children}
+    </div>
   );
 }

--- a/supabase/functions/sunze-sales-ingest/index.ts
+++ b/supabase/functions/sunze-sales-ingest/index.ts
@@ -19,6 +19,8 @@ const supabase =
 
 type SunzeIngestRow = {
   sourceOrderNumber?: unknown;
+  tradeName?: unknown;
+  itemQuantity?: unknown;
   machineCode?: unknown;
   machineName?: unknown;
   orderAmountCents?: unknown;
@@ -43,6 +45,12 @@ type SalesFact = {
   payment_method: string;
   net_sales_cents: number;
   transaction_count: number;
+  source_order_hash: string;
+  source_trade_name: string | null;
+  item_quantity: number;
+  tax_cents: number;
+  source_payment_status: string;
+  payment_time: string;
   source: "sunze_browser";
   source_row_hash: string;
   import_run_id: string;
@@ -180,6 +188,7 @@ const normalizePayloadRows = async (
   for (const [index, row] of rows.entries()) {
     const rowNumber = index + 1;
     const sourceOrderNumber = requiredText(row.sourceOrderNumber, `rows[${rowNumber}].sourceOrderNumber`);
+    const tradeName = sanitizeText(row.tradeName, 500);
     const machineCode = requiredText(row.machineCode, `rows[${rowNumber}].machineCode`);
     const machine = machineBySunzeId.get(machineCode.toLowerCase());
     const saleDate = requiredText(row.saleDate, `rows[${rowNumber}].saleDate`);
@@ -192,6 +201,7 @@ const normalizePayloadRows = async (
       `rows[${rowNumber}].orderAmountCents`
     );
     const taxCents = nonNegativeInteger(row.taxCents ?? 0, `rows[${rowNumber}].taxCents`);
+    const itemQuantity = nonNegativeInteger(row.itemQuantity ?? 1, `rows[${rowNumber}].itemQuantity`);
 
     if (!machine) {
       throw new Error(`Unknown Sunze machine code at row ${rowNumber}. Configure the machine first.`);
@@ -234,11 +244,19 @@ const normalizePayloadRows = async (
       payment_method: paymentMethod,
       net_sales_cents: orderAmountCents,
       transaction_count: 1,
+      source_order_hash: sourceOrderHash,
+      source_trade_name: tradeName || null,
+      item_quantity: itemQuantity,
+      tax_cents: taxCents,
+      source_payment_status: sourceStatus,
+      payment_time: paymentTimeIso,
       source: "sunze_browser",
       source_row_hash: sourceRowHash,
       import_run_id: importRunId,
       raw_payload: {
         source_order_hash: sourceOrderHash,
+        trade_name: tradeName || null,
+        item_quantity: itemQuantity,
         machine_code: machineCode,
         machine_name: sanitizeText(row.machineName, 200),
         payment_method_source: sourcePaymentMethod,

--- a/supabase/migrations/202604260002_partner_reporting_foundation.sql
+++ b/supabase/migrations/202604260002_partner_reporting_foundation.sql
@@ -1,0 +1,1238 @@
+-- Partner reporting foundation: admin partnership setup, machine-level tax
+-- rates, effective-dated machine assignments, and enriched order facts.
+
+alter table public.machine_sales_facts
+  add column if not exists source_order_hash text,
+  add column if not exists source_trade_name text,
+  add column if not exists item_quantity integer not null default 1 check (item_quantity >= 0),
+  add column if not exists tax_cents integer not null default 0 check (tax_cents >= 0),
+  add column if not exists source_payment_status text,
+  add column if not exists payment_time timestamptz;
+
+create index if not exists machine_sales_facts_payment_time_idx
+  on public.machine_sales_facts (payment_time desc)
+  where payment_time is not null;
+
+create table if not exists public.reporting_partners (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  partner_type text not null default 'revenue_share_partner'
+    check (partner_type in ('venue', 'event_operator', 'platform_partner', 'revenue_share_partner', 'internal', 'other')),
+  primary_contact_name text,
+  primary_contact_email text,
+  status text not null default 'active'
+    check (status in ('active', 'archived')),
+  notes text,
+  created_by uuid references auth.users (id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint reporting_partners_name_present check (length(trim(name)) > 0)
+);
+
+create unique index if not exists reporting_partners_name_unique_idx
+  on public.reporting_partners (lower(name));
+
+drop trigger if exists reporting_partners_set_updated_at on public.reporting_partners;
+create trigger reporting_partners_set_updated_at
+before update on public.reporting_partners
+for each row execute function public.set_updated_at();
+
+create table if not exists public.reporting_partnerships (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  partnership_type text not null default 'revenue_share'
+    check (partnership_type in ('venue', 'event', 'platform', 'revenue_share', 'internal', 'other')),
+  reporting_week_end_day integer not null default 0 check (reporting_week_end_day between 0 and 6),
+  timezone text not null default 'America/Los_Angeles',
+  effective_start_date date not null,
+  effective_end_date date,
+  status text not null default 'draft'
+    check (status in ('draft', 'active', 'archived')),
+  notes text,
+  created_by uuid references auth.users (id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint reporting_partnerships_name_present check (length(trim(name)) > 0),
+  constraint reporting_partnerships_valid_window check (
+    effective_end_date is null or effective_end_date >= effective_start_date
+  )
+);
+
+create unique index if not exists reporting_partnerships_name_unique_idx
+  on public.reporting_partnerships (lower(name));
+
+create index if not exists reporting_partnerships_status_idx
+  on public.reporting_partnerships (status, effective_start_date desc);
+
+drop trigger if exists reporting_partnerships_set_updated_at on public.reporting_partnerships;
+create trigger reporting_partnerships_set_updated_at
+before update on public.reporting_partnerships
+for each row execute function public.set_updated_at();
+
+create table if not exists public.reporting_partnership_parties (
+  id uuid primary key default gen_random_uuid(),
+  partnership_id uuid not null references public.reporting_partnerships (id) on delete cascade,
+  partner_id uuid not null references public.reporting_partners (id) on delete cascade,
+  party_role text not null default 'revenue_share_recipient'
+    check (party_role in ('venue_partner', 'event_partner', 'platform_partner', 'revenue_share_recipient', 'operator', 'internal', 'other')),
+  share_basis_points integer check (share_basis_points is null or share_basis_points between 0 and 10000),
+  is_report_recipient boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create unique index if not exists reporting_partnership_parties_unique_idx
+  on public.reporting_partnership_parties (partnership_id, partner_id, party_role);
+
+create index if not exists reporting_partnership_parties_partnership_idx
+  on public.reporting_partnership_parties (partnership_id);
+
+drop trigger if exists reporting_partnership_parties_set_updated_at on public.reporting_partnership_parties;
+create trigger reporting_partnership_parties_set_updated_at
+before update on public.reporting_partnership_parties
+for each row execute function public.set_updated_at();
+
+create table if not exists public.reporting_machine_partnership_assignments (
+  id uuid primary key default gen_random_uuid(),
+  machine_id uuid not null references public.reporting_machines (id) on delete cascade,
+  partnership_id uuid not null references public.reporting_partnerships (id) on delete cascade,
+  assignment_role text not null default 'primary_reporting'
+    check (assignment_role in ('primary_reporting', 'venue', 'event', 'platform', 'internal')),
+  effective_start_date date not null,
+  effective_end_date date,
+  status text not null default 'active'
+    check (status in ('active', 'archived')),
+  notes text,
+  created_by uuid references auth.users (id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint reporting_machine_partnership_assignments_valid_window check (
+    effective_end_date is null or effective_end_date >= effective_start_date
+  )
+);
+
+create index if not exists reporting_machine_partnership_assignments_machine_idx
+  on public.reporting_machine_partnership_assignments (machine_id, assignment_role, effective_start_date desc);
+
+create index if not exists reporting_machine_partnership_assignments_partnership_idx
+  on public.reporting_machine_partnership_assignments (partnership_id, effective_start_date desc);
+
+drop trigger if exists reporting_machine_partnership_assignments_set_updated_at on public.reporting_machine_partnership_assignments;
+create trigger reporting_machine_partnership_assignments_set_updated_at
+before update on public.reporting_machine_partnership_assignments
+for each row execute function public.set_updated_at();
+
+create table if not exists public.reporting_machine_tax_rates (
+  id uuid primary key default gen_random_uuid(),
+  machine_id uuid not null references public.reporting_machines (id) on delete cascade,
+  tax_rate_percent numeric(7,4) not null check (tax_rate_percent >= 0 and tax_rate_percent <= 100),
+  effective_start_date date not null,
+  effective_end_date date,
+  status text not null default 'active'
+    check (status in ('active', 'archived')),
+  notes text,
+  created_by uuid references auth.users (id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint reporting_machine_tax_rates_valid_window check (
+    effective_end_date is null or effective_end_date >= effective_start_date
+  )
+);
+
+create index if not exists reporting_machine_tax_rates_machine_idx
+  on public.reporting_machine_tax_rates (machine_id, effective_start_date desc);
+
+drop trigger if exists reporting_machine_tax_rates_set_updated_at on public.reporting_machine_tax_rates;
+create trigger reporting_machine_tax_rates_set_updated_at
+before update on public.reporting_machine_tax_rates
+for each row execute function public.set_updated_at();
+
+create table if not exists public.reporting_partnership_financial_rules (
+  id uuid primary key default gen_random_uuid(),
+  partnership_id uuid not null references public.reporting_partnerships (id) on delete cascade,
+  calculation_model text not null default 'net_split'
+    check (calculation_model in ('gross_split', 'net_split', 'contribution_split', 'fixed_fee_plus_split', 'internal_only')),
+  split_base text not null default 'net_sales'
+    check (split_base in ('gross_sales', 'net_sales', 'contribution_after_costs')),
+  fee_amount_cents integer not null default 0 check (fee_amount_cents >= 0),
+  fee_basis text not null default 'none'
+    check (fee_basis in ('per_order', 'per_stick', 'per_transaction', 'none')),
+  cost_amount_cents integer not null default 0 check (cost_amount_cents >= 0),
+  cost_basis text not null default 'none'
+    check (cost_basis in ('per_stick', 'per_order', 'percentage_of_sales', 'none')),
+  deduction_timing text not null default 'before_split'
+    check (deduction_timing in ('before_split', 'after_split', 'reporting_only')),
+  gross_to_net_method text not null default 'machine_tax_plus_configured_fees'
+    check (gross_to_net_method in ('machine_tax_plus_configured_fees', 'imported_tax_plus_configured_fees', 'configured_fees_only')),
+  fever_share_basis_points integer not null default 0 check (fever_share_basis_points between 0 and 10000),
+  partner_share_basis_points integer not null default 0 check (partner_share_basis_points between 0 and 10000),
+  bloomjoy_share_basis_points integer not null default 0 check (bloomjoy_share_basis_points between 0 and 10000),
+  effective_start_date date not null,
+  effective_end_date date,
+  status text not null default 'draft'
+    check (status in ('draft', 'active', 'archived')),
+  notes text,
+  created_by uuid references auth.users (id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint reporting_partnership_financial_rules_valid_window check (
+    effective_end_date is null or effective_end_date >= effective_start_date
+  ),
+  constraint reporting_partnership_financial_rules_share_total check (
+    calculation_model in ('fixed_fee_plus_split', 'internal_only')
+    or fever_share_basis_points + partner_share_basis_points + bloomjoy_share_basis_points = 10000
+  ),
+  constraint reporting_partnership_financial_rules_contribution_cost check (
+    calculation_model <> 'contribution_split'
+    or cost_basis <> 'none'
+  )
+);
+
+create index if not exists reporting_partnership_financial_rules_partnership_idx
+  on public.reporting_partnership_financial_rules (partnership_id, status, effective_start_date desc);
+
+drop trigger if exists reporting_partnership_financial_rules_set_updated_at on public.reporting_partnership_financial_rules;
+create trigger reporting_partnership_financial_rules_set_updated_at
+before update on public.reporting_partnership_financial_rules
+for each row execute function public.set_updated_at();
+
+create table if not exists public.partner_report_snapshots (
+  id uuid primary key default gen_random_uuid(),
+  partnership_id uuid not null references public.reporting_partnerships (id) on delete cascade,
+  week_ending_date date not null,
+  status text not null default 'draft'
+    check (status in ('draft', 'approved', 'sent', 'voided')),
+  generated_at timestamptz not null default now(),
+  approved_at timestamptz,
+  sent_at timestamptz,
+  generated_by uuid references auth.users (id) on delete set null,
+  approved_by uuid references auth.users (id) on delete set null,
+  summary_json jsonb not null default '{}'::jsonb,
+  export_storage_path text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create unique index if not exists partner_report_snapshots_unique_week_idx
+  on public.partner_report_snapshots (partnership_id, week_ending_date, status)
+  where status in ('draft', 'approved', 'sent');
+
+drop trigger if exists partner_report_snapshots_set_updated_at on public.partner_report_snapshots;
+create trigger partner_report_snapshots_set_updated_at
+before update on public.partner_report_snapshots
+for each row execute function public.set_updated_at();
+
+alter table public.reporting_partners enable row level security;
+alter table public.reporting_partnerships enable row level security;
+alter table public.reporting_partnership_parties enable row level security;
+alter table public.reporting_machine_partnership_assignments enable row level security;
+alter table public.reporting_machine_tax_rates enable row level security;
+alter table public.reporting_partnership_financial_rules enable row level security;
+alter table public.partner_report_snapshots enable row level security;
+
+drop policy if exists "reporting_partners_super_admin_all" on public.reporting_partners;
+create policy "reporting_partners_super_admin_all"
+on public.reporting_partners
+for all
+using (public.is_super_admin((select auth.uid())))
+with check (public.is_super_admin((select auth.uid())));
+
+drop policy if exists "reporting_partnerships_super_admin_all" on public.reporting_partnerships;
+create policy "reporting_partnerships_super_admin_all"
+on public.reporting_partnerships
+for all
+using (public.is_super_admin((select auth.uid())))
+with check (public.is_super_admin((select auth.uid())));
+
+drop policy if exists "reporting_partnership_parties_super_admin_all" on public.reporting_partnership_parties;
+create policy "reporting_partnership_parties_super_admin_all"
+on public.reporting_partnership_parties
+for all
+using (public.is_super_admin((select auth.uid())))
+with check (public.is_super_admin((select auth.uid())));
+
+drop policy if exists "reporting_machine_partnership_assignments_super_admin_all" on public.reporting_machine_partnership_assignments;
+create policy "reporting_machine_partnership_assignments_super_admin_all"
+on public.reporting_machine_partnership_assignments
+for all
+using (public.is_super_admin((select auth.uid())))
+with check (public.is_super_admin((select auth.uid())));
+
+drop policy if exists "reporting_machine_tax_rates_super_admin_all" on public.reporting_machine_tax_rates;
+create policy "reporting_machine_tax_rates_super_admin_all"
+on public.reporting_machine_tax_rates
+for all
+using (public.is_super_admin((select auth.uid())))
+with check (public.is_super_admin((select auth.uid())));
+
+drop policy if exists "reporting_partnership_financial_rules_super_admin_all" on public.reporting_partnership_financial_rules;
+create policy "reporting_partnership_financial_rules_super_admin_all"
+on public.reporting_partnership_financial_rules
+for all
+using (public.is_super_admin((select auth.uid())))
+with check (public.is_super_admin((select auth.uid())));
+
+drop policy if exists "partner_report_snapshots_super_admin_all" on public.partner_report_snapshots;
+create policy "partner_report_snapshots_super_admin_all"
+on public.partner_report_snapshots
+for all
+using (public.is_super_admin((select auth.uid())))
+with check (public.is_super_admin((select auth.uid())));
+
+create or replace function public.reporting_admin_assert_reason(p_reason text)
+returns text
+language plpgsql
+stable
+as $$
+declare
+  normalized_reason text;
+begin
+  normalized_reason := trim(coalesce(p_reason, ''));
+
+  if normalized_reason = '' then
+    raise exception 'A reason is required';
+  end if;
+
+  return normalized_reason;
+end;
+$$;
+
+create or replace function public.reporting_date_windows_overlap(
+  a_start date,
+  a_end date,
+  b_start date,
+  b_end date
+)
+returns boolean
+language sql
+immutable
+as $$
+  select daterange(a_start, coalesce(a_end, 'infinity'::date), '[]')
+    && daterange(b_start, coalesce(b_end, 'infinity'::date), '[]');
+$$;
+
+drop function if exists public.admin_get_partnership_reporting_setup();
+create or replace function public.admin_get_partnership_reporting_setup()
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  result jsonb;
+begin
+  if not public.is_super_admin(auth.uid()) then
+    raise exception 'Admin access required';
+  end if;
+
+  with machines as (
+    select
+      machine.id,
+      machine.machine_label,
+      machine.machine_type,
+      machine.sunze_machine_id,
+      machine.status,
+      account.name as account_name,
+      location.name as location_name,
+      max(fact.sale_date) as latest_sale_date
+    from public.reporting_machines machine
+    join public.customer_accounts account on account.id = machine.account_id
+    join public.reporting_locations location on location.id = machine.location_id
+    left join public.machine_sales_facts fact on fact.reporting_machine_id = machine.id
+    group by machine.id, account.name, location.name
+  ),
+  assignment_rows as (
+    select
+      assignment.id,
+      assignment.machine_id,
+      machine.machine_label,
+      assignment.partnership_id,
+      partnership.name as partnership_name,
+      assignment.assignment_role,
+      assignment.effective_start_date,
+      assignment.effective_end_date,
+      assignment.status,
+      assignment.notes
+    from public.reporting_machine_partnership_assignments assignment
+    join public.reporting_machines machine on machine.id = assignment.machine_id
+    join public.reporting_partnerships partnership on partnership.id = assignment.partnership_id
+  ),
+  tax_rows as (
+    select
+      tax.id,
+      tax.machine_id,
+      machine.machine_label,
+      tax.tax_rate_percent,
+      tax.effective_start_date,
+      tax.effective_end_date,
+      tax.status,
+      tax.notes
+    from public.reporting_machine_tax_rates tax
+    join public.reporting_machines machine on machine.id = tax.machine_id
+  ),
+  rule_rows as (
+    select
+      rule.*,
+      partnership.name as partnership_name
+    from public.reporting_partnership_financial_rules rule
+    join public.reporting_partnerships partnership on partnership.id = rule.partnership_id
+  ),
+  warnings as (
+    select jsonb_build_object(
+      'warningType', 'missing_machine_tax_rate',
+      'machineId', machine.id,
+      'machineLabel', machine.machine_label,
+      'message', machine.machine_label || ' has no active machine tax rate.'
+    ) as warning
+    from public.reporting_machines machine
+    where not exists (
+      select 1
+      from public.reporting_machine_tax_rates tax
+      where tax.machine_id = machine.id
+        and tax.status = 'active'
+        and tax.effective_start_date <= current_date
+        and (tax.effective_end_date is null or tax.effective_end_date >= current_date)
+    )
+    union all
+    select jsonb_build_object(
+      'warningType', 'missing_partnership_assignment',
+      'machineId', machine.id,
+      'machineLabel', machine.machine_label,
+      'message', machine.machine_label || ' has no active partnership assignment.'
+    ) as warning
+    from public.reporting_machines machine
+    where not exists (
+      select 1
+      from public.reporting_machine_partnership_assignments assignment
+      where assignment.machine_id = machine.id
+        and assignment.status = 'active'
+        and assignment.assignment_role = 'primary_reporting'
+        and assignment.effective_start_date <= current_date
+        and (assignment.effective_end_date is null or assignment.effective_end_date >= current_date)
+    )
+    union all
+    select jsonb_build_object(
+      'warningType', 'missing_financial_rule',
+      'partnershipId', partnership.id,
+      'partnershipName', partnership.name,
+      'message', partnership.name || ' has no active financial rule.'
+    ) as warning
+    from public.reporting_partnerships partnership
+    where partnership.status = 'active'
+      and not exists (
+        select 1
+        from public.reporting_partnership_financial_rules rule
+        where rule.partnership_id = partnership.id
+          and rule.status = 'active'
+          and rule.effective_start_date <= current_date
+          and (rule.effective_end_date is null or rule.effective_end_date >= current_date)
+      )
+    union all
+    select jsonb_build_object(
+      'warningType', 'overlapping_partnership_assignments',
+      'machineId', left_assignment.machine_id,
+      'machineLabel', machine.machine_label,
+      'message', machine.machine_label || ' has overlapping active partnership assignments.'
+    ) as warning
+    from public.reporting_machine_partnership_assignments left_assignment
+    join public.reporting_machine_partnership_assignments right_assignment
+      on right_assignment.machine_id = left_assignment.machine_id
+      and right_assignment.assignment_role = left_assignment.assignment_role
+      and right_assignment.id > left_assignment.id
+      and right_assignment.status = 'active'
+      and left_assignment.status = 'active'
+      and public.reporting_date_windows_overlap(
+        left_assignment.effective_start_date,
+        left_assignment.effective_end_date,
+        right_assignment.effective_start_date,
+        right_assignment.effective_end_date
+      )
+    join public.reporting_machines machine on machine.id = left_assignment.machine_id
+  )
+  select jsonb_build_object(
+    'partners',
+    coalesce((select jsonb_agg(to_jsonb(partner) order by partner.name) from public.reporting_partners partner), '[]'::jsonb),
+    'partnerships',
+    coalesce((select jsonb_agg(to_jsonb(partnership) order by partnership.name) from public.reporting_partnerships partnership), '[]'::jsonb),
+    'machines',
+    coalesce((select jsonb_agg(to_jsonb(machines) order by machines.account_name, machines.location_name, machines.machine_label) from machines), '[]'::jsonb),
+    'assignments',
+    coalesce((select jsonb_agg(to_jsonb(assignment_rows) order by assignment_rows.effective_start_date desc) from assignment_rows), '[]'::jsonb),
+    'taxRates',
+    coalesce((select jsonb_agg(to_jsonb(tax_rows) order by tax_rows.effective_start_date desc) from tax_rows), '[]'::jsonb),
+    'financialRules',
+    coalesce((select jsonb_agg(to_jsonb(rule_rows) order by rule_rows.effective_start_date desc) from rule_rows), '[]'::jsonb),
+    'warnings',
+    coalesce((select jsonb_agg(warnings.warning) from warnings), '[]'::jsonb)
+  )
+  into result;
+
+  return result;
+end;
+$$;
+
+drop function if exists public.admin_upsert_reporting_partner(uuid, text, text, text, text, text, text, text);
+create or replace function public.admin_upsert_reporting_partner(
+  p_partner_id uuid,
+  p_name text,
+  p_partner_type text,
+  p_primary_contact_name text,
+  p_primary_contact_email text,
+  p_status text,
+  p_notes text,
+  p_reason text
+)
+returns public.reporting_partners
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  normalized_reason text;
+  before_row public.reporting_partners;
+  after_row public.reporting_partners;
+begin
+  if not public.is_super_admin(auth.uid()) then
+    raise exception 'Admin access required';
+  end if;
+
+  normalized_reason := public.reporting_admin_assert_reason(p_reason);
+
+  if trim(coalesce(p_name, '')) = '' then
+    raise exception 'Partner name is required';
+  end if;
+
+  if p_partner_id is not null then
+    select * into before_row from public.reporting_partners where id = p_partner_id;
+  end if;
+
+  if before_row.id is null then
+    insert into public.reporting_partners (
+      name,
+      partner_type,
+      primary_contact_name,
+      primary_contact_email,
+      status,
+      notes,
+      created_by
+    )
+    values (
+      trim(p_name),
+      lower(coalesce(nullif(trim(p_partner_type), ''), 'revenue_share_partner')),
+      nullif(trim(coalesce(p_primary_contact_name, '')), ''),
+      nullif(trim(coalesce(p_primary_contact_email, '')), ''),
+      lower(coalesce(nullif(trim(p_status), ''), 'active')),
+      nullif(trim(coalesce(p_notes, '')), ''),
+      auth.uid()
+    )
+    returning * into after_row;
+  else
+    update public.reporting_partners
+    set
+      name = trim(p_name),
+      partner_type = lower(coalesce(nullif(trim(p_partner_type), ''), 'revenue_share_partner')),
+      primary_contact_name = nullif(trim(coalesce(p_primary_contact_name, '')), ''),
+      primary_contact_email = nullif(trim(coalesce(p_primary_contact_email, '')), ''),
+      status = lower(coalesce(nullif(trim(p_status), ''), 'active')),
+      notes = nullif(trim(coalesce(p_notes, '')), '')
+    where id = before_row.id
+    returning * into after_row;
+  end if;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    auth.uid(),
+    case when before_row.id is null then 'reporting_partner.created' else 'reporting_partner.updated' end,
+    'reporting_partner',
+    after_row.id::text,
+    coalesce(to_jsonb(before_row), '{}'::jsonb),
+    to_jsonb(after_row),
+    jsonb_build_object('reason', normalized_reason)
+  );
+
+  return after_row;
+end;
+$$;
+
+drop function if exists public.admin_upsert_reporting_partnership(uuid, text, text, integer, text, date, date, text, text, text);
+create or replace function public.admin_upsert_reporting_partnership(
+  p_partnership_id uuid,
+  p_name text,
+  p_partnership_type text,
+  p_reporting_week_end_day integer,
+  p_timezone text,
+  p_effective_start_date date,
+  p_effective_end_date date,
+  p_status text,
+  p_notes text,
+  p_reason text
+)
+returns public.reporting_partnerships
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  normalized_reason text;
+  before_row public.reporting_partnerships;
+  after_row public.reporting_partnerships;
+begin
+  if not public.is_super_admin(auth.uid()) then
+    raise exception 'Admin access required';
+  end if;
+
+  normalized_reason := public.reporting_admin_assert_reason(p_reason);
+
+  if trim(coalesce(p_name, '')) = '' then
+    raise exception 'Partnership name is required';
+  end if;
+
+  if p_effective_start_date is null then
+    raise exception 'Effective start date is required';
+  end if;
+
+  if p_partnership_id is not null then
+    select * into before_row from public.reporting_partnerships where id = p_partnership_id;
+  end if;
+
+  if before_row.id is null then
+    insert into public.reporting_partnerships (
+      name,
+      partnership_type,
+      reporting_week_end_day,
+      timezone,
+      effective_start_date,
+      effective_end_date,
+      status,
+      notes,
+      created_by
+    )
+    values (
+      trim(p_name),
+      lower(coalesce(nullif(trim(p_partnership_type), ''), 'revenue_share')),
+      coalesce(p_reporting_week_end_day, 0),
+      coalesce(nullif(trim(p_timezone), ''), 'America/Los_Angeles'),
+      p_effective_start_date,
+      p_effective_end_date,
+      lower(coalesce(nullif(trim(p_status), ''), 'draft')),
+      nullif(trim(coalesce(p_notes, '')), ''),
+      auth.uid()
+    )
+    returning * into after_row;
+  else
+    update public.reporting_partnerships
+    set
+      name = trim(p_name),
+      partnership_type = lower(coalesce(nullif(trim(p_partnership_type), ''), 'revenue_share')),
+      reporting_week_end_day = coalesce(p_reporting_week_end_day, 0),
+      timezone = coalesce(nullif(trim(p_timezone), ''), 'America/Los_Angeles'),
+      effective_start_date = p_effective_start_date,
+      effective_end_date = p_effective_end_date,
+      status = lower(coalesce(nullif(trim(p_status), ''), 'draft')),
+      notes = nullif(trim(coalesce(p_notes, '')), '')
+    where id = before_row.id
+    returning * into after_row;
+  end if;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    auth.uid(),
+    case when before_row.id is null then 'reporting_partnership.created' else 'reporting_partnership.updated' end,
+    'reporting_partnership',
+    after_row.id::text,
+    coalesce(to_jsonb(before_row), '{}'::jsonb),
+    to_jsonb(after_row),
+    jsonb_build_object('reason', normalized_reason)
+  );
+
+  return after_row;
+end;
+$$;
+
+drop function if exists public.admin_upsert_reporting_machine_assignment(uuid, uuid, uuid, text, date, date, text, text, text);
+create or replace function public.admin_upsert_reporting_machine_assignment(
+  p_assignment_id uuid,
+  p_machine_id uuid,
+  p_partnership_id uuid,
+  p_assignment_role text,
+  p_effective_start_date date,
+  p_effective_end_date date,
+  p_status text,
+  p_notes text,
+  p_reason text
+)
+returns public.reporting_machine_partnership_assignments
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  normalized_reason text;
+  normalized_role text;
+  normalized_status text;
+  before_row public.reporting_machine_partnership_assignments;
+  after_row public.reporting_machine_partnership_assignments;
+begin
+  if not public.is_super_admin(auth.uid()) then
+    raise exception 'Admin access required';
+  end if;
+
+  normalized_reason := public.reporting_admin_assert_reason(p_reason);
+  normalized_role := lower(coalesce(nullif(trim(p_assignment_role), ''), 'primary_reporting'));
+  normalized_status := lower(coalesce(nullif(trim(p_status), ''), 'active'));
+
+  if p_machine_id is null or p_partnership_id is null or p_effective_start_date is null then
+    raise exception 'Machine, partnership, and effective start date are required';
+  end if;
+
+  if exists (
+    select 1
+    from public.reporting_machine_partnership_assignments existing
+    where existing.machine_id = p_machine_id
+      and existing.assignment_role = normalized_role
+      and existing.status = 'active'
+      and existing.id is distinct from p_assignment_id
+      and normalized_status = 'active'
+      and public.reporting_date_windows_overlap(
+        existing.effective_start_date,
+        existing.effective_end_date,
+        p_effective_start_date,
+        p_effective_end_date
+      )
+  ) then
+    raise exception 'This machine already has an overlapping active partnership assignment for that role';
+  end if;
+
+  if p_assignment_id is not null then
+    select * into before_row
+    from public.reporting_machine_partnership_assignments
+    where id = p_assignment_id;
+  end if;
+
+  if before_row.id is null then
+    insert into public.reporting_machine_partnership_assignments (
+      machine_id,
+      partnership_id,
+      assignment_role,
+      effective_start_date,
+      effective_end_date,
+      status,
+      notes,
+      created_by
+    )
+    values (
+      p_machine_id,
+      p_partnership_id,
+      normalized_role,
+      p_effective_start_date,
+      p_effective_end_date,
+      normalized_status,
+      nullif(trim(coalesce(p_notes, '')), ''),
+      auth.uid()
+    )
+    returning * into after_row;
+  else
+    update public.reporting_machine_partnership_assignments
+    set
+      machine_id = p_machine_id,
+      partnership_id = p_partnership_id,
+      assignment_role = normalized_role,
+      effective_start_date = p_effective_start_date,
+      effective_end_date = p_effective_end_date,
+      status = normalized_status,
+      notes = nullif(trim(coalesce(p_notes, '')), '')
+    where id = before_row.id
+    returning * into after_row;
+  end if;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    auth.uid(),
+    case when before_row.id is null then 'reporting_machine_partnership_assignment.created' else 'reporting_machine_partnership_assignment.updated' end,
+    'reporting_machine_partnership_assignment',
+    after_row.id::text,
+    coalesce(to_jsonb(before_row), '{}'::jsonb),
+    to_jsonb(after_row),
+    jsonb_build_object('reason', normalized_reason)
+  );
+
+  return after_row;
+end;
+$$;
+
+drop function if exists public.admin_upsert_reporting_machine_tax_rate(uuid, uuid, numeric, date, date, text, text, text);
+create or replace function public.admin_upsert_reporting_machine_tax_rate(
+  p_tax_rate_id uuid,
+  p_machine_id uuid,
+  p_tax_rate_percent numeric,
+  p_effective_start_date date,
+  p_effective_end_date date,
+  p_status text,
+  p_notes text,
+  p_reason text
+)
+returns public.reporting_machine_tax_rates
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  normalized_reason text;
+  normalized_status text;
+  before_row public.reporting_machine_tax_rates;
+  after_row public.reporting_machine_tax_rates;
+begin
+  if not public.is_super_admin(auth.uid()) then
+    raise exception 'Admin access required';
+  end if;
+
+  normalized_reason := public.reporting_admin_assert_reason(p_reason);
+  normalized_status := lower(coalesce(nullif(trim(p_status), ''), 'active'));
+
+  if p_machine_id is null or p_tax_rate_percent is null or p_effective_start_date is null then
+    raise exception 'Machine, tax rate, and effective start date are required';
+  end if;
+
+  if exists (
+    select 1
+    from public.reporting_machine_tax_rates existing
+    where existing.machine_id = p_machine_id
+      and existing.status = 'active'
+      and existing.id is distinct from p_tax_rate_id
+      and normalized_status = 'active'
+      and public.reporting_date_windows_overlap(
+        existing.effective_start_date,
+        existing.effective_end_date,
+        p_effective_start_date,
+        p_effective_end_date
+      )
+  ) then
+    raise exception 'This machine already has an overlapping active tax rate';
+  end if;
+
+  if p_tax_rate_id is not null then
+    select * into before_row
+    from public.reporting_machine_tax_rates
+    where id = p_tax_rate_id;
+  end if;
+
+  if before_row.id is null then
+    insert into public.reporting_machine_tax_rates (
+      machine_id,
+      tax_rate_percent,
+      effective_start_date,
+      effective_end_date,
+      status,
+      notes,
+      created_by
+    )
+    values (
+      p_machine_id,
+      p_tax_rate_percent,
+      p_effective_start_date,
+      p_effective_end_date,
+      normalized_status,
+      nullif(trim(coalesce(p_notes, '')), ''),
+      auth.uid()
+    )
+    returning * into after_row;
+  else
+    update public.reporting_machine_tax_rates
+    set
+      machine_id = p_machine_id,
+      tax_rate_percent = p_tax_rate_percent,
+      effective_start_date = p_effective_start_date,
+      effective_end_date = p_effective_end_date,
+      status = normalized_status,
+      notes = nullif(trim(coalesce(p_notes, '')), '')
+    where id = before_row.id
+    returning * into after_row;
+  end if;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    auth.uid(),
+    case when before_row.id is null then 'reporting_machine_tax_rate.created' else 'reporting_machine_tax_rate.updated' end,
+    'reporting_machine_tax_rate',
+    after_row.id::text,
+    coalesce(to_jsonb(before_row), '{}'::jsonb),
+    to_jsonb(after_row),
+    jsonb_build_object('reason', normalized_reason)
+  );
+
+  return after_row;
+end;
+$$;
+
+drop function if exists public.admin_upsert_reporting_financial_rule(uuid, uuid, text, text, integer, text, integer, text, text, text, integer, integer, integer, date, date, text, text, text);
+create or replace function public.admin_upsert_reporting_financial_rule(
+  p_rule_id uuid,
+  p_partnership_id uuid,
+  p_calculation_model text,
+  p_split_base text,
+  p_fee_amount_cents integer,
+  p_fee_basis text,
+  p_cost_amount_cents integer,
+  p_cost_basis text,
+  p_deduction_timing text,
+  p_gross_to_net_method text,
+  p_fever_share_basis_points integer,
+  p_partner_share_basis_points integer,
+  p_bloomjoy_share_basis_points integer,
+  p_effective_start_date date,
+  p_effective_end_date date,
+  p_status text,
+  p_notes text,
+  p_reason text
+)
+returns public.reporting_partnership_financial_rules
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  normalized_reason text;
+  normalized_status text;
+  before_row public.reporting_partnership_financial_rules;
+  after_row public.reporting_partnership_financial_rules;
+begin
+  if not public.is_super_admin(auth.uid()) then
+    raise exception 'Admin access required';
+  end if;
+
+  normalized_reason := public.reporting_admin_assert_reason(p_reason);
+  normalized_status := lower(coalesce(nullif(trim(p_status), ''), 'draft'));
+
+  if p_partnership_id is null or p_effective_start_date is null then
+    raise exception 'Partnership and effective start date are required';
+  end if;
+
+  if exists (
+    select 1
+    from public.reporting_partnership_financial_rules existing
+    where existing.partnership_id = p_partnership_id
+      and existing.status = 'active'
+      and existing.id is distinct from p_rule_id
+      and normalized_status = 'active'
+      and public.reporting_date_windows_overlap(
+        existing.effective_start_date,
+        existing.effective_end_date,
+        p_effective_start_date,
+        p_effective_end_date
+      )
+  ) then
+    raise exception 'This partnership already has an overlapping active financial rule';
+  end if;
+
+  if p_rule_id is not null then
+    select * into before_row
+    from public.reporting_partnership_financial_rules
+    where id = p_rule_id;
+  end if;
+
+  if before_row.id is null then
+    insert into public.reporting_partnership_financial_rules (
+      partnership_id,
+      calculation_model,
+      split_base,
+      fee_amount_cents,
+      fee_basis,
+      cost_amount_cents,
+      cost_basis,
+      deduction_timing,
+      gross_to_net_method,
+      fever_share_basis_points,
+      partner_share_basis_points,
+      bloomjoy_share_basis_points,
+      effective_start_date,
+      effective_end_date,
+      status,
+      notes,
+      created_by
+    )
+    values (
+      p_partnership_id,
+      lower(coalesce(nullif(trim(p_calculation_model), ''), 'net_split')),
+      lower(coalesce(nullif(trim(p_split_base), ''), 'net_sales')),
+      coalesce(p_fee_amount_cents, 0),
+      lower(coalesce(nullif(trim(p_fee_basis), ''), 'none')),
+      coalesce(p_cost_amount_cents, 0),
+      lower(coalesce(nullif(trim(p_cost_basis), ''), 'none')),
+      lower(coalesce(nullif(trim(p_deduction_timing), ''), 'before_split')),
+      lower(coalesce(nullif(trim(p_gross_to_net_method), ''), 'machine_tax_plus_configured_fees')),
+      coalesce(p_fever_share_basis_points, 0),
+      coalesce(p_partner_share_basis_points, 0),
+      coalesce(p_bloomjoy_share_basis_points, 0),
+      p_effective_start_date,
+      p_effective_end_date,
+      normalized_status,
+      nullif(trim(coalesce(p_notes, '')), ''),
+      auth.uid()
+    )
+    returning * into after_row;
+  else
+    update public.reporting_partnership_financial_rules
+    set
+      partnership_id = p_partnership_id,
+      calculation_model = lower(coalesce(nullif(trim(p_calculation_model), ''), 'net_split')),
+      split_base = lower(coalesce(nullif(trim(p_split_base), ''), 'net_sales')),
+      fee_amount_cents = coalesce(p_fee_amount_cents, 0),
+      fee_basis = lower(coalesce(nullif(trim(p_fee_basis), ''), 'none')),
+      cost_amount_cents = coalesce(p_cost_amount_cents, 0),
+      cost_basis = lower(coalesce(nullif(trim(p_cost_basis), ''), 'none')),
+      deduction_timing = lower(coalesce(nullif(trim(p_deduction_timing), ''), 'before_split')),
+      gross_to_net_method = lower(coalesce(nullif(trim(p_gross_to_net_method), ''), 'machine_tax_plus_configured_fees')),
+      fever_share_basis_points = coalesce(p_fever_share_basis_points, 0),
+      partner_share_basis_points = coalesce(p_partner_share_basis_points, 0),
+      bloomjoy_share_basis_points = coalesce(p_bloomjoy_share_basis_points, 0),
+      effective_start_date = p_effective_start_date,
+      effective_end_date = p_effective_end_date,
+      status = normalized_status,
+      notes = nullif(trim(coalesce(p_notes, '')), '')
+    where id = before_row.id
+    returning * into after_row;
+  end if;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    auth.uid(),
+    case when before_row.id is null then 'reporting_partnership_financial_rule.created' else 'reporting_partnership_financial_rule.updated' end,
+    'reporting_partnership_financial_rule',
+    after_row.id::text,
+    coalesce(to_jsonb(before_row), '{}'::jsonb),
+    to_jsonb(after_row),
+    jsonb_build_object('reason', normalized_reason)
+  );
+
+  return after_row;
+end;
+$$;
+
+drop function if exists public.admin_preview_partner_weekly_report(uuid, date);
+create or replace function public.admin_preview_partner_weekly_report(
+  p_partnership_id uuid,
+  p_week_ending_date date
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  week_start date;
+  result jsonb;
+begin
+  if not public.is_super_admin(auth.uid()) then
+    raise exception 'Admin access required';
+  end if;
+
+  if p_partnership_id is null or p_week_ending_date is null then
+    raise exception 'Partnership and week ending date are required';
+  end if;
+
+  week_start := p_week_ending_date - 6;
+
+  with scoped_facts as (
+    select
+      fact.id,
+      fact.reporting_machine_id,
+      machine.machine_label,
+      fact.sale_date,
+      fact.payment_method,
+      fact.net_sales_cents as gross_sales_cents,
+      fact.transaction_count,
+      fact.item_quantity,
+      fact.tax_cents as imported_tax_cents,
+      tax.tax_rate_percent,
+      rule.calculation_model,
+      rule.fee_amount_cents,
+      rule.fee_basis,
+      rule.cost_amount_cents,
+      rule.cost_basis,
+      rule.gross_to_net_method,
+      rule.fever_share_basis_points,
+      rule.partner_share_basis_points,
+      rule.bloomjoy_share_basis_points
+    from public.machine_sales_facts fact
+    join public.reporting_machines machine on machine.id = fact.reporting_machine_id
+    join public.reporting_machine_partnership_assignments assignment
+      on assignment.machine_id = fact.reporting_machine_id
+      and assignment.partnership_id = p_partnership_id
+      and assignment.assignment_role = 'primary_reporting'
+      and assignment.status = 'active'
+      and assignment.effective_start_date <= fact.sale_date
+      and (assignment.effective_end_date is null or assignment.effective_end_date >= fact.sale_date)
+    left join lateral (
+      select tax_rate.tax_rate_percent
+      from public.reporting_machine_tax_rates tax_rate
+      where tax_rate.machine_id = fact.reporting_machine_id
+        and tax_rate.status = 'active'
+        and tax_rate.effective_start_date <= fact.sale_date
+        and (tax_rate.effective_end_date is null or tax_rate.effective_end_date >= fact.sale_date)
+      order by tax_rate.effective_start_date desc
+      limit 1
+    ) tax on true
+    left join lateral (
+      select financial_rule.*
+      from public.reporting_partnership_financial_rules financial_rule
+      where financial_rule.partnership_id = p_partnership_id
+        and financial_rule.status = 'active'
+        and financial_rule.effective_start_date <= fact.sale_date
+        and (financial_rule.effective_end_date is null or financial_rule.effective_end_date >= fact.sale_date)
+      order by financial_rule.effective_start_date desc
+      limit 1
+    ) rule on true
+    where fact.sale_date between week_start and p_week_ending_date
+  ),
+  calculated as (
+    select
+      fact.*,
+      case
+        when fact.gross_sales_cents > 0 and fact.gross_to_net_method = 'imported_tax_plus_configured_fees'
+          then fact.imported_tax_cents
+        when fact.gross_sales_cents > 0
+          then round(fact.gross_sales_cents * coalesce(fact.tax_rate_percent, 0) / 100.0)::integer
+        else 0
+      end as calculated_tax_cents,
+      case
+        when fact.gross_sales_cents <= 0 then 0
+        when fact.fee_basis in ('per_order', 'per_transaction') then coalesce(fact.fee_amount_cents, 0)
+        when fact.fee_basis = 'per_stick' then coalesce(fact.fee_amount_cents, 0) * coalesce(fact.item_quantity, 1)
+        else 0
+      end as fee_cents,
+      case
+        when fact.gross_sales_cents <= 0 then 0
+        when fact.cost_basis = 'per_order' then coalesce(fact.cost_amount_cents, 0)
+        when fact.cost_basis = 'per_stick' then coalesce(fact.cost_amount_cents, 0) * coalesce(fact.item_quantity, 1)
+        when fact.cost_basis = 'percentage_of_sales' then round(fact.gross_sales_cents * coalesce(fact.cost_amount_cents, 0) / 10000.0)::integer
+        else 0
+      end as cost_cents
+    from scoped_facts fact
+  ),
+  row_amounts as (
+    select
+      calculated.*,
+      greatest(calculated.gross_sales_cents - calculated.calculated_tax_cents - calculated.fee_cents, 0) as net_sales_cents
+    from calculated
+  ),
+  split_rows as (
+    select
+      row_amounts.*,
+      case
+        when row_amounts.calculation_model = 'gross_split' then row_amounts.gross_sales_cents
+        when row_amounts.calculation_model = 'contribution_split' then greatest(row_amounts.net_sales_cents - row_amounts.cost_cents, 0)
+        when row_amounts.calculation_model = 'fixed_fee_plus_split' then greatest(row_amounts.net_sales_cents - row_amounts.cost_cents, 0)
+        else row_amounts.net_sales_cents
+      end as split_base_cents
+    from row_amounts
+  ),
+  machine_rows as (
+    select
+      reporting_machine_id,
+      machine_label,
+      count(*)::integer as order_count,
+      coalesce(sum(item_quantity), 0)::integer as item_quantity,
+      coalesce(sum(gross_sales_cents), 0)::bigint as gross_sales_cents,
+      coalesce(sum(calculated_tax_cents), 0)::bigint as tax_cents,
+      coalesce(sum(fee_cents), 0)::bigint as fee_cents,
+      coalesce(sum(cost_cents), 0)::bigint as cost_cents,
+      coalesce(sum(net_sales_cents), 0)::bigint as net_sales_cents,
+      coalesce(sum(split_base_cents), 0)::bigint as split_base_cents
+    from split_rows
+    group by reporting_machine_id, machine_label
+  ),
+  summary as (
+    select
+      count(*)::integer as order_count,
+      coalesce(sum(item_quantity), 0)::integer as item_quantity,
+      coalesce(sum(gross_sales_cents), 0)::bigint as gross_sales_cents,
+      coalesce(sum(calculated_tax_cents), 0)::bigint as tax_cents,
+      coalesce(sum(fee_cents), 0)::bigint as fee_cents,
+      coalesce(sum(cost_cents), 0)::bigint as cost_cents,
+      coalesce(sum(net_sales_cents), 0)::bigint as net_sales_cents,
+      coalesce(sum(split_base_cents), 0)::bigint as split_base_cents,
+      coalesce(sum(round(split_base_cents * coalesce(fever_share_basis_points, 0) / 10000.0)), 0)::bigint as fever_profit_cents,
+      coalesce(sum(round(split_base_cents * coalesce(partner_share_basis_points, 0) / 10000.0)), 0)::bigint as partner_profit_cents,
+      coalesce(sum(round(split_base_cents * coalesce(bloomjoy_share_basis_points, 0) / 10000.0)), 0)::bigint as bloomjoy_profit_cents
+    from split_rows
+  ),
+  warnings as (
+    select jsonb_build_object(
+      'warningType', 'missing_machine_tax_rate',
+      'machineId', fact.reporting_machine_id,
+      'machineLabel', fact.machine_label,
+      'message', fact.machine_label || ' has sales in this week without an active machine tax rate.'
+    ) as warning
+    from scoped_facts fact
+    where fact.tax_rate_percent is null
+    group by fact.reporting_machine_id, fact.machine_label
+    union all
+    select jsonb_build_object(
+      'warningType', 'missing_financial_rule',
+      'message', 'This report includes sales without an active partnership financial rule.'
+    ) as warning
+    where exists (select 1 from scoped_facts fact where fact.calculation_model is null)
+  )
+  select jsonb_build_object(
+    'partnershipId', p_partnership_id,
+    'weekEndingDate', p_week_ending_date,
+    'weekStartDate', week_start,
+    'summary', coalesce((select to_jsonb(summary) from summary), '{}'::jsonb),
+    'machines', coalesce((select jsonb_agg(to_jsonb(machine_rows) order by machine_rows.machine_label) from machine_rows), '[]'::jsonb),
+    'warnings', coalesce((select jsonb_agg(warnings.warning) from warnings), '[]'::jsonb)
+  )
+  into result;
+
+  return result;
+end;
+$$;
+
+grant execute on function public.admin_get_partnership_reporting_setup() to authenticated;
+grant execute on function public.admin_upsert_reporting_partner(uuid, text, text, text, text, text, text, text) to authenticated;
+grant execute on function public.admin_upsert_reporting_partnership(uuid, text, text, integer, text, date, date, text, text, text) to authenticated;
+grant execute on function public.admin_upsert_reporting_machine_assignment(uuid, uuid, uuid, text, date, date, text, text, text) to authenticated;
+grant execute on function public.admin_upsert_reporting_machine_tax_rate(uuid, uuid, numeric, date, date, text, text, text) to authenticated;
+grant execute on function public.admin_upsert_reporting_financial_rule(uuid, uuid, text, text, integer, text, integer, text, text, text, integer, integer, integer, date, date, text, text, text) to authenticated;
+grant execute on function public.admin_preview_partner_weekly_report(uuid, date) to authenticated;

--- a/supabase/migrations/202604260002_partner_reporting_foundation.sql
+++ b/supabase/migrations/202604260002_partner_reporting_foundation.sql
@@ -371,6 +371,22 @@ begin
     from public.reporting_machine_tax_rates tax
     join public.reporting_machines machine on machine.id = tax.machine_id
   ),
+  party_rows as (
+    select
+      party.id,
+      party.partnership_id,
+      partnership.name as partnership_name,
+      party.partner_id,
+      partner.name as partner_name,
+      party.party_role,
+      party.share_basis_points,
+      party.is_report_recipient,
+      party.created_at,
+      party.updated_at
+    from public.reporting_partnership_parties party
+    join public.reporting_partnerships partnership on partnership.id = party.partnership_id
+    join public.reporting_partners partner on partner.id = party.partner_id
+  ),
   rule_rows as (
     select
       rule.*,
@@ -461,6 +477,8 @@ begin
     coalesce((select jsonb_agg(to_jsonb(assignment_rows) order by assignment_rows.effective_start_date desc) from assignment_rows), '[]'::jsonb),
     'taxRates',
     coalesce((select jsonb_agg(to_jsonb(tax_rows) order by tax_rows.effective_start_date desc) from tax_rows), '[]'::jsonb),
+    'parties',
+    coalesce((select jsonb_agg(to_jsonb(party_rows) order by party_rows.partnership_name, party_rows.partner_name) from party_rows), '[]'::jsonb),
     'financialRules',
     coalesce((select jsonb_agg(to_jsonb(rule_rows) order by rule_rows.effective_start_date desc) from rule_rows), '[]'::jsonb),
     'warnings',
@@ -656,6 +674,99 @@ begin
     auth.uid(),
     case when before_row.id is null then 'reporting_partnership.created' else 'reporting_partnership.updated' end,
     'reporting_partnership',
+    after_row.id::text,
+    coalesce(to_jsonb(before_row), '{}'::jsonb),
+    to_jsonb(after_row),
+    jsonb_build_object('reason', normalized_reason)
+  );
+
+  return after_row;
+end;
+$$;
+
+drop function if exists public.admin_upsert_reporting_partnership_party(uuid, uuid, uuid, text, integer, boolean, text);
+create or replace function public.admin_upsert_reporting_partnership_party(
+  p_party_id uuid,
+  p_partnership_id uuid,
+  p_partner_id uuid,
+  p_party_role text,
+  p_share_basis_points integer,
+  p_is_report_recipient boolean,
+  p_reason text
+)
+returns public.reporting_partnership_parties
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  normalized_reason text;
+  normalized_role text;
+  before_row public.reporting_partnership_parties;
+  after_row public.reporting_partnership_parties;
+begin
+  if not public.is_super_admin(auth.uid()) then
+    raise exception 'Admin access required';
+  end if;
+
+  normalized_reason := public.reporting_admin_assert_reason(p_reason);
+  normalized_role := lower(coalesce(nullif(trim(p_party_role), ''), 'revenue_share_recipient'));
+
+  if p_partnership_id is null or p_partner_id is null then
+    raise exception 'Partnership and partner are required';
+  end if;
+
+  if coalesce(p_share_basis_points, 0) < 0 or coalesce(p_share_basis_points, 0) > 10000 then
+    raise exception 'Share percentage must be between 0 and 100';
+  end if;
+
+  if p_party_id is not null then
+    select * into before_row
+    from public.reporting_partnership_parties
+    where id = p_party_id;
+  end if;
+
+  if before_row.id is null then
+    insert into public.reporting_partnership_parties (
+      partnership_id,
+      partner_id,
+      party_role,
+      share_basis_points,
+      is_report_recipient
+    )
+    values (
+      p_partnership_id,
+      p_partner_id,
+      normalized_role,
+      nullif(coalesce(p_share_basis_points, 0), 0),
+      coalesce(p_is_report_recipient, false)
+    )
+    returning * into after_row;
+  else
+    update public.reporting_partnership_parties
+    set
+      partnership_id = p_partnership_id,
+      partner_id = p_partner_id,
+      party_role = normalized_role,
+      share_basis_points = nullif(coalesce(p_share_basis_points, 0), 0),
+      is_report_recipient = coalesce(p_is_report_recipient, false)
+    where id = before_row.id
+    returning * into after_row;
+  end if;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    auth.uid(),
+    case when before_row.id is null then 'reporting_partnership_party.created' else 'reporting_partnership_party.updated' end,
+    'reporting_partnership_party',
     after_row.id::text,
     coalesce(to_jsonb(before_row), '{}'::jsonb),
     to_jsonb(after_row),
@@ -1063,6 +1174,8 @@ as $$
 declare
   week_start date;
   result jsonb;
+  partnership_row public.reporting_partnerships;
+  actual_week_end_day integer;
 begin
   if not public.is_super_admin(auth.uid()) then
     raise exception 'Admin access required';
@@ -1070,6 +1183,21 @@ begin
 
   if p_partnership_id is null or p_week_ending_date is null then
     raise exception 'Partnership and week ending date are required';
+  end if;
+
+  select *
+  into partnership_row
+  from public.reporting_partnerships partnership
+  where partnership.id = p_partnership_id;
+
+  if partnership_row.id is null then
+    raise exception 'Partnership not found';
+  end if;
+
+  actual_week_end_day := extract(dow from p_week_ending_date)::integer;
+
+  if actual_week_end_day <> partnership_row.reporting_week_end_day then
+    raise exception 'Week ending date must match this partnership reporting week end day';
   end if;
 
   week_start := p_week_ending_date - 6;
@@ -1087,10 +1215,12 @@ begin
       fact.tax_cents as imported_tax_cents,
       tax.tax_rate_percent,
       rule.calculation_model,
+      rule.split_base,
       rule.fee_amount_cents,
       rule.fee_basis,
       rule.cost_amount_cents,
       rule.cost_basis,
+      rule.deduction_timing,
       rule.gross_to_net_method,
       rule.fever_share_basis_points,
       rule.partner_share_basis_points,
@@ -1130,11 +1260,10 @@ begin
     select
       fact.*,
       case
-        when fact.gross_sales_cents > 0 and fact.gross_to_net_method = 'imported_tax_plus_configured_fees'
-          then fact.imported_tax_cents
-        when fact.gross_sales_cents > 0
-          then round(fact.gross_sales_cents * coalesce(fact.tax_rate_percent, 0) / 100.0)::integer
-        else 0
+        when fact.gross_sales_cents <= 0 then 0
+        when fact.gross_to_net_method = 'imported_tax_plus_configured_fees' then fact.imported_tax_cents
+        when fact.gross_to_net_method = 'configured_fees_only' then 0
+        else round(fact.gross_sales_cents * coalesce(fact.tax_rate_percent, 0) / 100.0)::integer
       end as calculated_tax_cents,
       case
         when fact.gross_sales_cents <= 0 then 0
@@ -1154,16 +1283,19 @@ begin
   row_amounts as (
     select
       calculated.*,
-      greatest(calculated.gross_sales_cents - calculated.calculated_tax_cents - calculated.fee_cents, 0) as net_sales_cents
+      greatest(calculated.gross_sales_cents - calculated.calculated_tax_cents - calculated.fee_cents, 0) as net_sales_cents,
+      case
+        when calculated.deduction_timing = 'before_split' then calculated.cost_cents
+        else 0
+      end as split_deductible_cost_cents
     from calculated
   ),
   split_rows as (
     select
       row_amounts.*,
       case
-        when row_amounts.calculation_model = 'gross_split' then row_amounts.gross_sales_cents
-        when row_amounts.calculation_model = 'contribution_split' then greatest(row_amounts.net_sales_cents - row_amounts.cost_cents, 0)
-        when row_amounts.calculation_model = 'fixed_fee_plus_split' then greatest(row_amounts.net_sales_cents - row_amounts.cost_cents, 0)
+        when row_amounts.split_base = 'gross_sales' then row_amounts.gross_sales_cents
+        when row_amounts.split_base = 'contribution_after_costs' then greatest(row_amounts.net_sales_cents - row_amounts.split_deductible_cost_cents, 0)
         else row_amounts.net_sales_cents
       end as split_base_cents
     from row_amounts
@@ -1207,6 +1339,7 @@ begin
     ) as warning
     from scoped_facts fact
     where fact.tax_rate_percent is null
+      and coalesce(fact.gross_to_net_method, 'machine_tax_plus_configured_fees') <> 'configured_fees_only'
     group by fact.reporting_machine_id, fact.machine_label
     union all
     select jsonb_build_object(
@@ -1217,6 +1350,8 @@ begin
   )
   select jsonb_build_object(
     'partnershipId', p_partnership_id,
+    'partnershipName', partnership_row.name,
+    'reportingWeekEndDay', partnership_row.reporting_week_end_day,
     'weekEndingDate', p_week_ending_date,
     'weekStartDate', week_start,
     'summary', coalesce((select to_jsonb(summary) from summary), '{}'::jsonb),
@@ -1229,10 +1364,235 @@ begin
 end;
 $$;
 
+drop function if exists public.admin_set_user_machine_reporting_access(text, uuid[], text, text);
+create or replace function public.admin_set_user_machine_reporting_access(
+  p_user_email text,
+  p_machine_ids uuid[],
+  p_access_level text,
+  p_reason text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  normalized_email text;
+  normalized_reason text;
+  normalized_access_level text;
+  target_user_id uuid;
+  normalized_machine_ids uuid[];
+  existing_row public.reporting_machine_entitlements;
+  desired_machine_id uuid;
+  missing_machine_count bigint;
+  added_count integer := 0;
+  revoked_count integer := 0;
+begin
+  if not public.is_super_admin(auth.uid()) then
+    raise exception 'Admin access required';
+  end if;
+
+  normalized_email := lower(trim(coalesce(p_user_email, '')));
+  normalized_reason := public.reporting_admin_assert_reason(p_reason);
+  normalized_access_level := lower(coalesce(nullif(trim(p_access_level), ''), 'viewer'));
+
+  if normalized_email = '' then
+    raise exception 'User email is required';
+  end if;
+
+  if normalized_access_level not in ('viewer', 'report_manager') then
+    raise exception 'Invalid reporting access level';
+  end if;
+
+  select users.id
+  into target_user_id
+  from auth.users users
+  where lower(users.email) = normalized_email
+  limit 1;
+
+  if target_user_id is null then
+    raise exception 'No user found for email %', normalized_email;
+  end if;
+
+  select coalesce(array_agg(distinct requested.machine_id), '{}'::uuid[])
+  into normalized_machine_ids
+  from unnest(coalesce(p_machine_ids, '{}'::uuid[])) as requested(machine_id)
+  where requested.machine_id is not null;
+
+  select count(*)
+  into missing_machine_count
+  from unnest(normalized_machine_ids) as requested(machine_id)
+  left join public.reporting_machines machine on machine.id = requested.machine_id
+  where machine.id is null;
+
+  if missing_machine_count > 0 then
+    raise exception 'One or more reporting machines were not found';
+  end if;
+
+  for existing_row in
+    select *
+    from public.reporting_machine_entitlements entitlement
+    where entitlement.user_id = target_user_id
+      and entitlement.machine_id is not null
+      and public.reporting_entitlement_is_active(
+        entitlement.starts_at,
+        entitlement.expires_at,
+        entitlement.revoked_at
+      )
+  loop
+    if not (existing_row.machine_id = any(normalized_machine_ids)) then
+      perform public.admin_revoke_reporting_access(existing_row.id, normalized_reason);
+      revoked_count := revoked_count + 1;
+    end if;
+  end loop;
+
+  foreach desired_machine_id in array normalized_machine_ids
+  loop
+    if not exists (
+      select 1
+      from public.reporting_machine_entitlements entitlement
+      where entitlement.user_id = target_user_id
+        and entitlement.machine_id = desired_machine_id
+        and public.reporting_entitlement_is_active(
+          entitlement.starts_at,
+          entitlement.expires_at,
+          entitlement.revoked_at
+        )
+    ) then
+      added_count := added_count + 1;
+
+      perform public.admin_grant_reporting_access(
+        normalized_email,
+        null,
+        null,
+        desired_machine_id,
+        normalized_access_level,
+        normalized_reason
+      );
+    end if;
+  end loop;
+
+  return jsonb_build_object(
+    'userId', target_user_id,
+    'machineCount', coalesce(array_length(normalized_machine_ids, 1), 0),
+    'addedCount', added_count,
+    'revokedCount', revoked_count
+  );
+end;
+$$;
+
+drop function if exists public.admin_grant_super_admin_by_email(text, text);
+create or replace function public.admin_grant_super_admin_by_email(
+  p_target_email text,
+  p_reason text default null
+)
+returns public.admin_roles
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  target_user_id uuid;
+  before_row public.admin_roles;
+  after_row public.admin_roles;
+  normalized_email text;
+  normalized_reason text;
+begin
+  if not public.is_super_admin(auth.uid()) then
+    raise exception 'Admin access required';
+  end if;
+
+  normalized_email := trim(lower(coalesce(p_target_email, '')));
+  normalized_reason := public.reporting_admin_assert_reason(p_reason);
+
+  if normalized_email = '' then
+    raise exception 'Target email is required';
+  end if;
+
+  select u.id
+  into target_user_id
+  from auth.users u
+  where lower(u.email) = normalized_email
+  limit 1;
+
+  if target_user_id is null then
+    raise exception 'No user found for email %', normalized_email;
+  end if;
+
+  select *
+  into before_row
+  from public.admin_roles
+  where user_id = target_user_id
+    and role = 'super_admin'
+  order by updated_at desc
+  limit 1;
+
+  if before_row.id is null then
+    insert into public.admin_roles (
+      user_id,
+      role,
+      active,
+      granted_by,
+      granted_at,
+      revoked_by,
+      revoked_at
+    )
+    values (
+      target_user_id,
+      'super_admin',
+      true,
+      auth.uid(),
+      now(),
+      null,
+      null
+    )
+    returning * into after_row;
+  elsif before_row.active = true then
+    after_row := before_row;
+  else
+    update public.admin_roles
+    set
+      active = true,
+      granted_by = auth.uid(),
+      granted_at = now(),
+      revoked_by = null,
+      revoked_at = null
+    where id = before_row.id
+    returning * into after_row;
+  end if;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    target_user_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    auth.uid(),
+    'admin_role.granted',
+    'admin_role',
+    after_row.id::text,
+    after_row.user_id,
+    coalesce(to_jsonb(before_row), '{}'::jsonb),
+    to_jsonb(after_row),
+    jsonb_build_object('reason', normalized_reason, 'target_email', normalized_email)
+  );
+
+  return after_row;
+end;
+$$;
+
 grant execute on function public.admin_get_partnership_reporting_setup() to authenticated;
 grant execute on function public.admin_upsert_reporting_partner(uuid, text, text, text, text, text, text, text) to authenticated;
 grant execute on function public.admin_upsert_reporting_partnership(uuid, text, text, integer, text, date, date, text, text, text) to authenticated;
+grant execute on function public.admin_upsert_reporting_partnership_party(uuid, uuid, uuid, text, integer, boolean, text) to authenticated;
 grant execute on function public.admin_upsert_reporting_machine_assignment(uuid, uuid, uuid, text, date, date, text, text, text) to authenticated;
 grant execute on function public.admin_upsert_reporting_machine_tax_rate(uuid, uuid, numeric, date, date, text, text, text) to authenticated;
 grant execute on function public.admin_upsert_reporting_financial_rule(uuid, uuid, text, text, integer, text, integer, text, text, text, integer, integer, integer, date, date, text, text, text) to authenticated;
 grant execute on function public.admin_preview_partner_weekly_report(uuid, date) to authenticated;
+grant execute on function public.admin_set_user_machine_reporting_access(text, uuid[], text, text) to authenticated;
+grant execute on function public.admin_grant_super_admin_by_email(text, text) to authenticated;


### PR DESCRIPTION
﻿## Summary
- Adds `/admin/access` as the consolidated people-first admin surface for users, Plus grants, global roles, audit history, and explicit machine-level reporting access.
- Refocuses `/admin/reporting` on reporting operations only: schedules, sync/import health, stale-data visibility, and export snapshots.
- Adds `/admin/partnerships` plus Supabase foundation tables/RPCs for partners, partnerships, machine assignments, machine-level tax rates, financial rules, and weekly partner report preview.
- Enriches Sunze order ingestion with trade name, parsed item quantity, tax, payment status, and payment timestamp fields.

## Files changed
- Admin UX/routes/nav: `src/App.tsx`, `src/components/layout/AppLayout.tsx`, `src/pages/admin/Access.tsx`, `src/pages/admin/Partnerships.tsx`, `src/pages/admin/Reporting.tsx`, `src/pages/admin/Dashboard.tsx`
- Reporting client libraries and Sunze ingest/parser: `src/lib/reporting.ts`, `src/lib/partnershipReporting.ts`, `scripts/sunze/*`, `supabase/functions/sunze-sales-ingest/index.ts`
- Database: `supabase/migrations/202604260002_partner_reporting_foundation.sql`
- Docs/checklists/SEO private route lists: `Docs/*`, `scripts/prerender-public-routes.mjs`, `scripts/seo-regression-check.mjs`

## Important model notes
- Reporting access remains explicit machine-level access for V1. Partnerships do not grant inherited user permissions yet.
- Tax rates are configured at the machine level through effective-dated `reporting_machine_tax_rates` records, not at the partnership level.
- Partnership setup is for financial reporting, partner grouping, schedules, and calculation rules.

## Verification
- `npm ci` - passed; npm audit still reports existing 10 vulnerabilities (5 moderate, 5 high).
- `npm run build` - passed; prerendered 13 public routes and 19 private routes. Existing Browserslist stale-data warning remains.
- `npm test --if-present` - passed; no test script is configured.
- `npm run lint --if-present` - passed with existing fast-refresh warnings in shared UI/Auth files.
- `npm run seo:check` - passed; 13 public routes and 19 private routes validated.
- `npm run reporting:validate-sunze-parser` - passed; 3 fixture rows parsed with credit/cash/other methods.
- `supabase db push --dry-run` - passed; would push only `202604260002_partner_reporting_foundation.sql`.
- Browser QA against `npm run preview -- --host 127.0.0.1 --port 4180` - `/admin/access`, `/admin/partnerships`, `/admin/reporting`, `/admin/accounts`, and `/admin/audit` returned 200 and redirected unauthenticated users to `/login` with no console/page errors.

## How to test
1. Check out this branch and run `npm ci`.
2. Apply the new Supabase migration in a development/staging project: `supabase db push`.
3. Start local dev: `npm run dev`.
4. Log in as a super-admin and open `/admin/access`.
5. In `/admin/access`, verify the Users, Reporting Access, Global Roles, and Audit tabs. Confirm `/admin/accounts` redirects to `/admin/access?tab=users` and `/admin/audit` redirects to `/admin/access?tab=audit`.
6. In `/admin/access?tab=reporting-access`, look up an existing user by email, grant multiple individual machines with a reason, then revoke one machine and confirm other viewers are unaffected.
7. Open `/admin/partnerships`; create/edit a partner, partnership, machine mapping, machine assignment, machine-level tax rate, and financial rule. Confirm setup warnings appear for missing assignment, missing active machine tax rate, missing active rule, or overlapping assignments.
8. Use `/admin/partnerships` Weekly Preview for a Monday-Sunday week and confirm it shows gross, orders, sticks, machine tax, fees, costs, net, split base, and partner/Fever/Bloomjoy shares.
9. Open `/admin/reporting` and confirm it only shows Schedules, Sync, and Exports operational views.

## Overlap / merge note
- PR #161 (`agent/sunze-sales-controls`) touches `scripts/sunze/sunze-orders.mjs`, `scripts/sunze/validate-sunze-orders-parser.mjs`, `src/lib/reporting.ts`, `src/pages/admin/Reporting.tsx`, `supabase/functions/sunze-sales-ingest/index.ts`, and several docs. Rebase this branch if #161 merges first.
- PR #143 contains older partner/operator account schema work and may overlap conceptually with the new partnership reporting foundation.
