### PR TITLE
docs: align technician spec with roadmap

### DIFF
--- a/Docs/ENTITLEMENTS_PERSONA_ROADMAP.md
+++ b/Docs/ENTITLEMENTS_PERSONA_ROADMAP.md
@@ -58,7 +58,7 @@ The near-term goal is to make the current role and entitlement direction clear e
 - `#150` remains the P2 umbrella for scalable roles, entitlements, and a future super-admin role-management UI.
 - `#123` should carry the Plus Account Owner technician-management scope, including the 10 technician grant cap, grant-only-owned-machines rule, and paid additional seats as P2.
 - `#128` should define Partner Viewer as explicit partner/reporting-only access with no inherited Plus benefits or admin powers.
-- Create or maintain one P1 issue for machine-scoped technician reporting entitlements, connecting current training-only grants with machine-specific reporting visibility.
+- `#183` is the P1 issue for machine-scoped technician reporting entitlements, connecting current training-only grants with machine-specific reporting visibility. See `Docs/TECHNICIAN_ENTITLEMENTS_SPEC.md` for the detailed implementation spec.
 
 ## Acceptance Criteria
 - The roadmap clearly answers who can see what, who can grant what, and what is deferred.

--- a/Docs/TECHNICIAN_ENTITLEMENTS_SPEC.md
+++ b/Docs/TECHNICIAN_ENTITLEMENTS_SPEC.md
@@ -3,8 +3,9 @@
 ## Status
 This is a docs-only implementation spec for GitHub issue `#183`: Define machine-scoped technician reporting entitlements.
 
-Dependency notes:
-- PR `#184` (`agent/entitlements-persona-roadmap`) is still open at the time of this spec. This document uses the persona roadmap from that PR as planning input and should be rebased against `Docs/ENTITLEMENTS_PERSONA_ROADMAP.md` after PR `#184` merges.
+Source and coordination notes:
+- `Docs/ENTITLEMENTS_PERSONA_ROADMAP.md` is the source of truth for the broader Super Admin, Scoped Admin, Plus Account Owner, Technician, and Partner Viewer persona boundaries.
+- This document is the detailed companion spec for the Technician portion of that roadmap.
 - PR `#182` is actively changing `/portal/reports`, partner dashboard UI, `src/lib/partnerDashboardReporting.ts`, and reporting preview migrations. This spec does not edit or require changes in those files.
 
 ## Scope


### PR DESCRIPTION
## Summary
- Updates the Technician entitlements spec now that PR #184 has merged.
- Makes `Docs/ENTITLEMENTS_PERSONA_ROADMAP.md` the explicit source of truth for persona boundaries.
- Adds a roadmap cross-reference from #183 to the detailed Technician spec.

## Files changed
- `Docs/TECHNICIAN_ENTITLEMENTS_SPEC.md` - replaces stale open-PR dependency wording with source/coordination notes.
- `Docs/ENTITLEMENTS_PERSONA_ROADMAP.md` - links the #183 roadmap item to the detailed Technician spec.

## Verification commands + results
- `npm ci` - passed; npm reported existing audit/deprecation warnings and no dependency files were changed.
- `npm run build` - passed; existing Browserslist data-age warning reported.
- `npm test --if-present` - passed; command completed without test output.
- `npm run lint --if-present` - passed with 8 existing Fast Refresh warnings and 0 errors.

## How to test
- Docs-only change; no localhost runtime behavior changed.
- Review `Docs/TECHNICIAN_ENTITLEMENTS_SPEC.md` and confirm it no longer treats PR #184 as open.
- Review `Docs/ENTITLEMENTS_PERSONA_ROADMAP.md` and confirm #183 links to the Technician detail spec.