### PR TITLE
Keep partner report timestamps ASCII clean

### DIFF
--- a/supabase/functions/_shared/partner-report-export.ts
+++ b/supabase/functions/_shared/partner-report-export.ts
@@ -45,8 +45,8 @@ const encoder = new TextEncoder();
 const toAscii = (value: unknown): string =>
   String(value ?? "")
     .normalize("NFKD")
-    .replace(/[^\x20-\x7e]/g, "")
     .replace(/\s+/g, " ")
+    .replace(/[^\x20-\x7e]/g, "")
     .trim();
 
 const escapePdfText = (value: string): string =>
@@ -128,7 +128,7 @@ const formatGeneratedAt = (value: unknown): string => {
   const date = new Date(String(value ?? ""));
   if (Number.isNaN(date.getTime())) return toAscii(value);
 
-  return new Intl.DateTimeFormat("en-US", {
+  return toAscii(new Intl.DateTimeFormat("en-US", {
     timeZone: "America/Los_Angeles",
     month: "short",
     day: "numeric",
@@ -136,7 +136,7 @@ const formatGeneratedAt = (value: unknown): string => {
     hour: "numeric",
     minute: "2-digit",
     timeZoneName: "short",
-  }).format(date);
+  }).format(date));
 };
 
 const csvCell = (value: unknown): string => {


### PR DESCRIPTION
## Summary
- Normalize Unicode whitespace before stripping non-ASCII in partner report exports.
- Ensure generated timestamps in CSV/PDF artifacts render as plain ASCII, e.g. `Apr 26, 2026, 1:38 PM PDT`.

## Files changed
- `supabase/functions/_shared/partner-report-export.ts`: ASCII normalization and timestamp formatting cleanup.

## Verification
- `npm ci`: passed; npm reports existing 2 moderate vulnerabilities.
- `npm run build`: passed.
- `npm test --if-present`: passed; no test script present.
- `npm run lint --if-present`: passed with existing fast-refresh warnings only.
- `deno check supabase/functions/partner-report-export/index.ts`: passed.
- Local fixture generation confirms the CSV `Generated` row has `nonAsciiCount: 0`.

## How to test
1. From this branch, run `npm ci`.
2. Run `npm run build`.
3. Generate or download a partner report CSV from `/admin/partnerships?partnershipId=923bdea5-ce97-42e0-8b76-646b28f35003&step=preview`.
4. Confirm the `Generated` row uses a normal ASCII space between time and `PM`/`AM`.