### PR TITLE
Add partnership contract reporting terms

### DIFF
--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -43,6 +43,7 @@
 - Reporting tax setup is intentionally simple in the UI: missing initial rates save with a hidden `2026-01-01` effective start, rare tax changes use a compact rate-change action, and tax history is read-only for audit context.
 - Partnership participants remain available for multi-stakeholder agreements. Reusable partner records are managed separately, participant roles make payout recipients explicit, and partnership-specific participant relationships stay inside the guided partnership flow without report-recipient or share-percentage friction.
 - Partnership setup exposes one agreement-level timeline plus a simple active/inactive control; payout-rule date/status fields remain backend compatibility fields and are not normal admin inputs.
+- Official agreement setup now needs legal/display partner naming, weekly-plus-monthly cadence tracking, invoice/payment terms, ownership model, and consumer-pricing authority so partner reports can match signed partnership agreements without turning the app into a full contract-management system.
 - Payout percentages live in one current Payout Rule as stable participant-named allocation rows plus Bloomjoy, with whole-percent inputs, a 100% allocation check, and weekly-preview labels that match the configured payout recipients while still mapping to the existing backend split fields for compatibility.
 - Weekly Preview now surfaces actionable readiness issues for the selected week, including missing active machine assignment coverage, missing active payout rules, and no imported sales for the selected week, and keeps RPC errors visible in-page instead of relying only on toast feedback.
 - The Bubble Planet workbook baseline uses Sunze order amount as gross sales, subtracts machine tax plus a configured `$0.40` per-stick/item fee before the 60/40 split, counts no-pay orders as `$0`, and reports completed Monday-Sunday weeks.
@@ -67,8 +68,8 @@
   - polished executive summary plus calculation appendix, not a summary-only report
   - typed configurable revenue-share rules, not hardcoded partner-specific math or a broad formula engine
   - conservative access: only super-admins configure, generate, review, and send partner reports in V1
-- Next code slice should add auditable partner-report snapshot/run support with reporting period, rule version, assumptions, generated-by user, status, recipients/download metadata, storage path, and warning state.
-- The partner PDF should replace the current simple text-style sales export for this use case with a branded settlement artifact: cover/summary, machine-level rollups, formula assumptions, warning states, generated timestamp, and snapshot ID.
+- Contract-alignment slice on branch `agent/partnership-contract-compliance` adds legal partner names, weekly/monthly cadence terms, invoice/payment due terms, ownership/pricing authority fields, contract references, labeled deduction notes, and visible snapshot IDs in partner exports.
+- Remaining partner-report snapshot/run hardening should still add structured rule version, recipient/download metadata, and warning-state columns instead of relying only on `summary_json`.
 - Parallel UX/CX track: issue `#172` should design the reporting tab experience where users see operator-style reporting for assigned machines by default, while partner dashboard views appear only when the user has explicit partner-dashboard permissions. V1 should default partner dashboard visibility to super-admins only.
 - Sequencing cleanup on `2026-04-26`: PRs `#161` and `#167` are merged, stale docs PRs `#157` and `#151` were closed as superseded, and stale go-live PR `#143` was closed as discarded. The next reporting slice should focus on the reviewed partner PDF milestone.
 

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -257,7 +257,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Admin dashboard and app nav expose separate Partner Records, Machines, Partnerships, and Reporting modules
 - [ ] Non-admin user cannot access `/admin/partner-records` or `/admin/machines`
 - [ ] Super-admin user can access `/admin/partner-records` and `/admin/machines`
-- [ ] Admin Partner Records can search, create, and edit reusable partner records without exposing "party" terminology
+- [ ] Admin Partner Records can search, create, and edit reusable partner records with separate display name and legal name fields, without exposing "party" terminology
 - [ ] Admin Partnerships setup loads without missing-RPC errors for `admin_get_partnership_reporting_setup`
 - [ ] Admin Partnerships opens as a guided setup flow with Details, Participants, Machines, Payout Rules, and Weekly Preview steps
 - [ ] Admin Partnerships is navigable on mobile with a compact partnership picker, `Step X of 5` header, horizontal step controls, and sticky Back/Next controls
@@ -272,8 +272,9 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Admin Machines can record a reporting tax rate change with only `New reporting tax %` and `Applies from`, and the previous active rate closes without overlap
 - [ ] Admin Machines exposes read-only reporting tax history for a machine without making normal admins manage tax status, end date, or notes
 - [ ] Machine tax warnings appear on Admin Machines, not Admin Partnerships
-- [ ] Admin Partnerships > Details exposes one agreement-level effective date window plus a simple active/inactive control, not a backend status dropdown
+- [ ] Admin Partnerships > Details exposes one agreement-level effective date window plus weekly/monthly cadence, report due days, invoice payment due days, payment method, ownership model, pricing authority, contract reference, and a simple active/inactive control
 - [ ] Admin Partnerships > Payout Rules shows a plain-language sales-to-payout summary, one current payout rule, stable participant-named Payout Allocation rows based on Participants marked `Receives payout`, whole-percent inputs, a 100% allocation check, click/tap help popovers, and no editable payout-rule date/status fields
+- [ ] Admin Partnerships > Payout Rules can save a contract-specific deduction label and additional deduction notes for cashless processing, royalties, or other agreement-specific deductions
 - [ ] Saving Admin Partnerships > Payout Rules repeatedly updates the current payout rule instead of creating duplicate visible rules
 - [ ] Admin Partnerships does not show example-specific `Fever` terminology in the admin UI
 - [ ] Admin Partnerships shows financial-rule warnings in Payout Rules and assignment warnings in the Machines step, not in a disconnected top-of-page warning box
@@ -283,9 +284,9 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Authenticated Weekly Preview smoke path is run from `Docs/WEEKLY_PREVIEW_SMOKE_TEST.md` with a super-admin on `/admin/partnerships?partnershipId=<qualified_fixture_partnership_id>&step=preview`
 - [ ] Authenticated Weekly Preview happy path for week ending `2026-04-19` shows `2026-04-13 through 2026-04-19`, `Ready`, `Orders` > 0, `Gross sales` > `$0`, and at least one `Sales by Machine` row after the Sunze backfill/setup dates are corrected
 - [ ] Authenticated Weekly Preview warning states are checked for `No machines are assigned for this week`, `No active payout rule covers this week`, and `No sales found for this selected week`
-- [ ] Admin Partnerships > Weekly Preview labels payout metrics with the same participant names used in Payout Rules plus Bloomjoy
+- [ ] Admin Partnerships > Weekly Preview labels payout metrics with legal partner names when recorded, otherwise the same participant names used in Payout Rules, plus Bloomjoy
 - [ ] Admin Partnerships > Weekly Preview matches the corrected Bubble Planet product math: Sunze order amount as gross, machine tax plus configured `$0.40` stick-level cost deduction before split, no-pay orders counted as `$0`, and 60/40 split when configured
-- [ ] Admin Partnerships > Weekly Preview can generate a branded partner PDF and a CSV reconciliation export from the loaded preview
+- [ ] Admin Partnerships > Weekly Preview can generate a branded partner PDF and a CSV reconciliation export from the loaded preview, and both exports include the snapshot ID
 - [ ] Corporate partner P0: super-admin can create a corporate partner, create a partnership/agreement, assign machines, configure machine tax assumptions, and configure typed revenue-share terms without developer support
 - [ ] Corporate partner P0: super-admin can preview a completed weekly report before generating a PDF and sees any missing tax, missing assignment, missing financial-rule, or stale-data warnings
 - [ ] Corporate partner P0: generated partner PDF includes executive summary, reporting period, gross sales, tax impact, net sales, unit/fee/cost assumptions, split calculation, amount owed, machine-level appendix, generated timestamp, and snapshot ID

--- a/src/lib/partnershipReporting.ts
+++ b/src/lib/partnershipReporting.ts
@@ -5,6 +5,7 @@ import type { ReportingMachineType } from '@/lib/reporting';
 export type ReportingPartner = {
   id: string;
   name: string;
+  legal_name: string | null;
   partner_type: string;
   primary_contact_name: string | null;
   primary_contact_email: string | null;
@@ -20,6 +21,13 @@ export type ReportingPartnership = {
   partnership_type: string;
   reporting_week_end_day: number;
   timezone: string;
+  reporting_frequency: 'weekly' | 'monthly' | 'weekly_and_monthly';
+  monthly_report_due_days: number | null;
+  invoice_payment_due_days: number | null;
+  payment_method: string | null;
+  machine_ownership_model: string;
+  consumer_pricing_authority: string;
+  contract_reference: string | null;
   effective_start_date: string;
   effective_end_date: string | null;
   status: 'draft' | 'active' | 'archived';
@@ -58,6 +66,7 @@ export type ReportingPartnershipParty = {
   partnership_name: string;
   partner_id: string;
   partner_name: string;
+  partner_legal_name: string | null;
   party_role: string;
   share_basis_points: number | null;
   is_report_recipient: boolean;
@@ -84,8 +93,11 @@ export type ReportingPartnershipFinancialRule = {
   split_base: string;
   fee_amount_cents: number;
   fee_basis: string;
+  fee_label: string;
   cost_amount_cents: number;
   cost_basis: string;
+  cost_label: string;
+  additional_deductions_notes: string | null;
   deduction_timing: string;
   gross_to_net_method: string;
   fever_share_basis_points: number;
@@ -191,6 +203,7 @@ const normalizePartnerWeeklyReportPreview = (
 export type UpsertPartnerInput = {
   partnerId?: string | null;
   name: string;
+  legalName?: string | null;
   partnerType: string;
   primaryContactName?: string | null;
   primaryContactEmail?: string | null;
@@ -205,6 +218,13 @@ export type UpsertPartnershipInput = {
   partnershipType: string;
   reportingWeekEndDay: number;
   timezone: string;
+  reportingFrequency: string;
+  monthlyReportDueDays?: number | null;
+  invoicePaymentDueDays?: number | null;
+  paymentMethod?: string | null;
+  machineOwnershipModel: string;
+  consumerPricingAuthority: string;
+  contractReference?: string | null;
   effectiveStartDate: string;
   effectiveEndDate?: string | null;
   status: string;
@@ -259,8 +279,11 @@ export type UpsertFinancialRuleInput = {
   splitBase: string;
   feeAmountCents: number;
   feeBasis: string;
+  feeLabel: string;
   costAmountCents: number;
   costBasis: string;
+  costLabel: string;
+  additionalDeductionsNotes?: string | null;
   deductionTiming: string;
   grossToNetMethod: string;
   feverShareBasisPoints: number;
@@ -312,6 +335,7 @@ export const upsertReportingPartnerAdmin = async (input: UpsertPartnerInput) => 
   const { data, error } = await supabaseClient.rpc('admin_upsert_reporting_partner', {
     p_partner_id: input.partnerId ?? null,
     p_name: input.name,
+    p_legal_name: input.legalName ?? null,
     p_partner_type: input.partnerType,
     p_primary_contact_name: input.primaryContactName ?? null,
     p_primary_contact_email: input.primaryContactEmail ?? null,
@@ -334,6 +358,13 @@ export const upsertReportingPartnershipAdmin = async (input: UpsertPartnershipIn
     p_partnership_type: input.partnershipType,
     p_reporting_week_end_day: input.reportingWeekEndDay,
     p_timezone: input.timezone,
+    p_reporting_frequency: input.reportingFrequency,
+    p_monthly_report_due_days: input.monthlyReportDueDays ?? null,
+    p_invoice_payment_due_days: input.invoicePaymentDueDays ?? null,
+    p_payment_method: input.paymentMethod ?? null,
+    p_machine_ownership_model: input.machineOwnershipModel,
+    p_consumer_pricing_authority: input.consumerPricingAuthority,
+    p_contract_reference: input.contractReference ?? null,
     p_effective_start_date: input.effectiveStartDate,
     p_effective_end_date: input.effectiveEndDate || null,
     p_status: input.status,
@@ -461,10 +492,13 @@ export const upsertReportingFinancialRuleAdmin = async (input: UpsertFinancialRu
     p_split_base: input.splitBase,
     p_fee_amount_cents: input.feeAmountCents,
     p_fee_basis: input.feeBasis,
+    p_fee_label: input.feeLabel,
     p_cost_amount_cents: input.costAmountCents,
     p_cost_basis: input.costBasis,
+    p_cost_label: input.costLabel,
     p_deduction_timing: input.deductionTiming,
     p_gross_to_net_method: input.grossToNetMethod,
+    p_additional_deductions_notes: input.additionalDeductionsNotes ?? null,
     p_fever_share_basis_points: input.feverShareBasisPoints,
     p_partner_share_basis_points: input.partnerShareBasisPoints,
     p_bloomjoy_share_basis_points: input.bloomjoyShareBasisPoints,

--- a/src/pages/admin/PartnerRecords.tsx
+++ b/src/pages/admin/PartnerRecords.tsx
@@ -40,6 +40,7 @@ const emptySetup: PartnershipReportingSetup = {
 const emptyPartnerForm = {
   partnerId: null as string | null,
   name: '',
+  legalName: '',
   partnerType: 'revenue_share_partner',
   primaryContactName: '',
   primaryContactEmail: '',
@@ -79,6 +80,7 @@ export default function AdminPartnerRecordsPage() {
         if (!normalizedSearch) return true;
         return [
           partner.name,
+          partner.legal_name ?? '',
           partner.partner_type,
           partner.primary_contact_name ?? '',
           partner.primary_contact_email ?? '',
@@ -153,7 +155,7 @@ export default function AdminPartnerRecordsPage() {
                     className="pl-9"
                     value={search}
                     onChange={(event) => setSearch(event.target.value)}
-                    placeholder="Name, contact, email, type"
+                    placeholder="Name, legal name, contact, email, type"
                   />
                 </div>
               </div>
@@ -203,7 +205,12 @@ export default function AdminPartnerRecordsPage() {
                   <tbody className="divide-y divide-border bg-background">
                     {filteredPartners.map((partner) => (
                       <tr key={partner.id}>
-                        <td className="px-4 py-3 font-medium text-foreground">{partner.name}</td>
+                        <td className="px-4 py-3">
+                          <div className="font-medium text-foreground">{partner.name}</div>
+                          <div className="mt-1 text-xs text-muted-foreground">
+                            {partner.legal_name ?? 'No legal name recorded'}
+                          </div>
+                        </td>
                         <td className="px-4 py-3 text-muted-foreground">{formatLabel(partner.partner_type)}</td>
                         <td className="px-4 py-3 text-muted-foreground">
                           {partner.primary_contact_name ?? 'n/a'}
@@ -272,6 +279,7 @@ function PartnerRecordDialog({
     setForm({
       partnerId: partner.id,
       name: partner.name,
+      legalName: partner.legal_name ?? '',
       partnerType: partner.partner_type,
       primaryContactName: partner.primary_contact_name ?? '',
       primaryContactEmail: partner.primary_contact_email ?? '',
@@ -282,6 +290,7 @@ function PartnerRecordDialog({
 
   const savePartner = async () => {
     const name = form.name.trim();
+    const legalName = form.legalName.trim();
     const primaryContactName = form.primaryContactName.trim();
     const primaryContactEmail = form.primaryContactEmail.trim();
     const notes = form.notes.trim();
@@ -311,6 +320,7 @@ function PartnerRecordDialog({
       await upsertReportingPartnerAdmin({
         ...form,
         name,
+        legalName: legalName || null,
         primaryContactName: primaryContactName || null,
         primaryContactEmail: primaryContactEmail || null,
         notes: notes || null,
@@ -342,6 +352,15 @@ function PartnerRecordDialog({
               id="partner-record-name"
               value={form.name}
               onChange={(event) => setForm({ ...form, name: event.target.value })}
+            />
+          </div>
+          <div>
+            <Label htmlFor="partner-record-legal-name">Legal name</Label>
+            <Input
+              id="partner-record-legal-name"
+              value={form.legalName}
+              onChange={(event) => setForm({ ...form, legalName: event.target.value })}
+              placeholder="Official contract counterparty"
             />
           </div>
           <div>

--- a/src/pages/admin/Partnerships.tsx
+++ b/src/pages/admin/Partnerships.tsx
@@ -66,6 +66,7 @@ import {
 import {
   basisPointsFromPercent,
   centsFromDollars,
+  consumerPricingAuthorities,
   dayNames,
   dollarsFromCents,
   formatDate,
@@ -73,10 +74,12 @@ import {
   formatMoney,
   getActiveMachineAssignments,
   getLastCompletedWeekEndingDate,
+  machineOwnershipModels,
   participantRoles,
   partnerTypes,
   partnershipTypes,
   percentFromBasisPoints,
+  reportingFrequencies,
   today,
   toDateInputValue,
 } from '@/pages/admin/reportingSetupUi';
@@ -123,6 +126,7 @@ const getSafeArchiveEndDate = (effectiveStartDate: string) => {
 const emptyPartnerForm = {
   partnerId: null as string | null,
   name: '',
+  legalName: '',
   partnerType: 'revenue_share_partner',
   primaryContactName: '',
   primaryContactEmail: '',
@@ -136,6 +140,13 @@ const emptyPartnershipForm = {
   partnershipType: 'revenue_share',
   reportingWeekEndDay: '0',
   timezone: 'America/Los_Angeles',
+  reportingFrequency: 'weekly_and_monthly',
+  monthlyReportDueDays: '10',
+  invoicePaymentDueDays: '',
+  paymentMethod: '',
+  machineOwnershipModel: 'unknown',
+  consumerPricingAuthority: 'unknown',
+  contractReference: '',
   effectiveStartDate: today(),
   effectiveEndDate: '',
   status: 'active',
@@ -158,8 +169,11 @@ const emptyRuleForm = {
   splitBase: 'net_sales',
   feeAmountDollars: '0.40',
   feeBasis: 'per_stick',
+  feeLabel: 'Stick cost deduction',
   costAmountDollars: '0.00',
   costBasis: 'none',
+  costLabel: 'Costs',
+  additionalDeductionsNotes: '',
   deductionTiming: 'before_split',
   grossToNetMethod: 'machine_tax_plus_configured_fees',
   primarySharePercent: '60',
@@ -225,6 +239,11 @@ const participantRoleLabels: Record<string, string> = {
 };
 
 const parseWholePercent = (value: string) => Math.round(Number(value) || 0);
+const optionalIntegerFromInput = (value: string) => {
+  if (!value.trim()) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? Math.round(parsed) : null;
+};
 
 const getWeekStartDate = (weekEndingDate: string) => {
   const date = new Date(`${weekEndingDate}T00:00:00`);
@@ -267,6 +286,7 @@ const normalizeComparableText = (value: string) => value.trim().replace(/\s+/g, 
 const getParticipantRoleLabel = (role: string) => participantRoleLabels[role] ?? formatLabel(role);
 const formatFeeBasisLabel = (feeBasis: string) =>
   feeBasis === 'per_stick' ? 'per paid stick/item' : formatLabel(feeBasis);
+const getPartyReportName = (party: ReportingPartnershipParty) => party.partner_legal_name || party.partner_name;
 
 const sortParticipantsByAddedDate = (participants: ReportingPartnershipParty[]) =>
   [...participants].sort(
@@ -348,8 +368,11 @@ const createRuleFormFromRule = (rule: ReportingPartnershipFinancialRule) => ({
   splitBase: rule.split_base,
   feeAmountDollars: dollarsFromCents(rule.fee_amount_cents),
   feeBasis: rule.fee_basis,
+  feeLabel: rule.fee_label || 'Stick cost deduction',
   costAmountDollars: dollarsFromCents(rule.cost_amount_cents),
   costBasis: rule.cost_basis,
+  costLabel: rule.cost_label || 'Costs',
+  additionalDeductionsNotes: rule.additional_deductions_notes ?? '',
   deductionTiming: rule.deduction_timing,
   grossToNetMethod: rule.gross_to_net_method,
   primarySharePercent: percentFromBasisPoints(rule.fever_share_basis_points),
@@ -393,6 +416,7 @@ const applyPayoutModelPreset = (
       splitBase: 'gross_sales',
       feeAmountDollars: '0.00',
       feeBasis: 'none',
+      feeLabel: 'Deductions',
       costBasis: 'none',
       costAmountDollars: '0.00',
       deductionTiming: 'reporting_only',
@@ -406,6 +430,7 @@ const applyPayoutModelPreset = (
       splitBase: 'net_sales',
       feeAmountDollars: '0.00',
       feeBasis: 'none',
+      feeLabel: 'Deductions',
       costBasis: 'none',
       costAmountDollars: '0.00',
       primarySharePercent: '0',
@@ -970,6 +995,21 @@ function PartnershipDetailsSection({
       partnershipType: selectedPartnership.partnership_type,
       reportingWeekEndDay: String(selectedPartnership.reporting_week_end_day),
       timezone: selectedPartnership.timezone,
+      reportingFrequency: selectedPartnership.reporting_frequency ?? 'weekly',
+      monthlyReportDueDays:
+        selectedPartnership.monthly_report_due_days === null ||
+        selectedPartnership.monthly_report_due_days === undefined
+          ? ''
+          : String(selectedPartnership.monthly_report_due_days),
+      invoicePaymentDueDays:
+        selectedPartnership.invoice_payment_due_days === null ||
+        selectedPartnership.invoice_payment_due_days === undefined
+          ? ''
+          : String(selectedPartnership.invoice_payment_due_days),
+      paymentMethod: selectedPartnership.payment_method ?? '',
+      machineOwnershipModel: selectedPartnership.machine_ownership_model ?? 'unknown',
+      consumerPricingAuthority: selectedPartnership.consumer_pricing_authority ?? 'unknown',
+      contractReference: selectedPartnership.contract_reference ?? '',
       effectiveStartDate: selectedPartnership.effective_start_date,
       effectiveEndDate: selectedPartnership.effective_end_date ?? '',
       status: selectedPartnership.status === 'archived' ? 'archived' : 'active',
@@ -985,9 +1025,18 @@ function PartnershipDetailsSection({
 
     setIsSaving(true);
     try {
+      const monthlyReportDueDays = optionalIntegerFromInput(form.monthlyReportDueDays);
+      const invoicePaymentDueDays = optionalIntegerFromInput(form.invoicePaymentDueDays);
       const savedPartnership = await upsertReportingPartnershipAdmin({
         ...form,
         reportingWeekEndDay: Number(form.reportingWeekEndDay),
+        reportingFrequency: form.reportingFrequency,
+        monthlyReportDueDays,
+        invoicePaymentDueDays,
+        paymentMethod: form.paymentMethod.trim() || null,
+        machineOwnershipModel: form.machineOwnershipModel,
+        consumerPricingAuthority: form.consumerPricingAuthority,
+        contractReference: form.contractReference.trim() || null,
         reason: form.partnershipId ? 'Partnership details updated' : 'Partnership created',
       });
       toast.success(form.partnershipId ? 'Partnership updated.' : 'Partnership created.');
@@ -1042,6 +1091,75 @@ function PartnershipDetailsSection({
             id="partnership-timezone"
             value={form.timezone}
             onChange={(event) => setForm({ ...form, timezone: event.target.value })}
+          />
+        </div>
+        <div>
+          <Label htmlFor="partnership-frequency">Reporting cadence</Label>
+          <FieldSelect
+            id="partnership-frequency"
+            value={form.reportingFrequency}
+            onChange={(value) => setForm({ ...form, reportingFrequency: value })}
+            options={reportingFrequencies}
+          />
+        </div>
+        <div>
+          <Label htmlFor="partnership-monthly-due">Monthly report due days</Label>
+          <Input
+            id="partnership-monthly-due"
+            type="number"
+            min="0"
+            max="90"
+            value={form.monthlyReportDueDays}
+            onChange={(event) => setForm({ ...form, monthlyReportDueDays: event.target.value })}
+            placeholder="10"
+          />
+        </div>
+        <div>
+          <Label htmlFor="partnership-payment-due">Payment due after invoice</Label>
+          <Input
+            id="partnership-payment-due"
+            type="number"
+            min="0"
+            max="120"
+            value={form.invoicePaymentDueDays}
+            onChange={(event) => setForm({ ...form, invoicePaymentDueDays: event.target.value })}
+            placeholder="15"
+          />
+        </div>
+        <div>
+          <Label htmlFor="partnership-payment-method">Payment method</Label>
+          <Input
+            id="partnership-payment-method"
+            value={form.paymentMethod}
+            onChange={(event) => setForm({ ...form, paymentMethod: event.target.value })}
+            placeholder="Bank transfer"
+          />
+        </div>
+        <div>
+          <Label htmlFor="partnership-machine-ownership">Machine ownership</Label>
+          <FieldSelect
+            id="partnership-machine-ownership"
+            value={form.machineOwnershipModel}
+            onChange={(value) => setForm({ ...form, machineOwnershipModel: value })}
+            options={machineOwnershipModels}
+          />
+        </div>
+        <div>
+          <Label htmlFor="partnership-pricing-authority">Consumer pricing authority</Label>
+          <FieldSelect
+            id="partnership-pricing-authority"
+            value={form.consumerPricingAuthority}
+            onChange={(value) => setForm({ ...form, consumerPricingAuthority: value })}
+            options={consumerPricingAuthorities}
+          />
+        </div>
+        <div className="lg:col-span-2">
+          <Label htmlFor="partnership-contract-reference">Contract reference</Label>
+          <Input
+            id="partnership-contract-reference"
+            value={form.contractReference}
+            onChange={(event) => setForm({ ...form, contractReference: event.target.value })}
+            placeholder="Agreement name, date, or SOW reference"
           />
         </div>
         <DateWindowFields
@@ -1239,6 +1357,7 @@ function ParticipantsSection({
                   <div className="font-medium text-foreground">{party.partner_name}</div>
                   <div className="mt-1 text-xs text-muted-foreground">
                     {getParticipantRoleLabel(party.party_role)}
+                    {party.partner_legal_name ? ` / ${party.partner_legal_name}` : ''}
                   </div>
                 </div>
                 {party.party_role === payoutRecipientRole && (
@@ -1767,6 +1886,9 @@ function FinancialTermsSection({
         partnershipId: selectedPartnership.id,
         feeAmountCents: centsFromDollars(form.feeAmountDollars),
         costAmountCents: centsFromDollars(form.costAmountDollars),
+        feeLabel: form.feeLabel.trim() || 'Stick cost deduction',
+        costLabel: form.costLabel.trim() || 'Costs',
+        additionalDeductionsNotes: form.additionalDeductionsNotes.trim() || null,
         feverShareBasisPoints: basisPointsFromPercent(normalizedShares.primarySharePercent),
         partnerShareBasisPoints: basisPointsFromPercent(normalizedShares.partnerSharePercent),
         bloomjoyShareBasisPoints: basisPointsFromPercent(normalizedShares.bloomjoySharePercent),
@@ -1840,6 +1962,18 @@ function FinancialTermsSection({
               onChange={(event) => updateStickLevelCostDeduction(event.target.value)}
             />
           </div>
+          <div>
+            <FieldLabel
+              htmlFor="fee-label"
+              label="Deduction label"
+              help="This label appears on partner-facing exports. Use a contract-specific label when fees combine cashless processing, royalties, or other agreed deductions."
+            />
+            <Input
+              id="fee-label"
+              value={form.feeLabel}
+              onChange={(event) => setForm({ ...form, feeLabel: event.target.value })}
+            />
+          </div>
         </div>
 
         <PayoutAllocationSection
@@ -1873,6 +2007,24 @@ function FinancialTermsSection({
                 placeholder="Optional"
               />
             </div>
+            <div>
+              <Label htmlFor="cost-label">Cost label</Label>
+              <Input
+                id="cost-label"
+                value={form.costLabel}
+                onChange={(event) => setForm({ ...form, costLabel: event.target.value })}
+                placeholder="Costs"
+              />
+            </div>
+            <div className="lg:col-span-2">
+              <Label htmlFor="additional-deductions-notes">Additional deduction notes</Label>
+              <Textarea
+                id="additional-deductions-notes"
+                value={form.additionalDeductionsNotes}
+                onChange={(event) => setForm({ ...form, additionalDeductionsNotes: event.target.value })}
+                placeholder="Cashless processing charges, other consumer charges, third-party royalties, or other contract-specific deductions."
+              />
+            </div>
             <div className="lg:col-span-2 rounded-md border border-border bg-muted/20 p-3 text-xs text-muted-foreground">
               <span className="font-medium text-foreground">Reporting calculation:</span>{' '}
               {formatLabel(form.calculationModel)} / {formatLabel(form.splitBase)} /{' '}
@@ -1903,7 +2055,7 @@ function FinancialTermsSection({
                 {formatLabel(currentFinancialRule.calculation_model)}
               </div>
               <div className="mt-1 text-xs text-muted-foreground">
-                Stick-level deduction {formatMoney(currentFinancialRule.fee_amount_cents)}{' '}
+                {currentFinancialRule.fee_label || 'Deduction'} {formatMoney(currentFinancialRule.fee_amount_cents)}{' '}
                 {formatFeeBasisLabel(currentFinancialRule.fee_basis)} /{' '}
                 {formatRuleAllocationSummary(currentFinancialRule, payoutParticipants)}
               </div>
@@ -1947,7 +2099,9 @@ function PayoutAllocationSection({
     ...payoutParticipants.map((participant, index) => ({
       id: participant.id,
       name: participant.partner_name,
-      description: getParticipantRoleLabel(participant.party_role),
+      description: participant.partner_legal_name
+        ? `${getParticipantRoleLabel(participant.party_role)} / ${participant.partner_legal_name}`
+        : getParticipantRoleLabel(participant.party_role),
       field: shareFieldsByParticipantIndex[index],
     })),
     {
@@ -2033,12 +2187,12 @@ function formatRuleAllocationSummary(
   const parts = [];
   if (payoutParticipants[0]) {
     parts.push(
-      `${payoutParticipants[0].partner_name} ${percentFromBasisPoints(rule.fever_share_basis_points)}%`
+      `${getPartyReportName(payoutParticipants[0])} ${percentFromBasisPoints(rule.fever_share_basis_points)}%`
     );
   }
   if (payoutParticipants[1]) {
     parts.push(
-      `${payoutParticipants[1].partner_name} ${percentFromBasisPoints(rule.partner_share_basis_points)}%`
+      `${getPartyReportName(payoutParticipants[1])} ${percentFromBasisPoints(rule.partner_share_basis_points)}%`
     );
   }
   parts.push(`Bloomjoy ${percentFromBasisPoints(rule.bloomjoy_share_basis_points)}%`);
@@ -2052,13 +2206,13 @@ function getPreviewPayoutMetrics(
   const metrics = [];
   if (payoutParticipants[0] || Number(summary.fever_profit_cents ?? 0) !== 0) {
     metrics.push({
-      label: payoutParticipants[0]?.partner_name ?? 'Payout recipient 1',
+      label: payoutParticipants[0] ? getPartyReportName(payoutParticipants[0]) : 'Payout recipient 1',
       value: formatMoney(summary.fever_profit_cents),
     });
   }
   if (payoutParticipants[1] || Number(summary.partner_profit_cents ?? 0) !== 0) {
     metrics.push({
-      label: payoutParticipants[1]?.partner_name ?? 'Payout recipient 2',
+      label: payoutParticipants[1] ? getPartyReportName(payoutParticipants[1]) : 'Payout recipient 2',
       value: formatMoney(summary.partner_profit_cents),
     });
   }
@@ -2079,11 +2233,11 @@ function PayoutFlowSummary({
   const deductionLabel = formatFeeBasisLabel(form.feeBasis);
   const deductionSummary =
     Number(form.feeAmountDollars) > 0
-      ? `${formatMoney(centsFromDollars(form.feeAmountDollars))} ${deductionLabel}`
+      ? `${form.feeLabel || 'Deduction'}: ${formatMoney(centsFromDollars(form.feeAmountDollars))} ${deductionLabel}`
       : 'no stick-level deduction';
   const splitSummary = [
-    payoutParticipants[0] && `${payoutParticipants[0].partner_name} ${parseWholePercent(form.primarySharePercent)}%`,
-    payoutParticipants[1] && `${payoutParticipants[1].partner_name} ${parseWholePercent(form.partnerSharePercent)}%`,
+    payoutParticipants[0] && `${getPartyReportName(payoutParticipants[0])} ${parseWholePercent(form.primarySharePercent)}%`,
+    payoutParticipants[1] && `${getPartyReportName(payoutParticipants[1])} ${parseWholePercent(form.partnerSharePercent)}%`,
     `Bloomjoy ${parseWholePercent(form.bloomjoySharePercent)}%`,
   ]
     .filter(Boolean)
@@ -2592,6 +2746,7 @@ function PartnerRecordDialog({
 
   const savePartner = async () => {
     const name = form.name.trim();
+    const legalName = form.legalName.trim();
     const primaryContactName = form.primaryContactName.trim();
     const primaryContactEmail = form.primaryContactEmail.trim();
     const notes = form.notes.trim();
@@ -2619,6 +2774,7 @@ function PartnerRecordDialog({
       const savedPartner = await upsertReportingPartnerAdmin({
         ...form,
         name,
+        legalName: legalName || null,
         primaryContactName: primaryContactName || null,
         primaryContactEmail: primaryContactEmail || null,
         notes: notes || null,
@@ -2652,6 +2808,15 @@ function PartnerRecordDialog({
               id="modal-partner-name"
               value={form.name}
               onChange={(event) => setForm({ ...form, name: event.target.value })}
+            />
+          </div>
+          <div>
+            <Label htmlFor="modal-partner-legal-name">Legal name</Label>
+            <Input
+              id="modal-partner-legal-name"
+              value={form.legalName}
+              onChange={(event) => setForm({ ...form, legalName: event.target.value })}
+              placeholder="Official contract counterparty"
             />
           </div>
           <div>
@@ -2764,7 +2929,7 @@ function PartnerSelectWithAdd({
         <option value="__add_new__">+ Add new partner record</option>
         {setup.partners.map((partner) => (
           <option key={partner.id} value={partner.id}>
-            {partner.name}
+            {partner.legal_name ? `${partner.name} / ${partner.legal_name}` : partner.name}
           </option>
         ))}
       </select>

--- a/src/pages/admin/reportingSetupUi.ts
+++ b/src/pages/admin/reportingSetupUi.ts
@@ -17,6 +17,15 @@ export const partnerTypes = [
 export const partnershipTypes = ['venue', 'event', 'platform', 'revenue_share', 'internal', 'other'];
 export const statuses = ['active', 'archived'];
 export const partnershipStatuses = ['draft', 'active', 'archived'];
+export const reportingFrequencies = ['weekly', 'monthly', 'weekly_and_monthly'];
+export const machineOwnershipModels = ['supplier_owned', 'partner_owned', 'mixed', 'unknown'];
+export const consumerPricingAuthorities = [
+  'supplier_controls',
+  'partner_controls',
+  'sow_supplier_with_partner_approval',
+  'shared',
+  'unknown',
+];
 
 export const participantRoles = [
   'venue_partner',

--- a/supabase/functions/_shared/partner-report-export.ts
+++ b/supabase/functions/_shared/partner-report-export.ts
@@ -38,6 +38,10 @@ export type PartnerReportExportContext = {
   payoutRecipientLabels: string[];
   calculationLabel: string;
   generatedAt: string;
+  snapshotId: string;
+  feeLabel?: string;
+  costLabel?: string;
+  additionalDeductionsNotes?: string | null;
 };
 
 const encoder = new TextEncoder();
@@ -154,6 +158,10 @@ export const buildPartnerReportCsv = ({
   payoutRecipientLabels,
   calculationLabel,
   generatedAt,
+  snapshotId,
+  feeLabel = "Stick cost deduction",
+  costLabel = "Costs",
+  additionalDeductionsNotes,
 }: PartnerReportExportContext): string => {
   const summary = preview.summary ?? {};
   const generatedAtLabel = formatGeneratedAt(generatedAt);
@@ -165,7 +173,11 @@ export const buildPartnerReportCsv = ({
       `${preview.weekStartDate ?? ""} through ${preview.weekEndingDate ?? ""}`,
     ]),
     csvRow(["Generated", generatedAtLabel]),
+    csvRow(["Snapshot ID", snapshotId]),
     csvRow(["Calculation", calculationLabel]),
+    ...(additionalDeductionsNotes
+      ? [csvRow(["Deduction notes", additionalDeductionsNotes])]
+      : []),
     "",
     csvRow(["Summary"]),
     csvRow(["Metric", "Value"]),
@@ -173,8 +185,8 @@ export const buildPartnerReportCsv = ({
     csvRow(["Sticks/items", formatInteger(summary.item_quantity)]),
     csvRow(["Gross sales", formatCurrency(summary.gross_sales_cents)]),
     csvRow(["Machine taxes", formatCurrency(summary.tax_cents)]),
-    csvRow(["Stick cost deduction", formatCurrency(summary.fee_cents)]),
-    csvRow(["Costs", formatCurrency(summary.cost_cents)]),
+    csvRow([feeLabel, formatCurrency(summary.fee_cents)]),
+    csvRow([costLabel, formatCurrency(summary.cost_cents)]),
     csvRow(["Net sales", formatCurrency(summary.net_sales_cents)]),
     csvRow([
       getPartnerPayoutLabel(payoutRecipientLabels),
@@ -200,8 +212,8 @@ export const buildPartnerReportCsv = ({
       "Sticks/items",
       "Gross sales",
       "Machine taxes",
-      "Stick cost deduction",
-      "Costs",
+      feeLabel,
+      costLabel,
       "Net sales",
     ]),
     ...((preview.machines ?? []).map((machine) =>
@@ -262,6 +274,10 @@ export const buildPartnerReportPdf = ({
   payoutRecipientLabels,
   calculationLabel,
   generatedAt,
+  snapshotId,
+  feeLabel = "Stick cost deduction",
+  costLabel = "Costs",
+  additionalDeductionsNotes,
 }: PartnerReportExportContext): Uint8Array => {
   const summary = preview.summary ?? {};
   const machines = preview.machines ?? [];
@@ -328,6 +344,15 @@ export const buildPartnerReportPdf = ({
         color: "muted",
       }),
     );
+    lines.push(
+      pdfText({
+        text: `Snapshot ${snapshotId}`,
+        x: 384,
+        y: 716,
+        size: 8,
+        color: "muted",
+      }),
+    );
 
     if (pageIndex === 0) {
       const cards = [
@@ -335,7 +360,7 @@ export const buildPartnerReportPdf = ({
         ["Sticks/items", formatInteger(summary.item_quantity)],
         ["Gross sales", formatCurrency(summary.gross_sales_cents)],
         ["Machine taxes", formatCurrency(summary.tax_cents)],
-        ["Stick cost deduction", formatCurrency(summary.fee_cents)],
+        [feeLabel, formatCurrency(summary.fee_cents)],
         ["Net sales", formatCurrency(summary.net_sales_cents)],
         [partnerLabel, formatCurrency(summary.fever_profit_cents)],
         ["Bloomjoy retained", formatCurrency(summary.bloomjoy_profit_cents)],
@@ -386,6 +411,20 @@ export const buildPartnerReportPdf = ({
           }),
         );
       });
+      if (additionalDeductionsNotes) {
+        wrapText(`Deduction notes: ${additionalDeductionsNotes}`, 104, 2)
+          .forEach((notesLine, index) => {
+            lines.push(
+              pdfText({
+                text: notesLine,
+                x: 44,
+                y: 480 - index * 12,
+                size: 8,
+                color: "muted",
+              }),
+            );
+          });
+      }
     }
 
     const tableTop = pageIndex === 0 ? 454 : 676;
@@ -451,7 +490,7 @@ export const buildPartnerReportPdf = ({
     );
     lines.push(
       pdfText({
-        text: "Stick cost",
+        text: truncateWithDots(feeLabel, 12),
         x: 468,
         y: tableTop - 24,
         size: 7,

--- a/supabase/functions/partner-report-export/index.ts
+++ b/supabase/functions/partner-report-export/index.ts
@@ -66,18 +66,29 @@ const formatCalculationLabel = (rule: Record<string, unknown> | null) => {
 
   const feeAmount = Number(rule.fee_amount_cents ?? 0);
   const feeBasis = String(rule.fee_basis ?? "none");
+  const feeLabel = String(rule.fee_label ?? "Stick cost deduction");
   const feeText = feeAmount > 0 && feeBasis === "per_stick"
     ? `$${
       (feeAmount / 100).toFixed(2)
-    } stick-level cost deduction per paid stick/item`
+    } ${feeLabel.toLowerCase()} per paid stick/item`
     : feeAmount > 0
     ? `$${(feeAmount / 100).toFixed(2)} ${
-      feeBasis.replaceAll("_", " ")
-    } deduction`
-    : "no stick-level deduction";
+      feeLabel.toLowerCase()
+    } (${feeBasis.replaceAll("_", " ")})`
+    : "no configured deduction";
+  const additionalNotes = String(rule.additional_deductions_notes ?? "").trim();
 
-  return `Net sales split: gross sales less machine taxes and ${feeText}; no-pay rows count in volume but deduct $0.`;
+  return `Net sales split: gross sales less machine taxes and ${feeText}; no-pay rows count in volume but deduct $0.${
+    additionalNotes ? ` Additional notes: ${additionalNotes}` : ""
+  }`;
 };
+
+const getRuleExportLabels = (rule: Record<string, unknown> | null) => ({
+  feeLabel: String(rule?.fee_label ?? "Stick cost deduction"),
+  costLabel: String(rule?.cost_label ?? "Costs"),
+  additionalDeductionsNotes: String(rule?.additional_deductions_notes ?? "")
+    .trim() || null,
+});
 
 const getPayoutRecipientLabels = async (
   partnershipId: string,
@@ -98,7 +109,7 @@ const getPayoutRecipientLabels = async (
   const partnerIds = parties.map((party) => party.partner_id).filter(Boolean);
   const { data: partners, error: partnersError } = await serviceSupabase
     .from("reporting_partners")
-    .select("id, name")
+    .select("id, name, legal_name")
     .in("id", partnerIds);
 
   if (partnersError || !partners?.length) {
@@ -106,7 +117,7 @@ const getPayoutRecipientLabels = async (
   }
 
   const partnerNameById = new Map(
-    partners.map((partner) => [partner.id, partner.name]),
+    partners.map((partner) => [partner.id, partner.legal_name || partner.name]),
   );
   return parties
     .map((party) => partnerNameById.get(party.partner_id))
@@ -294,19 +305,7 @@ serve(async (req) => {
       getActiveFinancialRule(partnershipId, weekStartDate, weekEndingDate),
     ]);
     const calculationLabel = formatCalculationLabel(financialRule);
-    const context = {
-      preview,
-      payoutRecipientLabels,
-      calculationLabel,
-      generatedAt,
-    };
-    const fileBytes = format === "pdf"
-      ? buildPartnerReportPdf(context)
-      : encoder.encode(buildPartnerReportCsv(context));
-    const contentType = format === "pdf" ? "application/pdf" : "text/csv";
-    const fileName = `${
-      slugify(preview.partnershipName ?? "partner-report")
-    }-${weekEndingDate}.${format}`;
+    const ruleExportLabels = getRuleExportLabels(financialRule);
     const snapshot = await getOrCreateSnapshot({
       partnershipId,
       weekEndingDate,
@@ -315,8 +314,25 @@ serve(async (req) => {
         preview,
         calculationLabel,
         payoutRecipientLabels,
+        ...ruleExportLabels,
+        generatedAt,
       },
     });
+    const context = {
+      preview,
+      payoutRecipientLabels,
+      calculationLabel,
+      generatedAt,
+      snapshotId: snapshot.id,
+      ...ruleExportLabels,
+    };
+    const fileBytes = format === "pdf"
+      ? buildPartnerReportPdf(context)
+      : encoder.encode(buildPartnerReportCsv(context));
+    const contentType = format === "pdf" ? "application/pdf" : "text/csv";
+    const fileName = `${
+      slugify(preview.partnershipName ?? "partner-report")
+    }-${weekEndingDate}.${format}`;
     const storagePath =
       `partner-reports/${partnershipId}/${snapshot.id}/${fileName}`;
 
@@ -350,6 +366,8 @@ serve(async (req) => {
       preview,
       calculationLabel,
       payoutRecipientLabels,
+      snapshotId: snapshot.id,
+      ...ruleExportLabels,
       exports: {
         ...(((snapshot.summary_json as Record<string, unknown> | null)
           ?.exports as Record<string, unknown> | undefined) ?? {}),

--- a/supabase/migrations/202604260014_partnership_contract_terms.sql
+++ b/supabase/migrations/202604260014_partnership_contract_terms.sql
@@ -1,0 +1,615 @@
+-- Add contract-facing setup fields needed for official partnership reporting.
+
+alter table public.reporting_partners
+  add column if not exists legal_name text;
+
+alter table public.reporting_partnerships
+  add column if not exists reporting_frequency text not null default 'weekly',
+  add column if not exists monthly_report_due_days integer,
+  add column if not exists invoice_payment_due_days integer,
+  add column if not exists payment_method text,
+  add column if not exists machine_ownership_model text not null default 'unknown',
+  add column if not exists consumer_pricing_authority text not null default 'unknown',
+  add column if not exists contract_reference text;
+
+alter table public.reporting_partnerships
+  drop constraint if exists reporting_partnerships_reporting_frequency_check,
+  drop constraint if exists reporting_partnerships_monthly_report_due_days_check,
+  drop constraint if exists reporting_partnerships_invoice_payment_due_days_check,
+  drop constraint if exists reporting_partnerships_machine_ownership_model_check,
+  drop constraint if exists reporting_partnerships_consumer_pricing_authority_check;
+
+alter table public.reporting_partnerships
+  add constraint reporting_partnerships_reporting_frequency_check
+    check (reporting_frequency in ('weekly', 'monthly', 'weekly_and_monthly')),
+  add constraint reporting_partnerships_monthly_report_due_days_check
+    check (monthly_report_due_days is null or monthly_report_due_days between 0 and 90),
+  add constraint reporting_partnerships_invoice_payment_due_days_check
+    check (invoice_payment_due_days is null or invoice_payment_due_days between 0 and 120),
+  add constraint reporting_partnerships_machine_ownership_model_check
+    check (machine_ownership_model in ('supplier_owned', 'partner_owned', 'mixed', 'unknown')),
+  add constraint reporting_partnerships_consumer_pricing_authority_check
+    check (consumer_pricing_authority in ('supplier_controls', 'partner_controls', 'sow_supplier_with_partner_approval', 'shared', 'unknown'));
+
+alter table public.reporting_partnership_financial_rules
+  add column if not exists fee_label text not null default 'Stick cost deduction',
+  add column if not exists cost_label text not null default 'Costs',
+  add column if not exists additional_deductions_notes text;
+
+drop function if exists public.admin_get_partnership_reporting_setup();
+create or replace function public.admin_get_partnership_reporting_setup()
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  result jsonb;
+begin
+  if not public.is_super_admin(auth.uid()) then
+    raise exception 'Admin access required';
+  end if;
+
+  with machines as (
+    select
+      machine.id,
+      machine.machine_label,
+      machine.machine_type,
+      machine.sunze_machine_id,
+      machine.status,
+      account.name as account_name,
+      location.name as location_name,
+      max(fact.sale_date) as latest_sale_date
+    from public.reporting_machines machine
+    join public.customer_accounts account on account.id = machine.account_id
+    join public.reporting_locations location on location.id = machine.location_id
+    left join public.machine_sales_facts fact on fact.reporting_machine_id = machine.id
+    group by machine.id, account.name, location.name
+  ),
+  assignment_rows as (
+    select
+      assignment.id,
+      assignment.machine_id,
+      machine.machine_label,
+      assignment.partnership_id,
+      partnership.name as partnership_name,
+      assignment.assignment_role,
+      assignment.effective_start_date,
+      assignment.effective_end_date,
+      assignment.status,
+      assignment.notes
+    from public.reporting_machine_partnership_assignments assignment
+    join public.reporting_machines machine on machine.id = assignment.machine_id
+    join public.reporting_partnerships partnership on partnership.id = assignment.partnership_id
+  ),
+  tax_rows as (
+    select
+      tax.id,
+      tax.machine_id,
+      machine.machine_label,
+      tax.tax_rate_percent,
+      tax.effective_start_date,
+      tax.effective_end_date,
+      tax.status,
+      tax.notes
+    from public.reporting_machine_tax_rates tax
+    join public.reporting_machines machine on machine.id = tax.machine_id
+  ),
+  party_rows as (
+    select
+      party.id,
+      party.partnership_id,
+      partnership.name as partnership_name,
+      party.partner_id,
+      partner.name as partner_name,
+      partner.legal_name as partner_legal_name,
+      party.party_role,
+      party.share_basis_points,
+      party.is_report_recipient,
+      party.created_at,
+      party.updated_at
+    from public.reporting_partnership_parties party
+    join public.reporting_partnerships partnership on partnership.id = party.partnership_id
+    join public.reporting_partners partner on partner.id = party.partner_id
+  ),
+  rule_rows as (
+    select
+      rule.*,
+      partnership.name as partnership_name
+    from public.reporting_partnership_financial_rules rule
+    join public.reporting_partnerships partnership on partnership.id = rule.partnership_id
+  ),
+  warnings as (
+    select jsonb_build_object(
+      'warningType', 'missing_machine_tax_rate',
+      'machineId', machine.id,
+      'machineLabel', machine.machine_label,
+      'message', machine.machine_label || ' has no active machine tax rate.'
+    ) as warning
+    from public.reporting_machines machine
+    where not exists (
+      select 1
+      from public.reporting_machine_tax_rates tax
+      where tax.machine_id = machine.id
+        and tax.status = 'active'
+        and tax.effective_start_date <= current_date
+        and (tax.effective_end_date is null or tax.effective_end_date >= current_date)
+    )
+    union all
+    select jsonb_build_object(
+      'warningType', 'missing_partnership_assignment',
+      'machineId', machine.id,
+      'machineLabel', machine.machine_label,
+      'message', machine.machine_label || ' has no active partnership assignment.'
+    ) as warning
+    from public.reporting_machines machine
+    where not exists (
+      select 1
+      from public.reporting_machine_partnership_assignments assignment
+      where assignment.machine_id = machine.id
+        and assignment.status = 'active'
+        and assignment.assignment_role = 'primary_reporting'
+        and assignment.effective_start_date <= current_date
+        and (assignment.effective_end_date is null or assignment.effective_end_date >= current_date)
+    )
+    union all
+    select jsonb_build_object(
+      'warningType', 'missing_financial_rule',
+      'partnershipId', partnership.id,
+      'partnershipName', partnership.name,
+      'message', partnership.name || ' has no active financial rule.'
+    ) as warning
+    from public.reporting_partnerships partnership
+    where partnership.status = 'active'
+      and not exists (
+        select 1
+        from public.reporting_partnership_financial_rules rule
+        where rule.partnership_id = partnership.id
+          and rule.status = 'active'
+          and rule.effective_start_date <= current_date
+          and (rule.effective_end_date is null or rule.effective_end_date >= current_date)
+      )
+    union all
+    select jsonb_build_object(
+      'warningType', 'overlapping_partnership_assignments',
+      'machineId', left_assignment.machine_id,
+      'machineLabel', machine.machine_label,
+      'message', machine.machine_label || ' has overlapping active partnership assignments.'
+    ) as warning
+    from public.reporting_machine_partnership_assignments left_assignment
+    join public.reporting_machine_partnership_assignments right_assignment
+      on right_assignment.machine_id = left_assignment.machine_id
+      and right_assignment.assignment_role = left_assignment.assignment_role
+      and right_assignment.id > left_assignment.id
+      and right_assignment.status = 'active'
+      and left_assignment.status = 'active'
+      and public.reporting_date_windows_overlap(
+        left_assignment.effective_start_date,
+        left_assignment.effective_end_date,
+        right_assignment.effective_start_date,
+        right_assignment.effective_end_date
+      )
+    join public.reporting_machines machine on machine.id = left_assignment.machine_id
+  )
+  select jsonb_build_object(
+    'partners',
+    coalesce((select jsonb_agg(to_jsonb(partner) order by partner.name) from public.reporting_partners partner), '[]'::jsonb),
+    'partnerships',
+    coalesce((select jsonb_agg(to_jsonb(partnership) order by partnership.name) from public.reporting_partnerships partnership), '[]'::jsonb),
+    'machines',
+    coalesce((select jsonb_agg(to_jsonb(machines) order by machines.account_name, machines.location_name, machines.machine_label) from machines), '[]'::jsonb),
+    'assignments',
+    coalesce((select jsonb_agg(to_jsonb(assignment_rows) order by assignment_rows.effective_start_date desc) from assignment_rows), '[]'::jsonb),
+    'taxRates',
+    coalesce((select jsonb_agg(to_jsonb(tax_rows) order by tax_rows.effective_start_date desc) from tax_rows), '[]'::jsonb),
+    'parties',
+    coalesce((select jsonb_agg(to_jsonb(party_rows) order by party_rows.partnership_name, party_rows.partner_name) from party_rows), '[]'::jsonb),
+    'financialRules',
+    coalesce((select jsonb_agg(to_jsonb(rule_rows) order by rule_rows.effective_start_date desc) from rule_rows), '[]'::jsonb),
+    'warnings',
+    coalesce((select jsonb_agg(warnings.warning) from warnings), '[]'::jsonb)
+  )
+  into result;
+
+  return result;
+end;
+$$;
+
+drop function if exists public.admin_upsert_reporting_partner(uuid, text, text, text, text, text, text, text);
+drop function if exists public.admin_upsert_reporting_partner(uuid, text, text, text, text, text, text, text, text);
+create or replace function public.admin_upsert_reporting_partner(
+  p_partner_id uuid,
+  p_name text,
+  p_legal_name text,
+  p_partner_type text,
+  p_primary_contact_name text,
+  p_primary_contact_email text,
+  p_status text,
+  p_notes text,
+  p_reason text
+)
+returns public.reporting_partners
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  normalized_reason text;
+  before_row public.reporting_partners;
+  after_row public.reporting_partners;
+begin
+  if not public.is_super_admin(auth.uid()) then
+    raise exception 'Admin access required';
+  end if;
+
+  normalized_reason := public.reporting_admin_assert_reason(p_reason);
+
+  if trim(coalesce(p_name, '')) = '' then
+    raise exception 'Partner name is required';
+  end if;
+
+  if p_partner_id is not null then
+    select * into before_row from public.reporting_partners where id = p_partner_id;
+  end if;
+
+  if before_row.id is null then
+    insert into public.reporting_partners (
+      name,
+      legal_name,
+      partner_type,
+      primary_contact_name,
+      primary_contact_email,
+      status,
+      notes,
+      created_by
+    )
+    values (
+      trim(p_name),
+      nullif(trim(coalesce(p_legal_name, '')), ''),
+      lower(coalesce(nullif(trim(p_partner_type), ''), 'revenue_share_partner')),
+      nullif(trim(coalesce(p_primary_contact_name, '')), ''),
+      nullif(trim(coalesce(p_primary_contact_email, '')), ''),
+      lower(coalesce(nullif(trim(p_status), ''), 'active')),
+      nullif(trim(coalesce(p_notes, '')), ''),
+      auth.uid()
+    )
+    returning * into after_row;
+  else
+    update public.reporting_partners
+    set
+      name = trim(p_name),
+      legal_name = nullif(trim(coalesce(p_legal_name, '')), ''),
+      partner_type = lower(coalesce(nullif(trim(p_partner_type), ''), 'revenue_share_partner')),
+      primary_contact_name = nullif(trim(coalesce(p_primary_contact_name, '')), ''),
+      primary_contact_email = nullif(trim(coalesce(p_primary_contact_email, '')), ''),
+      status = lower(coalesce(nullif(trim(p_status), ''), 'active')),
+      notes = nullif(trim(coalesce(p_notes, '')), '')
+    where id = before_row.id
+    returning * into after_row;
+  end if;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    auth.uid(),
+    case when before_row.id is null then 'reporting_partner.created' else 'reporting_partner.updated' end,
+    'reporting_partner',
+    after_row.id::text,
+    coalesce(to_jsonb(before_row), '{}'::jsonb),
+    to_jsonb(after_row),
+    jsonb_build_object('reason', normalized_reason)
+  );
+
+  return after_row;
+end;
+$$;
+
+drop function if exists public.admin_upsert_reporting_partnership(uuid, text, text, integer, text, date, date, text, text, text);
+drop function if exists public.admin_upsert_reporting_partnership(uuid, text, text, integer, text, text, integer, integer, text, text, text, text, date, date, text, text, text);
+create or replace function public.admin_upsert_reporting_partnership(
+  p_partnership_id uuid,
+  p_name text,
+  p_partnership_type text,
+  p_reporting_week_end_day integer,
+  p_timezone text,
+  p_reporting_frequency text,
+  p_monthly_report_due_days integer,
+  p_invoice_payment_due_days integer,
+  p_payment_method text,
+  p_machine_ownership_model text,
+  p_consumer_pricing_authority text,
+  p_contract_reference text,
+  p_effective_start_date date,
+  p_effective_end_date date,
+  p_status text,
+  p_notes text,
+  p_reason text
+)
+returns public.reporting_partnerships
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  normalized_reason text;
+  before_row public.reporting_partnerships;
+  after_row public.reporting_partnerships;
+begin
+  if not public.is_super_admin(auth.uid()) then
+    raise exception 'Admin access required';
+  end if;
+
+  normalized_reason := public.reporting_admin_assert_reason(p_reason);
+
+  if trim(coalesce(p_name, '')) = '' then
+    raise exception 'Partnership name is required';
+  end if;
+
+  if p_effective_start_date is null then
+    raise exception 'Effective start date is required';
+  end if;
+
+  if p_partnership_id is not null then
+    select * into before_row from public.reporting_partnerships where id = p_partnership_id;
+  end if;
+
+  if before_row.id is null then
+    insert into public.reporting_partnerships (
+      name,
+      partnership_type,
+      reporting_week_end_day,
+      timezone,
+      reporting_frequency,
+      monthly_report_due_days,
+      invoice_payment_due_days,
+      payment_method,
+      machine_ownership_model,
+      consumer_pricing_authority,
+      contract_reference,
+      effective_start_date,
+      effective_end_date,
+      status,
+      notes,
+      created_by
+    )
+    values (
+      trim(p_name),
+      lower(coalesce(nullif(trim(p_partnership_type), ''), 'revenue_share')),
+      coalesce(p_reporting_week_end_day, 0),
+      coalesce(nullif(trim(p_timezone), ''), 'America/Los_Angeles'),
+      lower(coalesce(nullif(trim(p_reporting_frequency), ''), 'weekly')),
+      p_monthly_report_due_days,
+      p_invoice_payment_due_days,
+      nullif(trim(coalesce(p_payment_method, '')), ''),
+      lower(coalesce(nullif(trim(p_machine_ownership_model), ''), 'unknown')),
+      lower(coalesce(nullif(trim(p_consumer_pricing_authority), ''), 'unknown')),
+      nullif(trim(coalesce(p_contract_reference, '')), ''),
+      p_effective_start_date,
+      p_effective_end_date,
+      lower(coalesce(nullif(trim(p_status), ''), 'draft')),
+      nullif(trim(coalesce(p_notes, '')), ''),
+      auth.uid()
+    )
+    returning * into after_row;
+  else
+    update public.reporting_partnerships
+    set
+      name = trim(p_name),
+      partnership_type = lower(coalesce(nullif(trim(p_partnership_type), ''), 'revenue_share')),
+      reporting_week_end_day = coalesce(p_reporting_week_end_day, 0),
+      timezone = coalesce(nullif(trim(p_timezone), ''), 'America/Los_Angeles'),
+      reporting_frequency = lower(coalesce(nullif(trim(p_reporting_frequency), ''), 'weekly')),
+      monthly_report_due_days = p_monthly_report_due_days,
+      invoice_payment_due_days = p_invoice_payment_due_days,
+      payment_method = nullif(trim(coalesce(p_payment_method, '')), ''),
+      machine_ownership_model = lower(coalesce(nullif(trim(p_machine_ownership_model), ''), 'unknown')),
+      consumer_pricing_authority = lower(coalesce(nullif(trim(p_consumer_pricing_authority), ''), 'unknown')),
+      contract_reference = nullif(trim(coalesce(p_contract_reference, '')), ''),
+      effective_start_date = p_effective_start_date,
+      effective_end_date = p_effective_end_date,
+      status = lower(coalesce(nullif(trim(p_status), ''), 'draft')),
+      notes = nullif(trim(coalesce(p_notes, '')), '')
+    where id = before_row.id
+    returning * into after_row;
+  end if;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    auth.uid(),
+    case when before_row.id is null then 'reporting_partnership.created' else 'reporting_partnership.updated' end,
+    'reporting_partnership',
+    after_row.id::text,
+    coalesce(to_jsonb(before_row), '{}'::jsonb),
+    to_jsonb(after_row),
+    jsonb_build_object('reason', normalized_reason)
+  );
+
+  return after_row;
+end;
+$$;
+
+drop function if exists public.admin_upsert_reporting_financial_rule(uuid, uuid, text, text, integer, text, integer, text, text, text, integer, integer, integer, date, date, text, text, text);
+drop function if exists public.admin_upsert_reporting_financial_rule(uuid, uuid, text, text, integer, text, text, integer, text, text, text, text, text, integer, integer, integer, date, date, text, text, text);
+create or replace function public.admin_upsert_reporting_financial_rule(
+  p_rule_id uuid,
+  p_partnership_id uuid,
+  p_calculation_model text,
+  p_split_base text,
+  p_fee_amount_cents integer,
+  p_fee_basis text,
+  p_fee_label text,
+  p_cost_amount_cents integer,
+  p_cost_basis text,
+  p_cost_label text,
+  p_deduction_timing text,
+  p_gross_to_net_method text,
+  p_additional_deductions_notes text,
+  p_fever_share_basis_points integer,
+  p_partner_share_basis_points integer,
+  p_bloomjoy_share_basis_points integer,
+  p_effective_start_date date,
+  p_effective_end_date date,
+  p_status text,
+  p_notes text,
+  p_reason text
+)
+returns public.reporting_partnership_financial_rules
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  normalized_reason text;
+  normalized_status text;
+  before_row public.reporting_partnership_financial_rules;
+  after_row public.reporting_partnership_financial_rules;
+begin
+  if not public.is_super_admin(auth.uid()) then
+    raise exception 'Admin access required';
+  end if;
+
+  normalized_reason := public.reporting_admin_assert_reason(p_reason);
+  normalized_status := lower(coalesce(nullif(trim(p_status), ''), 'draft'));
+
+  if p_partnership_id is null or p_effective_start_date is null then
+    raise exception 'Partnership and effective start date are required';
+  end if;
+
+  if exists (
+    select 1
+    from public.reporting_partnership_financial_rules existing
+    where existing.partnership_id = p_partnership_id
+      and existing.status = 'active'
+      and existing.id is distinct from p_rule_id
+      and normalized_status = 'active'
+      and public.reporting_date_windows_overlap(
+        existing.effective_start_date,
+        existing.effective_end_date,
+        p_effective_start_date,
+        p_effective_end_date
+      )
+  ) then
+    raise exception 'This partnership already has an overlapping active financial rule';
+  end if;
+
+  if p_rule_id is not null then
+    select * into before_row
+    from public.reporting_partnership_financial_rules
+    where id = p_rule_id;
+  end if;
+
+  if before_row.id is null then
+    insert into public.reporting_partnership_financial_rules (
+      partnership_id,
+      calculation_model,
+      split_base,
+      fee_amount_cents,
+      fee_basis,
+      fee_label,
+      cost_amount_cents,
+      cost_basis,
+      cost_label,
+      deduction_timing,
+      gross_to_net_method,
+      additional_deductions_notes,
+      fever_share_basis_points,
+      partner_share_basis_points,
+      bloomjoy_share_basis_points,
+      effective_start_date,
+      effective_end_date,
+      status,
+      notes,
+      created_by
+    )
+    values (
+      p_partnership_id,
+      lower(coalesce(nullif(trim(p_calculation_model), ''), 'net_split')),
+      lower(coalesce(nullif(trim(p_split_base), ''), 'net_sales')),
+      coalesce(p_fee_amount_cents, 0),
+      lower(coalesce(nullif(trim(p_fee_basis), ''), 'none')),
+      coalesce(nullif(trim(p_fee_label), ''), 'Stick cost deduction'),
+      coalesce(p_cost_amount_cents, 0),
+      lower(coalesce(nullif(trim(p_cost_basis), ''), 'none')),
+      coalesce(nullif(trim(p_cost_label), ''), 'Costs'),
+      lower(coalesce(nullif(trim(p_deduction_timing), ''), 'before_split')),
+      lower(coalesce(nullif(trim(p_gross_to_net_method), ''), 'machine_tax_plus_configured_fees')),
+      nullif(trim(coalesce(p_additional_deductions_notes, '')), ''),
+      coalesce(p_fever_share_basis_points, 0),
+      coalesce(p_partner_share_basis_points, 0),
+      coalesce(p_bloomjoy_share_basis_points, 0),
+      p_effective_start_date,
+      p_effective_end_date,
+      normalized_status,
+      nullif(trim(coalesce(p_notes, '')), ''),
+      auth.uid()
+    )
+    returning * into after_row;
+  else
+    update public.reporting_partnership_financial_rules
+    set
+      partnership_id = p_partnership_id,
+      calculation_model = lower(coalesce(nullif(trim(p_calculation_model), ''), 'net_split')),
+      split_base = lower(coalesce(nullif(trim(p_split_base), ''), 'net_sales')),
+      fee_amount_cents = coalesce(p_fee_amount_cents, 0),
+      fee_basis = lower(coalesce(nullif(trim(p_fee_basis), ''), 'none')),
+      fee_label = coalesce(nullif(trim(p_fee_label), ''), 'Stick cost deduction'),
+      cost_amount_cents = coalesce(p_cost_amount_cents, 0),
+      cost_basis = lower(coalesce(nullif(trim(p_cost_basis), ''), 'none')),
+      cost_label = coalesce(nullif(trim(p_cost_label), ''), 'Costs'),
+      deduction_timing = lower(coalesce(nullif(trim(p_deduction_timing), ''), 'before_split')),
+      gross_to_net_method = lower(coalesce(nullif(trim(p_gross_to_net_method), ''), 'machine_tax_plus_configured_fees')),
+      additional_deductions_notes = nullif(trim(coalesce(p_additional_deductions_notes, '')), ''),
+      fever_share_basis_points = coalesce(p_fever_share_basis_points, 0),
+      partner_share_basis_points = coalesce(p_partner_share_basis_points, 0),
+      bloomjoy_share_basis_points = coalesce(p_bloomjoy_share_basis_points, 0),
+      effective_start_date = p_effective_start_date,
+      effective_end_date = p_effective_end_date,
+      status = normalized_status,
+      notes = nullif(trim(coalesce(p_notes, '')), '')
+    where id = before_row.id
+    returning * into after_row;
+  end if;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    auth.uid(),
+    case when before_row.id is null then 'reporting_partnership_financial_rule.created' else 'reporting_partnership_financial_rule.updated' end,
+    'reporting_partnership_financial_rule',
+    after_row.id::text,
+    coalesce(to_jsonb(before_row), '{}'::jsonb),
+    to_jsonb(after_row),
+    jsonb_build_object('reason', normalized_reason)
+  );
+
+  return after_row;
+end;
+$$;
+
+grant execute on function public.admin_get_partnership_reporting_setup() to authenticated;
+grant execute on function public.admin_upsert_reporting_partner(uuid, text, text, text, text, text, text, text, text) to authenticated;
+grant execute on function public.admin_upsert_reporting_partnership(uuid, text, text, integer, text, text, integer, integer, text, text, text, text, date, date, text, text, text) to authenticated;
+grant execute on function public.admin_upsert_reporting_financial_rule(uuid, uuid, text, text, integer, text, text, integer, text, text, text, text, text, integer, integer, integer, date, date, text, text, text) to authenticated;


### PR DESCRIPTION
﻿## Summary
- Adds contract-facing partnership setup fields for legal partner names, weekly/monthly cadence, report/payment due terms, payment method, machine ownership, pricing authority, and contract references.
- Adds labeled deduction metadata for partner payout rules so Merlin-style cashless/royalty deductions can be documented without broad formula-engine work.
- Includes partner report snapshot IDs in PDF/CSV exports and uses legal partner names in export payout labels when recorded.

## Files changed
- Database: `supabase/migrations/202604260014_partnership_contract_terms.sql`
- Admin UI/data client: `src/lib/partnershipReporting.ts`, `src/pages/admin/PartnerRecords.tsx`, `src/pages/admin/Partnerships.tsx`, `src/pages/admin/reportingSetupUi.ts`
- Partner report export: `supabase/functions/_shared/partner-report-export.ts`, `supabase/functions/partner-report-export/index.ts`
- Docs/checklists: `Docs/CURRENT_STATUS.md`, `Docs/QA_SMOKE_TEST_CHECKLIST.md`

## Verification commands + results
- `npm ci`: passed; npm reported existing 2 moderate audit findings and existing deprecated `glob` warning.
- `npm run build`: passed; existing Browserslist data-age warning reported.
- `npm test --if-present`: passed; no test script output.
- `npm run lint --if-present`: passed with 8 existing Fast Refresh warnings and 0 errors.
- `deno check supabase/functions/partner-report-export/index.ts`: passed.
- `git diff --cached --check`: passed before commit.
- Local smoke with dummy non-secret Supabase env: `/admin/partnerships` and `/admin/partner-records` returned 200 and redirected to `/login` cleanly in an unauthenticated session.

## How to test
1. From this branch, run `npm ci`.
2. Apply `supabase/migrations/202604260014_partnership_contract_terms.sql` to the target Supabase environment.
3. Deploy or serve `partner-report-export` with the updated shared export helper.
4. Run `npm run dev` and open `http://localhost:8080/admin/partner-records` as a super-admin.
5. Create or edit a partner record and confirm `Legal name` saves separately from display `Name`.
6. Open `http://localhost:8080/admin/partnerships`, select or create a partnership, and confirm Details can save weekly/monthly cadence, monthly report due days, invoice payment due days, payment method, ownership model, pricing authority, and contract reference.
7. In Payout Rules, save a deduction label plus additional deduction notes, then load Weekly Preview and export PDF/CSV.
8. Confirm the export uses legal partner payout labels when present and includes the snapshot ID.

## Overlap / coordination notes
- PR #216 was merged first because it also touched `Docs/QA_SMOKE_TEST_CHECKLIST.md`; this branch was rebased onto updated `main` and the checklist conflict was resolved by keeping both sets of QA coverage.
- Open draft PRs #155 and #142 still overlap docs/package-adjacent files but not the partner reporting code touched here.
- Dependabot PR #194 should remain deferred until this reporting slice lands because it changes Vite/esbuild and requires broader verification.
