### PR TITLE
Resolve pending Technician entitlements on login

### DIFF
--- a/Docs/LOCAL_DEV.md
+++ b/Docs/LOCAL_DEV.md
@@ -50,6 +50,8 @@
    - Technician grant/revoke RPCs: `supabase/migrations/202604260009_technician_entitlements_rpcs.sql`
    - Database migration hygiene repairs: `supabase/migrations/202604260010_database_migration_hygiene.sql`
    - Reporting setup corrections: `supabase/migrations/202604260011_reporting_setup_corrections.sql`
+   - Technician management context: `supabase/migrations/202604260012_technician_management_context.sql`
+   - Technician invite resolution: `supabase/migrations/202604260013_technician_invite_resolution.sql`
 2) Seed data (optional for local dev): `supabase/seed/20260122_training_seed.sql`
 3) Populate Vimeo fields after account setup:
    - `provider_video_id`

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -112,6 +112,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] `/portal/account` shipping save persists and reloads from `customer_profiles`
 - [ ] Plus Account Owner sees Technician Access on `/portal/account` with seat usage, owned machines, and current Technician grants
 - [ ] Plus Account Owner can add a Technician with one or more owned machines, then edit that Technician's machine assignments
+- [ ] Pending Technician invite resolves on first login so the Technician gets training plus assigned-machine reporting without admin repair
 - [ ] Plus Account Owner cannot assign Technician access when the account has no active controlled reporting machines
 - [ ] Plus Account Owner sees a clear no-paid-seats message when the default 10 Technician grant cap is reached
 - [ ] Plus Account Owner can revoke Technician access only after entering a revoke reason

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -17,6 +17,7 @@ import {
   fetchReportingAccessContext,
   type ReportingAccessContext,
 } from '@/lib/reporting';
+import { resolveMyTechnicianEntitlements } from '@/lib/technicianEntitlements';
 
 interface User {
   id: string;
@@ -138,8 +139,22 @@ const getPortalAccessContext = async (): Promise<PortalAccessContextRecord | nul
     : ((data as PortalAccessContextRecord | null) ?? null);
 };
 
+const resolveTechnicianEntitlements = async (): Promise<void> => {
+  try {
+    await resolveMyTechnicianEntitlements();
+  } catch {
+    // Missing or failed resolution should not block login; access checks below
+    // still reflect the database state already available to the session.
+  }
+};
+
 const buildAuthUser = async (supabaseUser: SupabaseUser): Promise<User> => {
   const email = supabaseUser.email ?? '';
+
+  if (email) {
+    await resolveTechnicianEntitlements();
+  }
+
   const [plusAccess, dbIsAdmin, portalAccessContext, reportingAccess] = await Promise.all([
     getPlusAccess(),
     getIsAdmin(supabaseUser.id),

--- a/src/lib/technicianEntitlements.ts
+++ b/src/lib/technicianEntitlements.ts
@@ -74,6 +74,14 @@ export type TechnicianMutationResult = {
   operatorTrainingGrantId: string | null;
 };
 
+export type TechnicianResolutionResult = {
+  technicianEmail: string | null;
+  resolvedGrantCount: number;
+  resolvedOperatorTrainingGrantCount: number;
+  upsertedReportingEntitlementCount: number;
+  skippedGrantCount: number;
+};
+
 type UnknownRecord = Record<string, unknown>;
 
 const isRecord = (value: unknown): value is UnknownRecord =>
@@ -116,6 +124,7 @@ const getTechnicianErrorMessage = (
     rawMessage.includes('schema cache') &&
     (rawMessage.includes('get_my_technician_management_context') ||
       rawMessage.includes('get_my_technician_grants') ||
+      rawMessage.includes('resolve_my_technician_entitlements') ||
       rawMessage.includes('grant_technician_access') ||
       rawMessage.includes('update_technician_machines') ||
       rawMessage.includes('revoke_technician_access'));
@@ -230,6 +239,33 @@ const mapMutationResult = (value: unknown): TechnicianMutationResult => {
     operatorTrainingGrantId: asNullableString(record.operatorTrainingGrantId),
   };
 };
+
+const mapResolutionResult = (value: unknown): TechnicianResolutionResult => {
+  const record = isRecord(value) ? value : {};
+
+  return {
+    technicianEmail: asNullableString(record.technicianEmail),
+    resolvedGrantCount: asNumber(record.resolvedGrantCount),
+    resolvedOperatorTrainingGrantCount: asNumber(record.resolvedOperatorTrainingGrantCount),
+    upsertedReportingEntitlementCount: asNumber(record.upsertedReportingEntitlementCount),
+    skippedGrantCount: asNumber(record.skippedGrantCount),
+  };
+};
+
+export const resolveMyTechnicianEntitlements =
+  async (): Promise<TechnicianResolutionResult> => {
+    const { data, error } = await supabaseClient.rpc('resolve_my_technician_entitlements', {
+      p_reason: 'Technician invite accepted',
+    });
+
+    if (error) {
+      throw new Error(
+        getTechnicianErrorMessage(error.message, 'Unable to resolve Technician access.')
+      );
+    }
+
+    return mapResolutionResult(data);
+  };
 
 export const fetchTechnicianManagementContext =
   async (): Promise<TechnicianManagementContext> => {

--- a/supabase/migrations/202604260013_technician_invite_resolution.sql
+++ b/supabase/migrations/202604260013_technician_invite_resolution.sql
@@ -1,0 +1,302 @@
+-- Resolve pending Technician grants when the invited email signs in.
+--
+-- Previous slices can create a Technician grant before the target email has an
+-- auth.users row. This RPC links those pending email grants to the signed-in
+-- user and materializes the derived machine reporting entitlements.
+
+drop function if exists public.resolve_my_technician_entitlements(text);
+
+create or replace function public.resolve_my_technician_entitlements(
+  p_reason text default 'Technician invite accepted'
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  current_user_id uuid;
+  current_user_email text;
+  normalized_email text;
+  normalized_reason text;
+  grant_before public.technician_grants;
+  grant_after public.technician_grants;
+  operator_before public.operator_training_grants;
+  operator_after public.operator_training_grants;
+  active_machine_ids uuid[];
+  grant_changed boolean;
+  operator_changed boolean;
+  entitlement_rows_changed integer;
+  resolved_grant_count integer := 0;
+  resolved_operator_grant_count integer := 0;
+  upserted_reporting_entitlement_count integer := 0;
+  skipped_grant_count integer := 0;
+begin
+  current_user_id := auth.uid();
+
+  if current_user_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  normalized_reason := public.technician_assert_reason(p_reason);
+
+  select auth_user.email
+  into current_user_email
+  from auth.users auth_user
+  where auth_user.id = current_user_id
+  limit 1;
+
+  normalized_email := public.normalize_technician_email(current_user_email);
+
+  if normalized_email = '' then
+    return jsonb_build_object(
+      'technicianEmail', null,
+      'resolvedGrantCount', 0,
+      'resolvedOperatorTrainingGrantCount', 0,
+      'upsertedReportingEntitlementCount', 0,
+      'skippedGrantCount', 0
+    );
+  end if;
+
+  for grant_before in
+    select *
+    from public.technician_grants grant_row
+    where public.normalize_technician_email(grant_row.technician_email) = normalized_email
+      and public.technician_grant_is_active(
+        grant_row.starts_at,
+        grant_row.expires_at,
+        grant_row.revoked_at,
+        grant_row.status
+      )
+      and (
+        grant_row.technician_user_id is null
+        or grant_row.technician_user_id = current_user_id
+      )
+    for update
+  loop
+    if not public.has_plus_access(grant_before.sponsor_user_id)
+      or not exists (
+        select 1
+        from public.customer_account_memberships membership
+        where membership.account_id = grant_before.account_id
+          and membership.user_id = grant_before.sponsor_user_id
+          and membership.active
+          and membership.role = 'owner'
+      ) then
+      skipped_grant_count := skipped_grant_count + 1;
+      continue;
+    end if;
+
+    grant_changed :=
+      grant_before.technician_user_id is distinct from current_user_id
+      or grant_before.status = 'pending';
+
+    if grant_changed then
+      update public.technician_grants
+      set
+        technician_user_id = current_user_id,
+        status = 'active'
+      where id = grant_before.id
+      returning * into grant_after;
+
+      resolved_grant_count := resolved_grant_count + 1;
+    else
+      grant_after := grant_before;
+    end if;
+
+    operator_changed := false;
+
+    if grant_after.operator_training_grant_id is not null then
+      select *
+      into operator_before
+      from public.operator_training_grants operator_grant
+      where operator_grant.id = grant_after.operator_training_grant_id
+        and operator_grant.revoked_at is null
+      limit 1
+      for update;
+
+      if operator_before.id is not null
+        and operator_before.operator_user_id is distinct from current_user_id then
+        update public.operator_training_grants
+        set operator_user_id = current_user_id
+        where id = operator_before.id
+        returning * into operator_after;
+
+        operator_changed := true;
+        resolved_operator_grant_count := resolved_operator_grant_count + 1;
+
+        insert into public.admin_audit_log (
+          actor_user_id,
+          action,
+          entity_type,
+          entity_id,
+          target_user_id,
+          before,
+          after,
+          meta
+        )
+        values (
+          current_user_id,
+          'operator_training.resolved',
+          'operator_training_grant',
+          operator_after.id::text,
+          current_user_id,
+          to_jsonb(operator_before),
+          to_jsonb(operator_after),
+          jsonb_build_object(
+            'automation', true,
+            'reason', normalized_reason,
+            'operator_email', normalized_email,
+            'source_type', 'technician_grant',
+            'source_id', grant_after.id
+          )
+        );
+      end if;
+    end if;
+
+    select coalesce(array_agg(assignment.machine_id order by assignment.machine_id), '{}'::uuid[])
+    into active_machine_ids
+    from public.technician_machine_assignments assignment
+    join public.reporting_machines machine on machine.id = assignment.machine_id
+    where assignment.technician_grant_id = grant_after.id
+      and machine.status = 'active'
+      and machine.account_id = grant_after.account_id
+      and public.technician_assignment_is_active(
+        assignment.starts_at,
+        assignment.expires_at,
+        assignment.revoked_at,
+        assignment.status
+      );
+
+    insert into public.reporting_machine_entitlements (
+      user_id,
+      account_id,
+      location_id,
+      machine_id,
+      access_level,
+      starts_at,
+      expires_at,
+      grant_reason,
+      granted_by,
+      revoked_at,
+      revoked_by,
+      revoke_reason,
+      source_type,
+      source_id
+    )
+    select
+      current_user_id,
+      null,
+      null,
+      assignment.machine_id,
+      'viewer',
+      assignment.starts_at,
+      assignment.expires_at,
+      assignment.grant_reason,
+      coalesce(
+        assignment.granted_by_user_id,
+        grant_after.granted_by_user_id,
+        grant_after.sponsor_user_id
+      ),
+      null,
+      null,
+      null,
+      'technician_grant',
+      grant_after.id
+    from public.technician_machine_assignments assignment
+    join public.reporting_machines machine on machine.id = assignment.machine_id
+    where assignment.technician_grant_id = grant_after.id
+      and machine.status = 'active'
+      and machine.account_id = grant_after.account_id
+      and public.technician_assignment_is_active(
+        assignment.starts_at,
+        assignment.expires_at,
+        assignment.revoked_at,
+        assignment.status
+      )
+    on conflict (source_type, source_id, machine_id)
+      where source_type = 'technician_grant'
+        and revoked_at is null
+    do update
+    set
+      user_id = excluded.user_id,
+      account_id = null,
+      location_id = null,
+      access_level = 'viewer',
+      starts_at = excluded.starts_at,
+      expires_at = excluded.expires_at,
+      grant_reason = excluded.grant_reason,
+      granted_by = excluded.granted_by,
+      revoked_at = null,
+      revoked_by = null,
+      revoke_reason = null
+    where reporting_machine_entitlements.user_id is distinct from excluded.user_id
+      or reporting_machine_entitlements.account_id is not null
+      or reporting_machine_entitlements.location_id is not null
+      or reporting_machine_entitlements.access_level <> 'viewer'
+      or reporting_machine_entitlements.starts_at is distinct from excluded.starts_at
+      or reporting_machine_entitlements.expires_at is distinct from excluded.expires_at
+      or reporting_machine_entitlements.grant_reason is distinct from excluded.grant_reason
+      or reporting_machine_entitlements.granted_by is distinct from excluded.granted_by
+      or reporting_machine_entitlements.revoked_at is not null
+      or reporting_machine_entitlements.revoked_by is not null
+      or reporting_machine_entitlements.revoke_reason is not null;
+
+    get diagnostics entitlement_rows_changed = row_count;
+    upserted_reporting_entitlement_count :=
+      upserted_reporting_entitlement_count + entitlement_rows_changed;
+
+    if grant_changed or operator_changed or entitlement_rows_changed > 0 then
+      insert into public.admin_audit_log (
+        actor_user_id,
+        action,
+        entity_type,
+        entity_id,
+        target_user_id,
+        before,
+        after,
+        meta
+      )
+      values (
+        current_user_id,
+        'technician_access.resolved',
+        'technician_grant',
+        grant_after.id::text,
+        current_user_id,
+        to_jsonb(grant_before),
+        to_jsonb(grant_after),
+        jsonb_build_object(
+          'automation', true,
+          'reason', normalized_reason,
+          'account_id', grant_after.account_id,
+          'sponsor_user_id', grant_after.sponsor_user_id,
+          'technician_email', normalized_email,
+          'technician_user_id', current_user_id,
+          'operator_training_grant_id', grant_after.operator_training_grant_id,
+          'operator_training_resolved', operator_changed,
+          'reporting_entitlements_upserted', entitlement_rows_changed,
+          'machine_ids', active_machine_ids,
+          'source_type', 'technician_grant',
+          'source_id', grant_after.id
+        )
+      );
+    end if;
+  end loop;
+
+  return jsonb_build_object(
+    'technicianEmail', normalized_email,
+    'resolvedGrantCount', resolved_grant_count,
+    'resolvedOperatorTrainingGrantCount', resolved_operator_grant_count,
+    'upsertedReportingEntitlementCount', upserted_reporting_entitlement_count,
+    'skippedGrantCount', skipped_grant_count
+  );
+end;
+$$;
+
+comment on function public.resolve_my_technician_entitlements(text) is
+  'Links pending Technician email grants to the signed-in user and materializes Technician-derived machine reporting entitlements.';
+
+revoke execute on function public.resolve_my_technician_entitlements(text) from public;
+grant execute on function public.resolve_my_technician_entitlements(text) to authenticated;
+
+select pg_notify('pgrst', 'reload schema');

--- a/supabase/migrations/202604260013_technician_invite_resolution.sql
+++ b/supabase/migrations/202604260013_technician_invite_resolution.sql
@@ -112,6 +112,8 @@ begin
       from public.operator_training_grants operator_grant
       where operator_grant.id = grant_after.operator_training_grant_id
         and operator_grant.revoked_at is null
+        and operator_grant.sponsor_user_id = grant_after.sponsor_user_id
+        and public.normalize_technician_email(operator_grant.operator_email) = normalized_email
       limit 1
       for update;
 


### PR DESCRIPTION
## Summary
- Add `resolve_my_technician_entitlements` so pending Technician email grants resolve to the signed-in auth user and materialize assigned-machine reporting entitlements.
- Call the resolver during auth session hydration before portal/reporting access checks run.
- Update local migration docs and the Technician smoke checklist for first-login resolution.

## Files changed
- `supabase/migrations/202604260013_technician_invite_resolution.sql`: new self-service Technician invite resolver RPC with audit logging.
- `src/lib/technicianEntitlements.ts`: typed client wrapper for the resolver.
- `src/contexts/AuthContext.tsx`: guarded resolver call before portal/reporting access context loading.
- `Docs/LOCAL_DEV.md`, `Docs/QA_SMOKE_TEST_CHECKLIST.md`: migration list and smoke coverage updates.

## Verification commands/results
- `npm ci` - passed. Existing repo state still reports 2 moderate npm audit vulnerabilities and a deprecated `glob` warning; no dependency changes made.
- `npm run build` - passed. Existing Browserslist/caniuse-lite stale-data warning remains.
- `npm test --if-present` - passed; no configured test output.
- `npm run lint --if-present` - passed with the existing 8 `react-refresh/only-export-components` warnings in shared UI/Auth files.
- `npm run auth:preflight` - blocked in this fresh worktree because local `.env` is absent (`VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` missing).
- `supabase db reset --local --no-seed` - passed on temporary local ports, replaying through `202604260013_technician_invite_resolution.sql`.
- `supabase db lint --local --fail-on error` - passed with only the existing `public.save_training_progress` warning about `current_timestamp`.
- Direct local SQL smoke - passed: owner-created pending Technician grant stayed pending before auth user creation, then `resolve_my_technician_entitlements` linked the Technician user, linked the operator training grant, created the Technician-derived reporting entitlement, and wrote `technician_access.resolved` audit metadata.

## How to test
1. Apply migrations through `202604260013_technician_invite_resolution.sql` and start the app with `npm run dev`.
2. As a Plus Account Owner, open `http://localhost:8080/portal/account` and add a Technician email that does not yet have an auth user, assigning one owned reporting machine.
3. Sign in or sign up as that Technician email.
4. Confirm `http://localhost:8080/portal/training` opens, `http://localhost:8080/portal/reports` shows only the assigned machine, and `http://localhost:8080/admin` plus owner/billing tools remain unavailable.
5. In Supabase, confirm the Technician grant is `active`, `operator_training_grants.operator_user_id` is set, the `reporting_machine_entitlements` row has `source_type = 'technician_grant'`, and `admin_audit_log` contains `technician_access.resolved`.

Coordination note: open PRs #186 and #155 also touch docs such as `Docs/LOCAL_DEV.md` or `Docs/QA_SMOKE_TEST_CHECKLIST.md`; this PR does not touch their code paths or dependency files.