### PR TITLE
docs: add AI-first GitHub guardrails

### DIFF
--- a/.github/ISSUE_TEMPLATE/ai_task.md
+++ b/.github/ISSUE_TEMPLATE/ai_task.md
@@ -1,0 +1,47 @@
+---
+name: AI task
+about: Define a focused task for an AI coding agent
+title: ""
+labels: ""
+assignees: ""
+---
+
+## Goal
+What user-visible or operational outcome should exist when this is done?
+
+## Acceptance criteria
+- 
+- 
+- 
+
+## In scope
+- 
+
+## Out of scope
+- 
+
+## Affected pages / features
+- 
+
+## Risk areas
+- [ ] Database / migrations
+- [ ] Edge Functions / server-side secrets
+- [ ] Auth / permissions
+- [ ] Stripe / payments
+- [ ] Reporting math / production data
+- [ ] GitHub Actions / deployment
+- [ ] UI / UX
+- [ ] Docs only
+
+## UAT expectations
+- Owner UAT required?
+  - [ ] No
+  - [ ] Yes
+- Preview/localhost pages to test:
+- Expected behavior:
+
+## Relevant context
+- Docs:
+- Related issues/PRs:
+- External dependencies or owner-controlled accounts:
+

--- a/.github/ISSUE_TEMPLATE/ai_task.md
+++ b/.github/ISSUE_TEMPLATE/ai_task.md
@@ -10,18 +10,18 @@ assignees: ""
 What user-visible or operational outcome should exist when this is done?
 
 ## Acceptance criteria
-- 
-- 
-- 
+- _TBD_
+- _TBD_
+- _TBD_
 
 ## In scope
-- 
+- _TBD_
 
 ## Out of scope
-- 
+- _TBD_
 
 ## Affected pages / features
-- 
+- _TBD_
 
 ## Risk areas
 - [ ] Database / migrations
@@ -44,4 +44,3 @@ What user-visible or operational outcome should exist when this is done?
 - Docs:
 - Related issues/PRs:
 - External dependencies or owner-controlled accounts:
-

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,4 +30,4 @@ assignees: ""
 - Approximate time observed:
 
 ## Notes
-- 
+- _TBD_

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: UAT or production bug
+about: Report something seen during UAT or on production
+title: ""
+labels: "bug"
+assignees: ""
+---
+
+## What happened?
+
+
+## What did you expect?
+
+
+## Where did it happen?
+- URL or route:
+- Environment:
+  - [ ] Localhost / preview
+  - [ ] Production
+
+## Impact
+- [ ] Blocks launch or revenue
+- [ ] Breaks a core workflow
+- [ ] Visual/UI issue
+- [ ] Minor issue
+
+## Evidence
+- Screenshot/video:
+- Error text:
+- Approximate time observed:
+
+## Notes
+- 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,45 @@
+## Summary
+- 
+
+## User-facing change
+- What changes for a customer, operator, partner, or admin?
+- If there is no user-facing change, write `None - internal/docs only`.
+
+## Risk level
+- [ ] Low - docs, copy, or small cleanup
+- [ ] Medium - UI/admin UX/non-critical scripts
+- [ ] High - database, Edge Functions, auth, Stripe/payments, reporting math, GitHub Actions, or production data paths
+
+## AI review evidence
+- Implementing agent self-check:
+- Independent AI/subagent review, if medium/high risk:
+- Labels applied:
+
+## Verification
+- `npm ci`:
+- `npm run build`:
+- `npm test --if-present`:
+- `npm run lint --if-present`:
+- Other relevant checks:
+
+## UAT / how to test
+- Preview URL or localhost URL:
+- Exact pages/routes:
+- Steps:
+  1.
+  2.
+  3.
+- Expected result:
+- Owner UAT required?
+  - [ ] No
+  - [ ] Yes - user-facing or high-risk change
+
+## Screenshots
+- Required for UI changes. Add desktop and mobile screenshots or write `Not applicable`.
+
+## Rollback plan
+- Usually: revert this PR.
+- If not that simple, explain the rollback steps:
+
+## Notes / open decisions
+- 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 ## Summary
-- 
+- _TBD_
 
 ## User-facing change
 - What changes for a customer, operator, partner, or admin?
@@ -42,4 +42,4 @@
 - If not that simple, explain the rollback steps:
 
 ## Notes / open decisions
-- 
+- _TBD_

--- a/Docs/AI_WORKFLOW.md
+++ b/Docs/AI_WORKFLOW.md
@@ -1,0 +1,46 @@
+# AI Workflow
+
+This repo is operated primarily through AI coding agents. The owner is not expected to do code review. Agents should do the implementation, review hygiene, GitHub cleanup, labeling, verification, and UAT preparation wherever possible.
+
+## Operating model
+- Keep PRs small, scoped, and reversible.
+- Start meaningful work from a GitHub issue when possible.
+- Convert vague ideas, parked work, or exploratory branches into issues instead of leaving long-lived draft PRs.
+- Use the GitHub PR template as the source of truth for risk, verification, UAT steps, screenshots, and rollback.
+- Ask the owner only for product judgment, external-account actions, final high-risk UAT, or ambiguous go/no-go decisions.
+
+## Risk levels
+- Low risk: docs-only, copy-only, small cleanup, or non-runtime guardrails.
+- Medium risk: UI changes, admin UX, non-critical scripts, or user-facing copy/layout.
+- High risk: Supabase migrations, Edge Functions, auth, Stripe/payments, reporting math, GitHub Actions, production data paths, or server-side secrets.
+
+## Agent responsibilities
+- Classify every PR as low, medium, or high risk.
+- Apply useful labels such as `docs-only`, `ui-change`, `risky-db-change`, `risky-auth-payment`, `ready-for-uat`, `uat-required`, `ai-reviewed`, `needs-owner-decision`, `blocked-external`, `parked`, or `superseded`.
+- Run the repo verification expected by the PR template and report exact results.
+- For UI changes, provide preview/localhost links and desktop/mobile screenshots.
+- For user-facing changes, provide exact UAT steps and expected results.
+- For high-risk changes, include an explicit rollback plan and independent AI review evidence.
+
+Use an independent AI reviewer or delegated subagent for high-risk review when the current agent environment allows it. If not available, perform a separate review pass and record what was checked.
+
+## Owner involvement
+- Low risk: no owner involvement unless wording or product direction is unclear.
+- Medium risk: owner UAT is optional; agents still provide a preview checklist.
+- High risk: owner UAT or go/no-go confirmation is required before merge or production rollout.
+
+The owner should not need to inspect code diffs to make routine decisions. PRs should present enough evidence for a product-level go/no-go.
+
+## Weekly hygiene
+Agents should periodically:
+- list stale PRs and recommend close, merge, park, or rebuild;
+- close/supersede stale PRs after owner approval when needed;
+- prune branches and worktrees only after confirming no uncommitted work remains;
+- keep `Docs/CURRENT_STATUS.md` aligned with current P0/P1 reality;
+- ensure GitHub issues and labels reflect the actual work queue.
+
+## Avoid
+- Do not bundle unrelated product, database, and docs changes in one PR.
+- Do not leave broad exploratory draft PRs open as planning artifacts.
+- Do not make the owner maintain labels, stale PRs, or branch cleanup manually.
+- Do not add heavier process, new CI jobs, CODEOWNERS, or required human code review unless explicitly requested.

--- a/Docs/PR_TEMPLATE.md
+++ b/Docs/PR_TEMPLATE.md
@@ -1,3 +1,6 @@
+GitHub PRs should use `.github/pull_request_template.md` as the canonical template.
+This older copy remains only for quick local reference.
+
 ## Summary
 - 
 

--- a/Docs/TASK_TEMPLATE.md
+++ b/Docs/TASK_TEMPLATE.md
@@ -1,5 +1,8 @@
 # Task Template (copy/paste into an agent)
 
+For GitHub issues, use `.github/ISSUE_TEMPLATE/ai_task.md` as the canonical task template.
+This older copy remains only for quick local prompting.
+
 ## Goal
 (What user-visible outcome should exist?)
 


### PR DESCRIPTION
## Summary
- Adds GitHub-recognized PR and issue templates for AI-first guardrails.
- Adds `Docs/AI_WORKFLOW.md` so agents own hygiene, risk classification, AI review evidence, UAT prep, and stale-PR cleanup.
- Keeps the legacy `Docs/PR_TEMPLATE.md` and `Docs/TASK_TEMPLATE.md` as local references pointing to the canonical GitHub templates.

## User-facing change
- None - docs/templates/labels only. Product runtime behavior is unchanged.

## Risk level
- [x] Low - docs, copy, or small cleanup
- [ ] Medium - UI/admin UX/non-critical scripts
- [ ] High - database, Edge Functions, auth, Stripe/payments, reporting math, GitHub Actions, or production data paths

## AI review evidence
- Implementing agent self-check: verified scope is limited to templates/docs plus repo labels; no branch protection, CODEOWNERS, CI workflow, runtime, database, auth, or payment changes.
- Independent AI/subagent review, if medium/high risk: Not required; low-risk docs/config guardrail change.
- Labels applied: `docs-only`, `ai-reviewed`.

## Verification
- `npm ci`: passed; npm reported existing audit findings/deprecated glob warning.
- `npm run build`: passed; existing Browserslist data-age warning reported.
- `npm test --if-present`: passed.
- `npm run lint --if-present`: passed with 8 existing fast-refresh warnings and 0 errors.
- Other relevant checks: `git diff --check` passed; `gh label list` confirmed the new guardrail labels exist.

## UAT / how to test
- Preview URL or localhost URL: no runtime UI change expected.
- Exact pages/routes: GitHub PR/issue creation screens after merge.
- Steps:
  1. After merge, open a new PR and confirm `.github/pull_request_template.md` appears.
  2. Open a new issue and confirm AI task and UAT/production bug templates appear.
  3. Confirm agents can reference `Docs/AI_WORKFLOW.md` for risk, UAT, and hygiene expectations.
- Expected result: PRs/issues prompt agents for AI review evidence, risk level, verification, UAT steps, screenshots where relevant, and rollback plan.
- Owner UAT required?
  - [x] No
  - [ ] Yes - user-facing or high-risk change

## Screenshots
- Not applicable.

## Rollback plan
- Revert this PR. Labels can remain harmlessly, or be deleted manually if desired.

## Notes / open decisions
- No branch protection, CODEOWNERS, or CI changes were made by design.