### PR TITLE
Update reporting closeout docs

### DIFF
--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -6,15 +6,16 @@
 - First priority is to **stabilize the POC** and align it to the MVP routing + docs workflow.
 - Write updates in plain language so non-technical readers can follow.
 
-## Sales reporting foundation snapshot (2026-04-24)
+## Sales reporting/admin reporting snapshot (2026-04-25)
 - Production runtime hotfix branch `agent/fix-reporting-chart-runtime` removes the forced Recharts manual chunk split that caused the app shell to crash with `Cannot access 'P' before initialization` after the reporting deployment.
-- Sales reporting is being added as a Supabase-backed extension to the existing operator app on branch `agent/sales-reporting-foundation`.
-- This slice adds account/location/machine reporting entitlements, normalized sales facts, refund adjustment facts, import run audit records, export snapshots, partner schedules, and private PDF export storage.
+- Sales reporting is now a Supabase-backed extension to the existing operator app on `main`.
+- The reporting foundation includes account/location/machine reporting entitlements, normalized sales facts, refund adjustment facts, import run audit records, export snapshots, partner schedules, and private PDF export storage.
 - The portal now has `/portal/reports` for entitled users, with date/grain/location/machine/payment filters and on-demand PDF export.
-- Admin access and reporting operations are being split into clearer surfaces:
+- Admin access and reporting operations are split into clearer surfaces:
   - `/admin/access` is the single admin place for users, Plus grants, global roles, audit history, and explicit machine-level reporting access.
   - `/admin/partnerships` is the setup area for partners, partnerships, machine assignments, machine-level tax rates, and financial rules.
   - `/admin/reporting` is focused on report schedules, import/sync status, freshness, and export archive visibility.
+- Production RPC repair is complete: migration `202604260004_reporting_admin_rpc_repair.sql` reapplied missing admin reporting/partnership RPCs, restored PostgREST schema visibility, and aligned production migration history with repo migrations through `202604260004`.
 - Reporting visibility remains machine-level only for V1. Partnerships are for financial reporting and grouping, not permission inheritance.
 - Tax rates are configured directly on machines with effective dates, not on partnerships.
 - The Bubble Planet workbook baseline uses Sunze order amount as gross sales, subtracts machine tax plus a configured `$0.40` paid-order fee before the 60/40 split, counts no-pay orders as `$0`, and reports completed Monday-Sunday weeks.

--- a/Docs/DECISIONS.md
+++ b/Docs/DECISIONS.md
@@ -48,6 +48,19 @@ Admin permission work and partnership financial setup are separate concerns.
 - Keeping user access machine-level avoids hidden permission inheritance while the reporting feature is still new.
 - Machine-level tax rates reflect real operating differences and keep tax changes auditable over time.
 
+## 2026-04-25 - Reporting migration repair and schema-cache checks
+Production reporting/admin RPC fixes must move forward through new migrations, not edits to migrations Supabase already marked applied.
+
+**Canonical migration rule**
+- Do not rely on editing an already-applied migration to repair production. Supabase will not replay it.
+- If production is missing tables, RPCs, grants, or function definitions from an already-applied migration, add a later forward-only, idempotent repair migration.
+- Frontend-facing RPC migrations should end with `select pg_notify('pgrst', 'reload schema');` so PostgREST refreshes function metadata.
+- Production validation for admin/reporting RPC changes must include direct REST probes that confirm key RPCs do not return `404` or `PGRST202`.
+
+**Why this choice**
+- The reporting admin outage came from schema drift: production had an older migration version marked applied before the final admin/partnership RPCs existed.
+- Forward repair migrations keep repo history and production history aligned without manual rollback or destructive database operations.
+
 ## 2026-04-14 - Training-only operator access grants
 Bloomjoy now supports a narrow operator access tier for staff who need training without becoming paid Bloomjoy Plus members.
 

--- a/Docs/LOCAL_DEV.md
+++ b/Docs/LOCAL_DEV.md
@@ -40,11 +40,17 @@
    - Sales reporting foundation migration: `supabase/migrations/202604240001_sales_reporting_foundation.sql`
    - Sales reporting daily automation helpers: `supabase/migrations/202604250001_sales_reporting_daily_automation.sql`
    - Partner reporting foundation: `supabase/migrations/202604260002_partner_reporting_foundation.sql`
+   - Sunze unmapped-machine queue: `supabase/migrations/202604260003_sunze_unmapped_machine_queue.sql`
+   - Reporting admin RPC repair: `supabase/migrations/202604260004_reporting_admin_rpc_repair.sql`
 2) Seed data (optional for local dev): `supabase/seed/20260122_training_seed.sql`
 3) Populate Vimeo fields after account setup:
    - `provider_video_id`
    - `provider_hash`
    - `meta.thumbnail_url` (first-party key in `training-thumbnails` bucket, for example `vimeo/<video_id>.jpg`)
+
+Migration notes:
+- Supabase will not replay an edited migration after production has marked that version applied. Add a later forward-only repair migration when production schema drift needs to be fixed.
+- After migrations that add or replace frontend-facing RPCs, verify `supabase db push --dry-run` is clean and confirm the live REST endpoint does not return `404` or `PGRST202` for the changed RPCs.
 
 ## Sales reporting import helpers
 Use these after the sales reporting migration has been applied.

--- a/Docs/PRODUCTION_RUNBOOK.md
+++ b/Docs/PRODUCTION_RUNBOOK.md
@@ -2,7 +2,7 @@
 
 Purpose: provide a single launch-day procedure for Bloomjoy Hub production release and rollback.
 
-Last updated: 2026-04-06
+Last updated: 2026-04-25
 
 ## 1) Roles and ownership
 - Release owner: coordinates launch window and final go/no-go call.
@@ -35,6 +35,15 @@ Set the following values before launch.
 | `SUPABASE_URL` | Server-only | Stripe/order/support Edge Functions | Supabase project URL | Technical owner |
 | `SUPABASE_ANON_KEY` | Server-only | `stripe-sugar-checkout`, `stripe-plus-checkout`, `stripe-customer-portal` | Supabase project anon key | Technical owner |
 | `SUPABASE_SERVICE_ROLE_KEY` | Server-only | `stripe-webhook`, `stripe-sugar-checkout`, `lead-submission-intake`, `support-request-intake` | Supabase service role key | Technical owner |
+| `REPORT_SCHEDULER_SECRET` | Server-only | `sales-report-scheduler` | Generated secret stored in function secrets | Technical owner |
+| `REPORTING_INGEST_TOKEN` | Server-only + GitHub Actions secret | `sunze-sales-ingest`, Sunze sync workflow | Generated ingest token | Technical owner |
+| `REPORTING_ROW_HASH_SALT` | Server-only | `sunze-sales-ingest` | Generated secret stored in function secrets | Technical owner |
+| `GOOGLE_REFUNDS_SHEET_ID` | Server-only | `refund-adjustment-sync` | Google Sheet ID for refunds/complaints | Operations owner |
+| `GOOGLE_SERVICE_ACCOUNT_JSON` | Server-only | `refund-adjustment-sync` | Google service account JSON | Technical owner |
+| `SUNZE_LOGIN_URL` | GitHub Actions secret | Sunze sync workflow | Sunze service-account login URL | Technical owner |
+| `SUNZE_REPORTING_EMAIL` | GitHub Actions secret | Sunze sync workflow | Sunze service-account email | Technical owner |
+| `SUNZE_REPORTING_PASSWORD` | GitHub Actions secret | Sunze sync workflow | Sunze service-account password | Technical owner |
+| `REPORTING_INGEST_URL` | GitHub Actions secret | Sunze sync workflow | Supabase `sunze-sales-ingest` function URL | Technical owner |
 
 Security rule:
 - Never place secrets in `VITE_` variables.
@@ -66,6 +75,13 @@ Recommended:
    - `supabase link --project-ref <project-ref>`
 2) Push migrations:
    - `supabase db push`
+3) If a migration adds or replaces frontend-facing RPCs, confirm PostgREST schema visibility:
+   - Changed RPCs do not return `404` or `PGRST202`.
+   - Admin/reporting examples: `admin_get_account_summaries`, `admin_set_user_machine_reporting_access`, and `admin_get_partnership_reporting_setup`.
+
+Migration repair rule:
+- Do not edit an already-applied migration and expect production to replay it.
+- If production is missing schema from an already-applied migration, add a later forward-only, idempotent repair migration and include `select pg_notify('pgrst', 'reload schema');`.
 
 ### Step B: Set/refresh Edge Function secrets
 Run once per environment or when values rotate:
@@ -89,6 +105,11 @@ supabase secrets set WECOM_ALERT_TO_USERIDS=ethan.trifari,ops.manager
 supabase secrets set SUPABASE_URL=...
 supabase secrets set SUPABASE_ANON_KEY=...
 supabase secrets set SUPABASE_SERVICE_ROLE_KEY=...
+supabase secrets set REPORT_SCHEDULER_SECRET=...
+supabase secrets set REPORTING_INGEST_TOKEN=...
+supabase secrets set REPORTING_ROW_HASH_SALT=...
+supabase secrets set GOOGLE_REFUNDS_SHEET_ID=...
+supabase secrets set GOOGLE_SERVICE_ACCOUNT_JSON=...
 ```
 
 Before continuing, run:
@@ -100,8 +121,8 @@ npm run commerce:preflight -- --project-ref <project-ref>
 WeCom note:
 - If token auth succeeds but live sends fail with `60020: not allow to access from your ip`, the remaining issue is WeCom-side network/IP policy, not the secret values. Fix the app/network restriction in WeCom admin, then re-run a live smoke order.
 
-### Step C: Deploy Stripe Edge Functions
-Deploy all current checkout/submission functions:
+### Step C: Deploy Supabase Edge Functions
+Deploy all current checkout, submission, and reporting functions:
 
 ```bash
 supabase functions deploy stripe-sugar-checkout --no-verify-jwt
@@ -111,6 +132,11 @@ supabase functions deploy stripe-customer-portal --no-verify-jwt
 supabase functions deploy stripe-webhook --no-verify-jwt
 supabase functions deploy lead-submission-intake --no-verify-jwt
 supabase functions deploy support-request-intake --no-verify-jwt
+supabase functions deploy sales-report-export --no-verify-jwt
+supabase functions deploy sales-report-scheduler --no-verify-jwt
+supabase functions deploy sunze-sales-ingest --no-verify-jwt
+supabase functions deploy sunze-sales-sync --no-verify-jwt
+supabase functions deploy refund-adjustment-sync --no-verify-jwt
 ```
 
 ### Step D: Configure Stripe webhook endpoint
@@ -155,6 +181,11 @@ Run immediately after deploy:
 - [ ] Quote request on `/contact` sends internal summary email to configured operations recipients.
 - [ ] Quote/order/support events send WeCom alerts to configured internal recipients (or log non-blocking warning on dispatch failure).
 - [ ] `/admin/orders` shows address, pricing tier, receipt URL, order breakdown, and notification status for the test orders.
+- [ ] `/admin/access?tab=users` loads account summaries without a red error state.
+- [ ] `/admin/access?tab=reporting-access` can save machine reporting grants with a required reason.
+- [ ] `/admin/partnerships` loads setup tabs without missing-RPC errors.
+- [ ] Admin/reporting network console does not show `404` or `PGRST202` for `admin_get_account_summaries`, `admin_set_user_machine_reporting_access`, or `admin_get_partnership_reporting_setup`.
+- [ ] `/portal/reports` for an entitled test user shows only the machines granted to that user.
 - [ ] WeChat onboarding concierge submit on `/portal/support` creates `support_requests.request_type=wechat_onboarding` with populated `intake_meta`.
 - [ ] Stripe customer portal opens from `/portal/account`.
 - [ ] No critical frontend console errors on key pages.

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -221,6 +221,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] `/admin/accounts` redirects to `/admin/access?tab=users`
 - [ ] `/admin/audit` redirects to `/admin/access?tab=audit`
 - [ ] Admin Access > Users search returns rows by email/user ID and shows membership/order/support summary data
+- [ ] Admin Access > Users does not show "Unable to load account summaries" and the network console does not show `404`/`PGRST202` for `admin_get_account_summaries`
 - [ ] Admin account search can find an existing Supabase Auth user by email even if they do not have orders yet
 - [ ] Admin Access > Users shows paid subscription status separately from free Plus grant status
 - [ ] Super-admin cannot grant free Plus access without a future expiry date and grant reason
@@ -233,12 +234,14 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Machine count edits create `admin_audit_log` entries with `action=machine_inventory.upserted`
 - [ ] Admin Access > Reporting Access uses a people-first explicit machine access matrix
 - [ ] Admin Access > Reporting Access can look up an existing user by email, select multiple machines, save with a reason, and update that person's machine grants in one transactional save
+- [ ] Admin Access > Reporting Access save does not show missing-function errors for `admin_set_user_machine_reporting_access`
 - [ ] Admin Access > Reporting Access can revoke one user's machine access without removing other viewers from the same machine
 - [ ] Super-admin users show all-machine reporting access as read-only in Admin Access
 - [ ] Admin Access > Global Roles can grant and revoke super-admin role with required reason metadata
 - [ ] Admin Access > Audit supports filtering and shows role + operational actions
 - [ ] Non-admin user cannot access `/admin/partnerships`
 - [ ] Super-admin user can access `/admin/partnerships`
+- [ ] Admin Partnerships setup loads without missing-RPC errors for `admin_get_partnership_reporting_setup`
 - [ ] Admin Partnerships can create/edit partner and partnership records
 - [ ] Admin Partnerships > Parties can attach partners to partnerships with role, optional share percentage, report-recipient flag, and required reason
 - [ ] Admin Partnerships > Machine Assignments can update Sunze machine mapping with account, location, machine label, machine type, Sunze ID, and required reason


### PR DESCRIPTION
## Summary
- Update current status for the merged sales reporting/admin access work and production RPC repair.
- Record the Supabase migration repair rule: use forward-only repair migrations and reload PostgREST schema for frontend-facing RPC changes.
- Add admin/reporting schema-cache smoke checks to local dev, production runbook, and QA checklist.

## Files changed
- `Docs/CURRENT_STATUS.md`: reporting/admin closeout status and RPC repair note.
- `Docs/DECISIONS.md`: migration repair and schema-cache decision.
- `Docs/LOCAL_DEV.md`: latest reporting migrations and RPC verification notes.
- `Docs/PRODUCTION_RUNBOOK.md`: reporting secrets/functions and production admin reporting checks.
- `Docs/QA_SMOKE_TEST_CHECKLIST.md`: checks for the missing-RPC failure mode seen in production.

## Verification commands + results
- `npm ci` - passed; npm reported existing audit warnings.
- `npm run build` - passed.
- `npm test --if-present` - passed; no test script is currently defined.
- `npm run lint --if-present` - passed with existing Fast Refresh warnings only.
- `npm run seo:check` - passed.
- `git diff --check` - passed; only CRLF conversion warnings.

## How to test
1. Review the closeout docs in `Docs/CURRENT_STATUS.md`, `Docs/DECISIONS.md`, `Docs/LOCAL_DEV.md`, `Docs/PRODUCTION_RUNBOOK.md`, and `Docs/QA_SMOKE_TEST_CHECKLIST.md`.
2. Confirm the production runbook includes the reporting secrets/functions and the PostgREST `PGRST202` smoke checks.
3. Confirm the QA checklist now covers `/admin/access?tab=users`, reporting access saves, and `/admin/partnerships` missing-RPC checks.