### PR TITLE
Document partner reporting PM plan

### DIFF
--- a/Docs/BACKLOG.md
+++ b/Docs/BACKLOG.md
@@ -76,39 +76,47 @@ Guidelines:
    - Keep delivery manual for V1: super-admin reviews, downloads, then sends outside automation until the report is trusted.
    - Dependency: partnership setup UX and reliable Sunze sales facts.
 
-21. **Operator performance dashboards**
+## P1 - Reporting UX/CX follow-ups
+21. **Partner dashboard UX/CX and reporting tab design** (`#172`)
+   - Design the reporting tab so users see operator-style reporting for assigned machines by default.
+   - Add a partner dashboard concept for users with partner-dashboard permissions.
+   - Default V1 partner dashboard access to super-admins only until explicit partner-viewer permissions are implemented.
+   - Define dashboard KPIs, period controls, machine rollups, warning states, PDF export/review entry points, and mobile/desktop behavior.
+   - Dependency: corporate partner reporting model and admin partnership setup direction.
+
+22. **Operator performance dashboards** (`#171`)
    - Add operator dashboards only after corporate partner reporting reaches acceptance.
    - Show assigned-machine sales, units sold, trends, and machine comparisons.
    - Dependency: accepted corporate partner reporting flow.
 
 ## P0 - Training UX/performance hardening (new)
-22. **Training performance: Vimeo load speed + startup UX** (`#89`)
+23. **Training performance: Vimeo load speed + startup UX** (`#89`)
    - Improve perceived startup speed for training detail video playback.
    - Add clear loading-state UX while Vimeo player initializes.
    - Dependency: existing training detail embeds.
 
-23. **Training detail clarity: learning/checklist/resources sections** (`#91`)
+24. **Training detail clarity: learning/checklist/resources sections** (`#91`)
    - Clarify purpose/copy for "What you will learn", "Checklist", and "Resources".
    - Add consistent structure + fallback states for empty content.
    - Dependency: existing training detail content model.
 
-24. **Module tag support in training library (Module 1/2/3)** (`#90`)
+25. **Module tag support in training library (Module 1/2/3)** (`#90`)
    - Use module tags for library grouping/filtering and discovery.
    - Document operations workflow for Vimeo tag mapping/update.
    - Dependency: Vimeo tagging + training metadata sync.
 
 ## P1 - Nice-to-have
-25. Sticks product page (if offered)
-26. Training progress tracking
-27. Basic admin view for support requests
-28. Remove temporary static admin email allowlist and rely on `admin_roles` + RLS only
-29. Replace third-party Vimeo thumbnail fallback (`vumbnail`) with first-party stored thumbnail URLs
-30. **Training hub UX polish after content expansion** (`#125`)
+26. Sticks product page (if offered)
+27. Training progress tracking
+28. Basic admin view for support requests
+29. Remove temporary static admin email allowlist and rely on `admin_roles` + RLS only
+30. Replace third-party Vimeo thumbnail fallback (`vumbnail`) with first-party stored thumbnail URLs
+31. **Training hub UX polish after content expansion** (`#125`)
    - Simplify the above-the-fold hierarchy so one primary next action is obvious.
    - Rebalance `Start Here`, task paths, featured items, and full-library stacking.
    - Make the new document-first job aids feel curated without adding clutter.
    - Validate final desktop/mobile hierarchy with authenticated QA on `/portal/training`.
-31. **Public CX polish audit remediation**
+32. **Public CX polish audit remediation**
    - Keep Micro Machine quote-led and remove direct machine cart behavior until direct machine commerce is intentionally implemented.
    - Make the shared cart resilient on mobile and keep checkout clearly sugar-only.
    - Tighten public page spacing on `/machines`, `/resources`, `/plus`, and `/contact` without changing the global visual system.
@@ -116,7 +124,7 @@ Guidelines:
    - Validate the remediated public routes on desktop and common mobile viewport sizes.
 
 ## P2 - Ops hardening follow-ups
-32. **Operationalize WeCom alerts + WeChat onboarding concierge** (`#110`)
+33. **Operationalize WeCom alerts + WeChat onboarding concierge** (`#110`)
    - Define referral-buddy onboarding runbook and response-time SLA.
    - Validate 1-week WeCom delivery reliability for quote/order/support alerts.
    - Capture sign-off evidence for onboarding intake + non-blocking alert failure behavior.

--- a/Docs/BACKLOG.md
+++ b/Docs/BACKLOG.md
@@ -59,35 +59,56 @@ Guidelines:
 16. Plus Basic subscription checkout + customer portal link
 17. Webhook sync (membership/order status -> DB)
 
+## P0 - Corporate partner reporting (current critical path)
+18. **Harden Sunze sales source controls before partner report launch** (`#161`)
+   - Merge the hardened Sunze sync controls before relying on weekly partner reporting.
+   - Confirm mapped-machine imports, unmapped-machine quarantine, dry-run/live sync, and freshness reporting are green.
+   - Dependency: merged sales reporting foundation.
+
+19. **Streamline admin partnership setup** (`#167`)
+   - Merge the selected-partnership setup workflow after syncing with `main`.
+   - Keep participants, assigned machines, current machine tax rates, financial split terms, and weekly preview together in `/admin/partnerships`.
+   - Dependency: Sunze controls and merged partnership reporting foundation.
+
+20. **Corporate partner reviewed PDF milestone**
+   - Add partner-report snapshot/run records for reporting period, rule version, assumptions, generated-by user, status, recipients/download metadata, storage path, and warning state.
+   - Generate a polished weekly PDF with executive summary, machine-level appendix, calculation assumptions, amount owed, generated timestamp, and snapshot ID.
+   - Keep delivery manual for V1: super-admin reviews, downloads, then sends outside automation until the report is trusted.
+   - Dependency: partnership setup UX and reliable Sunze sales facts.
+
+21. **Operator performance dashboards**
+   - Add operator dashboards only after corporate partner reporting reaches acceptance.
+   - Show assigned-machine sales, units sold, trends, and machine comparisons.
+   - Dependency: accepted corporate partner reporting flow.
 
 ## P0 - Training UX/performance hardening (new)
-18. **Training performance: Vimeo load speed + startup UX** (`#89`)
+22. **Training performance: Vimeo load speed + startup UX** (`#89`)
    - Improve perceived startup speed for training detail video playback.
    - Add clear loading-state UX while Vimeo player initializes.
    - Dependency: existing training detail embeds.
 
-19. **Training detail clarity: learning/checklist/resources sections** (`#91`)
+23. **Training detail clarity: learning/checklist/resources sections** (`#91`)
    - Clarify purpose/copy for "What you will learn", "Checklist", and "Resources".
    - Add consistent structure + fallback states for empty content.
    - Dependency: existing training detail content model.
 
-20. **Module tag support in training library (Module 1/2/3)** (`#90`)
+24. **Module tag support in training library (Module 1/2/3)** (`#90`)
    - Use module tags for library grouping/filtering and discovery.
    - Document operations workflow for Vimeo tag mapping/update.
    - Dependency: Vimeo tagging + training metadata sync.
 
 ## P1 - Nice-to-have
-21. Sticks product page (if offered)
-22. Training progress tracking
-23. Basic admin view for support requests
-24. Remove temporary static admin email allowlist and rely on `admin_roles` + RLS only
-25. Replace third-party Vimeo thumbnail fallback (`vumbnail`) with first-party stored thumbnail URLs
-26. **Training hub UX polish after content expansion** (`#125`)
+25. Sticks product page (if offered)
+26. Training progress tracking
+27. Basic admin view for support requests
+28. Remove temporary static admin email allowlist and rely on `admin_roles` + RLS only
+29. Replace third-party Vimeo thumbnail fallback (`vumbnail`) with first-party stored thumbnail URLs
+30. **Training hub UX polish after content expansion** (`#125`)
    - Simplify the above-the-fold hierarchy so one primary next action is obvious.
    - Rebalance `Start Here`, task paths, featured items, and full-library stacking.
    - Make the new document-first job aids feel curated without adding clutter.
    - Validate final desktop/mobile hierarchy with authenticated QA on `/portal/training`.
-27. **Public CX polish audit remediation**
+31. **Public CX polish audit remediation**
    - Keep Micro Machine quote-led and remove direct machine cart behavior until direct machine commerce is intentionally implemented.
    - Make the shared cart resilient on mobile and keep checkout clearly sugar-only.
    - Tighten public page spacing on `/machines`, `/resources`, `/plus`, and `/contact` without changing the global visual system.
@@ -95,7 +116,7 @@ Guidelines:
    - Validate the remediated public routes on desktop and common mobile viewport sizes.
 
 ## P2 - Ops hardening follow-ups
-28. **Operationalize WeCom alerts + WeChat onboarding concierge** (`#110`)
+32. **Operationalize WeCom alerts + WeChat onboarding concierge** (`#110`)
    - Define referral-buddy onboarding runbook and response-time SLA.
    - Validate 1-week WeCom delivery reliability for quote/order/support alerts.
    - Capture sign-off evidence for onboarding intake + non-blocking alert failure behavior.

--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -24,6 +24,22 @@
 - Google Sheets complaints/refunds ingestion is represented as a server-side adjustment sync stub plus a CSV import helper. Production Sheets API ingestion still depends on confirming the sheet columns and service-account setup.
 - Open overlap to watch: issue `#150` and PR `#151` cover the broader account/entitlement roadmap, while open PR `#143` contains older partner/operator account schema work that may overlap the new `customer_accounts` foundation.
 
+## Partner reporting PM roadmap (2026-04-25)
+- Corporate partner revenue-share reporting is the current P0 business milestone. Operator dashboards remain important, but they should wait until corporate partner reporting has a trusted review/download flow.
+- First deliverable: a super-admin can create a corporate partner, assign machines, configure tax and revenue-share assumptions, preview a completed weekly report, generate a polished PDF, review it, and manually download/send it.
+- Locked V1 delivery choices:
+  - manual super-admin review before scheduled auto-email delivery
+  - polished executive summary plus calculation appendix, not a summary-only report
+  - typed configurable revenue-share rules, not hardcoded partner-specific math or a broad formula engine
+  - conservative access: only super-admins configure, generate, review, and send partner reports in V1
+- Next code slice should add auditable partner-report snapshot/run support with reporting period, rule version, assumptions, generated-by user, status, recipients/download metadata, storage path, and warning state.
+- The partner PDF should replace the current simple text-style sales export for this use case with a branded settlement artifact: cover/summary, machine-level rollups, formula assumptions, warning states, generated timestamp, and snapshot ID.
+- Current PR sequencing recommendation:
+  1. Merge PR `#161` first because it hardens Sunze ingestion/source controls and production-aligned migrations/functions.
+  2. Sync and merge PR `#167` next because it improves `/admin/partnerships` setup UX and overlaps the partnership admin surface.
+  3. Refresh/merge PR `#166` after `#161` and `#167` so closeout docs reflect the final merged state.
+  4. Treat PRs `#157` and `#151` as older docs that should be reconciled or superseded rather than merged unchanged.
+
 ## Mini launch update (2026-04-09)
 - Mini is now live on the public site as a sales-led machine offer at `$4,000`.
 - Public Mini demand no longer goes to a waitlist form:
@@ -78,6 +94,11 @@
   - a live `$0` Stripe checkout smoke order after the webhook email redesign deployment
 
 ## Next P0 milestones
+- Complete the corporate partner reporting review/download milestone before building operator performance dashboards:
+  - merge the Sunze controls and partnership UX PRs in the recommended order
+  - add partner-report snapshots/runs for auditability
+  - generate a polished weekly partner PDF from configured partnership rules
+  - validate the flow with the Bubble Planet-style Monday-Sunday revenue-share fixture
 - Clear the remaining WeCom production blocker:
   - confirm whether the Bloomjoy Alerts app enforces an IP allowlist or trusted network restriction in WeCom
   - update the WeCom app policy so Supabase Edge Function traffic can send messages successfully

--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -34,6 +34,7 @@
   - conservative access: only super-admins configure, generate, review, and send partner reports in V1
 - Next code slice should add auditable partner-report snapshot/run support with reporting period, rule version, assumptions, generated-by user, status, recipients/download metadata, storage path, and warning state.
 - The partner PDF should replace the current simple text-style sales export for this use case with a branded settlement artifact: cover/summary, machine-level rollups, formula assumptions, warning states, generated timestamp, and snapshot ID.
+- Parallel UX/CX track: issue `#172` should design the reporting tab experience where users see operator-style reporting for assigned machines by default, while partner dashboard views appear only when the user has explicit partner-dashboard permissions. V1 should default partner dashboard visibility to super-admins only.
 - Current PR sequencing recommendation:
   1. Merge PR `#161` first because it hardens Sunze ingestion/source controls and production-aligned migrations/functions.
   2. Sync and merge PR `#167` next because it improves `/admin/partnerships` setup UX and overlaps the partnership admin surface.

--- a/Docs/DECISIONS.md
+++ b/Docs/DECISIONS.md
@@ -56,11 +56,18 @@ The next P0 reporting milestone is a trusted corporate partner report that Bloom
 - Manual super-admin review comes before scheduled auto-email. Scheduled delivery remains future automation after the report content and math are trusted.
 - Corporate partners do not get inherited portal access from partnership setup in V1. Partner-facing value is delivered through reviewed PDFs first.
 - Operator performance dashboards are deferred until the corporate partner review/download workflow is accepted.
+- Partner dashboard UX/CX can be designed in parallel, but it is not required for the first reviewed-PDF milestone.
 
 **Canonical partner report**
 - The PDF should be a polished settlement artifact, not the current simple text-style sales export.
 - Required report shape: executive summary, reporting period, gross sales, tax impact, net sales, unit/fee/cost assumptions, split calculation, amount owed, machine-level appendix, warning states, generated timestamp, and snapshot ID.
 - Generated partner reports must have auditable snapshot/run records with period, rule version, assumptions, generated-by user, status, recipients/download metadata, storage path, and any warnings.
+
+**Canonical dashboard direction**
+- The reporting tab should default to an operator-style view for the user's assigned machines.
+- A partner dashboard view should appear only when the access context grants partner-dashboard visibility.
+- V1 partner dashboard visibility defaults to super-admins only until explicit partner-viewer permissions are implemented.
+- The browser dashboard should emphasize smooth period controls, summary KPIs, machine-level rollups, warning states, and calculation transparency; the PDF remains the formal settlement artifact.
 
 **Canonical rule approach**
 - Revenue-share rules should be typed and configurable: week-ending day, machine tax method, fee basis, cost basis, split base, and share percentages.

--- a/Docs/DECISIONS.md
+++ b/Docs/DECISIONS.md
@@ -48,6 +48,30 @@ Admin permission work and partnership financial setup are separate concerns.
 - Keeping user access machine-level avoids hidden permission inheritance while the reporting feature is still new.
 - Machine-level tax rates reflect real operating differences and keep tax changes auditable over time.
 
+## 2026-04-25 - Corporate partner reporting first deliverable
+The next P0 reporting milestone is a trusted corporate partner report that Bloomjoy can review before sending.
+
+**Canonical V1 delivery**
+- Super-admins generate corporate partner reports from `/admin/partnerships` after partnership setup, machine assignments, tax assumptions, and financial terms are configured.
+- Manual super-admin review comes before scheduled auto-email. Scheduled delivery remains future automation after the report content and math are trusted.
+- Corporate partners do not get inherited portal access from partnership setup in V1. Partner-facing value is delivered through reviewed PDFs first.
+- Operator performance dashboards are deferred until the corporate partner review/download workflow is accepted.
+
+**Canonical partner report**
+- The PDF should be a polished settlement artifact, not the current simple text-style sales export.
+- Required report shape: executive summary, reporting period, gross sales, tax impact, net sales, unit/fee/cost assumptions, split calculation, amount owed, machine-level appendix, warning states, generated timestamp, and snapshot ID.
+- Generated partner reports must have auditable snapshot/run records with period, rule version, assumptions, generated-by user, status, recipients/download metadata, storage path, and any warnings.
+
+**Canonical rule approach**
+- Revenue-share rules should be typed and configurable: week-ending day, machine tax method, fee basis, cost basis, split base, and share percentages.
+- Bubble Planet-style reporting is the first validation fixture, but the implementation must not hardcode Bubble Planet-specific names or terms into the calculation model.
+- Do not introduce a new reporting platform, CMS, or headless reporting service for this milestone.
+
+**Why this choice**
+- The business risk is partner trust, so reviewed and explainable numbers matter more than early automation.
+- A typed rule model supports multiple partnership patterns without building an unsafe open-ended formula engine.
+- Keeping partner delivery PDF-first avoids expanding the permission model before the internal reporting process is stable.
+
 ## 2026-04-14 - Training-only operator access grants
 Bloomjoy now supports a narrow operator access tier for staff who need training without becoming paid Bloomjoy Plus members.
 

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -248,6 +248,12 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Admin Partnerships shows warnings for missing machine tax rate, missing partnership assignment, missing financial rule, and overlapping active assignments
 - [ ] Admin Partnerships > Weekly Preview enforces the partnership week-ending day and uses the previous completed Monday-Sunday week for Bubble Planet-style reporting
 - [ ] Admin Partnerships > Weekly Preview matches the Bubble Planet workbook math: Sunze order amount as gross, machine tax plus configured paid-order fee before split, no-pay orders counted as `$0`, and 60/40 split when configured
+- [ ] Corporate partner P0: super-admin can create a corporate partner, create a partnership/agreement, assign machines, configure machine tax assumptions, and configure typed revenue-share terms without developer support
+- [ ] Corporate partner P0: super-admin can preview a completed weekly report before generating a PDF and sees any missing tax, missing assignment, missing financial-rule, or stale-data warnings
+- [ ] Corporate partner P0: generated partner PDF includes executive summary, reporting period, gross sales, tax impact, net sales, unit/fee/cost assumptions, split calculation, amount owed, machine-level appendix, generated timestamp, and snapshot ID
+- [ ] Corporate partner P0: generated partner PDF is backed by an auditable snapshot/run record with period, rule version, assumptions, generated-by user, status, storage path, and warning state
+- [ ] Corporate partner P0: super-admin can download the reviewed partner PDF for manual sending; scheduled auto-email is not required for V1 acceptance
+- [ ] Non-admin user cannot generate or download corporate partner report PDFs from admin routes
 - [ ] Non-admin user cannot access `/admin/reporting`
 - [ ] Super-admin user can access `/admin/reporting`
 - [ ] Admin can create a weekly partner PDF schedule with recipients and sees it in active schedules


### PR DESCRIPTION
## Summary
- Documents the active Bloomjoy partner reporting PM roadmap and current PR sequencing.
- Records the corporate partner reviewed-PDF milestone as the current P0 business priority.
- Adds acceptance checks for super-admin partner setup, weekly preview, auditable partner PDFs, manual download/send, and non-admin blocking.

## Files changed
- `Docs/CURRENT_STATUS.md`: adds partner reporting roadmap, merge sequence, and next P0 milestone guidance.
- `Docs/DECISIONS.md`: records V1 delivery, partner report shape, typed rule approach, and platform constraints.
- `Docs/BACKLOG.md`: adds the corporate partner reporting critical path and defers operator dashboards.
- `Docs/QA_SMOKE_TEST_CHECKLIST.md`: adds P0 corporate partner report acceptance checks.

## Verification commands + results
- `npm ci` - passed; npm reported existing 10 audit findings (5 moderate, 5 high) and a deprecated `glob` warning.
- `npm run build` - passed; prerendered 13 public routes and 19 private routes. Existing Browserslist stale-data warning remains.
- `npm test --if-present` - passed; no test script is configured.
- `npm run lint --if-present` - passed with 8 existing Fast Refresh warnings in shared UI/Auth files.
- `git diff --check` - passed with line-ending normalization warnings only.

## How to test
1. Check out this branch or use `C:\Repos\wt-reporting-pm-plan`.
2. Run `npm ci`.
3. Run `npm run build`.
4. Run `npm test --if-present`.
5. Run `npm run lint --if-present`.
6. Review the updated docs and confirm the active reporting roadmap prioritizes reviewed corporate partner PDFs before operator dashboards.

Key docs:
- `Docs/CURRENT_STATUS.md`
- `Docs/DECISIONS.md`
- `Docs/BACKLOG.md`
- `Docs/QA_SMOKE_TEST_CHECKLIST.md`

## Overlap / coordination
- PR #161 should still merge first because it hardens Sunze sales ingestion/source controls.
- PR #167 should sync from `main` after #161 if needed because it overlaps `/admin/partnerships` and reporting docs.
- PR #166 should be refreshed after #161/#167 so reporting closeout docs reflect the final merged state.
- PRs #157 and #151 are older/dirty docs branches and should be reconciled or superseded rather than merged unchanged.