### PR TITLE
docs: add Codex agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,15 @@ PR description includes:
   - Branch: `agent/<short-task-slug>`
 - If you must run without worktrees, run only one agent at a time to avoid branch switching.
 
+### Sub-agents, plugins, and skills
+- Default to one agent for small or single-surface work. Use sub-agents only when the user asks for parallel agents or explicitly approves it in the plan.
+- Good sub-agent fits: read-only codebase exploration, PR review lanes, test/log triage, or independent implementation slices with clearly disjoint files.
+- Avoid sub-agents for tiny edits, urgent single-path fixes, shared-doc edits, secrets work, or flows that need one dev server/auth session.
+- For write-heavy sub-agent work, assign separate file ownership and separate worktrees/branches; the parent agent owns integration, conflict checks, final verification, and the PR.
+- Use a plugin when Codex needs an external tool or source of truth; use a skill when Codex needs to follow a repeatable process or specialized workflow.
+- Helpful repo plugins/skills: GitHub for issues/PRs/CI, Browser Use or Vercel browser verification for localhost UI checks, Build Web Apps/shadcn/React skills for UI work, Supabase Postgres guidance for migrations/RLS/reporting SQL, Stripe guidance for checkout/billing/webhooks, and Vercel guidance for redirects/domains/deploy config.
+- Use Gmail, Google Drive, or Sheets only when the task explicitly depends on connected business source material. Never move secrets or private operational data into repo files.
+
 ## Operational safeguards (must follow)
 - Work only in a worktree (never edit `C:\Repos\Bloomjoy_hub` directly).
 - Run the preflight check in `Docs/LOCAL_DEV.md` before making edits.


### PR DESCRIPTION
## Summary
- Add concise AGENTS.md guidance for when sub-agents make sense versus single-agent live coding.
- Add repo-specific plugin and skill recommendations with boundaries for external source material and secrets.

## Files changed
- `AGENTS.md`: adds a short `Sub-agents, plugins, and skills` guidance section under multi-agent worktree safety.

## Verification commands + results
- `npm ci` - pass; installed 409 packages and audited 410 packages. Existing audit output reports 10 vulnerabilities (5 moderate, 5 high).
- `npm run build` - pass; Vite build and public/private route prerender completed. Existing Browserslist stale-data notice remains.
- `npm test --if-present` - pass; no test script is configured, so npm exited without running tests.
- `npm run lint --if-present` - pass with 8 existing `react-refresh/only-export-components` warnings in generated/shared UI files.

## How to test
1. Check out `agent/codex-agent-guidance` in a worktree.
2. Open `AGENTS.md` and confirm the new `Sub-agents, plugins, and skills` section appears below multi-agent worktree safety.
3. Confirm the guidance still keeps the existing one-worktree-per-agent and PR-to-main workflow intact.

Key URLs: not applicable; docs-only change.
Test credentials: not applicable.

## Overlap / branch safety
- Open PR #126 also touches `AGENTS.md` for session closeout hygiene. If #126 merges first, sync this branch from `main` and re-run verification before merge.