### PR TITLE
Build reporting portal shell and partner preview

### DIFF
--- a/Docs/LOCAL_DEV.md
+++ b/Docs/LOCAL_DEV.md
@@ -44,6 +44,7 @@
    - Reporting admin/partner foundation repair: `supabase/migrations/202604260004_reporting_admin_rpc_repair.sql`
    - Sunze enriched sales upsert repair: `supabase/migrations/202604260005_sunze_enriched_fact_upsert.sql`
    - Sunze order-hash idempotency repair: `supabase/migrations/202604260006_sunze_order_hash_index_repair.sql`
+   - Partner dashboard period preview: `supabase/migrations/202604260007_partner_period_preview.sql`
 2) Seed data (optional for local dev): `supabase/seed/20260122_training_seed.sql`
 3) Populate Vimeo fields after account setup:
    - `provider_video_id`

--- a/src/components/portal/portalNavigation.ts
+++ b/src/components/portal/portalNavigation.ts
@@ -51,8 +51,8 @@ export const portalDestinations: PortalDestination[] = [
   },
   {
     href: '/portal/reports',
-    label: 'Reports',
-    description: 'Machine sales, location rollups, and partner-ready exports.',
+    label: 'Reporting',
+    description: 'Machine sales, location rollups, and partner dashboard previews.',
     icon: BarChart3,
     access: 'reporting',
     mobileOrder: 4,

--- a/src/lib/partnerDashboardReporting.ts
+++ b/src/lib/partnerDashboardReporting.ts
@@ -1,0 +1,214 @@
+import { supabaseClient } from '@/lib/supabaseClient';
+
+export type PartnerDashboardPeriodGrain = 'reporting_week' | 'calendar_month';
+
+export type PartnerDashboardPartnershipOption = {
+  id: string;
+  name: string;
+  status: 'draft' | 'active' | 'archived';
+  reportingWeekEndDay: number;
+  timezone: string;
+};
+
+export type PartnerDashboardTotals = {
+  orderCount: number;
+  itemQuantity: number;
+  grossSalesCents: number;
+  taxCents: number;
+  feeCents: number;
+  costCents: number;
+  netSalesCents: number;
+  splitBaseCents: number;
+  amountOwedCents: number;
+  bloomjoyRetainedCents: number;
+};
+
+export type PartnerDashboardPeriod = PartnerDashboardTotals & {
+  periodStart: string;
+  periodEnd: string;
+};
+
+export type PartnerDashboardMachinePeriod = PartnerDashboardTotals & {
+  periodStart: string;
+  periodEnd: string;
+  reportingMachineId: string;
+  machineLabel: string;
+  locationName: string | null;
+};
+
+export type PartnerDashboardWarning = {
+  warningType: string;
+  severity: 'blocking' | 'non_blocking';
+  machineId: string | null;
+  machineLabel: string | null;
+  message: string;
+};
+
+export type PartnerDashboardPeriodPreview = {
+  partnershipId: string;
+  partnershipName: string;
+  periodGrain: PartnerDashboardPeriodGrain;
+  dateFrom: string;
+  dateTo: string;
+  summary: PartnerDashboardTotals;
+  periods: PartnerDashboardPeriod[];
+  machinePeriods: PartnerDashboardMachinePeriod[];
+  warnings: PartnerDashboardWarning[];
+};
+
+type PartnershipSetupRpc = {
+  partnerships?: Array<{
+    id?: string;
+    name?: string;
+    status?: 'draft' | 'active' | 'archived';
+    reporting_week_end_day?: number;
+    timezone?: string;
+  }>;
+};
+
+type PartnerDashboardTotalsRpc = {
+  order_count?: number;
+  item_quantity?: number;
+  gross_sales_cents?: number;
+  tax_cents?: number;
+  fee_cents?: number;
+  cost_cents?: number;
+  net_sales_cents?: number;
+  split_base_cents?: number;
+  amount_owed_cents?: number;
+  bloomjoy_retained_cents?: number;
+};
+
+type PartnerDashboardPeriodRpc = PartnerDashboardTotalsRpc & {
+  period_start?: string;
+  period_end?: string;
+};
+
+type PartnerDashboardMachinePeriodRpc = PartnerDashboardPeriodRpc & {
+  reporting_machine_id?: string;
+  machine_label?: string;
+  location_name?: string | null;
+};
+
+type PartnerDashboardWarningRpc = {
+  warning_type?: string;
+  severity?: string;
+  machine_id?: string | null;
+  machine_label?: string | null;
+  message?: string;
+};
+
+type PartnerDashboardPeriodPreviewRpc = {
+  partnership_id?: string;
+  partnership_name?: string;
+  period_grain?: PartnerDashboardPeriodGrain;
+  date_from?: string;
+  date_to?: string;
+  summary?: PartnerDashboardTotalsRpc;
+  periods?: PartnerDashboardPeriodRpc[];
+  machine_periods?: PartnerDashboardMachinePeriodRpc[];
+  warnings?: PartnerDashboardWarningRpc[];
+};
+
+const numberValue = (value: unknown): number => {
+  const normalized = Number(value ?? 0);
+  return Number.isFinite(normalized) ? normalized : 0;
+};
+
+const mapTotals = (record: PartnerDashboardTotalsRpc | undefined): PartnerDashboardTotals => ({
+  orderCount: numberValue(record?.order_count),
+  itemQuantity: numberValue(record?.item_quantity),
+  grossSalesCents: numberValue(record?.gross_sales_cents),
+  taxCents: numberValue(record?.tax_cents),
+  feeCents: numberValue(record?.fee_cents),
+  costCents: numberValue(record?.cost_cents),
+  netSalesCents: numberValue(record?.net_sales_cents),
+  splitBaseCents: numberValue(record?.split_base_cents),
+  amountOwedCents: numberValue(record?.amount_owed_cents),
+  bloomjoyRetainedCents: numberValue(record?.bloomjoy_retained_cents),
+});
+
+const mapPeriod = (record: PartnerDashboardPeriodRpc): PartnerDashboardPeriod => ({
+  periodStart: String(record.period_start ?? ''),
+  periodEnd: String(record.period_end ?? ''),
+  ...mapTotals(record),
+});
+
+const mapMachinePeriod = (
+  record: PartnerDashboardMachinePeriodRpc
+): PartnerDashboardMachinePeriod => ({
+  periodStart: String(record.period_start ?? ''),
+  periodEnd: String(record.period_end ?? ''),
+  reportingMachineId: String(record.reporting_machine_id ?? ''),
+  machineLabel: String(record.machine_label ?? 'Unnamed machine'),
+  locationName: record.location_name ?? null,
+  ...mapTotals(record),
+});
+
+const mapWarning = (record: PartnerDashboardWarningRpc): PartnerDashboardWarning => ({
+  warningType: String(record.warning_type ?? 'unknown'),
+  severity: record.severity === 'non_blocking' ? 'non_blocking' : 'blocking',
+  machineId: record.machine_id ?? null,
+  machineLabel: record.machine_label ?? null,
+  message: String(record.message ?? 'Review this reporting issue before sharing numbers.'),
+});
+
+export const fetchPartnerDashboardPartnerships = async (): Promise<
+  PartnerDashboardPartnershipOption[]
+> => {
+  const { data, error } = await supabaseClient.rpc('admin_get_partnership_reporting_setup');
+
+  if (error) {
+    throw new Error(error.message || 'Unable to load partner dashboard setup.');
+  }
+
+  const setup = (data as PartnershipSetupRpc | null) ?? {};
+
+  return (setup.partnerships ?? [])
+    .filter((partnership) => partnership.id && partnership.status === 'active')
+    .map((partnership) => ({
+      id: partnership.id as string,
+      name: partnership.name ?? 'Unnamed partnership',
+      status: partnership.status ?? 'draft',
+      reportingWeekEndDay: Number(partnership.reporting_week_end_day ?? 0),
+      timezone: partnership.timezone ?? 'America/Los_Angeles',
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name));
+};
+
+export const fetchPartnerDashboardPeriodPreview = async ({
+  partnershipId,
+  dateFrom,
+  dateTo,
+  periodGrain,
+}: {
+  partnershipId: string;
+  dateFrom: string;
+  dateTo: string;
+  periodGrain: PartnerDashboardPeriodGrain;
+}): Promise<PartnerDashboardPeriodPreview> => {
+  const { data, error } = await supabaseClient.rpc('admin_preview_partner_period_report', {
+    p_partnership_id: partnershipId,
+    p_date_from: dateFrom,
+    p_date_to: dateTo,
+    p_period_grain: periodGrain,
+  });
+
+  if (error) {
+    throw new Error(error.message || 'Unable to load partner dashboard preview.');
+  }
+
+  const record = (data as PartnerDashboardPeriodPreviewRpc | null) ?? {};
+
+  return {
+    partnershipId: String(record.partnership_id ?? partnershipId),
+    partnershipName: String(record.partnership_name ?? 'Partnership'),
+    periodGrain: record.period_grain ?? periodGrain,
+    dateFrom: String(record.date_from ?? dateFrom),
+    dateTo: String(record.date_to ?? dateTo),
+    summary: mapTotals(record.summary),
+    periods: (record.periods ?? []).map(mapPeriod),
+    machinePeriods: (record.machine_periods ?? []).map(mapMachinePeriod),
+    warnings: (record.warnings ?? []).map(mapWarning),
+  };
+};

--- a/src/pages/portal/Reports.tsx
+++ b/src/pages/portal/Reports.tsx
@@ -1,18 +1,59 @@
-import { useMemo, useState } from 'react';
+import { type ReactNode, useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from 'recharts';
-import { Download, Loader2, RefreshCw } from 'lucide-react';
+import {
+  AlertTriangle,
+  CalendarDays,
+  Download,
+  Info,
+  Loader2,
+  RefreshCw,
+  TrendingDown,
+  TrendingUp,
+} from 'lucide-react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
 import {
   ChartContainer,
   ChartTooltip,
   ChartTooltipContent,
   type ChartConfig,
 } from '@/components/ui/chart';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { PortalLayout } from '@/components/portal/PortalLayout';
 import { PortalPageIntro } from '@/components/portal/PortalPageIntro';
+import { useAuth } from '@/contexts/AuthContext';
 import {
+  emptyReportingAccessContext,
   exportSalesReportPdf,
   fetchReportingAccessContext,
   fetchReportingDimensions,
@@ -20,16 +61,64 @@ import {
   summarizeSalesReport,
   type PaymentMethod,
   type ReportGrain,
+  type ReportingAccessContext,
   type SalesReportFilters,
   type SalesReportRow,
 } from '@/lib/reporting';
+import {
+  fetchPartnerDashboardPartnerships,
+  fetchPartnerDashboardPeriodPreview,
+  type PartnerDashboardMachinePeriod,
+  type PartnerDashboardPartnershipOption,
+  type PartnerDashboardPeriod,
+  type PartnerDashboardPeriodGrain,
+  type PartnerDashboardPeriodPreview,
+  type PartnerDashboardTotals,
+} from '@/lib/partnerDashboardReporting';
+import { cn } from '@/lib/utils';
+
+type ReportingView = 'operator' | 'partner';
+type OperatorPeriodPreset = 'this_week' | 'last_week' | 'last_30_days' | 'month_to_date' | 'custom';
+type PartnerPeriodMode = 'weekly' | 'monthly';
 
 const paymentMethods: PaymentMethod[] = ['cash', 'credit', 'other', 'unknown'];
+const paymentMethodLabels: Record<PaymentMethod, string> = {
+  cash: 'Cash',
+  credit: 'Credit',
+  other: 'Other',
+  unknown: 'Unknown',
+};
 
-const chartConfig = {
+const operatorChartConfig = {
   netSales: { label: 'Net sales', color: 'hsl(var(--primary))' },
   grossSales: { label: 'Gross sales', color: 'hsl(var(--sage))' },
 } satisfies ChartConfig;
+
+const dollarsChartConfig = {
+  dollars: { label: 'Sales dollars', color: 'hsl(var(--sage))' },
+} satisfies ChartConfig;
+
+const volumeChartConfig = {
+  volume: { label: 'Volume', color: 'hsl(var(--primary))' },
+} satisfies ChartConfig;
+
+const moneyFormatter = new Intl.NumberFormat(undefined, {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 0,
+});
+
+const exactMoneyFormatter = new Intl.NumberFormat(undefined, {
+  style: 'currency',
+  currency: 'USD',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const numberFormatter = new Intl.NumberFormat();
+
+const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
 
 const toDateInput = (date: Date) => {
   const year = date.getFullYear();
@@ -38,27 +127,117 @@ const toDateInput = (date: Date) => {
   return `${year}-${month}-${day}`;
 };
 
-const getDefaultDateFrom = () => {
-  const date = new Date();
-  date.setDate(date.getDate() - 30);
-  return toDateInput(date);
+const parseDateInput = (value: string) => new Date(`${value}T00:00:00`);
+
+const addDays = (date: Date, days: number) => {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
 };
 
-const formatCurrency = (cents: number) =>
-  new Intl.NumberFormat(undefined, {
-    style: 'currency',
-    currency: 'USD',
-    maximumFractionDigits: 0,
-  }).format(cents / 100);
+const addMonths = (date: Date, months: number) => {
+  const next = new Date(date);
+  next.setMonth(next.getMonth() + months);
+  return next;
+};
 
-const formatDate = (value: string | null) =>
+const startOfMonth = (date: Date) => new Date(date.getFullYear(), date.getMonth(), 1);
+const endOfMonth = (date: Date) => new Date(date.getFullYear(), date.getMonth() + 1, 0);
+
+const startOfOperatorWeek = (date: Date) => {
+  const next = new Date(date);
+  const day = next.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  next.setDate(next.getDate() + diff);
+  return next;
+};
+
+const getOperatorPresetRange = (preset: OperatorPeriodPreset) => {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  if (preset === 'this_week') {
+    return { dateFrom: toDateInput(startOfOperatorWeek(today)), dateTo: toDateInput(today), grain: 'day' as ReportGrain };
+  }
+
+  if (preset === 'last_week') {
+    const thisWeekStart = startOfOperatorWeek(today);
+    const lastWeekStart = addDays(thisWeekStart, -7);
+    return {
+      dateFrom: toDateInput(lastWeekStart),
+      dateTo: toDateInput(addDays(lastWeekStart, 6)),
+      grain: 'day' as ReportGrain,
+    };
+  }
+
+  if (preset === 'month_to_date') {
+    return { dateFrom: toDateInput(startOfMonth(today)), dateTo: toDateInput(today), grain: 'day' as ReportGrain };
+  }
+
+  return {
+    dateFrom: toDateInput(addDays(today, -30)),
+    dateTo: toDateInput(today),
+    grain: 'week' as ReportGrain,
+  };
+};
+
+const getLastCompletedWeekEnd = (weekEndDay: number) => {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  let daysSinceWeekEnd = (today.getDay() - weekEndDay + 7) % 7;
+  if (daysSinceWeekEnd === 0) daysSinceWeekEnd = 7;
+  return addDays(today, -daysSinceWeekEnd);
+};
+
+const getPartnerDateRange = (
+  partnership: PartnerDashboardPartnershipOption | undefined,
+  mode: PartnerPeriodMode
+) => {
+  if (!partnership) return null;
+
+  if (mode === 'weekly') {
+    const lastWeekEnd = getLastCompletedWeekEnd(partnership.reportingWeekEndDay);
+    const firstWeekStart = addDays(lastWeekEnd, -(7 * 7 + 6));
+    return {
+      dateFrom: toDateInput(firstWeekStart),
+      dateTo: toDateInput(lastWeekEnd),
+      periodGrain: 'reporting_week' as PartnerDashboardPeriodGrain,
+      label: `Last 8 completed weeks ending ${dayNames[partnership.reportingWeekEndDay]}`,
+    };
+  }
+
+  const currentMonthStart = startOfMonth(new Date());
+  const lastCompletedMonthEnd = addDays(currentMonthStart, -1);
+  const firstMonthStart = startOfMonth(addMonths(lastCompletedMonthEnd, -5));
+
+  return {
+    dateFrom: toDateInput(firstMonthStart),
+    dateTo: toDateInput(endOfMonth(lastCompletedMonthEnd)),
+    periodGrain: 'calendar_month' as PartnerDashboardPeriodGrain,
+    label: 'Last 6 completed months',
+  };
+};
+
+const formatCurrency = (cents: number, exact = false) =>
+  (exact ? exactMoneyFormatter : moneyFormatter).format(cents / 100);
+
+const formatDate = (value: string | null | undefined) =>
   value
-    ? new Date(`${value}T00:00:00`).toLocaleDateString(undefined, {
+    ? parseDateInput(value).toLocaleDateString(undefined, {
         month: 'short',
         day: 'numeric',
         year: 'numeric',
       })
     : 'n/a';
+
+const formatShortDate = (value: string) =>
+  parseDateInput(value).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+
+const formatMonth = (value: string) =>
+  parseDateInput(value).toLocaleDateString(undefined, { month: 'short', year: 'numeric' });
+
+const formatDateRange = (start: string | undefined, end: string | undefined) =>
+  start && end ? `${formatShortDate(start)} - ${formatShortDate(end)}` : 'No period selected';
 
 const formatDateTime = (value: string | null | undefined) =>
   value
@@ -71,6 +250,25 @@ const formatDateTime = (value: string | null | undefined) =>
       })
     : 'not available';
 
+const formatPercentChange = (current: number, previous: number) => {
+  if (previous === 0) return current > 0 ? 'New activity' : 'No change';
+  const value = ((current - previous) / previous) * 100;
+  return `${value >= 0 ? '+' : ''}${value.toFixed(1)}%`;
+};
+
+const periodVolume = (period: PartnerDashboardTotals | undefined) =>
+  period ? period.itemQuantity || period.orderCount : 0;
+
+const getChangeTone = (current: number, previous: number) => {
+  if (current === previous) return 'text-muted-foreground';
+  return current > previous ? 'text-sage' : 'text-amber';
+};
+
+const getTrendIcon = (current: number, previous: number) => {
+  if (current === previous) return Info;
+  return current > previous ? TrendingUp : TrendingDown;
+};
+
 const groupRows = <TKey extends string>(
   rows: SalesReportRow[],
   getKey: (row: SalesReportRow) => TKey,
@@ -81,6 +279,7 @@ const groupRows = <TKey extends string>(
     {
       key: TKey;
       label: string;
+      locationName: string;
       netSalesCents: number;
       grossSalesCents: number;
       refundAmountCents: number;
@@ -95,6 +294,7 @@ const groupRows = <TKey extends string>(
       {
         key,
         label: getLabel(row),
+        locationName: row.locationName,
         netSalesCents: 0,
         grossSalesCents: 0,
         refundAmountCents: 0,
@@ -112,10 +312,85 @@ const groupRows = <TKey extends string>(
 };
 
 export default function ReportsPage() {
+  const { isAdmin } = useAuth();
+  const [activeView, setActiveView] = useState<ReportingView>('operator');
+
+  const { data: accessContext = emptyReportingAccessContext, isFetching: accessFetching } =
+    useQuery({
+      queryKey: ['reporting-access-context'],
+      queryFn: fetchReportingAccessContext,
+      staleTime: 1000 * 60,
+    });
+
+  useEffect(() => {
+    if (!isAdmin && activeView === 'partner') {
+      setActiveView('operator');
+    }
+  }, [activeView, isAdmin]);
+
+  return (
+    <PortalLayout>
+      <section className="portal-section">
+        <div className="container-page">
+          <PortalPageIntro
+            title="Reporting"
+            description="Track assigned machine performance, review sales trends, and use the internal partner dashboard when settlement math needs a closer look."
+            badges={[
+              {
+                label: `${accessContext.accessibleMachineCount} machines available`,
+                tone: 'muted',
+              },
+              { label: `Latest sale ${formatDate(accessContext.latestSaleDate)}`, tone: 'muted' },
+              {
+                label: `Last import ${formatDateTime(accessContext.latestImportCompletedAt)}`,
+                tone: 'muted',
+              },
+              {
+                label: accessFetching ? 'Refreshing' : isAdmin ? 'Super-admin reporting' : 'Operator reporting',
+                tone: isAdmin ? 'accent' : 'default',
+              },
+            ]}
+            actions={
+              isAdmin ? (
+                <ToggleGroup
+                  type="single"
+                  value={activeView}
+                  onValueChange={(value) => {
+                    if (value === 'operator' || value === 'partner') setActiveView(value);
+                  }}
+                  className="grid w-full grid-cols-2 rounded-lg border border-border bg-background p-1 sm:w-[340px]"
+                >
+                  <ToggleGroupItem value="operator" className="h-9 rounded-md text-sm">
+                    Operator view
+                  </ToggleGroupItem>
+                  <ToggleGroupItem value="partner" className="h-9 rounded-md text-sm">
+                    Partner dashboard
+                  </ToggleGroupItem>
+                </ToggleGroup>
+              ) : undefined
+            }
+          />
+
+          <div className="mt-6">
+            {activeView === 'partner' && isAdmin ? (
+              <PartnerDashboardView />
+            ) : (
+              <OperatorReportingView accessContext={accessContext} />
+            )}
+          </div>
+        </div>
+      </section>
+    </PortalLayout>
+  );
+}
+
+function OperatorReportingView({ accessContext }: { accessContext: ReportingAccessContext }) {
   const queryClient = useQueryClient();
-  const [dateFrom, setDateFrom] = useState(getDefaultDateFrom);
-  const [dateTo, setDateTo] = useState(() => toDateInput(new Date()));
-  const [grain, setGrain] = useState<ReportGrain>('week');
+  const defaultRange = useMemo(() => getOperatorPresetRange('last_30_days'), []);
+  const [periodPreset, setPeriodPreset] = useState<OperatorPeriodPreset>('last_30_days');
+  const [dateFrom, setDateFrom] = useState(defaultRange.dateFrom);
+  const [dateTo, setDateTo] = useState(defaultRange.dateTo);
+  const [grain, setGrain] = useState<ReportGrain>(defaultRange.grain);
   const [machineId, setMachineId] = useState('all');
   const [locationId, setLocationId] = useState('all');
   const [selectedPayments, setSelectedPayments] = useState<PaymentMethod[]>([]);
@@ -130,11 +405,26 @@ export default function ReportsPage() {
     queryFn: fetchReportingDimensions,
     staleTime: 1000 * 60,
   });
-  const { data: accessContext } = useQuery({
-    queryKey: ['reporting-access-context'],
-    queryFn: fetchReportingAccessContext,
-    staleTime: 1000 * 60,
-  });
+
+  const locations = useMemo(() => {
+    const byId = new Map<string, string>();
+    dimensions.forEach((dimension) => byId.set(dimension.locationId, dimension.locationName));
+    return [...byId.entries()].map(([id, name]) => ({ id, name }));
+  }, [dimensions]);
+
+  const machineOptions = useMemo(
+    () =>
+      locationId === 'all'
+        ? dimensions
+        : dimensions.filter((dimension) => dimension.locationId === locationId),
+    [dimensions, locationId]
+  );
+
+  useEffect(() => {
+    if (machineId !== 'all' && !machineOptions.some((machine) => machine.machineId === machineId)) {
+      setMachineId('all');
+    }
+  }, [machineId, machineOptions]);
 
   const filters: SalesReportFilters = useMemo(
     () => ({
@@ -160,16 +450,13 @@ export default function ReportsPage() {
     staleTime: 1000 * 30,
   });
 
-  const locations = useMemo(() => {
-    const byId = new Map<string, string>();
-    dimensions.forEach((dimension) => byId.set(dimension.locationId, dimension.locationName));
-    return [...byId.entries()].map(([id, name]) => ({ id, name }));
-  }, [dimensions]);
-
   const summary = useMemo(() => summarizeSalesReport(reportRows), [reportRows]);
+  const averageOrderCents =
+    summary.transactionCount > 0 ? Math.round(summary.netSalesCents / summary.transactionCount) : 0;
+
   const chartRows = useMemo(
     () =>
-      groupRows(reportRows, (row) => row.periodStart, (row) => formatDate(row.periodStart))
+      groupRows(reportRows, (row) => row.periodStart, (row) => formatShortDate(row.periodStart))
         .sort((left, right) => left.key.localeCompare(right.key))
         .map((row) => ({
           period: row.label,
@@ -178,24 +465,27 @@ export default function ReportsPage() {
         })),
     [reportRows]
   );
+
   const machineRows = useMemo(
     () => groupRows(reportRows, (row) => row.machineId, (row) => row.machineLabel),
     [reportRows]
   );
 
+  const applyPeriodPreset = (preset: OperatorPeriodPreset) => {
+    setPeriodPreset(preset);
+    if (preset === 'custom') return;
+    const nextRange = getOperatorPresetRange(preset);
+    setDateFrom(nextRange.dateFrom);
+    setDateTo(nextRange.dateTo);
+    setGrain(nextRange.grain);
+  };
+
   const refreshReport = async () => {
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: ['sales-report'] }),
       queryClient.invalidateQueries({ queryKey: ['reporting-dimensions'] }),
+      queryClient.invalidateQueries({ queryKey: ['reporting-access-context'] }),
     ]);
-  };
-
-  const togglePaymentMethod = (paymentMethod: PaymentMethod) => {
-    setSelectedPayments((current) =>
-      current.includes(paymentMethod)
-        ? current.filter((value) => value !== paymentMethod)
-        : [...current, paymentMethod]
-    );
   };
 
   const exportPdf = async () => {
@@ -203,7 +493,7 @@ export default function ReportsPage() {
     try {
       const exportResult = await exportSalesReportPdf({
         ...filters,
-        title: `Bloomjoy sales report ${dateFrom} to ${dateTo}`,
+        title: `Bloomjoy operator sales report ${dateFrom} to ${dateTo}`,
       });
       toast.success('Sales report PDF is ready.');
       window.open(exportResult.signedUrl, '_blank', 'noopener,noreferrer');
@@ -214,320 +504,1120 @@ export default function ReportsPage() {
     }
   };
 
+  const hasLoadError = Boolean(error || dimensionsError);
+
   return (
-    <PortalLayout>
-      <section className="portal-section">
-        <div className="container-page">
-          <PortalPageIntro
-            title="Sales Reports"
-            description="Review entitled machine sales by period, location, machine, and payment method. Gross sales adds refund adjustments back to Sunze net sales until the source definition is validated."
-            badges={[
-              { label: `${dimensions.length} machines available`, tone: 'muted' },
-              {
-                label: `Latest sale ${formatDate(accessContext?.latestSaleDate ?? null)}`,
-                tone: 'muted',
-              },
-              {
-                label: `Last import ${formatDateTime(accessContext?.latestImportCompletedAt)}`,
-                tone: 'muted',
-              },
-              { label: isFetching ? 'Refreshing' : 'Ready for export', tone: 'default' },
-            ]}
-            actions={
-              <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:flex-wrap">
-                <Button variant="outline" onClick={refreshReport} disabled={isFetching}>
-                  {isFetching ? (
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  ) : (
-                    <RefreshCw className="mr-2 h-4 w-4" />
-                  )}
-                  Refresh
-                </Button>
-                <Button onClick={exportPdf} disabled={isExporting || reportRows.length === 0}>
-                  {isExporting ? (
-                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  ) : (
-                    <Download className="mr-2 h-4 w-4" />
-                  )}
-                  Export PDF
-                </Button>
-              </div>
-            }
-          />
+    <div className="flex flex-col gap-6">
+      {hasLoadError && (
+        <Alert variant="destructive">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertTitle>Unable to load reporting data</AlertTitle>
+          <AlertDescription>
+            Check the selected filters and try refreshing. Your filter choices will stay in place.
+          </AlertDescription>
+        </Alert>
+      )}
 
-          {(error || dimensionsError) && (
-            <div className="mt-4 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
-              Unable to load sales reporting data. Please try again.
+      <Card>
+        <CardHeader className="gap-2">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+            <div>
+              <CardTitle className="text-xl">Operator performance</CardTitle>
+              <CardDescription>
+                Sales and transaction trends for the machines assigned to this account.
+              </CardDescription>
             </div>
-          )}
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Button variant="outline" onClick={refreshReport} disabled={isFetching}>
+                {isFetching ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <RefreshCw className="mr-2 h-4 w-4" />
+                )}
+                Refresh
+              </Button>
+              <Button onClick={exportPdf} disabled={isExporting || reportRows.length === 0}>
+                {isExporting ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <Download className="mr-2 h-4 w-4" />
+                )}
+                Export PDF
+              </Button>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-5">
+          <div className="grid gap-4 xl:grid-cols-[1.15fr_0.85fr]">
+            <div className="flex flex-col gap-2">
+              <Label>Period</Label>
+              <ToggleGroup
+                type="single"
+                value={periodPreset}
+                onValueChange={(value) => {
+                  if (value) applyPeriodPreset(value as OperatorPeriodPreset);
+                }}
+                className="grid grid-cols-2 items-stretch rounded-lg border border-border bg-background p-1 sm:grid-cols-5"
+              >
+                <ToggleGroupItem value="this_week" className="h-9 rounded-md text-xs sm:text-sm">
+                  This week
+                </ToggleGroupItem>
+                <ToggleGroupItem value="last_week" className="h-9 rounded-md text-xs sm:text-sm">
+                  Last week
+                </ToggleGroupItem>
+                <ToggleGroupItem value="last_30_days" className="h-9 rounded-md text-xs sm:text-sm">
+                  Last 30 days
+                </ToggleGroupItem>
+                <ToggleGroupItem value="month_to_date" className="h-9 rounded-md text-xs sm:text-sm">
+                  Month to date
+                </ToggleGroupItem>
+                <ToggleGroupItem value="custom" className="h-9 rounded-md text-xs sm:text-sm">
+                  Custom
+                </ToggleGroupItem>
+              </ToggleGroup>
+            </div>
 
-          <div className="mt-6 rounded-xl border border-border bg-card p-4 shadow-[var(--shadow-sm)]">
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-5">
-              <label className="text-sm font-medium text-foreground">
-                <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  From
-                </span>
-                <input
+            <div className="grid gap-3 sm:grid-cols-3">
+              <LabeledControl label="From">
+                <Input
                   type="date"
                   value={dateFrom}
-                  onChange={(event) => setDateFrom(event.target.value)}
-                  className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                  onChange={(event) => {
+                    setDateFrom(event.target.value);
+                    setPeriodPreset('custom');
+                  }}
                 />
-              </label>
-              <label className="text-sm font-medium text-foreground">
-                <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  To
-                </span>
-                <input
+              </LabeledControl>
+              <LabeledControl label="To">
+                <Input
                   type="date"
                   value={dateTo}
-                  onChange={(event) => setDateTo(event.target.value)}
-                  className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                  onChange={(event) => {
+                    setDateTo(event.target.value);
+                    setPeriodPreset('custom');
+                  }}
                 />
-              </label>
-              <label className="text-sm font-medium text-foreground">
-                <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  View
-                </span>
-                <select
-                  value={grain}
-                  onChange={(event) => setGrain(event.target.value as ReportGrain)}
-                  className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
-                >
-                  <option value="day">Daily</option>
-                  <option value="week">Weekly</option>
-                  <option value="month">Monthly</option>
-                </select>
-              </label>
-              <label className="text-sm font-medium text-foreground">
-                <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  Location
-                </span>
-                <select
-                  value={locationId}
-                  onChange={(event) => setLocationId(event.target.value)}
-                  className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
-                >
-                  <option value="all">All locations</option>
-                  {locations.map((location) => (
-                    <option key={location.id} value={location.id}>
-                      {location.name}
-                    </option>
-                  ))}
-                </select>
-              </label>
-              <label className="text-sm font-medium text-foreground">
-                <span className="mb-1 block text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  Machine
-                </span>
-                <select
-                  value={machineId}
-                  onChange={(event) => setMachineId(event.target.value)}
-                  className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
-                >
-                  <option value="all">All machines</option>
-                  {dimensions.map((dimension) => (
-                    <option key={dimension.machineId} value={dimension.machineId}>
-                      {dimension.machineLabel}
-                    </option>
-                  ))}
-                </select>
-              </label>
+              </LabeledControl>
+              <LabeledControl label="View">
+                <Select value={grain} onValueChange={(value) => setGrain(value as ReportGrain)}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectItem value="day">Daily</SelectItem>
+                      <SelectItem value="week">Weekly</SelectItem>
+                      <SelectItem value="month">Monthly</SelectItem>
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+              </LabeledControl>
             </div>
-            <div className="mt-4 flex flex-wrap gap-2">
-              {paymentMethods.map((paymentMethod) => {
-                const active = selectedPayments.includes(paymentMethod);
-                return (
-                  <button
+          </div>
+
+          <div className="grid gap-3 lg:grid-cols-[1fr_1fr_1.2fr]">
+            <LabeledControl label="Location">
+              <Select value={locationId} onValueChange={setLocationId}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectItem value="all">All locations</SelectItem>
+                    {locations.map((location) => (
+                      <SelectItem key={location.id} value={location.id}>
+                        {location.name}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            </LabeledControl>
+
+            <LabeledControl label="Machine">
+              <Select value={machineId} onValueChange={setMachineId}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectItem value="all">All machines</SelectItem>
+                    {machineOptions.map((dimension) => (
+                      <SelectItem key={dimension.machineId} value={dimension.machineId}>
+                        {dimension.machineLabel}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            </LabeledControl>
+
+            <div className="flex flex-col gap-2">
+              <Label>Payment</Label>
+              <ToggleGroup
+                type="multiple"
+                value={selectedPayments}
+                onValueChange={(value) => setSelectedPayments(value as PaymentMethod[])}
+                className="grid grid-cols-2 rounded-lg border border-border bg-background p-1 sm:grid-cols-4"
+              >
+                {paymentMethods.map((paymentMethod) => (
+                  <ToggleGroupItem
                     key={paymentMethod}
-                    type="button"
-                    onClick={() => togglePaymentMethod(paymentMethod)}
-                    className={`rounded-full border px-3 py-1.5 text-sm font-medium transition-colors ${
-                      active
-                        ? 'border-primary/20 bg-primary/10 text-primary'
-                        : 'border-border bg-background text-muted-foreground hover:bg-muted'
-                    }`}
+                    value={paymentMethod}
+                    className="h-9 rounded-md text-sm"
                   >
-                    {paymentMethod}
-                  </button>
-                );
-              })}
+                    {paymentMethodLabels[paymentMethod]}
+                  </ToggleGroupItem>
+                ))}
+              </ToggleGroup>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        {isLoading ? (
+          <>
+            <MetricSkeleton />
+            <MetricSkeleton />
+            <MetricSkeleton />
+            <MetricSkeleton />
+          </>
+        ) : (
+          <>
+            <MetricCard
+              label="Net sales"
+              value={formatCurrency(summary.netSalesCents)}
+              context={`${formatCurrency(averageOrderCents)} average order`}
+            />
+            <MetricCard
+              label="Gross sales"
+              value={formatCurrency(summary.grossSalesCents)}
+              context="Net plus refund adjustments"
+            />
+            <MetricCard
+              label="Refund impact"
+              value={formatCurrency(summary.refundAmountCents)}
+              context="Added back for gross view"
+            />
+            <MetricCard
+              label="Transactions"
+              value={numberFormatter.format(summary.transactionCount)}
+              context={`${dimensions.length} assigned machines`}
+            />
+          </>
+        )}
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-[1.15fr_0.85fr]">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">Sales trend</CardTitle>
+            <CardDescription>
+              Net and gross sales for the selected date grain.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <ChartSkeleton />
+            ) : chartRows.length === 0 ? (
+              <EmptyPanel title="No sales found" description="Widen the period or clear filters to check for activity." />
+            ) : (
+              <ChartContainer config={operatorChartConfig} className="h-[320px] w-full">
+                <BarChart data={chartRows}>
+                  <CartesianGrid vertical={false} />
+                  <XAxis dataKey="period" tickLine={false} axisLine={false} />
+                  <YAxis tickLine={false} axisLine={false} width={56} />
+                  <ChartTooltip content={<ChartTooltipContent />} />
+                  <Bar dataKey="netSales" fill="var(--color-netSales)" radius={[5, 5, 0, 0]} />
+                  <Bar dataKey="grossSales" fill="var(--color-grossSales)" radius={[5, 5, 0, 0]} />
+                </BarChart>
+              </ChartContainer>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-xl">Machine comparison</CardTitle>
+            <CardDescription>
+              Ranked by net sales for the selected period.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {machineRows.length === 0 ? (
+              <EmptyPanel title="No machine rows yet" description="Sales will appear here once the selected filters match imported rows." />
+            ) : (
+              <div className="flex flex-col gap-3">
+                {machineRows.slice(0, 6).map((row) => (
+                  <MachineSummaryRow
+                    key={row.key}
+                    label={row.label}
+                    context={`${row.transactionCount.toLocaleString()} transactions`}
+                    primary={formatCurrency(row.netSalesCents)}
+                    secondary={`Gross ${formatCurrency(row.grossSalesCents)}`}
+                  />
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-xl">Report rows</CardTitle>
+          <CardDescription>
+            Source rows grouped by period, machine, location, and payment method.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Period</TableHead>
+                <TableHead>Machine</TableHead>
+                <TableHead>Location</TableHead>
+                <TableHead>Payment</TableHead>
+                <TableHead className="text-right">Net</TableHead>
+                <TableHead className="text-right">Gross</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {reportRows.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={6} className="h-24 text-center text-muted-foreground">
+                    No rows found for the selected filters.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                reportRows.map((row) => (
+                  <TableRow key={`${row.periodStart}-${row.machineId}-${row.paymentMethod}`}>
+                    <TableCell>{formatDate(row.periodStart)}</TableCell>
+                    <TableCell className="font-medium">{row.machineLabel}</TableCell>
+                    <TableCell className="text-muted-foreground">{row.locationName}</TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {paymentMethodLabels[row.paymentMethod]}
+                    </TableCell>
+                    <TableCell className="text-right">{formatCurrency(row.netSalesCents)}</TableCell>
+                    <TableCell className="text-right">{formatCurrency(row.grossSalesCents)}</TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      <div className="rounded-lg border border-border bg-background px-4 py-3 text-sm text-muted-foreground">
+        Sales data last updated {formatDateTime(accessContext.latestImportCompletedAt)}. Admin-only data quality
+        details stay out of the operator view.
+      </div>
+    </div>
+  );
+}
+
+function PartnerDashboardView() {
+  const queryClient = useQueryClient();
+  const [periodMode, setPeriodMode] = useState<PartnerPeriodMode>('weekly');
+  const [selectedPartnershipId, setSelectedPartnershipId] = useState('');
+
+  const {
+    data: partnerships = [],
+    isLoading: partnershipsLoading,
+    error: partnershipsError,
+  } = useQuery({
+    queryKey: ['partner-dashboard-partnerships'],
+    queryFn: fetchPartnerDashboardPartnerships,
+    staleTime: 1000 * 60,
+  });
+
+  useEffect(() => {
+    if (!selectedPartnershipId && partnerships.length > 0) {
+      setSelectedPartnershipId(partnerships[0].id);
+    }
+  }, [partnerships, selectedPartnershipId]);
+
+  const selectedPartnership = partnerships.find(
+    (partnership) => partnership.id === selectedPartnershipId
+  );
+
+  const partnerRange = useMemo(
+    () => getPartnerDateRange(selectedPartnership, periodMode),
+    [periodMode, selectedPartnership]
+  );
+
+  const {
+    data: preview,
+    isLoading: previewLoading,
+    isFetching: previewFetching,
+    error: previewError,
+  } = useQuery({
+    queryKey: [
+      'partner-dashboard-period-preview',
+      selectedPartnershipId,
+      partnerRange?.periodGrain,
+      partnerRange?.dateFrom,
+      partnerRange?.dateTo,
+    ],
+    queryFn: () =>
+      fetchPartnerDashboardPeriodPreview({
+        partnershipId: selectedPartnershipId,
+        dateFrom: partnerRange?.dateFrom ?? '',
+        dateTo: partnerRange?.dateTo ?? '',
+        periodGrain: partnerRange?.periodGrain ?? 'reporting_week',
+      }),
+    enabled: Boolean(selectedPartnershipId && partnerRange),
+    staleTime: 1000 * 30,
+  });
+
+  const sortedPeriods = useMemo(
+    () => [...(preview?.periods ?? [])].sort((left, right) => left.periodStart.localeCompare(right.periodStart)),
+    [preview?.periods]
+  );
+  const currentPeriod = sortedPeriods[sortedPeriods.length - 1];
+  const previousPeriod = sortedPeriods[sortedPeriods.length - 2];
+
+  const machineRows = useMemo(
+    () => buildPartnerMachineRows(preview, currentPeriod, previousPeriod),
+    [currentPeriod, preview, previousPeriod]
+  );
+
+  const blockingWarnings = preview?.warnings.filter((warning) => warning.severity === 'blocking') ?? [];
+  const trendLabel = periodMode === 'weekly' ? 'Weekly' : 'Monthly';
+
+  const refreshPartnerDashboard = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['partner-dashboard-partnerships'] }),
+      queryClient.invalidateQueries({ queryKey: ['partner-dashboard-period-preview'] }),
+    ]);
+  };
+
+  if (partnershipsLoading) {
+    return <PartnerDashboardSkeleton />;
+  }
+
+  if (partnershipsError) {
+    return (
+      <Alert variant="destructive">
+        <AlertTriangle className="h-4 w-4" />
+        <AlertTitle>Unable to load partner dashboard setup</AlertTitle>
+        <AlertDescription>
+          The partner dashboard uses admin-only reporting setup data. Refresh or check the setup RPC.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (partnerships.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>No active partnerships yet</CardTitle>
+          <CardDescription>
+            Add an active partnership, assign machines, and configure financial rules before the
+            dashboard can preview settlement math.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button asChild>
+            <Link to="/admin/partnerships">Open partnership setup</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <CardContent className="flex flex-col gap-4 p-4 lg:flex-row lg:items-end lg:justify-between">
+          <div className="grid flex-1 gap-4 lg:grid-cols-[minmax(260px,0.8fr)_minmax(220px,0.6fr)_1fr]">
+            <LabeledControl label="Partnership">
+              <Select value={selectedPartnershipId} onValueChange={setSelectedPartnershipId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select partnership" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    {partnerships.map((partnership) => (
+                      <SelectItem key={partnership.id} value={partnership.id}>
+                        {partnership.name}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            </LabeledControl>
+
+            <div className="flex flex-col gap-2">
+              <Label>View</Label>
+              <ToggleGroup
+                type="single"
+                value={periodMode}
+                onValueChange={(value) => {
+                  if (value === 'weekly' || value === 'monthly') setPeriodMode(value);
+                }}
+                className="grid grid-cols-2 rounded-lg border border-border bg-background p-1"
+              >
+                <ToggleGroupItem value="weekly" className="h-9 rounded-md text-sm">
+                  Weekly
+                </ToggleGroupItem>
+                <ToggleGroupItem value="monthly" className="h-9 rounded-md text-sm">
+                  Monthly
+                </ToggleGroupItem>
+              </ToggleGroup>
+            </div>
+
+            <div className="flex items-end">
+              <div className="rounded-lg border border-border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+                <span className="font-medium text-foreground">{partnerRange?.label}</span>
+                <span className="block">
+                  {partnerRange ? `${formatDate(partnerRange.dateFrom)} through ${formatDate(partnerRange.dateTo)}` : 'Select a partnership'}
+                </span>
+              </div>
             </div>
           </div>
 
-          <div className="mt-6 grid gap-4 md:grid-cols-4">
-            <div className="card-elevated p-5">
-              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Net Sales
-              </p>
-              <p className="mt-2 text-2xl font-semibold text-foreground">
-                {formatCurrency(summary.netSalesCents)}
-              </p>
-            </div>
-            <div className="card-elevated p-5">
-              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Refund Adjustments
-              </p>
-              <p className="mt-2 text-2xl font-semibold text-foreground">
-                {formatCurrency(summary.refundAmountCents)}
-              </p>
-            </div>
-            <div className="card-elevated p-5">
-              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Gross Sales
-              </p>
-              <p className="mt-2 text-2xl font-semibold text-foreground">
-                {formatCurrency(summary.grossSalesCents)}
-              </p>
-            </div>
-            <div className="card-elevated p-5">
-              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                Transactions
-              </p>
-              <p className="mt-2 text-2xl font-semibold text-foreground">
-                {summary.transactionCount.toLocaleString()}
-              </p>
-            </div>
-          </div>
+          <Button variant="outline" onClick={refreshPartnerDashboard} disabled={previewFetching}>
+            {previewFetching ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <RefreshCw className="mr-2 h-4 w-4" />
+            )}
+            Refresh
+          </Button>
+        </CardContent>
+      </Card>
 
-          <div className="mt-6 grid gap-6 xl:grid-cols-[1.1fr_0.9fr]">
-            <div className="rounded-xl border border-border bg-card p-5 shadow-[var(--shadow-sm)]">
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <h2 className="font-semibold text-foreground">Sales by Period</h2>
-                  <p className="mt-1 text-sm text-muted-foreground">
-                    Net and gross sales for the selected date grain.
-                  </p>
-                </div>
-              </div>
-              <div className="mt-5">
-                {isLoading ? (
-                  <div className="flex h-72 items-center justify-center text-sm text-muted-foreground">
-                    Loading report...
-                  </div>
-                ) : chartRows.length === 0 ? (
-                  <div className="flex h-72 items-center justify-center text-center text-sm text-muted-foreground">
-                    No sales rows match the selected filters.
-                  </div>
-                ) : (
-                  <ChartContainer config={chartConfig} className="h-72 w-full">
-                    <BarChart data={chartRows}>
-                      <CartesianGrid vertical={false} />
-                      <XAxis dataKey="period" tickLine={false} axisLine={false} />
-                      <YAxis tickLine={false} axisLine={false} width={48} />
-                      <ChartTooltip content={<ChartTooltipContent />} />
-                      <Bar dataKey="netSales" fill="var(--color-netSales)" radius={[4, 4, 0, 0]} />
-                      <Bar
-                        dataKey="grossSales"
-                        fill="var(--color-grossSales)"
-                        radius={[4, 4, 0, 0]}
-                      />
-                    </BarChart>
-                  </ChartContainer>
-                )}
-              </div>
-            </div>
+      {previewError && (
+        <Alert variant="destructive">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertTitle>Unable to load partner preview</AlertTitle>
+          <AlertDescription>
+            {previewError instanceof Error
+              ? previewError.message
+              : 'Check the partnership setup and try again.'}
+          </AlertDescription>
+        </Alert>
+      )}
 
-            <div className="rounded-xl border border-border bg-card p-5 shadow-[var(--shadow-sm)]">
-              <h2 className="font-semibold text-foreground">Sales by Machine</h2>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Useful for partner weekly rollups such as Bubble Planet.
-              </p>
-              <div className="mt-5 space-y-3">
-                {machineRows.length === 0 ? (
-                  <div className="rounded-lg border border-border bg-background px-4 py-8 text-center text-sm text-muted-foreground">
-                    No machine rows yet.
-                  </div>
-                ) : (
-                  machineRows.map((row) => (
-                    <div
-                      key={row.key}
-                      className="rounded-lg border border-border bg-background p-4 text-sm"
-                    >
-                      <div className="flex items-start justify-between gap-3">
-                        <div>
-                          <p className="font-semibold text-foreground">{row.label}</p>
-                          <p className="mt-1 text-muted-foreground">
-                            {row.transactionCount.toLocaleString()} transactions
-                          </p>
-                        </div>
-                        <div className="text-right">
-                          <p className="font-semibold text-foreground">
-                            {formatCurrency(row.netSalesCents)}
-                          </p>
-                          <p className="mt-1 text-muted-foreground">
-                            Gross {formatCurrency(row.grossSalesCents)}
-                          </p>
-                        </div>
-                      </div>
+      {previewLoading ? (
+        <PartnerDashboardSkeleton />
+      ) : preview ? (
+        <>
+          <PartnerAnswerBand
+            preview={preview}
+            currentPeriod={currentPeriod}
+            previousPeriod={previousPeriod}
+            blockingWarningCount={blockingWarnings.length}
+            trendLabel={trendLabel}
+          />
+
+          {preview.warnings.length > 0 && (
+            <Alert className="border-amber/20 bg-amber/10 text-foreground">
+              <AlertTriangle className="h-4 w-4" />
+              <AlertTitle>Admin-only data quality review</AlertTitle>
+              <AlertDescription>
+                <div className="mt-2 flex flex-col gap-2">
+                  {preview.warnings.slice(0, 4).map((warning, index) => (
+                    <div key={`${warning.warningType}-${warning.machineId ?? 'scope'}-${index}`}>
+                      <Badge variant={warning.severity === 'blocking' ? 'destructive' : 'outline'}>
+                        {warning.severity === 'blocking' ? 'Blocking' : 'Review'}
+                      </Badge>{' '}
+                      {warning.message}
                     </div>
-                  ))
-                )}
-              </div>
-            </div>
+                  ))}
+                  {preview.warnings.length > 4 && (
+                    <div>{preview.warnings.length - 4} more admin-only warnings hidden.</div>
+                  )}
+                </div>
+              </AlertDescription>
+            </Alert>
+          )}
+
+          <div className="grid min-w-0 gap-6 xl:grid-cols-2">
+            <PartnerTrendCard
+              title="Sales dollars"
+              description={`${trendLabel} gross sales across the selected partnership.`}
+              data={sortedPeriods.map((period) => ({
+                period: periodMode === 'weekly' ? formatDateRange(period.periodStart, period.periodEnd) : formatMonth(period.periodStart),
+                dollars: period.grossSalesCents / 100,
+              }))}
+              config={dollarsChartConfig}
+              dataKey="dollars"
+              value={formatCurrency(currentPeriod?.grossSalesCents ?? 0)}
+              change={formatPercentChange(
+                currentPeriod?.grossSalesCents ?? 0,
+                previousPeriod?.grossSalesCents ?? 0
+              )}
+              current={currentPeriod?.grossSalesCents ?? 0}
+              previous={previousPeriod?.grossSalesCents ?? 0}
+            />
+            <PartnerTrendCard
+              title="Volume"
+              description={`${trendLabel} sticks/items sold across assigned machines.`}
+              data={sortedPeriods.map((period) => ({
+                period: periodMode === 'weekly' ? formatDateRange(period.periodStart, period.periodEnd) : formatMonth(period.periodStart),
+                volume: periodVolume(period),
+              }))}
+              config={volumeChartConfig}
+              dataKey="volume"
+              value={numberFormatter.format(periodVolume(currentPeriod))}
+              change={formatPercentChange(
+                periodVolume(currentPeriod),
+                periodVolume(previousPeriod)
+              )}
+              current={periodVolume(currentPeriod)}
+              previous={periodVolume(previousPeriod)}
+            />
           </div>
 
-          <div className="mt-6 overflow-x-auto rounded-xl border border-border bg-card">
-            <table className="min-w-[760px] w-full">
-              <thead className="border-b border-border bg-muted/40">
-                <tr>
-                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                    Period
-                  </th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                    Machine
-                  </th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                    Location
-                  </th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                    Payment
-                  </th>
-                  <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                    Net
-                  </th>
-                  <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                    Gross
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {reportRows.length === 0 ? (
-                  <tr>
-                    <td colSpan={6} className="px-4 py-10 text-center text-sm text-muted-foreground">
-                      No rows found.
-                    </td>
-                  </tr>
+          <div className="grid min-w-0 gap-6 xl:grid-cols-[1.25fr_0.75fr]">
+            <Card className="min-w-0">
+              <CardHeader>
+                <CardTitle className="text-xl">Machine rollups</CardTitle>
+                <CardDescription>
+                  Current {periodMode === 'weekly' ? 'week' : 'month'} compared with the previous period.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                {machineRows.length === 0 ? (
+                  <EmptyPanel title="No machine rollups" description="Assign machines and import sales before this table can show partner performance." />
                 ) : (
-                  reportRows.map((row) => (
-                    <tr
-                      key={`${row.periodStart}-${row.machineId}-${row.paymentMethod}`}
-                      className="border-b border-border/70"
-                    >
-                      <td className="px-4 py-3 text-sm text-foreground">
-                        {formatDate(row.periodStart)}
-                      </td>
-                      <td className="px-4 py-3 text-sm text-foreground">{row.machineLabel}</td>
-                      <td className="px-4 py-3 text-sm text-muted-foreground">
-                        {row.locationName}
-                      </td>
-                      <td className="px-4 py-3 text-sm text-muted-foreground">
-                        {row.paymentMethod}
-                      </td>
-                      <td className="px-4 py-3 text-right text-sm text-foreground">
-                        {formatCurrency(row.netSalesCents)}
-                      </td>
-                      <td className="px-4 py-3 text-right text-sm text-foreground">
-                        {formatCurrency(row.grossSalesCents)}
-                      </td>
-                    </tr>
-                  ))
+                  <>
+                    <div className="flex flex-col gap-3 md:hidden">
+                      {machineRows.map((row) => (
+                        <PartnerMachineMobileCard key={row.current.reportingMachineId} row={row} />
+                      ))}
+                    </div>
+                    <div className="hidden md:block">
+                      <Table>
+                        <TableHeader>
+                          <TableRow>
+                            <TableHead>Machine</TableHead>
+                            <TableHead className="text-right">Sales dollars</TableHead>
+                            <TableHead className="text-right">Volume</TableHead>
+                            <TableHead className="text-right">Tax + fees</TableHead>
+                            <TableHead className="text-right">Net sales</TableHead>
+                            <TableHead className="text-right">Split base</TableHead>
+                            <TableHead className="text-right">Amount owed</TableHead>
+                            <TableHead className="text-right">Change</TableHead>
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {machineRows.map((row) => {
+                            const TrendIcon = getTrendIcon(row.current.grossSalesCents, row.previous?.grossSalesCents ?? 0);
+                            return (
+                              <TableRow key={row.current.reportingMachineId}>
+                                <TableCell>
+                                  <div className="font-medium">{row.current.machineLabel}</div>
+                                  <div className="text-xs text-muted-foreground">
+                                    {row.current.locationName ?? 'No location'}
+                                  </div>
+                                </TableCell>
+                                <TableCell className="text-right">
+                                  {formatCurrency(row.current.grossSalesCents)}
+                                </TableCell>
+                                <TableCell className="text-right">
+                                  <div>{numberFormatter.format(periodVolume(row.current))} items</div>
+                                  <div className="text-xs text-muted-foreground">
+                                    {numberFormatter.format(row.current.orderCount)} orders
+                                  </div>
+                                </TableCell>
+                                <TableCell className="text-right">
+                                  <div>{formatCurrency(row.current.taxCents + row.current.feeCents, true)}</div>
+                                  <div className="text-xs text-muted-foreground">
+                                    Costs {formatCurrency(row.current.costCents, true)}
+                                  </div>
+                                </TableCell>
+                                <TableCell className="text-right">
+                                  {formatCurrency(row.current.netSalesCents, true)}
+                                </TableCell>
+                                <TableCell className="text-right">
+                                  {formatCurrency(row.current.splitBaseCents, true)}
+                                </TableCell>
+                                <TableCell className="text-right">
+                                  {formatCurrency(row.current.amountOwedCents, true)}
+                                </TableCell>
+                                <TableCell className="text-right">
+                                  <div
+                                    className={cn(
+                                      'inline-flex items-center justify-end gap-1 font-medium',
+                                      getChangeTone(row.current.grossSalesCents, row.previous?.grossSalesCents ?? 0)
+                                    )}
+                                  >
+                                    <TrendIcon className="h-4 w-4" />
+                                    {formatPercentChange(
+                                      row.current.grossSalesCents,
+                                      row.previous?.grossSalesCents ?? 0
+                                    )}
+                                  </div>
+                                  <div
+                                    className={cn(
+                                      'text-xs',
+                                      getChangeTone(periodVolume(row.current), periodVolume(row.previous))
+                                    )}
+                                  >
+                                    Volume {formatPercentChange(periodVolume(row.current), periodVolume(row.previous))}
+                                  </div>
+                                </TableCell>
+                              </TableRow>
+                            );
+                          })}
+                        </TableBody>
+                      </Table>
+                    </div>
+                  </>
                 )}
-              </tbody>
-            </table>
+              </CardContent>
+            </Card>
+
+            <PartnerCalculationCard summary={preview.summary} />
+          </div>
+        </>
+      ) : (
+        <EmptyPanel title="Select a partnership" description="Choose an active partnership to load the partner dashboard preview." />
+      )}
+    </div>
+  );
+}
+
+function PartnerAnswerBand({
+  preview,
+  currentPeriod,
+  previousPeriod,
+  blockingWarningCount,
+  trendLabel,
+}: {
+  preview: PartnerDashboardPeriodPreview;
+  currentPeriod: PartnerDashboardPeriod | undefined;
+  previousPeriod: PartnerDashboardPeriod | undefined;
+  blockingWarningCount: number;
+  trendLabel: string;
+}) {
+  const hasBlockingWarnings = blockingWarningCount > 0;
+  const TrendIcon = getTrendIcon(currentPeriod?.amountOwedCents ?? 0, previousPeriod?.amountOwedCents ?? 0);
+
+  return (
+    <Card>
+      <CardContent className="grid gap-5 p-5 md:grid-cols-2 xl:grid-cols-4">
+        <AnswerItem
+          label="Amount owed"
+          value={formatCurrency(currentPeriod?.amountOwedCents ?? preview.summary.amountOwedCents, true)}
+          detail="Due to partner for the current period"
+          emphasis
+        />
+        <AnswerItem
+          label="Period"
+          value={formatDateRange(currentPeriod?.periodStart, currentPeriod?.periodEnd)}
+          detail={`${trendLabel} view: ${formatDate(preview.dateFrom)} - ${formatDate(preview.dateTo)}`}
+          icon={<CalendarDays className="h-5 w-5 text-muted-foreground" />}
+        />
+        <AnswerItem
+          label="Status"
+          value={hasBlockingWarnings ? 'Blocked' : 'Ready for review'}
+          detail={hasBlockingWarnings ? `${blockingWarningCount} blocking admin items` : 'No blocking admin warnings'}
+          badgeTone={hasBlockingWarnings ? 'destructive' : 'default'}
+        />
+        <AnswerItem
+          label="Movement"
+          value={formatPercentChange(
+            currentPeriod?.amountOwedCents ?? 0,
+            previousPeriod?.amountOwedCents ?? 0
+          )}
+          detail="Amount owed vs previous period"
+          icon={
+            <TrendIcon
+              className={cn(
+                'h-5 w-5',
+                getChangeTone(currentPeriod?.amountOwedCents ?? 0, previousPeriod?.amountOwedCents ?? 0)
+              )}
+            />
+          }
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+function PartnerTrendCard({
+  title,
+  description,
+  data,
+  config,
+  dataKey,
+  value,
+  change,
+  current,
+  previous,
+}: {
+  title: string;
+  description: string;
+  data: Array<Record<string, string | number>>;
+  config: ChartConfig;
+  dataKey: string;
+  value: string;
+  change: string;
+  current: number;
+  previous: number;
+}) {
+  const TrendIcon = getTrendIcon(current, previous);
+
+  return (
+    <Card className="min-w-0">
+      <CardHeader className="gap-2">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <CardTitle className="text-xl">{title}</CardTitle>
+            <CardDescription>{description}</CardDescription>
+          </div>
+          <div className="text-left sm:text-right">
+            <div className="text-2xl font-semibold text-foreground">{value}</div>
+            <div className={cn('mt-1 inline-flex items-center gap-1 text-sm', getChangeTone(current, previous))}>
+              <TrendIcon className="h-4 w-4" />
+              {change}
+            </div>
           </div>
         </div>
-      </section>
-    </PortalLayout>
+      </CardHeader>
+      <CardContent>
+        {data.length === 0 ? (
+          <EmptyPanel title="No trend data" description="This period has no imported partner sales yet." />
+        ) : (
+          <ChartContainer config={config} className="h-[280px] w-full">
+            <BarChart data={data}>
+              <CartesianGrid vertical={false} />
+              <XAxis dataKey="period" tickLine={false} axisLine={false} />
+              <YAxis tickLine={false} axisLine={false} width={56} />
+              <ChartTooltip content={<ChartTooltipContent />} />
+              <Bar dataKey={dataKey} fill={`var(--color-${dataKey})`} radius={[5, 5, 0, 0]} />
+            </BarChart>
+          </ChartContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function PartnerMachineMobileCard({
+  row,
+}: {
+  row: {
+    current: PartnerDashboardMachinePeriod;
+    previous?: PartnerDashboardMachinePeriod;
+  };
+}) {
+  const TrendIcon = getTrendIcon(row.current.grossSalesCents, row.previous?.grossSalesCents ?? 0);
+
+  return (
+    <div className="rounded-lg border border-border bg-background p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="font-medium text-foreground">{row.current.machineLabel}</div>
+          <div className="text-sm text-muted-foreground">
+            {row.current.locationName ?? 'No location'}
+          </div>
+        </div>
+        <div className="shrink-0 text-right">
+          <div className="font-semibold text-foreground">
+            {formatCurrency(row.current.grossSalesCents)}
+          </div>
+          <div
+            className={cn(
+              'mt-1 inline-flex items-center gap-1 text-xs font-medium',
+              getChangeTone(row.current.grossSalesCents, row.previous?.grossSalesCents ?? 0)
+            )}
+          >
+            <TrendIcon className="h-3.5 w-3.5" />
+            {formatPercentChange(row.current.grossSalesCents, row.previous?.grossSalesCents ?? 0)}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-4 grid grid-cols-2 gap-3 text-sm">
+        <MobileProofItem
+          label="Volume"
+          value={`${numberFormatter.format(periodVolume(row.current))} items`}
+          detail={`${numberFormatter.format(row.current.orderCount)} orders`}
+        />
+        <MobileProofItem
+          label="Amount owed"
+          value={formatCurrency(row.current.amountOwedCents, true)}
+          detail={`Volume ${formatPercentChange(periodVolume(row.current), periodVolume(row.previous))}`}
+        />
+        <MobileProofItem
+          label="Net sales"
+          value={formatCurrency(row.current.netSalesCents, true)}
+          detail={`Split ${formatCurrency(row.current.splitBaseCents, true)}`}
+        />
+        <MobileProofItem
+          label="Tax, fees, costs"
+          value={formatCurrency(row.current.taxCents + row.current.feeCents, true)}
+          detail={`Costs ${formatCurrency(row.current.costCents, true)}`}
+        />
+      </div>
+    </div>
+  );
+}
+
+function MobileProofItem({
+  label,
+  value,
+  detail,
+}: {
+  label: string;
+  value: string;
+  detail: string;
+}) {
+  return (
+    <div className="rounded-md bg-muted/30 p-3">
+      <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      <div className="mt-1 font-medium text-foreground">{value}</div>
+      <div className="mt-1 text-xs text-muted-foreground">{detail}</div>
+    </div>
+  );
+}
+
+function PartnerCalculationCard({ summary }: { summary: PartnerDashboardTotals }) {
+  return (
+    <Card className="min-w-0">
+      <CardHeader className="flex flex-row items-start justify-between gap-3">
+        <div>
+          <CardTitle className="text-xl">Calculation</CardTitle>
+          <CardDescription>Current selected range across the partnership.</CardDescription>
+        </div>
+        <Badge variant="outline">Preview</Badge>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <CalculationLine label="Gross sales" value={formatCurrency(summary.grossSalesCents, true)} />
+        <CalculationLine label="Tax impact" value={`-${formatCurrency(summary.taxCents, true)}`} />
+        <CalculationLine label="Fees" value={`-${formatCurrency(summary.feeCents, true)}`} />
+        <CalculationLine label="Costs" value={`-${formatCurrency(summary.costCents, true)}`} />
+        <CalculationLine label="Net sales" value={formatCurrency(summary.netSalesCents, true)} />
+        <CalculationLine label="Split base" value={formatCurrency(summary.splitBaseCents, true)} />
+        <CalculationLine
+          label="Amount owed"
+          value={formatCurrency(summary.amountOwedCents, true)}
+          emphasis
+        />
+        <CalculationLine
+          label="Bloomjoy retained"
+          value={formatCurrency(summary.bloomjoyRetainedCents, true)}
+        />
+        <div className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
+          <div className="font-medium text-foreground">How this is calculated</div>
+          <p className="mt-2">
+            Gross sales minus configured tax and fees creates net sales. The active financial rule
+            determines the split base, then applies the partner share to calculate amount owed.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function buildPartnerMachineRows(
+  preview: PartnerDashboardPeriodPreview | undefined,
+  currentPeriod: PartnerDashboardPeriod | undefined,
+  previousPeriod: PartnerDashboardPeriod | undefined
+) {
+  if (!preview || !currentPeriod) return [];
+
+  const previousByMachine = new Map<string, PartnerDashboardMachinePeriod>();
+  if (previousPeriod) {
+    preview.machinePeriods
+      .filter((machine) => machine.periodStart === previousPeriod.periodStart)
+      .forEach((machine) => previousByMachine.set(machine.reportingMachineId, machine));
+  }
+
+  return preview.machinePeriods
+    .filter((machine) => machine.periodStart === currentPeriod.periodStart)
+    .map((current) => ({
+      current,
+      previous: previousByMachine.get(current.reportingMachineId),
+    }))
+    .sort((left, right) => right.current.grossSalesCents - left.current.grossSalesCents);
+}
+
+function LabeledControl({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="flex flex-col gap-2">
+      <Label>{label}</Label>
+      {children}
+    </div>
+  );
+}
+
+function MetricCard({
+  label,
+  value,
+  context,
+}: {
+  label: string;
+  value: string;
+  context: string;
+}) {
+  return (
+    <Card>
+      <CardContent className="p-5">
+        <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {label}
+        </div>
+        <div className="mt-2 text-2xl font-semibold text-foreground">{value}</div>
+        <div className="mt-2 text-sm text-muted-foreground">{context}</div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function MetricSkeleton() {
+  return (
+    <Card>
+      <CardContent className="flex flex-col gap-3 p-5">
+        <Skeleton className="h-4 w-24" />
+        <Skeleton className="h-8 w-32" />
+        <Skeleton className="h-4 w-40" />
+      </CardContent>
+    </Card>
+  );
+}
+
+function PartnerDashboardSkeleton() {
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <CardContent className="grid gap-4 p-5 md:grid-cols-2 xl:grid-cols-4">
+          <MetricSkeletonContent />
+          <MetricSkeletonContent />
+          <MetricSkeletonContent />
+          <MetricSkeletonContent />
+        </CardContent>
+      </Card>
+      <div className="grid gap-6 xl:grid-cols-2">
+        <Card>
+          <CardContent className="p-6">
+            <ChartSkeleton />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="p-6">
+            <ChartSkeleton />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+function MetricSkeletonContent() {
+  return (
+    <div className="flex flex-col gap-3">
+      <Skeleton className="h-4 w-24" />
+      <Skeleton className="h-8 w-36" />
+      <Skeleton className="h-4 w-44" />
+    </div>
+  );
+}
+
+function ChartSkeleton() {
+  return (
+    <div className="flex h-[280px] flex-col justify-end gap-3">
+      <Skeleton className="h-full w-full" />
+    </div>
+  );
+}
+
+function EmptyPanel({ title, description }: { title: string; description: string }) {
+  return (
+    <div className="flex min-h-[180px] flex-col items-center justify-center rounded-lg border border-dashed border-border bg-muted/20 p-6 text-center">
+      <div className="font-medium text-foreground">{title}</div>
+      <div className="mt-2 max-w-md text-sm text-muted-foreground">{description}</div>
+    </div>
+  );
+}
+
+function MachineSummaryRow({
+  label,
+  context,
+  primary,
+  secondary,
+}: {
+  label: string;
+  context: string;
+  primary: string;
+  secondary: string;
+}) {
+  return (
+    <div className="rounded-lg border border-border bg-background p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="truncate font-medium text-foreground">{label}</div>
+          <div className="mt-1 text-sm text-muted-foreground">{context}</div>
+        </div>
+        <div className="shrink-0 text-right">
+          <div className="font-semibold text-foreground">{primary}</div>
+          <div className="mt-1 text-sm text-muted-foreground">{secondary}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AnswerItem({
+  label,
+  value,
+  detail,
+  icon,
+  emphasis = false,
+  badgeTone,
+}: {
+  label: string;
+  value: string;
+  detail: string;
+  icon?: ReactNode;
+  emphasis?: boolean;
+  badgeTone?: 'default' | 'destructive';
+}) {
+  return (
+    <div className="flex min-w-0 flex-col gap-2 border-border md:border-r md:pr-5 md:last:border-r-0">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <span>{label}</span>
+        {icon}
+      </div>
+      {badgeTone ? (
+        <div>
+          <Badge variant={badgeTone}>{value}</Badge>
+        </div>
+      ) : (
+        <div className={cn('text-2xl font-semibold text-foreground', emphasis && 'text-sage')}>
+          {value}
+        </div>
+      )}
+      <div className="text-sm text-muted-foreground">{detail}</div>
+    </div>
+  );
+}
+
+function CalculationLine({
+  label,
+  value,
+  emphasis = false,
+}: {
+  label: string;
+  value: string;
+  emphasis?: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-4 text-sm">
+      <div className={cn('text-muted-foreground', emphasis && 'font-medium text-foreground')}>
+        {label}
+      </div>
+      <div className={cn('font-medium text-foreground', emphasis && 'text-lg text-sage')}>
+        {value}
+      </div>
+    </div>
   );
 }

--- a/src/pages/portal/Reports.tsx
+++ b/src/pages/portal/Reports.tsx
@@ -902,6 +902,8 @@ function PartnerDashboardView() {
     [periodMode, sortedPeriods]
   );
 
+  const hasBlockingWarnings =
+    preview?.warnings.some((warning) => warning.severity === 'blocking') ?? false;
   const trendLabel = periodMode === 'weekly' ? 'Weekly' : 'Monthly';
 
   const refreshPartnerDashboard = async () => {
@@ -913,6 +915,14 @@ function PartnerDashboardView() {
 
   const exportPartnerPdf = () => {
     if (!preview) return;
+    if (previewFetching) {
+      toast.error('Wait for the latest partner dashboard numbers before exporting.');
+      return;
+    }
+    if (hasBlockingWarnings) {
+      toast.error('Resolve blocking admin review items before exporting the partner PDF.');
+      return;
+    }
 
     toast.success('Opening branded partner report for PDF export.');
     window.setTimeout(() => window.print(), 50);
@@ -1018,7 +1028,10 @@ function PartnerDashboardView() {
               )}
               Refresh
             </Button>
-            <Button onClick={exportPartnerPdf} disabled={!preview || previewLoading}>
+            <Button
+              onClick={exportPartnerPdf}
+              disabled={!preview || previewLoading || previewFetching || hasBlockingWarnings}
+            >
               <FileText className="mr-2 h-4 w-4" />
               Export PDF
             </Button>
@@ -1056,6 +1069,11 @@ function PartnerDashboardView() {
               <AlertTitle>Admin-only data quality review</AlertTitle>
               <AlertDescription>
                 <div className="mt-2 flex flex-col gap-2">
+                  {hasBlockingWarnings && (
+                    <div className="font-medium">
+                      Partner PDF export is locked until blocking items are resolved.
+                    </div>
+                  )}
                   {preview.warnings.slice(0, 4).map((warning, index) => (
                     <div key={`${warning.warningType}-${warning.machineId ?? 'scope'}-${index}`}>
                       <Badge variant={warning.severity === 'blocking' ? 'destructive' : 'outline'}>
@@ -1204,7 +1222,7 @@ function PartnerDashboardView() {
         <EmptyPanel title="Select a partnership" description="Choose an active partnership to load the partner dashboard preview." />
       )}
       </div>
-      {preview && (
+      {preview && !hasBlockingWarnings && (
         <PartnerPrintableReport
           preview={preview}
           periods={sortedPeriods}
@@ -1320,37 +1338,55 @@ function PartnerTrendCard({
         {data.length === 0 || !hasVisibleValues ? (
           <EmptyPanel title="No trend data" description="This period has no imported partner sales yet." />
         ) : (
-          <ChartContainer config={config} className="h-[320px] w-full">
-            <BarChart data={data} margin={{ left: 8, right: 8 }}>
-              <CartesianGrid vertical={false} />
-              <XAxis dataKey="period" tickLine={false} axisLine={false} />
-              <YAxis
-                tickLine={false}
-                axisLine={false}
-                width={64}
-                tickFormatter={(tick) =>
-                  valueFormatter ? valueFormatter(Number(tick)) : numberFormatter.format(Number(tick))
-                }
-              />
-              <ChartTooltip
-                content={
-                  <ChartTooltipContent
-                    formatter={(tooltipValue) =>
-                      valueFormatter
-                        ? valueFormatter(Number(tooltipValue))
-                        : numberFormatter.format(Number(tooltipValue))
-                    }
-                  />
-                }
-              />
-              <Bar
-                dataKey={dataKey}
-                fill={`var(--color-${dataKey})`}
-                radius={[5, 5, 0, 0]}
-                isAnimationActive={false}
-              />
-            </BarChart>
-          </ChartContainer>
+          <>
+            <ChartContainer config={config} className="h-[320px] w-full">
+              <BarChart data={data} margin={{ left: 8, right: 8 }}>
+                <CartesianGrid vertical={false} />
+                <XAxis dataKey="period" tickLine={false} axisLine={false} />
+                <YAxis
+                  tickLine={false}
+                  axisLine={false}
+                  width={64}
+                  tickFormatter={(tick) =>
+                    valueFormatter ? valueFormatter(Number(tick)) : numberFormatter.format(Number(tick))
+                  }
+                />
+                <ChartTooltip
+                  content={
+                    <ChartTooltipContent
+                      formatter={(tooltipValue) =>
+                        valueFormatter
+                          ? valueFormatter(Number(tooltipValue))
+                          : numberFormatter.format(Number(tooltipValue))
+                      }
+                    />
+                  }
+                />
+                <Bar
+                  dataKey={dataKey}
+                  fill={`var(--color-${dataKey})`}
+                  radius={[5, 5, 0, 0]}
+                  isAnimationActive={false}
+                />
+              </BarChart>
+            </ChartContainer>
+            <div className="mt-4 grid gap-2 md:hidden">
+              {data.map((point) => {
+                const rawValue = Number(point[dataKey] ?? 0);
+                return (
+                  <div
+                    key={`${point.period}-${rawValue}`}
+                    className="flex items-center justify-between gap-3 rounded-md bg-muted/30 px-3 py-2 text-sm"
+                  >
+                    <span className="min-w-0 text-muted-foreground">{point.period}</span>
+                    <span className="shrink-0 font-medium text-foreground">
+                      {valueFormatter ? valueFormatter(rawValue) : numberFormatter.format(rawValue)}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </>
         )}
       </CardContent>
     </Card>
@@ -1390,6 +1426,11 @@ function PartnerPrintableReport({
       <style>
         {`
           @media print {
+            @page {
+              size: letter;
+              margin: 0.45in;
+            }
+
             body * {
               visibility: hidden;
             }
@@ -1411,7 +1452,7 @@ function PartnerPrintableReport({
           }
         `}
       </style>
-      <div className="partner-print-report mx-auto flex max-w-[7.5in] flex-col gap-6 p-8 text-foreground">
+      <div className="partner-print-report mx-auto flex w-full max-w-none flex-col gap-6 p-8 text-foreground">
         <header className="flex items-start justify-between gap-6 border-b border-border pb-5">
           <div>
             <div className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
@@ -1575,8 +1616,9 @@ function PartnerPrintableReport({
           <div>
             <h2 className="text-lg font-semibold text-foreground">Calculation summary</h2>
             <p className="mt-2 text-sm leading-6 text-muted-foreground">
-              Gross sales minus tax, configured fees, and costs creates net sales and the split
-              base. The active partnership rule calculates the partner owed amount from that base.
+              Gross sales minus tax and configured fees creates net sales. Configured costs can
+              reduce the split base when the active partnership rule uses contribution after costs.
+              The partner owed amount is calculated from that split base.
             </p>
           </div>
           <div className="flex flex-col gap-2 text-sm">
@@ -1731,8 +1773,9 @@ function PartnerCalculationCard({
         <div className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
           <div className="font-medium text-foreground">How this is calculated</div>
           <p className="mt-2">
-            Gross sales minus configured tax and fees creates net sales. The active financial rule
-            determines the split base, then applies the partner share to calculate amount owed.
+            Gross sales minus configured tax and fees creates net sales. Configured costs can reduce
+            the split base when the active rule uses contribution after costs. The partner share is
+            applied to that split base to calculate amount owed.
           </p>
         </div>
       </CardContent>

--- a/src/pages/portal/Reports.tsx
+++ b/src/pages/portal/Reports.tsx
@@ -3,8 +3,8 @@ import { Link } from 'react-router-dom';
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from 'recharts';
 import {
   AlertTriangle,
-  CalendarDays,
   Download,
+  FileText,
   Info,
   Loader2,
   RefreshCw,
@@ -80,6 +80,10 @@ import { cn } from '@/lib/utils';
 type ReportingView = 'operator' | 'partner';
 type OperatorPeriodPreset = 'this_week' | 'last_week' | 'last_30_days' | 'month_to_date' | 'custom';
 type PartnerPeriodMode = 'weekly' | 'monthly';
+type PartnerMachineComparisonRow = {
+  current: PartnerDashboardMachinePeriod;
+  previous?: PartnerDashboardMachinePeriod;
+};
 
 const paymentMethods: PaymentMethod[] = ['cash', 'credit', 'other', 'unknown'];
 const paymentMethodLabels: Record<PaymentMethod, string> = {
@@ -91,15 +95,10 @@ const paymentMethodLabels: Record<PaymentMethod, string> = {
 
 const operatorChartConfig = {
   netSales: { label: 'Net sales', color: 'hsl(var(--primary))' },
-  grossSales: { label: 'Gross sales', color: 'hsl(var(--sage))' },
 } satisfies ChartConfig;
 
-const dollarsChartConfig = {
-  dollars: { label: 'Sales dollars', color: 'hsl(var(--sage))' },
-} satisfies ChartConfig;
-
-const volumeChartConfig = {
-  volume: { label: 'Volume', color: 'hsl(var(--primary))' },
+const partnerNetSalesChartConfig = {
+  netSales: { label: 'Net sales', color: 'hsl(var(--sage))' },
 } satisfies ChartConfig;
 
 const moneyFormatter = new Intl.NumberFormat(undefined, {
@@ -238,6 +237,14 @@ const formatMonth = (value: string) =>
 
 const formatDateRange = (start: string | undefined, end: string | undefined) =>
   start && end ? `${formatShortDate(start)} - ${formatShortDate(end)}` : 'No period selected';
+
+const formatPartnerPeriod = (
+  period: Pick<PartnerDashboardPeriod, 'periodStart' | 'periodEnd'>,
+  periodMode: PartnerPeriodMode
+) =>
+  periodMode === 'weekly'
+    ? formatDateRange(period.periodStart, period.periodEnd)
+    : formatMonth(period.periodStart);
 
 const formatDateTime = (value: string | null | undefined) =>
   value
@@ -461,7 +468,6 @@ function OperatorReportingView({ accessContext }: { accessContext: ReportingAcce
         .map((row) => ({
           period: row.label,
           netSales: row.netSalesCents / 100,
-          grossSales: row.grossSalesCents / 100,
         })),
     [reportRows]
   );
@@ -714,7 +720,7 @@ function OperatorReportingView({ accessContext }: { accessContext: ReportingAcce
           <CardHeader>
             <CardTitle className="text-xl">Sales trend</CardTitle>
             <CardDescription>
-              Net and gross sales for the selected date grain.
+              Net sales for the selected date grain.
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -729,8 +735,12 @@ function OperatorReportingView({ accessContext }: { accessContext: ReportingAcce
                   <XAxis dataKey="period" tickLine={false} axisLine={false} />
                   <YAxis tickLine={false} axisLine={false} width={56} />
                   <ChartTooltip content={<ChartTooltipContent />} />
-                  <Bar dataKey="netSales" fill="var(--color-netSales)" radius={[5, 5, 0, 0]} />
-                  <Bar dataKey="grossSales" fill="var(--color-grossSales)" radius={[5, 5, 0, 0]} />
+                  <Bar
+                    dataKey="netSales"
+                    fill="var(--color-netSales)"
+                    radius={[5, 5, 0, 0]}
+                    isAnimationActive={false}
+                  />
                 </BarChart>
               </ChartContainer>
             )}
@@ -883,7 +893,15 @@ function PartnerDashboardView() {
     [currentPeriod, preview, previousPeriod]
   );
 
-  const blockingWarnings = preview?.warnings.filter((warning) => warning.severity === 'blocking') ?? [];
+  const netSalesTrendData = useMemo(
+    () =>
+      sortedPeriods.map((period) => ({
+        period: formatPartnerPeriod(period, periodMode),
+        netSales: period.netSalesCents / 100,
+      })),
+    [periodMode, sortedPeriods]
+  );
+
   const trendLabel = periodMode === 'weekly' ? 'Weekly' : 'Monthly';
 
   const refreshPartnerDashboard = async () => {
@@ -891,6 +909,13 @@ function PartnerDashboardView() {
       queryClient.invalidateQueries({ queryKey: ['partner-dashboard-partnerships'] }),
       queryClient.invalidateQueries({ queryKey: ['partner-dashboard-period-preview'] }),
     ]);
+  };
+
+  const exportPartnerPdf = () => {
+    if (!preview) return;
+
+    toast.success('Opening branded partner report for PDF export.');
+    window.setTimeout(() => window.print(), 50);
   };
 
   if (partnershipsLoading) {
@@ -929,7 +954,8 @@ function PartnerDashboardView() {
   }
 
   return (
-    <div className="flex flex-col gap-6">
+    <>
+      <div className="flex flex-col gap-6 print:hidden">
       <Card>
         <CardContent className="flex flex-col gap-4 p-4 lg:flex-row lg:items-end lg:justify-between">
           <div className="grid flex-1 gap-4 lg:grid-cols-[minmax(260px,0.8fr)_minmax(220px,0.6fr)_1fr]">
@@ -979,14 +1005,24 @@ function PartnerDashboardView() {
             </div>
           </div>
 
-          <Button variant="outline" onClick={refreshPartnerDashboard} disabled={previewFetching}>
-            {previewFetching ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            ) : (
-              <RefreshCw className="mr-2 h-4 w-4" />
-            )}
-            Refresh
-          </Button>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <Button
+              variant="outline"
+              onClick={refreshPartnerDashboard}
+              disabled={previewFetching}
+            >
+              {previewFetching ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <RefreshCw className="mr-2 h-4 w-4" />
+              )}
+              Refresh
+            </Button>
+            <Button onClick={exportPartnerPdf} disabled={!preview || previewLoading}>
+              <FileText className="mr-2 h-4 w-4" />
+              Export PDF
+            </Button>
+          </div>
         </CardContent>
       </Card>
 
@@ -1010,8 +1046,8 @@ function PartnerDashboardView() {
             preview={preview}
             currentPeriod={currentPeriod}
             previousPeriod={previousPeriod}
-            blockingWarningCount={blockingWarnings.length}
             trendLabel={trendLabel}
+            periodMode={periodMode}
           />
 
           {preview.warnings.length > 0 && (
@@ -1036,44 +1072,25 @@ function PartnerDashboardView() {
             </Alert>
           )}
 
-          <div className="grid min-w-0 gap-6 xl:grid-cols-2">
+          <div className="grid min-w-0 gap-6">
             <PartnerTrendCard
-              title="Sales dollars"
-              description={`${trendLabel} gross sales across the selected partnership.`}
-              data={sortedPeriods.map((period) => ({
-                period: periodMode === 'weekly' ? formatDateRange(period.periodStart, period.periodEnd) : formatMonth(period.periodStart),
-                dollars: period.grossSalesCents / 100,
-              }))}
-              config={dollarsChartConfig}
-              dataKey="dollars"
-              value={formatCurrency(currentPeriod?.grossSalesCents ?? 0)}
+              title="Net sales trend"
+              description={`${trendLabel} net sales across the selected partnership.`}
+              data={netSalesTrendData}
+              config={partnerNetSalesChartConfig}
+              dataKey="netSales"
+              value={formatCurrency(currentPeriod?.netSalesCents ?? 0)}
               change={formatPercentChange(
-                currentPeriod?.grossSalesCents ?? 0,
-                previousPeriod?.grossSalesCents ?? 0
+                currentPeriod?.netSalesCents ?? 0,
+                previousPeriod?.netSalesCents ?? 0
               )}
-              current={currentPeriod?.grossSalesCents ?? 0}
-              previous={previousPeriod?.grossSalesCents ?? 0}
-            />
-            <PartnerTrendCard
-              title="Volume"
-              description={`${trendLabel} sticks/items sold across assigned machines.`}
-              data={sortedPeriods.map((period) => ({
-                period: periodMode === 'weekly' ? formatDateRange(period.periodStart, period.periodEnd) : formatMonth(period.periodStart),
-                volume: periodVolume(period),
-              }))}
-              config={volumeChartConfig}
-              dataKey="volume"
-              value={numberFormatter.format(periodVolume(currentPeriod))}
-              change={formatPercentChange(
-                periodVolume(currentPeriod),
-                periodVolume(previousPeriod)
-              )}
-              current={periodVolume(currentPeriod)}
-              previous={periodVolume(previousPeriod)}
+              current={currentPeriod?.netSalesCents ?? 0}
+              previous={previousPeriod?.netSalesCents ?? 0}
+              valueFormatter={(value) => formatCurrency(Math.round(value * 100))}
             />
           </div>
 
-          <div className="grid min-w-0 gap-6 xl:grid-cols-[1.25fr_0.75fr]">
+          <div className="grid min-w-0 gap-6">
             <Card className="min-w-0">
               <CardHeader>
                 <CardTitle className="text-xl">Machine rollups</CardTitle>
@@ -1096,7 +1113,7 @@ function PartnerDashboardView() {
                         <TableHeader>
                           <TableRow>
                             <TableHead>Machine</TableHead>
-                            <TableHead className="text-right">Sales dollars</TableHead>
+                            <TableHead className="text-right">Gross sales</TableHead>
                             <TableHead className="text-right">Volume</TableHead>
                             <TableHead className="text-right">Tax + fees</TableHead>
                             <TableHead className="text-right">Net sales</TableHead>
@@ -1122,7 +1139,7 @@ function PartnerDashboardView() {
                                 <TableCell className="text-right">
                                   <div>{numberFormatter.format(periodVolume(row.current))} items</div>
                                   <div className="text-xs text-muted-foreground">
-                                    {numberFormatter.format(row.current.orderCount)} orders
+                                    {numberFormatter.format(row.current.orderCount)} transactions
                                   </div>
                                 </TableCell>
                                 <TableCell className="text-right">
@@ -1173,13 +1190,31 @@ function PartnerDashboardView() {
               </CardContent>
             </Card>
 
-            <PartnerCalculationCard summary={preview.summary} />
+            <PartnerCalculationCard
+              summary={currentPeriod ?? preview.summary}
+              periodLabel={
+                currentPeriod
+                  ? formatPartnerPeriod(currentPeriod, periodMode)
+                  : `${formatDate(preview.dateFrom)} - ${formatDate(preview.dateTo)}`
+              }
+            />
           </div>
         </>
       ) : (
         <EmptyPanel title="Select a partnership" description="Choose an active partnership to load the partner dashboard preview." />
       )}
-    </div>
+      </div>
+      {preview && (
+        <PartnerPrintableReport
+          preview={preview}
+          periods={sortedPeriods}
+          machineRows={machineRows}
+          currentPeriod={currentPeriod}
+          previousPeriod={previousPeriod}
+          periodMode={periodMode}
+        />
+      )}
+    </>
   );
 }
 
@@ -1187,54 +1222,51 @@ function PartnerAnswerBand({
   preview,
   currentPeriod,
   previousPeriod,
-  blockingWarningCount,
   trendLabel,
+  periodMode,
 }: {
   preview: PartnerDashboardPeriodPreview;
   currentPeriod: PartnerDashboardPeriod | undefined;
   previousPeriod: PartnerDashboardPeriod | undefined;
-  blockingWarningCount: number;
   trendLabel: string;
+  periodMode: PartnerPeriodMode;
 }) {
-  const hasBlockingWarnings = blockingWarningCount > 0;
-  const TrendIcon = getTrendIcon(currentPeriod?.amountOwedCents ?? 0, previousPeriod?.amountOwedCents ?? 0);
+  const current = currentPeriod ?? preview.summary;
+  const previous = previousPeriod;
+  const periodLabel = currentPeriod
+    ? formatPartnerPeriod(currentPeriod, periodMode)
+    : `${formatDate(preview.dateFrom)} - ${formatDate(preview.dateTo)}`;
+  const lowerTrendLabel = trendLabel.toLowerCase();
 
   return (
     <Card>
-      <CardContent className="grid gap-5 p-5 md:grid-cols-2 xl:grid-cols-4">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-xl">Partner performance summary</CardTitle>
+        <CardDescription>
+          {preview.partnershipName} - {periodLabel} - {trendLabel} view
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="grid gap-5 p-5 pt-0 md:grid-cols-2 xl:grid-cols-4">
         <AnswerItem
           label="Amount owed"
-          value={formatCurrency(currentPeriod?.amountOwedCents ?? preview.summary.amountOwedCents, true)}
-          detail="Due to partner for the current period"
+          value={formatCurrency(current.amountOwedCents, true)}
+          detail={`${formatPercentChange(current.amountOwedCents, previous?.amountOwedCents ?? 0)} vs previous ${lowerTrendLabel}`}
           emphasis
         />
         <AnswerItem
-          label="Period"
-          value={formatDateRange(currentPeriod?.periodStart, currentPeriod?.periodEnd)}
-          detail={`${trendLabel} view: ${formatDate(preview.dateFrom)} - ${formatDate(preview.dateTo)}`}
-          icon={<CalendarDays className="h-5 w-5 text-muted-foreground" />}
+          label="Gross sales"
+          value={formatCurrency(current.grossSalesCents, true)}
+          detail={`${formatPercentChange(current.grossSalesCents, previous?.grossSalesCents ?? 0)} vs previous ${lowerTrendLabel}`}
         />
         <AnswerItem
-          label="Status"
-          value={hasBlockingWarnings ? 'Blocked' : 'Ready for review'}
-          detail={hasBlockingWarnings ? `${blockingWarningCount} blocking admin items` : 'No blocking admin warnings'}
-          badgeTone={hasBlockingWarnings ? 'destructive' : 'default'}
+          label="Transactions"
+          value={numberFormatter.format(current.orderCount)}
+          detail={`${numberFormatter.format(current.itemQuantity)} items sold`}
         />
         <AnswerItem
-          label="Movement"
-          value={formatPercentChange(
-            currentPeriod?.amountOwedCents ?? 0,
-            previousPeriod?.amountOwedCents ?? 0
-          )}
-          detail="Amount owed vs previous period"
-          icon={
-            <TrendIcon
-              className={cn(
-                'h-5 w-5',
-                getChangeTone(currentPeriod?.amountOwedCents ?? 0, previousPeriod?.amountOwedCents ?? 0)
-              )}
-            />
-          }
+          label="Net sales"
+          value={formatCurrency(current.netSalesCents, true)}
+          detail="After tax and configured fees"
         />
       </CardContent>
     </Card>
@@ -1251,6 +1283,7 @@ function PartnerTrendCard({
   change,
   current,
   previous,
+  valueFormatter,
 }: {
   title: string;
   description: string;
@@ -1261,8 +1294,10 @@ function PartnerTrendCard({
   change: string;
   current: number;
   previous: number;
+  valueFormatter?: (value: number) => string;
 }) {
   const TrendIcon = getTrendIcon(current, previous);
+  const hasVisibleValues = data.some((point) => Number(point[dataKey] ?? 0) > 0);
 
   return (
     <Card className="min-w-0">
@@ -1282,16 +1317,38 @@ function PartnerTrendCard({
         </div>
       </CardHeader>
       <CardContent>
-        {data.length === 0 ? (
+        {data.length === 0 || !hasVisibleValues ? (
           <EmptyPanel title="No trend data" description="This period has no imported partner sales yet." />
         ) : (
-          <ChartContainer config={config} className="h-[280px] w-full">
-            <BarChart data={data}>
+          <ChartContainer config={config} className="h-[320px] w-full">
+            <BarChart data={data} margin={{ left: 8, right: 8 }}>
               <CartesianGrid vertical={false} />
               <XAxis dataKey="period" tickLine={false} axisLine={false} />
-              <YAxis tickLine={false} axisLine={false} width={56} />
-              <ChartTooltip content={<ChartTooltipContent />} />
-              <Bar dataKey={dataKey} fill={`var(--color-${dataKey})`} radius={[5, 5, 0, 0]} />
+              <YAxis
+                tickLine={false}
+                axisLine={false}
+                width={64}
+                tickFormatter={(tick) =>
+                  valueFormatter ? valueFormatter(Number(tick)) : numberFormatter.format(Number(tick))
+                }
+              />
+              <ChartTooltip
+                content={
+                  <ChartTooltipContent
+                    formatter={(tooltipValue) =>
+                      valueFormatter
+                        ? valueFormatter(Number(tooltipValue))
+                        : numberFormatter.format(Number(tooltipValue))
+                    }
+                  />
+                }
+              />
+              <Bar
+                dataKey={dataKey}
+                fill={`var(--color-${dataKey})`}
+                radius={[5, 5, 0, 0]}
+                isAnimationActive={false}
+              />
             </BarChart>
           </ChartContainer>
         )}
@@ -1300,13 +1357,274 @@ function PartnerTrendCard({
   );
 }
 
+function PartnerPrintableReport({
+  preview,
+  periods,
+  machineRows,
+  currentPeriod,
+  previousPeriod,
+  periodMode,
+}: {
+  preview: PartnerDashboardPeriodPreview;
+  periods: PartnerDashboardPeriod[];
+  machineRows: PartnerMachineComparisonRow[];
+  currentPeriod: PartnerDashboardPeriod | undefined;
+  previousPeriod: PartnerDashboardPeriod | undefined;
+  periodMode: PartnerPeriodMode;
+}) {
+  const current = currentPeriod ?? preview.summary;
+  const periodLabel = currentPeriod
+    ? formatPartnerPeriod(currentPeriod, periodMode)
+    : `${formatDate(preview.dateFrom)} - ${formatDate(preview.dateTo)}`;
+  const generatedAt = new Date().toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+  const modeLabel = periodMode === 'weekly' ? 'Weekly' : 'Monthly';
+
+  return (
+    <section className="hidden print:block">
+      <style>
+        {`
+          @media print {
+            body * {
+              visibility: hidden;
+            }
+
+            .partner-print-report,
+            .partner-print-report * {
+              visibility: visible;
+            }
+
+            .partner-print-report {
+              display: block !important;
+              position: absolute;
+              top: 0;
+              right: 0;
+              left: 0;
+              width: 100%;
+              margin: 0 auto;
+            }
+          }
+        `}
+      </style>
+      <div className="partner-print-report mx-auto flex max-w-[7.5in] flex-col gap-6 p-8 text-foreground">
+        <header className="flex items-start justify-between gap-6 border-b border-border pb-5">
+          <div>
+            <div className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              Bloomjoy
+            </div>
+            <h1 className="mt-2 text-3xl font-semibold text-foreground">
+              Partner performance report
+            </h1>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {preview.partnershipName} - {periodLabel}
+            </p>
+          </div>
+          <div className="text-right text-sm text-muted-foreground">
+            <div className="font-medium text-foreground">{modeLabel} report</div>
+            <div>Generated {generatedAt}</div>
+            <div>
+              Data range {formatDate(preview.dateFrom)} - {formatDate(preview.dateTo)}
+            </div>
+          </div>
+        </header>
+
+        <section className="grid grid-cols-4 gap-3">
+          <PrintableMetric
+            label="Amount owed"
+            value={formatCurrency(current.amountOwedCents, true)}
+            detail={`${formatPercentChange(current.amountOwedCents, previousPeriod?.amountOwedCents ?? 0)} vs prior`}
+            emphasis
+          />
+          <PrintableMetric
+            label="Gross sales"
+            value={formatCurrency(current.grossSalesCents, true)}
+            detail={`${formatPercentChange(current.grossSalesCents, previousPeriod?.grossSalesCents ?? 0)} vs prior`}
+          />
+          <PrintableMetric
+            label="Net sales"
+            value={formatCurrency(current.netSalesCents, true)}
+            detail="After tax and fees"
+          />
+          <PrintableMetric
+            label="Transactions"
+            value={numberFormatter.format(current.orderCount)}
+            detail={`${numberFormatter.format(current.itemQuantity)} items sold`}
+          />
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <div>
+            <h2 className="text-lg font-semibold text-foreground">{modeLabel} sales trend</h2>
+            <p className="text-sm text-muted-foreground">
+              Net sales, gross sales, volume, and partner owed across the selected period.
+            </p>
+          </div>
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-muted-foreground">
+                <th className="py-2 pr-3 font-medium">Period</th>
+                <th className="px-3 py-2 text-right font-medium">Gross sales</th>
+                <th className="px-3 py-2 text-right font-medium">Net sales</th>
+                <th className="px-3 py-2 text-right font-medium">Transactions</th>
+                <th className="px-3 py-2 text-right font-medium">Items</th>
+                <th className="py-2 pl-3 text-right font-medium">Amount owed</th>
+              </tr>
+            </thead>
+            <tbody>
+              {periods.map((period) => (
+                <tr key={period.periodStart} className="border-b border-border/60">
+                  <td className="py-2 pr-3 font-medium text-foreground">
+                    {formatPartnerPeriod(period, periodMode)}
+                  </td>
+                  <td className="px-3 py-2 text-right">
+                    {formatCurrency(period.grossSalesCents, true)}
+                  </td>
+                  <td className="px-3 py-2 text-right">
+                    {formatCurrency(period.netSalesCents, true)}
+                  </td>
+                  <td className="px-3 py-2 text-right">
+                    {numberFormatter.format(period.orderCount)}
+                  </td>
+                  <td className="px-3 py-2 text-right">
+                    {numberFormatter.format(period.itemQuantity)}
+                  </td>
+                  <td className="py-2 pl-3 text-right font-medium text-foreground">
+                    {formatCurrency(period.amountOwedCents, true)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <div>
+            <h2 className="text-lg font-semibold text-foreground">Machine rollup</h2>
+            <p className="text-sm text-muted-foreground">
+              Current {periodMode === 'weekly' ? 'week' : 'month'} performance by assigned machine.
+            </p>
+          </div>
+          <table className="w-full border-collapse text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-muted-foreground">
+                <th className="py-2 pr-3 font-medium">Machine</th>
+                <th className="px-3 py-2 text-right font-medium">Gross sales</th>
+                <th className="px-3 py-2 text-right font-medium">Volume</th>
+                <th className="px-3 py-2 text-right font-medium">Net sales</th>
+                <th className="px-3 py-2 text-right font-medium">Amount owed</th>
+                <th className="py-2 pl-3 text-right font-medium">Change</th>
+              </tr>
+            </thead>
+            <tbody>
+              {machineRows.length === 0 ? (
+                <tr>
+                  <td colSpan={6} className="py-6 text-center text-muted-foreground">
+                    No machine sales found for this period.
+                  </td>
+                </tr>
+              ) : (
+                machineRows.map((row) => (
+                  <tr key={row.current.reportingMachineId} className="border-b border-border/60">
+                    <td className="py-2 pr-3">
+                      <div className="font-medium text-foreground">{row.current.machineLabel}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {row.current.locationName ?? 'No location'}
+                      </div>
+                    </td>
+                    <td className="px-3 py-2 text-right">
+                      {formatCurrency(row.current.grossSalesCents, true)}
+                    </td>
+                    <td className="px-3 py-2 text-right">
+                      <div>{numberFormatter.format(periodVolume(row.current))} items</div>
+                      <div className="text-xs text-muted-foreground">
+                        {numberFormatter.format(row.current.orderCount)} transactions
+                      </div>
+                    </td>
+                    <td className="px-3 py-2 text-right">
+                      {formatCurrency(row.current.netSalesCents, true)}
+                    </td>
+                    <td className="px-3 py-2 text-right font-medium text-foreground">
+                      {formatCurrency(row.current.amountOwedCents, true)}
+                    </td>
+                    <td className="py-2 pl-3 text-right">
+                      <div>
+                        {formatPercentChange(
+                          row.current.grossSalesCents,
+                          row.previous?.grossSalesCents ?? 0
+                        )}{' '}
+                        sales
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {formatPercentChange(periodVolume(row.current), periodVolume(row.previous))}{' '}
+                        volume
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </section>
+
+        <section className="grid grid-cols-[1fr_1fr] gap-5 border-t border-border pt-5">
+          <div>
+            <h2 className="text-lg font-semibold text-foreground">Calculation summary</h2>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">
+              Gross sales minus tax, configured fees, and costs creates net sales and the split
+              base. The active partnership rule calculates the partner owed amount from that base.
+            </p>
+          </div>
+          <div className="flex flex-col gap-2 text-sm">
+            <CalculationLine label="Gross sales" value={formatCurrency(current.grossSalesCents, true)} />
+            <CalculationLine label="Tax impact" value={`-${formatCurrency(current.taxCents, true)}`} />
+            <CalculationLine label="Fees" value={`-${formatCurrency(current.feeCents, true)}`} />
+            <CalculationLine label="Costs" value={`-${formatCurrency(current.costCents, true)}`} />
+            <CalculationLine label="Net sales" value={formatCurrency(current.netSalesCents, true)} />
+            <CalculationLine
+              label="Amount owed"
+              value={formatCurrency(current.amountOwedCents, true)}
+              emphasis
+            />
+          </div>
+        </section>
+      </div>
+    </section>
+  );
+}
+
+function PrintableMetric({
+  label,
+  value,
+  detail,
+  emphasis = false,
+}: {
+  label: string;
+  value: string;
+  detail: string;
+  emphasis?: boolean;
+}) {
+  return (
+    <div className="rounded-lg border border-border p-3">
+      <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      <div className={cn('mt-2 text-xl font-semibold text-foreground', emphasis && 'text-sage')}>
+        {value}
+      </div>
+      <div className="mt-1 text-xs text-muted-foreground">{detail}</div>
+    </div>
+  );
+}
+
 function PartnerMachineMobileCard({
   row,
 }: {
-  row: {
-    current: PartnerDashboardMachinePeriod;
-    previous?: PartnerDashboardMachinePeriod;
-  };
+  row: PartnerMachineComparisonRow;
 }) {
   const TrendIcon = getTrendIcon(row.current.grossSalesCents, row.previous?.grossSalesCents ?? 0);
 
@@ -1339,7 +1657,7 @@ function PartnerMachineMobileCard({
         <MobileProofItem
           label="Volume"
           value={`${numberFormatter.format(periodVolume(row.current))} items`}
-          detail={`${numberFormatter.format(row.current.orderCount)} orders`}
+          detail={`${numberFormatter.format(row.current.orderCount)} transactions`}
         />
         <MobileProofItem
           label="Amount owed"
@@ -1381,15 +1699,18 @@ function MobileProofItem({
   );
 }
 
-function PartnerCalculationCard({ summary }: { summary: PartnerDashboardTotals }) {
+function PartnerCalculationCard({
+  summary,
+  periodLabel,
+}: {
+  summary: PartnerDashboardTotals;
+  periodLabel: string;
+}) {
   return (
     <Card className="min-w-0">
-      <CardHeader className="flex flex-row items-start justify-between gap-3">
-        <div>
-          <CardTitle className="text-xl">Calculation</CardTitle>
-          <CardDescription>Current selected range across the partnership.</CardDescription>
-        </div>
-        <Badge variant="outline">Preview</Badge>
+      <CardHeader>
+        <CardTitle className="text-xl">Calculation</CardTitle>
+        <CardDescription>{periodLabel} settlement calculation.</CardDescription>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
         <CalculationLine label="Gross sales" value={formatCurrency(summary.grossSalesCents, true)} />
@@ -1423,7 +1744,7 @@ function buildPartnerMachineRows(
   preview: PartnerDashboardPeriodPreview | undefined,
   currentPeriod: PartnerDashboardPeriod | undefined,
   previousPeriod: PartnerDashboardPeriod | undefined
-) {
+): PartnerMachineComparisonRow[] {
   if (!preview || !currentPeriod) return [];
 
   const previousByMachine = new Map<string, PartnerDashboardMachinePeriod>();

--- a/src/pages/portal/Reports.tsx
+++ b/src/pages/portal/Reports.tsx
@@ -1502,7 +1502,7 @@ function PartnerPrintableReport({
           <div>
             <h2 className="text-lg font-semibold text-foreground">{modeLabel} sales trend</h2>
             <p className="text-sm text-muted-foreground">
-              Net sales, gross sales, volume, and partner owed across the selected period.
+              Net sales, gross sales, volume, and amount owed across the selected period.
             </p>
           </div>
           <table className="w-full border-collapse text-sm">
@@ -1616,9 +1616,9 @@ function PartnerPrintableReport({
           <div>
             <h2 className="text-lg font-semibold text-foreground">Calculation summary</h2>
             <p className="mt-2 text-sm leading-6 text-muted-foreground">
-              Gross sales minus tax and configured fees creates net sales. Configured costs can
-              reduce the split base when the active partnership rule uses contribution after costs.
-              The partner owed amount is calculated from that split base.
+              Gross sales uses the Sunze order amount for partner settlement. Machine tax and
+              configured fees are deducted once to create net sales. Configured costs can reduce
+              the split base when the active partnership rule uses contribution after costs.
             </p>
           </div>
           <div className="flex flex-col gap-2 text-sm">
@@ -1773,9 +1773,9 @@ function PartnerCalculationCard({
         <div className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
           <div className="font-medium text-foreground">How this is calculated</div>
           <p className="mt-2">
-            Gross sales minus configured tax and fees creates net sales. Configured costs can reduce
-            the split base when the active rule uses contribution after costs. The partner share is
-            applied to that split base to calculate amount owed.
+            Gross sales uses the Sunze order amount for partner settlement. Machine tax and
+            configured fees are deducted once to create net sales, then the partner share is
+            applied to the active split base to calculate amount owed.
           </p>
         </div>
       </CardContent>

--- a/supabase/migrations/202604260007_partner_period_preview.sql
+++ b/supabase/migrations/202604260007_partner_period_preview.sql
@@ -1,0 +1,365 @@
+drop function if exists public.admin_preview_partner_period_report(uuid, date, date, text);
+
+create or replace function public.admin_preview_partner_period_report(
+  p_partnership_id uuid,
+  p_date_from date,
+  p_date_to date,
+  p_period_grain text
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  normalized_grain text;
+  result jsonb;
+  partnership_row public.reporting_partnerships;
+begin
+  if not public.is_super_admin(auth.uid()) then
+    raise exception 'Admin access required';
+  end if;
+
+  normalized_grain := lower(coalesce(nullif(trim(p_period_grain), ''), 'reporting_week'));
+
+  if p_partnership_id is null then
+    raise exception 'Partnership is required';
+  end if;
+
+  if p_date_from is null or p_date_to is null then
+    raise exception 'Date range is required';
+  end if;
+
+  if p_date_from > p_date_to then
+    raise exception 'Date range is invalid';
+  end if;
+
+  if normalized_grain not in ('reporting_week', 'calendar_month') then
+    raise exception 'Invalid period grain: %', p_period_grain;
+  end if;
+
+  select *
+  into partnership_row
+  from public.reporting_partnerships partnership
+  where partnership.id = p_partnership_id;
+
+  if partnership_row.id is null then
+    raise exception 'Partnership not found';
+  end if;
+
+  with weekly_bounds as (
+    select
+      (
+        p_date_from
+        + ((partnership_row.reporting_week_end_day - extract(dow from p_date_from)::integer + 7) % 7)
+      )::date as first_week_end,
+      (
+        p_date_to
+        - ((extract(dow from p_date_to)::integer - partnership_row.reporting_week_end_day + 7) % 7)
+      )::date as last_week_end
+  ),
+  period_windows as (
+    select
+      (week_end::date - 6) as period_start,
+      week_end::date as period_end
+    from weekly_bounds bounds
+    cross join lateral generate_series(
+      bounds.first_week_end,
+      bounds.last_week_end,
+      interval '7 days'
+    ) as week_end
+    where normalized_grain = 'reporting_week'
+      and bounds.first_week_end <= bounds.last_week_end
+
+    union all
+
+    select
+      month_start::date as period_start,
+      (month_start + interval '1 month' - interval '1 day')::date as period_end
+    from generate_series(
+      date_trunc('month', p_date_from::timestamp)::date,
+      date_trunc('month', p_date_to::timestamp)::date,
+      interval '1 month'
+    ) as month_start
+    where normalized_grain = 'calendar_month'
+  ),
+  assigned_machine_periods as (
+    select distinct
+      period.period_start,
+      period.period_end,
+      machine.id as reporting_machine_id,
+      machine.machine_label,
+      location.name as location_name
+    from period_windows period
+    join public.reporting_machine_partnership_assignments assignment
+      on assignment.partnership_id = p_partnership_id
+      and assignment.assignment_role = 'primary_reporting'
+      and assignment.status = 'active'
+      and assignment.effective_start_date <= period.period_end
+      and (assignment.effective_end_date is null or assignment.effective_end_date >= period.period_start)
+    join public.reporting_machines machine on machine.id = assignment.machine_id
+    left join public.reporting_locations location on location.id = machine.location_id
+  ),
+  scoped_facts as (
+    select
+      period.period_start,
+      period.period_end,
+      fact.id,
+      fact.reporting_machine_id,
+      machine.machine_label,
+      location.name as location_name,
+      fact.sale_date,
+      fact.payment_method,
+      fact.net_sales_cents as gross_sales_cents,
+      fact.transaction_count,
+      fact.item_quantity,
+      fact.tax_cents as imported_tax_cents,
+      tax.tax_rate_percent,
+      rule.calculation_model,
+      rule.split_base,
+      rule.fee_amount_cents,
+      rule.fee_basis,
+      rule.cost_amount_cents,
+      rule.cost_basis,
+      rule.deduction_timing,
+      rule.gross_to_net_method,
+      rule.fever_share_basis_points,
+      rule.partner_share_basis_points,
+      rule.bloomjoy_share_basis_points
+    from public.machine_sales_facts fact
+    join period_windows period on fact.sale_date between period.period_start and period.period_end
+    join public.reporting_machines machine on machine.id = fact.reporting_machine_id
+    left join public.reporting_locations location on location.id = machine.location_id
+    join public.reporting_machine_partnership_assignments assignment
+      on assignment.machine_id = fact.reporting_machine_id
+      and assignment.partnership_id = p_partnership_id
+      and assignment.assignment_role = 'primary_reporting'
+      and assignment.status = 'active'
+      and assignment.effective_start_date <= fact.sale_date
+      and (assignment.effective_end_date is null or assignment.effective_end_date >= fact.sale_date)
+    left join lateral (
+      select tax_rate.tax_rate_percent
+      from public.reporting_machine_tax_rates tax_rate
+      where tax_rate.machine_id = fact.reporting_machine_id
+        and tax_rate.status = 'active'
+        and tax_rate.effective_start_date <= fact.sale_date
+        and (tax_rate.effective_end_date is null or tax_rate.effective_end_date >= fact.sale_date)
+      order by tax_rate.effective_start_date desc
+      limit 1
+    ) tax on true
+    left join lateral (
+      select financial_rule.*
+      from public.reporting_partnership_financial_rules financial_rule
+      where financial_rule.partnership_id = p_partnership_id
+        and financial_rule.status = 'active'
+        and financial_rule.effective_start_date <= fact.sale_date
+        and (financial_rule.effective_end_date is null or financial_rule.effective_end_date >= fact.sale_date)
+      order by financial_rule.effective_start_date desc
+      limit 1
+    ) rule on true
+    where fact.sale_date between p_date_from and p_date_to
+  ),
+  calculated as (
+    select
+      fact.*,
+      case
+        when fact.gross_sales_cents <= 0 then 0
+        when fact.gross_to_net_method = 'imported_tax_plus_configured_fees' then fact.imported_tax_cents
+        when fact.gross_to_net_method = 'configured_fees_only' then 0
+        else round(fact.gross_sales_cents * coalesce(fact.tax_rate_percent, 0) / 100.0)::integer
+      end as calculated_tax_cents,
+      case
+        when fact.gross_sales_cents <= 0 then 0
+        when fact.fee_basis in ('per_order', 'per_transaction') then coalesce(fact.fee_amount_cents, 0) * coalesce(fact.transaction_count, 1)
+        when fact.fee_basis = 'per_stick' then coalesce(fact.fee_amount_cents, 0) * coalesce(fact.item_quantity, 1)
+        else 0
+      end as fee_cents,
+      case
+        when fact.gross_sales_cents <= 0 then 0
+        when fact.cost_basis = 'per_order' then coalesce(fact.cost_amount_cents, 0) * coalesce(fact.transaction_count, 1)
+        when fact.cost_basis = 'per_stick' then coalesce(fact.cost_amount_cents, 0) * coalesce(fact.item_quantity, 1)
+        when fact.cost_basis = 'percentage_of_sales' then round(fact.gross_sales_cents * coalesce(fact.cost_amount_cents, 0) / 10000.0)::integer
+        else 0
+      end as cost_cents
+    from scoped_facts fact
+  ),
+  row_amounts as (
+    select
+      calculated.*,
+      greatest(calculated.gross_sales_cents - calculated.calculated_tax_cents - calculated.fee_cents, 0) as net_sales_cents,
+      case
+        when calculated.deduction_timing = 'before_split' then calculated.cost_cents
+        else 0
+      end as split_deductible_cost_cents
+    from calculated
+  ),
+  split_rows as (
+    select
+      row_amounts.*,
+      case
+        when row_amounts.split_base = 'gross_sales' then row_amounts.gross_sales_cents
+        when row_amounts.split_base = 'contribution_after_costs' then greatest(row_amounts.net_sales_cents - row_amounts.split_deductible_cost_cents, 0)
+        else row_amounts.net_sales_cents
+      end as split_base_cents
+    from row_amounts
+  ),
+  split_amounts as (
+    select
+      split_rows.*,
+      round(split_rows.split_base_cents * coalesce(split_rows.partner_share_basis_points, 0) / 10000.0)::bigint as amount_owed_cents,
+      round(split_rows.split_base_cents * coalesce(split_rows.bloomjoy_share_basis_points, 0) / 10000.0)::bigint as bloomjoy_retained_cents
+    from split_rows
+  ),
+  period_amounts as (
+    select
+      period_start,
+      period_end,
+      coalesce(sum(transaction_count), 0)::integer as order_count,
+      coalesce(sum(item_quantity), 0)::integer as item_quantity,
+      coalesce(sum(gross_sales_cents), 0)::bigint as gross_sales_cents,
+      coalesce(sum(calculated_tax_cents), 0)::bigint as tax_cents,
+      coalesce(sum(fee_cents), 0)::bigint as fee_cents,
+      coalesce(sum(cost_cents), 0)::bigint as cost_cents,
+      coalesce(sum(net_sales_cents), 0)::bigint as net_sales_cents,
+      coalesce(sum(split_base_cents), 0)::bigint as split_base_cents,
+      coalesce(sum(amount_owed_cents), 0)::bigint as amount_owed_cents,
+      coalesce(sum(bloomjoy_retained_cents), 0)::bigint as bloomjoy_retained_cents
+    from split_amounts
+    group by period_start, period_end
+  ),
+  machine_amounts as (
+    select
+      period_start,
+      period_end,
+      reporting_machine_id,
+      machine_label,
+      location_name,
+      coalesce(sum(transaction_count), 0)::integer as order_count,
+      coalesce(sum(item_quantity), 0)::integer as item_quantity,
+      coalesce(sum(gross_sales_cents), 0)::bigint as gross_sales_cents,
+      coalesce(sum(calculated_tax_cents), 0)::bigint as tax_cents,
+      coalesce(sum(fee_cents), 0)::bigint as fee_cents,
+      coalesce(sum(cost_cents), 0)::bigint as cost_cents,
+      coalesce(sum(net_sales_cents), 0)::bigint as net_sales_cents,
+      coalesce(sum(split_base_cents), 0)::bigint as split_base_cents,
+      coalesce(sum(amount_owed_cents), 0)::bigint as amount_owed_cents,
+      coalesce(sum(bloomjoy_retained_cents), 0)::bigint as bloomjoy_retained_cents
+    from split_amounts
+    group by period_start, period_end, reporting_machine_id, machine_label, location_name
+  ),
+  periods as (
+    select
+      period.period_start,
+      period.period_end,
+      coalesce(amount.order_count, 0)::integer as order_count,
+      coalesce(amount.item_quantity, 0)::integer as item_quantity,
+      coalesce(amount.gross_sales_cents, 0)::bigint as gross_sales_cents,
+      coalesce(amount.tax_cents, 0)::bigint as tax_cents,
+      coalesce(amount.fee_cents, 0)::bigint as fee_cents,
+      coalesce(amount.cost_cents, 0)::bigint as cost_cents,
+      coalesce(amount.net_sales_cents, 0)::bigint as net_sales_cents,
+      coalesce(amount.split_base_cents, 0)::bigint as split_base_cents,
+      coalesce(amount.amount_owed_cents, 0)::bigint as amount_owed_cents,
+      coalesce(amount.bloomjoy_retained_cents, 0)::bigint as bloomjoy_retained_cents
+    from period_windows period
+    left join period_amounts amount
+      on amount.period_start = period.period_start
+      and amount.period_end = period.period_end
+  ),
+  machine_periods as (
+    select
+      assigned.period_start,
+      assigned.period_end,
+      assigned.reporting_machine_id,
+      assigned.machine_label,
+      assigned.location_name,
+      coalesce(amount.order_count, 0)::integer as order_count,
+      coalesce(amount.item_quantity, 0)::integer as item_quantity,
+      coalesce(amount.gross_sales_cents, 0)::bigint as gross_sales_cents,
+      coalesce(amount.tax_cents, 0)::bigint as tax_cents,
+      coalesce(amount.fee_cents, 0)::bigint as fee_cents,
+      coalesce(amount.cost_cents, 0)::bigint as cost_cents,
+      coalesce(amount.net_sales_cents, 0)::bigint as net_sales_cents,
+      coalesce(amount.split_base_cents, 0)::bigint as split_base_cents,
+      coalesce(amount.amount_owed_cents, 0)::bigint as amount_owed_cents,
+      coalesce(amount.bloomjoy_retained_cents, 0)::bigint as bloomjoy_retained_cents
+    from assigned_machine_periods assigned
+    left join machine_amounts amount
+      on amount.period_start = assigned.period_start
+      and amount.period_end = assigned.period_end
+      and amount.reporting_machine_id = assigned.reporting_machine_id
+  ),
+  summary as (
+    select
+      coalesce(sum(order_count), 0)::integer as order_count,
+      coalesce(sum(item_quantity), 0)::integer as item_quantity,
+      coalesce(sum(gross_sales_cents), 0)::bigint as gross_sales_cents,
+      coalesce(sum(tax_cents), 0)::bigint as tax_cents,
+      coalesce(sum(fee_cents), 0)::bigint as fee_cents,
+      coalesce(sum(cost_cents), 0)::bigint as cost_cents,
+      coalesce(sum(net_sales_cents), 0)::bigint as net_sales_cents,
+      coalesce(sum(split_base_cents), 0)::bigint as split_base_cents,
+      coalesce(sum(amount_owed_cents), 0)::bigint as amount_owed_cents,
+      coalesce(sum(bloomjoy_retained_cents), 0)::bigint as bloomjoy_retained_cents
+    from periods
+  ),
+  warnings as (
+    select jsonb_build_object(
+      'warning_type', 'missing_machine_tax_rate',
+      'severity', 'blocking',
+      'machine_id', fact.reporting_machine_id,
+      'machine_label', fact.machine_label,
+      'message', fact.machine_label || ' has sales in this period without an active machine tax rate.'
+    ) as warning
+    from scoped_facts fact
+    where fact.tax_rate_percent is null
+      and coalesce(fact.gross_to_net_method, 'machine_tax_plus_configured_fees') <> 'configured_fees_only'
+    group by fact.reporting_machine_id, fact.machine_label
+    union all
+    select jsonb_build_object(
+      'warning_type', 'missing_financial_rule',
+      'severity', 'blocking',
+      'message', 'This report includes sales without an active partnership financial rule.'
+    ) as warning
+    where exists (select 1 from scoped_facts fact where fact.calculation_model is null)
+    union all
+    select jsonb_build_object(
+      'warning_type', 'no_assigned_machines',
+      'severity', 'blocking',
+      'message', 'This partnership has no active reporting machines for the selected period.'
+    ) as warning
+    where not exists (select 1 from assigned_machine_periods)
+    union all
+    select jsonb_build_object(
+      'warning_type', 'no_sales_for_machine',
+      'severity', 'non_blocking',
+      'machine_id', assigned.reporting_machine_id,
+      'machine_label', assigned.machine_label,
+      'message', assigned.machine_label || ' has no sales in the selected period.'
+    ) as warning
+    from (
+      select reporting_machine_id, machine_label, sum(order_count) as total_orders
+      from machine_periods
+      group by reporting_machine_id, machine_label
+    ) assigned
+    where coalesce(assigned.total_orders, 0) = 0
+  )
+  select jsonb_build_object(
+    'partnership_id', p_partnership_id,
+    'partnership_name', partnership_row.name,
+    'period_grain', normalized_grain,
+    'date_from', p_date_from,
+    'date_to', p_date_to,
+    'summary', coalesce((select to_jsonb(summary) from summary), '{}'::jsonb),
+    'periods', coalesce((select jsonb_agg(to_jsonb(periods) order by periods.period_start) from periods), '[]'::jsonb),
+    'machine_periods', coalesce((select jsonb_agg(to_jsonb(machine_periods) order by machine_periods.period_start, machine_periods.machine_label) from machine_periods), '[]'::jsonb),
+    'warnings', coalesce((select jsonb_agg(warnings.warning) from warnings), '[]'::jsonb)
+  )
+  into result;
+
+  return result;
+end;
+$$;
+
+grant execute on function public.admin_preview_partner_period_report(uuid, date, date, text) to authenticated;

--- a/supabase/migrations/202604260007_partner_period_preview.sql
+++ b/supabase/migrations/202604260007_partner_period_preview.sql
@@ -102,6 +102,9 @@ begin
     left join public.reporting_locations location on location.id = machine.location_id
   ),
   scoped_facts as (
+    -- Partner settlement follows the canonical Bubble Planet baseline:
+    -- Sunze Order amount is the gross sales basis, then machine tax and configured
+    -- paid-order fees are deducted before applying the active split rule.
     select
       period.period_start,
       period.period_end,
@@ -111,7 +114,7 @@ begin
       location.name as location_name,
       fact.sale_date,
       fact.payment_method,
-      fact.net_sales_cents as gross_sales_cents,
+      fact.net_sales_cents as source_order_amount_cents,
       fact.transaction_count,
       fact.item_quantity,
       fact.tax_cents as imported_tax_cents,
@@ -164,22 +167,22 @@ begin
     select
       fact.*,
       case
-        when fact.gross_sales_cents <= 0 then 0
+        when fact.source_order_amount_cents <= 0 then 0
         when fact.gross_to_net_method = 'imported_tax_plus_configured_fees' then fact.imported_tax_cents
         when fact.gross_to_net_method = 'configured_fees_only' then 0
-        else round(fact.gross_sales_cents * coalesce(fact.tax_rate_percent, 0) / 100.0)::integer
+        else round(fact.source_order_amount_cents * coalesce(fact.tax_rate_percent, 0) / 100.0)::integer
       end as calculated_tax_cents,
       case
-        when fact.gross_sales_cents <= 0 then 0
+        when fact.source_order_amount_cents <= 0 then 0
         when fact.fee_basis in ('per_order', 'per_transaction') then coalesce(fact.fee_amount_cents, 0) * coalesce(fact.transaction_count, 1)
         when fact.fee_basis = 'per_stick' then coalesce(fact.fee_amount_cents, 0) * coalesce(fact.item_quantity, 1)
         else 0
       end as fee_cents,
       case
-        when fact.gross_sales_cents <= 0 then 0
+        when fact.source_order_amount_cents <= 0 then 0
         when fact.cost_basis = 'per_order' then coalesce(fact.cost_amount_cents, 0) * coalesce(fact.transaction_count, 1)
         when fact.cost_basis = 'per_stick' then coalesce(fact.cost_amount_cents, 0) * coalesce(fact.item_quantity, 1)
-        when fact.cost_basis = 'percentage_of_sales' then round(fact.gross_sales_cents * coalesce(fact.cost_amount_cents, 0) / 10000.0)::integer
+        when fact.cost_basis = 'percentage_of_sales' then round(fact.source_order_amount_cents * coalesce(fact.cost_amount_cents, 0) / 10000.0)::integer
         else 0
       end as cost_cents
     from scoped_facts fact
@@ -187,7 +190,8 @@ begin
   row_amounts as (
     select
       calculated.*,
-      greatest(calculated.gross_sales_cents - calculated.calculated_tax_cents - calculated.fee_cents, 0) as net_sales_cents,
+      calculated.source_order_amount_cents as gross_sales_cents,
+      greatest(calculated.source_order_amount_cents - calculated.calculated_tax_cents - calculated.fee_cents, 0) as net_sales_cents,
       case
         when calculated.deduction_timing = 'before_split' then calculated.cost_cents
         else 0


### PR DESCRIPTION
﻿## Summary
- Builds the `/portal/reports` Reporting shell with Operator view as the default and a super-admin-only Partner dashboard toggle for V1.
- Refines the partner dashboard around what partners need first: amount owed, gross sales, transactions/items, net sales, one clear net-sales trend, full-width machine rollups, and current-period calculation transparency.
- Adds partner-facing browser PDF export from the Partner dashboard, locked when blocking admin data-quality warnings exist.
- Adds additive `admin_preview_partner_period_report(p_partnership_id uuid, p_date_from date, p_date_to date, p_period_grain text)` RPC plus a portal-specific frontend adapter.
- Clarifies the partner settlement source basis: for the Bubble Planet-style partner report, Sunze `Order amount` is the gross sales basis, then machine tax and configured fees are deducted before split.

## Files changed
- `src/pages/portal/Reports.tsx`: Reporting UI, operator presets, simplified operator net-sales chart, partner dashboard preview, PDF export/print report, warning export lock, mobile period detail list, desktop/mobile states, and clarified settlement copy.
- `src/lib/partnerDashboardReporting.ts`: portal-only partner dashboard data adapter and snake_case to camelCase mapping.
- `supabase/migrations/202604260007_partner_period_preview.sql`: new super-admin-gated weekly/monthly partner preview RPC with explicit `source_order_amount_cents` internal basis before public gross/net outputs.
- `src/components/portal/portalNavigation.ts`: renames the portal tab label to Reporting.
- `Docs/LOCAL_DEV.md`: adds the new migration to the local setup checklist.

## Verification
- Rebased onto current `origin/main` after the admin reporting setup merge, then reran verification.
- `npm ci` - passed; npm reported existing audit findings: 5 moderate, 5 high.
- `npm run build` - passed; Vite build/prerender completed. Browserslist stale-data warning remains existing/tooling-level.
- `npm test --if-present` - passed; no test output/script present.
- `npm run lint --if-present` - passed with 8 existing fast-refresh warnings in shared UI/Auth files.
- `git diff --check` - passed.
- Local Playwright browser QA with mocked Supabase RPCs on `http://127.0.0.1:8087/portal/reports`:
  - Super-admin desktop: Partner dashboard renders, weekly chart has bars, Export PDF is enabled with no blocking warnings, and no console/page errors were captured.
  - Super-admin monthly switch: monthly net-sales chart renders with bars.
  - Super-admin mobile 390px: controls, KPI stack, chart, explicit period/value list, machine cards, and calculation fit with no horizontal overflow.
  - QA screenshots saved locally under `C:\Users\ethtr\AppData\Local\Temp\bloomjoy-reporting-qa-rebased`.

## Source-data investigation
- `Docs/DECISIONS.md` now has the controlling partner-specific rule: Bubble Planet workbook parity uses Sunze `Order amount` as gross sales, subtracts machine-rate tax plus configured paid-order fees before the split.
- The older operator-reporting convention still treats sales facts as net sales and refund adjustments separately; that should stay scoped to operator reporting unless a partner refund policy is explicitly added.
- This PR keeps refunds out of partner settlement math for now and makes the source basis explicit in the new period RPC so the SQL no longer looks like an accidental double-deduction.

## How to test
1. Apply the new migration in a Supabase environment that already has the reporting/partnership foundation migrations.
2. From this branch, run `npm ci` and `npm run dev` with `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` configured.
3. Log in as a non-admin user with machine reporting access and visit `http://localhost:8080/portal/reports`; confirm only Operator view is available.
4. Log in as a super-admin, or in local dev use a valid signed-in user listed in `VITE_DEV_ADMIN_EMAILS`; visit `/portal/reports` and confirm the Operator/Partner dashboard toggle appears.
5. In Partner dashboard, select an active partnership and switch Weekly/Monthly; confirm the KPI banner, single net-sales trend, machine rollups, current-period calculation, loading/error/empty states, and mobile layout behave as expected.
6. Click `Export PDF`; confirm the browser print/save flow shows the branded partner report and does not include admin warnings.
7. Force/seed a blocking warning; confirm the admin warning is visible in the browser and `Export PDF` is disabled.

## Overlap / coordination notes
- Issue: implements the current portal reporting build slice from #172.
- Synced with current `main` after the admin reporting setup work landed, including overlap in reporting/partnership files.
- Open PR #184 is docs-only with no direct overlap.
- Open PR #186 has a small `Docs/LOCAL_DEV.md` overlap only; no code overlap.
- Open Dependabot PRs do not have direct file overlap with this branch.
- Server-side PDF snapshot/review/send workflow and future `partner_viewer` permission are intentionally not implemented in this slice; this adds a browser PDF export path only after admin data is clean.
