### PR TITLE
docs: add owner UAT persona playbook

### DIFF
--- a/Docs/AI_WORKFLOW.md
+++ b/Docs/AI_WORKFLOW.md
@@ -20,6 +20,7 @@ This repo is operated primarily through AI coding agents. The owner is not expec
 - Run the repo verification expected by the PR template and report exact results.
 - For UI changes, provide preview/localhost links and desktop/mobile screenshots.
 - For user-facing changes, provide exact UAT steps and expected results.
+- Use `Docs/UAT_PERSONA_PLAYBOOK.md` when preparing owner UAT steps for public, portal, admin, reporting, Technician, or Partner Viewer changes.
 - For high-risk changes, include an explicit rollback plan and independent AI review evidence.
 
 Use an independent AI reviewer or delegated subagent for high-risk review when the current agent environment allows it. If not available, perform a separate review pass and record what was checked.
@@ -30,6 +31,8 @@ Use an independent AI reviewer or delegated subagent for high-risk review when t
 - High risk: owner UAT or go/no-go confirmation is required before merge or production rollout.
 
 The owner should not need to inspect code diffs to make routine decisions. PRs should present enough evidence for a product-level go/no-go.
+
+See `Docs/UAT_PERSONA_PLAYBOOK.md` for the persona-based checklist agents should use before asking the owner for UAT.
 
 ## Weekly hygiene
 Agents should periodically:

--- a/Docs/UAT_PERSONA_PLAYBOOK.md
+++ b/Docs/UAT_PERSONA_PLAYBOOK.md
@@ -1,0 +1,195 @@
+# Owner UAT Persona Playbook
+
+## Purpose
+This playbook helps the owner validate product behavior without reviewing code.
+
+Agents should use it when a PR changes customer-facing, admin-facing, reporting, auth, payment, entitlement, or partner behavior. The owner should receive exact steps, expected results, and enough evidence to make a product-level go/no-go decision.
+
+## What Agents Must Provide
+Before asking for owner UAT, the agent must provide:
+
+- PR link and branch name.
+- Preview URL or localhost URL.
+- Exact route list to test.
+- Persona to use for each step.
+- Exact steps and expected result for each step.
+- Desktop and mobile screenshots for UI changes.
+- Risk notes, especially for auth, Stripe/payments, reporting math, Supabase migrations, Edge Functions, production data, and entitlement boundaries.
+- Any known limits or intentionally untested paths.
+- Rollback plan for medium/high-risk work.
+
+Do not put real passwords, secret keys, service-role tokens, Stripe secrets, Sunze credentials, Google credentials, or Supabase secrets in the repo, PRs, issues, screenshots, or chat. If a test account is needed, identify the persona and email only; share passwords through the owner's approved secure channel.
+
+## Owner UAT Versus AI Verification
+
+| Change type | AI verification only | Owner UAT recommended | Owner go/no-go required |
+| --- | --- | --- | --- |
+| Docs-only, templates, labels, copy with no product decision | Yes | No, unless wording needs owner judgment | No |
+| Small non-user-facing cleanup | Yes | No | No |
+| Public site layout, copy, CTAs, SEO, cart UX, supplies UX | AI verifies build/lint and route behavior | Yes | Only when launch-critical |
+| Portal dashboard, training, support, onboarding, account UX | AI verifies route behavior and screenshots | Yes | When it changes customer promises or access |
+| Technician, Partner Viewer, reporting, admin access, or entitlement boundaries | AI verifies tests, RLS/RPC behavior, and screenshots | Yes | Yes for high-risk permission changes |
+| Stripe/payments, auth, production redirects, Edge Functions, migrations, reporting math, production data paths | AI verifies locally and records evidence | Yes | Yes before production rollout |
+| Pure implementation refactor with unchanged behavior | AI verifies regression tests and build | Optional | No, unless risk is high |
+
+AI verification should prove the implementation works. Owner UAT should answer whether the behavior, wording, permissions, and operational flow are acceptable for the business.
+
+## Persona Coverage
+
+### Public Buyer
+Use this persona for storefront, quote, and public SEO changes.
+
+Key routes:
+
+- `/`
+- `/machines`
+- `/machines/commercial-robotic-machine`
+- `/machines/mini`
+- `/machines/micro`
+- `/supplies`
+- `/supplies?order=sugar`
+- `/supplies?order=sticks`
+- `/supplies?order=custom`
+- `/plus`
+- `/contact`
+- `/cart`
+- `/privacy`, `/terms`, `/billing-cancellation`
+
+Owner UAT focus:
+
+- Product names, pricing, availability, CTAs, and quote/order flow make business sense.
+- Public pages look professional on desktop and mobile.
+- Cart and supplies flows are understandable without internal explanation.
+- No private portal/admin language appears on public pages.
+
+### Plus Account Owner
+Use this persona for paying or granted Plus customers who own an account and machines.
+
+Key routes:
+
+- `/login`
+- `/portal`
+- `/portal/orders`
+- `/portal/account`
+- `/portal/onboarding`
+- `/portal/support`
+- `/portal/training`
+- `/portal/reports`
+
+Owner UAT focus:
+
+- Plus benefits and limits are clear.
+- Account, billing, order, support, onboarding, and training flows are usable.
+- Reporting shows only machines the owner should control.
+- Technician management, when present, only allows assigned machines the owner already controls.
+- The default Technician cap is clear when reached.
+
+### Technician
+Use this persona for customer staff with training and assigned-machine reporting access.
+
+Key routes:
+
+- `/login`
+- `/portal`
+- `/portal/training`
+- `/portal/training/*`
+- `/portal/reports`
+
+Owner UAT focus:
+
+- Technician can see training.
+- Technician can see reporting only for assigned machines.
+- Technician cannot see unassigned machines.
+- Technician cannot see Plus discounts, billing, account-owner tools, partner settlement, admin routes, or grant-management controls.
+- Reassigning or revoking a Technician changes access as expected after refresh or re-login.
+
+### Super Admin
+Use this persona for internal Bloomjoy admin work.
+
+Key routes:
+
+- `/admin`
+- `/admin/access`
+- `/admin/orders`
+- `/admin/support`
+- `/admin/partner-records`
+- `/admin/machines`
+- `/admin/partnerships`
+- `/admin/reporting`
+- `/admin/audit`
+
+Owner UAT focus:
+
+- Admin tools expose the right operational controls without leaking them to customers.
+- Required reasons, audit trails, and safety prompts appear for sensitive changes.
+- Reporting setup, machine mapping, partner setup, and access management are understandable.
+- Internal-only workflows stay under `/admin`.
+
+### Partner Or Report Viewer
+Use this persona only when partner/report-viewer flows are explicitly enabled.
+
+Expected route direction:
+
+- `/portal/reports` for permissioned partner/reporting views.
+- Approved report artifacts or dashboards only after the product flow supports them.
+
+Owner UAT focus:
+
+- Partner Viewer sees only approved partner/reporting information.
+- Partner Viewer does not get Plus benefits, billing, technician management, imports, tax/rule editing, schedules, warning ledgers, or `/admin`.
+- Partnership setup alone does not create partner portal access.
+
+## UAT Packet Template
+Agents can paste this into a PR comment or status update:
+
+```md
+## Owner UAT Packet
+- PR:
+- Branch:
+- Preview or localhost URL:
+- Risk level:
+- Personas:
+- Routes:
+
+## Steps
+1. Sign in as `<persona/email>`.
+2. Open `<route>`.
+3. Do `<action>`.
+4. Expected result: `<plain English result>`.
+
+## Screenshots
+- Desktop:
+- Mobile:
+
+## Owner decision needed
+- Confirm whether `<behavior/copy/flow>` is acceptable.
+
+## Not in scope
+- `<paths intentionally not changed>`
+```
+
+## Route-To-Persona Quick Reference
+
+| Area | Personas to cover |
+| --- | --- |
+| Public marketing/storefront | Public Buyer |
+| Quote/contact flow | Public Buyer |
+| Cart/supplies/Stripe checkout | Public Buyer, Plus Account Owner when discounts apply |
+| Login/reset/Google auth | Public Buyer for entry, Plus Account Owner, Technician, Super Admin as applicable |
+| Portal dashboard/account/orders | Plus Account Owner |
+| Training | Plus Account Owner, Technician, training-only operator when relevant |
+| Technician management | Plus Account Owner, Technician, Super Admin when override exists |
+| Customer reporting | Plus Account Owner, Technician |
+| Partner reporting | Partner Viewer, Super Admin |
+| Admin support/orders/access/audit | Super Admin |
+| Partnership setup, machine mapping, partner PDFs | Super Admin, Partner Viewer only for approved output views |
+
+## Final Check Before Asking The Owner
+Before asking for UAT, confirm:
+
+- The PR has passed the required verification commands.
+- The branch is current enough with `main` for the changed area.
+- Screenshots are attached for visible UI changes.
+- The requested owner decision is plain English.
+- Secrets and passwords are not included anywhere.
+- The owner is not being asked to review code or infer expected behavior.


### PR DESCRIPTION
## Summary
- Adds a plain-language owner UAT persona playbook for public, portal, admin, reporting, Technician, and Partner Viewer validation.
- Links `Docs/AI_WORKFLOW.md` to the new playbook so agents use it before asking for owner UAT.
- Keeps the change docs-only; no runtime, dependency, database, or CI behavior changes.

Closes #202

## Files changed
- `Docs/UAT_PERSONA_PLAYBOOK.md`: new UAT packet requirements, AI-vs-owner verification guidance, persona route coverage, and quick-reference checklist.
- `Docs/AI_WORKFLOW.md`: adds references to the UAT playbook in agent and owner-involvement guidance.

## Verification commands/results
- `npm ci`: passed; npm reported existing 2 moderate audit findings and the existing deprecated `glob` warning.
- `npm run build`: passed; existing Browserslist data-age warning reported.
- `npm test --if-present`: passed; no output.
- `npm run lint --if-present`: passed with 8 existing Fast Refresh warnings and 0 errors.
- `git diff --check`: passed.

## How to test
- Localhost is not required for this docs-only PR because no app routes changed.
- Optional local sanity check: run `npm run dev`, open `http://localhost:8080`, and confirm the app still loads.
- Review `Docs/UAT_PERSONA_PLAYBOOK.md` and confirm it covers owner UAT packets, public buyer, Plus Account Owner, Technician, super-admin, and Partner/Report Viewer flows.
- Review `Docs/AI_WORKFLOW.md` and confirm it links agents to the UAT playbook before owner UAT.