### PR TITLE
Add Plus Account Owner Technician management UX

### DIFF
--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -110,6 +110,14 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] `/portal/account` has no horizontal page overflow on mobile viewports (360x800, 390x844, 414x896)
 - [ ] `/portal/account` profile save persists and reloads from `customer_profiles`
 - [ ] `/portal/account` shipping save persists and reloads from `customer_profiles`
+- [ ] Plus Account Owner sees Technician Access on `/portal/account` with seat usage, owned machines, and current Technician grants
+- [ ] Plus Account Owner can add a Technician with one or more owned machines, then edit that Technician's machine assignments
+- [ ] Plus Account Owner cannot assign Technician access when the account has no active controlled reporting machines
+- [ ] Plus Account Owner sees a clear no-paid-seats message when the default 10 Technician grant cap is reached
+- [ ] Plus Account Owner can revoke Technician access only after entering a revoke reason
+- [ ] Baseline, training-only, Technician, Partner Viewer, and non-owner reporting users do not see Technician management controls
+- [ ] Technician login can open `/portal/training*` and `/portal/reports`, and reporting filters/results include only assigned machines
+- [ ] Technician login cannot access Plus discounts, billing, account-owner tools, partner settlement, or `/admin`
 - [ ] Onboarding checklist progress updates when steps are toggled
 - [ ] Onboarding progress persists for the same user after page refresh/re-login
 - [ ] Training catalog visible to logged-in users

--- a/src/components/portal/TechnicianManagementPanel.tsx
+++ b/src/components/portal/TechnicianManagementPanel.tsx
@@ -1,0 +1,864 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  AlertCircle,
+  CheckCircle2,
+  Loader2,
+  Pencil,
+  UserMinus,
+  UserPlus,
+  Users,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Textarea } from '@/components/ui/textarea';
+import { useAuth } from '@/contexts/AuthContext';
+import {
+  fetchMyTechnicianGrants,
+  fetchTechnicianManagementContext,
+  grantTechnicianAccess,
+  revokeTechnicianAccess,
+  updateTechnicianMachines,
+  type TechnicianGrant,
+  type TechnicianGrantStatus,
+  type TechnicianManagementMachine,
+} from '@/lib/technicianEntitlements';
+import { cn } from '@/lib/utils';
+
+const DEFAULT_TECHNICIAN_REASON = 'Technician access';
+const DEFAULT_UPDATE_REASON = 'Technician machine assignments updated';
+const DEFAULT_REVOKE_REASON = 'Technician no longer needs access';
+
+const formatDateTime = (value: string | null | undefined) => {
+  if (!value) return 'Not available';
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return 'Not available';
+  }
+
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+};
+
+const formatStatusLabel = (status: TechnicianGrantStatus) =>
+  status
+    .split('_')
+    .map((token) => token[0].toUpperCase() + token.slice(1))
+    .join(' ');
+
+const getStatusBadgeVariant = (status: TechnicianGrantStatus) => {
+  if (status === 'active') return 'default';
+  if (status === 'pending') return 'secondary';
+  if (status === 'suspended') return 'outline';
+  return 'destructive';
+};
+
+const toggleMachineId = (currentIds: string[], machineId: string, checked: boolean) => {
+  if (checked) {
+    return currentIds.includes(machineId) ? currentIds : [...currentIds, machineId];
+  }
+
+  return currentIds.filter((id) => id !== machineId);
+};
+
+const haveSameMachineIds = (left: string[], right: string[]) => {
+  if (left.length !== right.length) return false;
+
+  const rightIds = new Set(right);
+  return left.every((id) => rightIds.has(id));
+};
+
+export function TechnicianManagementPanel() {
+  const { user } = useAuth();
+  const queryClient = useQueryClient();
+  const [selectedAccountId, setSelectedAccountId] = useState('');
+  const [technicianEmail, setTechnicianEmail] = useState('');
+  const [selectedMachineIds, setSelectedMachineIds] = useState<string[]>([]);
+  const [grantReason, setGrantReason] = useState(DEFAULT_TECHNICIAN_REASON);
+  const [editingGrantId, setEditingGrantId] = useState<string | null>(null);
+  const [editingMachineIds, setEditingMachineIds] = useState<string[]>([]);
+  const [editReason, setEditReason] = useState(DEFAULT_UPDATE_REASON);
+  const [revokeTarget, setRevokeTarget] = useState<TechnicianGrant | null>(null);
+  const [revokeReason, setRevokeReason] = useState(DEFAULT_REVOKE_REASON);
+
+  const {
+    data: managementContext,
+    isLoading: managementLoading,
+    isFetching: managementFetching,
+    error: managementError,
+  } = useQuery({
+    queryKey: ['technician-management-context', user?.id],
+    queryFn: fetchTechnicianManagementContext,
+    enabled: Boolean(user?.id),
+    staleTime: 1000 * 30,
+  });
+  const shouldLoadTechnicianGrants = Boolean(user?.id && managementContext?.canManage);
+
+  const {
+    data: technicianGrants = [],
+    isLoading: grantsLoading,
+    isFetching: grantsFetching,
+    error: grantsError,
+  } = useQuery({
+    queryKey: ['technician-grants', user?.id],
+    queryFn: fetchMyTechnicianGrants,
+    enabled: shouldLoadTechnicianGrants,
+    staleTime: 1000 * 30,
+  });
+
+  const accounts = useMemo(() => managementContext?.accounts ?? [], [managementContext?.accounts]);
+  const selectedAccount =
+    accounts.find((account) => account.accountId === selectedAccountId) ?? accounts[0] ?? null;
+  const selectedAccountMachineIds = useMemo(
+    () => new Set((selectedAccount?.machines ?? []).map((machine) => machine.machineId)),
+    [selectedAccount]
+  );
+  const currentAccountGrants = useMemo(
+    () =>
+      technicianGrants
+        .filter(
+          (grant) =>
+            grant.canManage &&
+            !grant.revokedAt &&
+            (!selectedAccount || grant.accountId === selectedAccount.accountId)
+        )
+        .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt)),
+    [technicianGrants, selectedAccount]
+  );
+  const activeSeatCount =
+    selectedAccount?.activeSeatCount ??
+    currentAccountGrants.filter((grant) => grant.isActive).length;
+  const seatCap = selectedAccount?.seatCap ?? managementContext?.seatCap ?? 10;
+  const capReached = Boolean(selectedAccount && activeSeatCount >= seatCap);
+  const normalizedTechnicianEmail = technicianEmail.trim().toLowerCase();
+  const addEmailMatchesExistingGrant = currentAccountGrants.some(
+    (grant) => grant.technicianEmail.toLowerCase() === normalizedTechnicianEmail
+  );
+  const addBlockedByCap = capReached && !addEmailMatchesExistingGrant;
+  const isLoading = Boolean(managementContext?.canManage && grantsLoading);
+  const isRefreshing = managementFetching || grantsFetching;
+  const hasMachines = Boolean(selectedAccount?.machines.length);
+  const managementErrorMessage =
+    managementError instanceof Error ? managementError.message : null;
+  const grantsErrorMessage = grantsError instanceof Error ? grantsError.message : null;
+
+  useEffect(() => {
+    if (accounts.length === 0) {
+      setSelectedAccountId('');
+      return;
+    }
+
+    if (!selectedAccountId || !accounts.some((account) => account.accountId === selectedAccountId)) {
+      setSelectedAccountId(accounts[0].accountId);
+    }
+  }, [accounts, selectedAccountId]);
+
+  useEffect(() => {
+    setSelectedMachineIds((currentIds) =>
+      currentIds.filter((machineId) => selectedAccountMachineIds.has(machineId))
+    );
+    setEditingMachineIds((currentIds) =>
+      currentIds.filter((machineId) => selectedAccountMachineIds.has(machineId))
+    );
+  }, [selectedAccountMachineIds]);
+
+  const invalidateTechnicianQueries = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['technician-management-context', user?.id] }),
+      queryClient.invalidateQueries({ queryKey: ['technician-grants', user?.id] }),
+    ]);
+  };
+
+  const grantMutation = useMutation({
+    mutationFn: grantTechnicianAccess,
+    onSuccess: async () => {
+      setTechnicianEmail('');
+      setSelectedMachineIds([]);
+      setGrantReason(DEFAULT_TECHNICIAN_REASON);
+      await invalidateTechnicianQueries();
+      toast.success('Technician access saved.');
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: updateTechnicianMachines,
+    onSuccess: async () => {
+      setEditingGrantId(null);
+      setEditingMachineIds([]);
+      setEditReason(DEFAULT_UPDATE_REASON);
+      await invalidateTechnicianQueries();
+      toast.success('Technician machine assignments updated.');
+    },
+  });
+
+  const revokeMutation = useMutation({
+    mutationFn: revokeTechnicianAccess,
+    onSuccess: async () => {
+      setRevokeTarget(null);
+      setRevokeReason(DEFAULT_REVOKE_REASON);
+      await invalidateTechnicianQueries();
+      toast.success('Technician access revoked.');
+    },
+  });
+
+  if (managementLoading && !managementErrorMessage) {
+    return null;
+  }
+
+  if (!managementContext?.canManage && !managementErrorMessage) {
+    return null;
+  }
+
+  const handleAddTechnician = async () => {
+    const normalizedEmail = technicianEmail.trim().toLowerCase();
+
+    if (!normalizedEmail) {
+      toast.error('Enter a Technician email.');
+      return;
+    }
+
+    if (addBlockedByCap) {
+      toast.error('This Plus account is already at the 10 Technician grant cap.');
+      return;
+    }
+
+    if (selectedMachineIds.length === 0) {
+      toast.error('Select at least one machine.');
+      return;
+    }
+
+    try {
+      await grantMutation.mutateAsync({
+        technicianEmail: normalizedEmail,
+        machineIds: selectedMachineIds,
+        reason: grantReason.trim() || DEFAULT_TECHNICIAN_REASON,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to save Technician access.';
+      toast.error(message);
+    }
+  };
+
+  const startEditingGrant = (grant: TechnicianGrant) => {
+    setEditingGrantId(grant.grantId);
+    setEditingMachineIds(
+      grant.machines
+        .filter((machine) => machine.isActive)
+        .map((machine) => machine.machineId)
+        .filter((machineId) => selectedAccountMachineIds.has(machineId))
+    );
+    setEditReason(DEFAULT_UPDATE_REASON);
+  };
+
+  const handleSaveEdit = async (grant: TechnicianGrant) => {
+    if (editingMachineIds.length === 0) {
+      toast.error('Select at least one machine, or revoke Technician access.');
+      return;
+    }
+
+    try {
+      await updateMutation.mutateAsync({
+        grantId: grant.grantId,
+        machineIds: editingMachineIds,
+        reason: editReason.trim() || DEFAULT_UPDATE_REASON,
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Unable to update Technician machines.';
+      toast.error(message);
+    }
+  };
+
+  const handleRevoke = async () => {
+    if (!revokeTarget) return;
+
+    if (!revokeReason.trim()) {
+      toast.error('Enter a revoke reason.');
+      return;
+    }
+
+    try {
+      await revokeMutation.mutateAsync({
+        grantId: revokeTarget.grantId,
+        reason: revokeReason.trim(),
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to revoke Technician access.';
+      toast.error(message);
+    }
+  };
+
+  return (
+    <div className="mt-8 card-elevated min-w-0 p-5 sm:p-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="flex min-w-0 items-start gap-3">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+            <Users className="h-5 w-5 text-primary" />
+          </div>
+          <div className="min-w-0">
+            <h2 className="font-display text-lg font-semibold text-foreground">
+              Technician Access
+            </h2>
+            <p className="mt-1 max-w-3xl text-sm leading-6 text-muted-foreground">
+              Add staff who need training plus reporting for specific machines. Technicians do not
+              receive billing, Plus discounts, partner settlement, or admin tools.
+            </p>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Badge variant={capReached ? 'destructive' : 'outline'}>
+            {activeSeatCount} / {seatCap} seats used
+          </Badge>
+          {isRefreshing && <Badge variant="secondary">Refreshing</Badge>}
+        </div>
+      </div>
+
+      {isLoading ? (
+        <TechnicianPanelSkeleton />
+      ) : (
+        <div className="mt-6 flex flex-col gap-6">
+          {(managementErrorMessage || grantsErrorMessage) && (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>Unable to load Technician management</AlertTitle>
+              <AlertDescription>
+                {managementErrorMessage ?? grantsErrorMessage}
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {managementContext?.canManage && selectedAccount && (
+            <>
+              <div className="grid gap-4 lg:grid-cols-[0.38fr_0.62fr]">
+                <div className="flex flex-col gap-4 rounded-md border border-border bg-muted/20 p-4">
+                  <div>
+                    <Label htmlFor="technician-account">Account</Label>
+                    {accounts.length > 1 ? (
+                      <Select value={selectedAccount.accountId} onValueChange={setSelectedAccountId}>
+                        <SelectTrigger id="technician-account" className="mt-2">
+                          <SelectValue placeholder="Select account" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectGroup>
+                            {accounts.map((account) => (
+                              <SelectItem key={account.accountId} value={account.accountId}>
+                                {account.accountName}
+                              </SelectItem>
+                            ))}
+                          </SelectGroup>
+                        </SelectContent>
+                      </Select>
+                    ) : (
+                      <p className="mt-2 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground">
+                        {selectedAccount.accountName}
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-3">
+                    <div className="rounded-md border border-border bg-background p-3">
+                      <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                        Machines
+                      </p>
+                      <p className="mt-1 text-2xl font-semibold text-foreground">
+                        {selectedAccount.machineCount}
+                      </p>
+                    </div>
+                    <div className="rounded-md border border-border bg-background p-3">
+                      <p className="text-xs font-medium uppercase tracking-[0.14em] text-muted-foreground">
+                        Seats
+                      </p>
+                      <p className="mt-1 text-2xl font-semibold text-foreground">
+                        {activeSeatCount}/{seatCap}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="flex flex-col gap-4 rounded-md border border-border bg-background p-4">
+                  <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+                    <div>
+                      <Label htmlFor="technician-email">Technician email</Label>
+                      <Input
+                        id="technician-email"
+                        type="email"
+                        value={technicianEmail}
+                        onChange={(event) => setTechnicianEmail(event.target.value)}
+                        placeholder="technician@example.com"
+                        className="mt-2"
+                        disabled={!hasMachines || grantMutation.isPending}
+                      />
+                      <p className="mt-2 text-xs leading-5 text-muted-foreground">
+                        Existing emails are updated instead of consuming another seat.
+                      </p>
+                    </div>
+                    <div>
+                      <Label htmlFor="technician-reason">Reason</Label>
+                      <Input
+                        id="technician-reason"
+                        value={grantReason}
+                        onChange={(event) => setGrantReason(event.target.value)}
+                        className="mt-2"
+                        disabled={!hasMachines || grantMutation.isPending}
+                      />
+                    </div>
+                  </div>
+
+                  {capReached && (
+                    <Alert>
+                      <AlertCircle className="h-4 w-4" />
+                      <AlertTitle>Technician seat cap reached</AlertTitle>
+                      <AlertDescription>
+                        This Plus account already has 10 active Technician grants. Paid additional
+                        seats are planned later and are not available in this flow.
+                      </AlertDescription>
+                    </Alert>
+                  )}
+
+                  {!hasMachines ? (
+                    <Alert>
+                      <AlertCircle className="h-4 w-4" />
+                      <AlertTitle>No controlled machines available</AlertTitle>
+                      <AlertDescription>
+                        Bloomjoy needs to add active reporting machines to this Plus account before
+                        the owner can assign Technician reporting access.
+                      </AlertDescription>
+                    </Alert>
+                  ) : (
+                    <MachineChecklist
+                      idPrefix="add-technician"
+                      machines={selectedAccount.machines}
+                      selectedIds={selectedMachineIds}
+                      onToggle={(machineId, checked) =>
+                        setSelectedMachineIds((currentIds) =>
+                          toggleMachineId(currentIds, machineId, checked)
+                        )
+                      }
+                      disabled={addBlockedByCap || grantMutation.isPending}
+                    />
+                  )}
+
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <p className="text-xs leading-5 text-muted-foreground">
+                      {selectedMachineIds.length > 0
+                        ? `${selectedMachineIds.length} machine${
+                            selectedMachineIds.length === 1 ? '' : 's'
+                          } selected.`
+                        : 'Select the machines this Technician should report on.'}
+                    </p>
+                    <Button
+                      className="w-full sm:w-auto"
+                      onClick={handleAddTechnician}
+                      disabled={
+                        grantMutation.isPending ||
+                        addBlockedByCap ||
+                        !hasMachines ||
+                        selectedMachineIds.length === 0 ||
+                        !technicianEmail.trim()
+                      }
+                    >
+                      {grantMutation.isPending ? (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      ) : (
+                        <UserPlus className="mr-2 h-4 w-4" />
+                      )}
+                      Save Technician
+                    </Button>
+                  </div>
+                </div>
+              </div>
+
+              <div className="flex flex-col gap-3">
+                <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+                  <div>
+                    <h3 className="font-semibold text-foreground">Current Technicians</h3>
+                    <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                      Edit machine assignments or revoke access when a Technician no longer needs
+                      training and assigned-machine reporting.
+                    </p>
+                  </div>
+                  <Badge variant="outline">{currentAccountGrants.length} grants</Badge>
+                </div>
+
+                {currentAccountGrants.length === 0 ? (
+                  <p className="rounded-md border border-border bg-muted/20 px-3 py-3 text-sm text-muted-foreground">
+                    No Technician access has been added for this account yet.
+                  </p>
+                ) : (
+                  currentAccountGrants.map((grant) => (
+                    <TechnicianGrantRow
+                      key={grant.grantId}
+                      grant={grant}
+                      machines={selectedAccount.machines}
+                      isEditing={editingGrantId === grant.grantId}
+                      editingMachineIds={editingMachineIds}
+                      editReason={editReason}
+                      isSaving={updateMutation.isPending}
+                      onStartEdit={() => startEditingGrant(grant)}
+                      onCancelEdit={() => {
+                        setEditingGrantId(null);
+                        setEditingMachineIds([]);
+                        setEditReason(DEFAULT_UPDATE_REASON);
+                      }}
+                      onToggleEditMachine={(machineId, checked) =>
+                        setEditingMachineIds((currentIds) =>
+                          toggleMachineId(currentIds, machineId, checked)
+                        )
+                      }
+                      onChangeEditReason={setEditReason}
+                      onSaveEdit={() => handleSaveEdit(grant)}
+                      onRevoke={() => {
+                        setRevokeTarget(grant);
+                        setRevokeReason(DEFAULT_REVOKE_REASON);
+                      }}
+                    />
+                  ))
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
+      <Dialog open={Boolean(revokeTarget)} onOpenChange={(open) => !open && setRevokeTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Revoke Technician access?</DialogTitle>
+            <DialogDescription>
+              This removes Technician-sourced training and assigned-machine reporting access for{' '}
+              {revokeTarget?.technicianEmail ?? 'this Technician'}. Manual reporting grants are not
+              removed.
+            </DialogDescription>
+          </DialogHeader>
+          <div>
+            <Label htmlFor="technician-revoke-reason">Required revoke reason</Label>
+            <Textarea
+              id="technician-revoke-reason"
+              value={revokeReason}
+              onChange={(event) => setRevokeReason(event.target.value)}
+              className="mt-2 min-h-24"
+              disabled={revokeMutation.isPending}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setRevokeTarget(null)}
+              disabled={revokeMutation.isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={handleRevoke}
+              disabled={revokeMutation.isPending || !revokeReason.trim()}
+            >
+              {revokeMutation.isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <UserMinus className="mr-2 h-4 w-4" />
+              )}
+              Revoke Access
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function TechnicianGrantRow({
+  grant,
+  machines,
+  isEditing,
+  editingMachineIds,
+  editReason,
+  isSaving,
+  onStartEdit,
+  onCancelEdit,
+  onToggleEditMachine,
+  onChangeEditReason,
+  onSaveEdit,
+  onRevoke,
+}: {
+  grant: TechnicianGrant;
+  machines: TechnicianManagementMachine[];
+  isEditing: boolean;
+  editingMachineIds: string[];
+  editReason: string;
+  isSaving: boolean;
+  onStartEdit: () => void;
+  onCancelEdit: () => void;
+  onToggleEditMachine: (machineId: string, checked: boolean) => void;
+  onChangeEditReason: (value: string) => void;
+  onSaveEdit: () => void;
+  onRevoke: () => void;
+}) {
+  const activeMachines = grant.machines.filter((machine) => machine.isActive);
+  const originalMachineIds = activeMachines.map((machine) => machine.machineId);
+  const hasChanges = !haveSameMachineIds(editingMachineIds, originalMachineIds);
+
+  return (
+    <div className="rounded-md border border-border bg-muted/20 px-3 py-3">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="break-words text-sm font-semibold text-foreground">
+              {grant.technicianEmail}
+            </p>
+            <Badge variant={getStatusBadgeVariant(grant.status)}>
+              {formatStatusLabel(grant.status)}
+            </Badge>
+          </div>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">
+            {activeMachines.length} assigned machine{activeMachines.length === 1 ? '' : 's'} ·
+            Updated {formatDateTime(grant.updatedAt)}
+          </p>
+          {activeMachines.length > 0 && (
+            <div className="mt-2 flex flex-wrap gap-2">
+              {activeMachines.map((machine) => (
+                <Badge key={machine.machineId} variant="outline">
+                  {machine.machineLabel}
+                </Badge>
+              ))}
+            </div>
+          )}
+        </div>
+        <div className="flex flex-col gap-2 sm:flex-row lg:shrink-0">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onStartEdit}
+            disabled={isSaving}
+            className="w-full sm:w-auto"
+          >
+            <Pencil className="mr-1.5 h-4 w-4" />
+            Edit Machines
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onRevoke}
+            disabled={isSaving}
+            className="w-full sm:w-auto"
+          >
+            <UserMinus className="mr-1.5 h-4 w-4" />
+            Revoke
+          </Button>
+        </div>
+      </div>
+
+      {isEditing && (
+        <div className="mt-4 flex flex-col gap-4 rounded-md border border-border bg-background p-4">
+          <MachineChecklist
+            idPrefix={`edit-technician-${grant.grantId}`}
+            machines={machines}
+            selectedIds={editingMachineIds}
+            onToggle={onToggleEditMachine}
+            disabled={isSaving}
+          />
+          <div>
+            <Label htmlFor={`edit-reason-${grant.grantId}`}>Reason</Label>
+            <Input
+              id={`edit-reason-${grant.grantId}`}
+              value={editReason}
+              onChange={(event) => onChangeEditReason(event.target.value)}
+              className="mt-2"
+              disabled={isSaving}
+            />
+          </div>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-xs leading-5 text-muted-foreground">
+              {editingMachineIds.length === 0
+                ? 'Select at least one machine, or revoke access instead.'
+                : `${editingMachineIds.length} machine${
+                    editingMachineIds.length === 1 ? '' : 's'
+                  } selected.`}
+            </p>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Button type="button" variant="outline" onClick={onCancelEdit} disabled={isSaving}>
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                onClick={onSaveEdit}
+                disabled={isSaving || editingMachineIds.length === 0 || !hasChanges}
+              >
+                {isSaving ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <CheckCircle2 className="mr-2 h-4 w-4" />
+                )}
+                Save Machines
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MachineChecklist({
+  idPrefix,
+  machines,
+  selectedIds,
+  onToggle,
+  disabled = false,
+}: {
+  idPrefix: string;
+  machines: TechnicianManagementMachine[];
+  selectedIds: string[];
+  onToggle: (machineId: string, checked: boolean) => void;
+  disabled?: boolean;
+}) {
+  const selectedMachineIds = useMemo(() => new Set(selectedIds), [selectedIds]);
+  const groupedMachines = useMemo(() => {
+    const groups = new Map<string, { key: string; locationName: string; machines: TechnicianManagementMachine[] }>();
+
+    machines.forEach((machine) => {
+      const key = machine.locationId || machine.locationName;
+      const existingGroup =
+        groups.get(key) ??
+        {
+          key,
+          locationName: machine.locationName,
+          machines: [],
+        };
+
+      existingGroup.machines.push(machine);
+      groups.set(key, existingGroup);
+    });
+
+    return Array.from(groups.values()).sort((left, right) =>
+      left.locationName.localeCompare(right.locationName)
+    );
+  }, [machines]);
+
+  if (machines.length === 0) {
+    return (
+      <p className="rounded-md border border-border bg-muted/20 px-3 py-3 text-sm text-muted-foreground">
+        No machines are available for this account.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <Label>Assigned machines</Label>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => machines.forEach((machine) => onToggle(machine.machineId, true))}
+            disabled={disabled || selectedIds.length === machines.length}
+          >
+            Select All
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => selectedIds.forEach((machineId) => onToggle(machineId, false))}
+            disabled={disabled || selectedIds.length === 0}
+          >
+            Clear
+          </Button>
+        </div>
+      </div>
+      <div className="max-h-72 overflow-y-auto rounded-md border border-border">
+        {groupedMachines.map((group) => (
+          <div key={group.key} className="border-b border-border last:border-b-0">
+            <div className="bg-muted/40 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {group.locationName}
+            </div>
+            {group.machines.map((machine) => {
+              const checkboxId = `${idPrefix}-${machine.machineId}`;
+
+              return (
+                <label
+                  key={machine.machineId}
+                  htmlFor={checkboxId}
+                  className={cn(
+                    'flex cursor-pointer items-start gap-3 border-b border-border/60 p-3 last:border-b-0',
+                    disabled && 'cursor-not-allowed opacity-70'
+                  )}
+                >
+                  <Checkbox
+                    id={checkboxId}
+                    checked={selectedMachineIds.has(machine.machineId)}
+                    onCheckedChange={(checked) => onToggle(machine.machineId, checked === true)}
+                    disabled={disabled}
+                  />
+                  <span className="min-w-0 flex-1">
+                    <span className="block break-words text-sm font-medium text-foreground">
+                      {machine.machineLabel}
+                    </span>
+                    <span className="mt-1 block text-xs text-muted-foreground">
+                      {machine.machineType} · {machine.status}
+                    </span>
+                  </span>
+                </label>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TechnicianPanelSkeleton() {
+  return (
+    <div className="mt-6 grid gap-4 lg:grid-cols-[0.38fr_0.62fr]">
+      <div className="rounded-md border border-border bg-muted/20 p-4">
+        <Skeleton className="h-4 w-24" />
+        <Skeleton className="mt-3 h-10 w-full" />
+        <div className="mt-4 grid grid-cols-2 gap-3">
+          <Skeleton className="h-20 w-full" />
+          <Skeleton className="h-20 w-full" />
+        </div>
+      </div>
+      <div className="rounded-md border border-border bg-background p-4">
+        <Skeleton className="h-4 w-32" />
+        <Skeleton className="mt-3 h-10 w-full" />
+        <Skeleton className="mt-4 h-36 w-full" />
+      </div>
+    </div>
+  );
+}

--- a/src/lib/technicianEntitlements.ts
+++ b/src/lib/technicianEntitlements.ts
@@ -1,0 +1,323 @@
+import { supabaseClient } from '@/lib/supabaseClient';
+
+export type TechnicianGrantStatus = 'pending' | 'active' | 'suspended' | 'revoked';
+
+export type TechnicianManagementMachine = {
+  machineId: string;
+  machineLabel: string;
+  machineType: string;
+  locationId: string;
+  locationName: string;
+  status: string;
+};
+
+export type TechnicianManagementAccount = {
+  accountId: string;
+  accountName: string;
+  accountStatus: string;
+  seatCap: number;
+  activeSeatCount: number;
+  machineCount: number;
+  machines: TechnicianManagementMachine[];
+};
+
+export type TechnicianManagementContext = {
+  canManage: boolean;
+  seatCap: number;
+  accounts: TechnicianManagementAccount[];
+};
+
+export type TechnicianGrantMachine = {
+  assignmentId: string;
+  machineId: string;
+  machineLabel: string;
+  locationId: string;
+  locationName: string;
+  status: string;
+  startsAt: string;
+  expiresAt: string | null;
+  revokedAt: string | null;
+  revokeReason: string | null;
+  isActive: boolean;
+};
+
+export type TechnicianGrant = {
+  grantId: string;
+  accountId: string;
+  sponsorUserId: string;
+  technicianEmail: string;
+  technicianUserId: string | null;
+  operatorTrainingGrantId: string | null;
+  status: TechnicianGrantStatus;
+  startsAt: string;
+  expiresAt: string | null;
+  grantReason: string;
+  revokedAt: string | null;
+  revokeReason: string | null;
+  createdAt: string;
+  updatedAt: string;
+  isActive: boolean;
+  canManage: boolean;
+  authorityPath: string;
+  seatCap: number;
+  activeSeatCount: number;
+  machines: TechnicianGrantMachine[];
+  activeReportingEntitlementCount: number;
+};
+
+export type TechnicianMutationResult = {
+  grantId: string;
+  accountId: string;
+  technicianEmail: string;
+  technicianUserId: string | null;
+  status: TechnicianGrantStatus;
+  operatorTrainingGrantId: string | null;
+};
+
+type UnknownRecord = Record<string, unknown>;
+
+const isRecord = (value: unknown): value is UnknownRecord =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const asString = (value: unknown, fallback = ''): string =>
+  typeof value === 'string' ? value : fallback;
+
+const asNullableString = (value: unknown): string | null =>
+  typeof value === 'string' ? value : null;
+
+const asBoolean = (value: unknown): boolean => Boolean(value);
+
+const asNumber = (value: unknown, fallback = 0): number => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const asArray = <T>(value: unknown, mapItem: (item: unknown) => T): T[] =>
+  Array.isArray(value) ? value.map(mapItem) : [];
+
+const normalizeStatus = (value: unknown): TechnicianGrantStatus => {
+  switch (value) {
+    case 'active':
+    case 'suspended':
+    case 'revoked':
+      return value;
+    case 'pending':
+    default:
+      return 'pending';
+  }
+};
+
+const getTechnicianErrorMessage = (
+  message: string | undefined,
+  fallback: string
+): string => {
+  const rawMessage = message ?? '';
+  const missingRpc =
+    rawMessage.includes('schema cache') &&
+    (rawMessage.includes('get_my_technician_management_context') ||
+      rawMessage.includes('get_my_technician_grants') ||
+      rawMessage.includes('grant_technician_access') ||
+      rawMessage.includes('update_technician_machines') ||
+      rawMessage.includes('revoke_technician_access'));
+
+  if (missingRpc) {
+    return 'Technician management is not enabled in this environment yet. Bloomjoy needs to finish the database rollout before Technician access can be managed.';
+  }
+
+  if (rawMessage.includes('Technician grant cap exceeded')) {
+    return 'This Plus account already has 10 active Technician grants. Paid additional seats are not enabled yet.';
+  }
+
+  if (rawMessage.includes('outside your control')) {
+    return 'One or more selected machines are outside this Plus account owner boundary.';
+  }
+
+  if (rawMessage.includes('At least one reporting machine is required')) {
+    return 'Select at least one reporting machine for this Technician.';
+  }
+
+  if (rawMessage.includes('Use a different email')) {
+    return 'Use a different email for Technician access.';
+  }
+
+  return rawMessage || fallback;
+};
+
+const mapManagementMachine = (item: unknown): TechnicianManagementMachine => {
+  const record = isRecord(item) ? item : {};
+
+  return {
+    machineId: asString(record.machineId),
+    machineLabel: asString(record.machineLabel, 'Unnamed machine'),
+    machineType: asString(record.machineType, 'unknown'),
+    locationId: asString(record.locationId),
+    locationName: asString(record.locationName, 'Unassigned location'),
+    status: asString(record.status, 'active'),
+  };
+};
+
+const mapManagementAccount = (item: unknown): TechnicianManagementAccount => {
+  const record = isRecord(item) ? item : {};
+
+  return {
+    accountId: asString(record.accountId),
+    accountName: asString(record.accountName, 'Bloomjoy account'),
+    accountStatus: asString(record.accountStatus, 'active'),
+    seatCap: asNumber(record.seatCap, 10),
+    activeSeatCount: asNumber(record.activeSeatCount),
+    machineCount: asNumber(record.machineCount),
+    machines: asArray(record.machines, mapManagementMachine).filter((machine) => machine.machineId),
+  };
+};
+
+const mapTechnicianGrantMachine = (item: unknown): TechnicianGrantMachine => {
+  const record = isRecord(item) ? item : {};
+
+  return {
+    assignmentId: asString(record.assignmentId),
+    machineId: asString(record.machineId),
+    machineLabel: asString(record.machineLabel, 'Unnamed machine'),
+    locationId: asString(record.locationId),
+    locationName: asString(record.locationName, 'Unassigned location'),
+    status: asString(record.status, 'active'),
+    startsAt: asString(record.startsAt),
+    expiresAt: asNullableString(record.expiresAt),
+    revokedAt: asNullableString(record.revokedAt),
+    revokeReason: asNullableString(record.revokeReason),
+    isActive: asBoolean(record.isActive),
+  };
+};
+
+const mapTechnicianGrant = (item: unknown): TechnicianGrant => {
+  const record = isRecord(item) ? item : {};
+
+  return {
+    grantId: asString(record.grantId),
+    accountId: asString(record.accountId),
+    sponsorUserId: asString(record.sponsorUserId),
+    technicianEmail: asString(record.technicianEmail),
+    technicianUserId: asNullableString(record.technicianUserId),
+    operatorTrainingGrantId: asNullableString(record.operatorTrainingGrantId),
+    status: normalizeStatus(record.status),
+    startsAt: asString(record.startsAt),
+    expiresAt: asNullableString(record.expiresAt),
+    grantReason: asString(record.grantReason, 'Technician access'),
+    revokedAt: asNullableString(record.revokedAt),
+    revokeReason: asNullableString(record.revokeReason),
+    createdAt: asString(record.createdAt),
+    updatedAt: asString(record.updatedAt),
+    isActive: asBoolean(record.isActive),
+    canManage: asBoolean(record.canManage),
+    authorityPath: asString(record.authorityPath, 'technician'),
+    seatCap: asNumber(record.seatCap, 10),
+    activeSeatCount: asNumber(record.activeSeatCount),
+    machines: asArray(record.machines, mapTechnicianGrantMachine).filter(
+      (machine) => machine.machineId
+    ),
+    activeReportingEntitlementCount: asNumber(record.activeReportingEntitlementCount),
+  };
+};
+
+const mapMutationResult = (value: unknown): TechnicianMutationResult => {
+  const record = isRecord(value) ? value : {};
+
+  return {
+    grantId: asString(record.grantId),
+    accountId: asString(record.accountId),
+    technicianEmail: asString(record.technicianEmail),
+    technicianUserId: asNullableString(record.technicianUserId),
+    status: normalizeStatus(record.status),
+    operatorTrainingGrantId: asNullableString(record.operatorTrainingGrantId),
+  };
+};
+
+export const fetchTechnicianManagementContext =
+  async (): Promise<TechnicianManagementContext> => {
+    const { data, error } = await supabaseClient.rpc('get_my_technician_management_context');
+
+    if (error) {
+      throw new Error(
+        getTechnicianErrorMessage(error.message, 'Unable to load Technician management.')
+      );
+    }
+
+    const record = isRecord(data) ? data : {};
+
+    return {
+      canManage: asBoolean(record.canManage),
+      seatCap: asNumber(record.seatCap, 10),
+      accounts: asArray(record.accounts, mapManagementAccount).filter(
+        (account) => account.accountId
+      ),
+    };
+  };
+
+export const fetchMyTechnicianGrants = async (): Promise<TechnicianGrant[]> => {
+  const { data, error } = await supabaseClient.rpc('get_my_technician_grants');
+
+  if (error) {
+    throw new Error(
+      getTechnicianErrorMessage(error.message, 'Unable to load Technician access.')
+    );
+  }
+
+  return asArray(data, mapTechnicianGrant).filter((grant) => grant.grantId);
+};
+
+export const grantTechnicianAccess = async (input: {
+  technicianEmail: string;
+  machineIds: string[];
+  reason?: string;
+}): Promise<TechnicianMutationResult> => {
+  const { data, error } = await supabaseClient.rpc('grant_technician_access', {
+    p_technician_email: input.technicianEmail.trim(),
+    p_machine_ids: input.machineIds,
+    p_reason: input.reason?.trim() || 'Technician access',
+  });
+
+  if (error || !data) {
+    throw new Error(
+      getTechnicianErrorMessage(error?.message, 'Unable to grant Technician access.')
+    );
+  }
+
+  return mapMutationResult(data);
+};
+
+export const updateTechnicianMachines = async (input: {
+  grantId: string;
+  machineIds: string[];
+  reason?: string;
+}): Promise<TechnicianMutationResult> => {
+  const { data, error } = await supabaseClient.rpc('update_technician_machines', {
+    p_grant_id: input.grantId,
+    p_machine_ids: input.machineIds,
+    p_reason: input.reason?.trim() || 'Technician machine assignments updated',
+  });
+
+  if (error || !data) {
+    throw new Error(
+      getTechnicianErrorMessage(error?.message, 'Unable to update Technician machines.')
+    );
+  }
+
+  return mapMutationResult(data);
+};
+
+export const revokeTechnicianAccess = async (input: {
+  grantId: string;
+  reason: string;
+}): Promise<TechnicianMutationResult> => {
+  const { data, error } = await supabaseClient.rpc('revoke_technician_access', {
+    p_grant_id: input.grantId,
+    p_reason: input.reason.trim(),
+  });
+
+  if (error || !data) {
+    throw new Error(
+      getTechnicianErrorMessage(error?.message, 'Unable to revoke Technician access.')
+    );
+  }
+
+  return mapMutationResult(data);
+};

--- a/src/pages/portal/Account.tsx
+++ b/src/pages/portal/Account.tsx
@@ -15,6 +15,7 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { PortalLayout } from '@/components/portal/PortalLayout';
 import { PortalPageIntro } from '@/components/portal/PortalPageIntro';
+import { TechnicianManagementPanel } from '@/components/portal/TechnicianManagementPanel';
 import { useAuth } from '@/contexts/AuthContext';
 import { openCustomerPortal } from '@/lib/stripeCheckout';
 import { hasPlusAccess } from '@/lib/membership';
@@ -616,6 +617,8 @@ export default function AccountPage() {
 
             </div>
           </div>
+
+          <TechnicianManagementPanel />
 
           {canManageOperatorTraining && (
             <div className="mt-8 card-elevated min-w-0 p-5 sm:p-6">

--- a/supabase/migrations/202604260012_technician_management_context.sql
+++ b/supabase/migrations/202604260012_technician_management_context.sql
@@ -1,0 +1,102 @@
+-- Customer portal helper for Plus Account Owner Technician management.
+--
+-- This intentionally exposes only the signed-in owner's own Plus accounts and
+-- active reporting machines. Super-admin override remains a backend capability,
+-- not a broad customer-portal account picker.
+
+drop function if exists public.get_my_technician_management_context();
+
+create or replace function public.get_my_technician_management_context()
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public, auth
+as $$
+declare
+  current_user_id uuid;
+  result jsonb;
+begin
+  current_user_id := auth.uid();
+
+  if current_user_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  with owner_accounts as (
+    select
+      account.id,
+      account.name,
+      account.status,
+      public.count_active_technician_grants(account.id) as active_seat_count
+    from public.customer_account_memberships membership
+    join public.customer_accounts account on account.id = membership.account_id
+    where membership.user_id = current_user_id
+      and membership.active
+      and membership.role = 'owner'
+      and account.status = 'active'
+      and public.has_plus_access(current_user_id)
+  ),
+  account_payloads as (
+    select
+      owner_accounts.name as account_name,
+      jsonb_build_object(
+        'accountId', owner_accounts.id,
+        'accountName', owner_accounts.name,
+        'accountStatus', owner_accounts.status,
+        'seatCap', 10,
+        'activeSeatCount', owner_accounts.active_seat_count,
+        'machineCount', (
+          select count(*)::integer
+          from public.reporting_machines machine
+          where machine.account_id = owner_accounts.id
+            and machine.status = 'active'
+        ),
+        'machines', coalesce((
+          select jsonb_agg(
+            jsonb_build_object(
+              'machineId', machine.id,
+              'machineLabel', machine.machine_label,
+              'machineType', machine.machine_type,
+              'locationId', location.id,
+              'locationName', location.name,
+              'status', machine.status
+            )
+            order by location.name, machine.machine_label, machine.id
+          )
+          from public.reporting_machines machine
+          join public.reporting_locations location on location.id = machine.location_id
+          where machine.account_id = owner_accounts.id
+            and machine.status = 'active'
+        ), '[]'::jsonb)
+      ) as payload
+    from owner_accounts
+  )
+  select jsonb_build_object(
+    'canManage', exists (select 1 from owner_accounts),
+    'seatCap', 10,
+    'accounts', coalesce(
+      jsonb_agg(account_payloads.payload order by account_payloads.account_name),
+      '[]'::jsonb
+    )
+  )
+  into result
+  from account_payloads;
+
+  return coalesce(
+    result,
+    jsonb_build_object(
+      'canManage', false,
+      'seatCap', 10,
+      'accounts', '[]'::jsonb
+    )
+  );
+end;
+$$;
+
+comment on function public.get_my_technician_management_context() is
+  'Returns the Plus Account Owner accounts and active machines that the signed-in owner can use for customer-portal Technician management.';
+
+grant execute on function public.get_my_technician_management_context() to authenticated;
+
+select pg_notify('pgrst', 'reload schema');


### PR DESCRIPTION
## Summary
- Adds a Plus Account Owner Technician Access panel on `/portal/account` for machine-scoped Technician add, edit, and revoke flows.
- Adds a read-only `get_my_technician_management_context()` RPC so the portal only shows owner-controlled active machines and does not guess from reporting visibility.
- Updates the smoke checklist for Technician management, cap, visibility, and assigned-machine reporting checks.

## Files changed
- `supabase/migrations/202604260012_technician_management_context.sql`: owner-safe management context RPC.
- `src/lib/technicianEntitlements.ts`: typed frontend wrappers for Technician context/grant/update/revoke RPCs.
- `src/components/portal/TechnicianManagementPanel.tsx`: account-page Technician management UI.
- `src/pages/portal/Account.tsx`: renders the new panel.
- `Docs/QA_SMOKE_TEST_CHECKLIST.md`: future smoke coverage for the Technician flow.

## Verification commands/results
- `npm ci` - passed. Existing output still reports 2 moderate vulnerabilities and a deprecated `glob` warning; no dependency changes were made.
- `npm run build` - passed. Existing Browserslist stale-data warning remains.
- `npm test --if-present` - passed; no test script output.
- `npm run lint --if-present` - passed with the existing 8 `react-refresh/only-export-components` warnings in shared UI/Auth files.
- `supabase db reset --local --no-seed` - passed after starting local Supabase on temporary non-default ports; replay reached `202604260012_technician_management_context.sql`.
- `supabase db lint --local --fail-on error` - passed with the existing `public.save_training_progress` warning about `current_timestamp`.

## How to test
1. From this branch, run `npm ci`, apply/start local Supabase migrations, then run `npm run dev` and open the printed localhost URL.
2. Sign in as a Plus Account Owner with an active owner membership and active reporting machines; open `/portal/account` and confirm Technician Access shows owned machines and `used / 10` seat usage.
3. Add a Technician with one or more owned machines, edit that Technician's machine assignments, then revoke access with a required reason.
4. Sign in as baseline, training-only, Technician, Partner Viewer, or non-owner reporting users and confirm Technician management controls are not shown.
5. For a Technician user, confirm `/portal/training*` works and `/portal/reports` shows only assigned machines.

## Coordination notes
- Closes #191.
- Started from current `origin/main` at `45f0865` after PR #206.
- Avoids `/portal/reports`, partner dashboard UI, `src/lib/partnerDashboardReporting.ts`, reporting preview migrations, PDF/report export behavior, and dependency files.
- Draft PR #207 touches `Docs/QA_SMOKE_TEST_CHECKLIST.md` and uses migration `202604260011_reporting_setup_corrections.sql`; this PR uses `202604260012_technician_management_context.sql` to avoid a migration-version collision. If #207 merges first, only the checklist may need a small conflict resolution.