### PR TITLE
Hide location UI and lock Sunze ID

### DIFF
--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -30,11 +30,11 @@
 - Production runtime hotfix branch `agent/fix-reporting-chart-runtime` removes the forced Recharts manual chunk split that caused the app shell to crash with `Cannot access 'P' before initialization` after the reporting deployment.
 - Sales reporting is now a Supabase-backed extension to the existing operator app on `main`.
 - The reporting foundation includes account/location/machine reporting entitlements, normalized sales facts, refund adjustment facts, import run audit records, export snapshots, partner schedules, and private PDF export storage.
-- The portal now has `/portal/reports` for entitled users, with date/grain/location/machine/payment filters and on-demand PDF export.
+- The portal now has `/portal/reports` for entitled users, with date/grain/machine/payment filters and on-demand PDF export.
 - Admin access and reporting operations are split into clearer surfaces:
   - `/admin/access` is the single admin place for users, Plus grants, global roles, audit history, and explicit machine-level reporting access.
   - `/admin/partner-records` is the reusable organization/contact directory for partnership participants.
-  - `/admin/machines` is the machine setup area for aliases, Sunze mapping, assignment readiness, and current machine tax rates.
+  - `/admin/machines` is the machine setup area for aliases, read-only Sunze mapping, assignment readiness, and current machine tax rates. Location stays as backend reporting structure but is hidden from current admin/reporting UI.
   - `/admin/partnerships` is the guided agreement setup flow for partnership details, role-only participants, bulk machine alignment, payout rules, and weekly preview.
   - `/admin/reporting` is focused on report schedules, import/sync status, freshness, and export archive visibility.
 - Production RPC repair is complete: migration `202604260004_reporting_admin_rpc_repair.sql` reapplied missing admin reporting/partnership RPCs, restored PostgREST schema visibility, and production migration history is aligned through `202604260006`.

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -174,7 +174,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] WeChat onboarding concierge submit writes `support_requests.request_type=wechat_onboarding` and structured `support_requests.intake_meta` values (`phone_region`, `phone_number`, `device_type`, `blocked_step`, `referral_needed`, optional `wechat_id`)
 - [ ] User with no reporting entitlement is blocked from `/portal/reports` with clear reporting-access copy
 - [ ] User with one reporting machine entitlement can open `/portal/reports` and sees only that machine in filters/results
-- [ ] `/portal/reports` supports date range, daily/weekly/monthly grain, location, machine, and cash/credit payment filters
+- [ ] `/portal/reports` supports date range, daily/weekly/monthly grain, machine, and cash/credit payment filters without exposing location controls or columns
 - [ ] `/portal/reports` shows net sales, refund adjustments, gross sales, transaction count, sales by period, and sales by machine without mobile overflow
 - [ ] `/portal/reports` export creates a private signed PDF link that matches the selected filters
 - [ ] `npm run reporting:validate-sunze-parser` passes with the sanitized Sunze `.xlsx` fixture
@@ -266,7 +266,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Admin Partnerships > Participants includes an `Add new partner record` dropdown option that opens a modal, saves minimum viable partner fields, and selects the new record
 - [ ] Admin Partnerships > Machines supports bulk searchable check/uncheck machine alignment and archives unchecked active assignments without exposing dates, status, role, or notes
 - [ ] Admin Partnerships > Machines shows when selected machines are already assigned to another active partnership and requires confirmation before saving an overlap
-- [ ] Admin Machines can edit machine label/alias, account, location, machine type, and Sunze ID
+- [ ] Admin Machines can edit machine label/alias, account, and machine type while hiding location and showing Sunze ID as read-only system metadata
 - [ ] Admin Machines shows a sortable/filterable table with assignment readiness, assignment state filters, latest sale, and current tax states: Missing, No tax, Configured
 - [ ] Admin Machines can save `0%` as intentional no-tax without exposing effective date fields in the normal edit flow, and newly documented rates apply from `2026-01-01`
 - [ ] Admin Machines can record a reporting tax rate change with only `New reporting tax %` and `Applies from`, and the previous active rate closes without overlap

--- a/src/pages/admin/Access.tsx
+++ b/src/pages/admin/Access.tsx
@@ -127,14 +127,11 @@ const mergePeople = (
 const groupMachines = (machines: AdminReportingAccessMachine[]) => {
   const groups = new Map<string, AdminReportingAccessMachine[]>();
   machines.forEach((machine) => {
-    const key = `${machine.accountName}||${machine.locationName}`;
+    const key = machine.accountName;
     groups.set(key, [...(groups.get(key) ?? []), machine]);
   });
 
-  return [...groups.entries()].map(([key, values]) => {
-    const [accountName, locationName] = key.split('||');
-    return { key, accountName, locationName, machines: values };
-  });
+  return [...groups.entries()].map(([key, values]) => ({ key, accountName: key, machines: values }));
 };
 
 const uniqueValues = (items: string[]) => [...new Set(items)].sort((a, b) => a.localeCompare(b));
@@ -645,7 +642,7 @@ function ReportingAccessTab() {
     const search = normalizeSearch(machineSearch);
     if (!search) return matrix.machines;
     return matrix.machines.filter((machine) =>
-      [machine.machineLabel, machine.sunzeMachineId ?? '', machine.accountName, machine.locationName]
+      [machine.machineLabel, machine.sunzeMachineId ?? '', machine.accountName]
         .join(' ')
         .toLowerCase()
         .includes(search)
@@ -873,7 +870,7 @@ function ReportingAccessTab() {
                       id="machine-search"
                       value={machineSearch}
                       onChange={(event) => setMachineSearch(event.target.value)}
-                      placeholder="Filter by label, Sunze ID, account, or location"
+                      placeholder="Filter by label, Sunze ID, or account"
                     />
                   </div>
 
@@ -884,7 +881,7 @@ function ReportingAccessTab() {
                       groupedMachines.map((group) => (
                         <div key={group.key} className="border-b border-border last:border-b-0">
                           <div className="bg-muted/40 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                            {group.accountName} / {group.locationName}
+                            {group.accountName}
                           </div>
                           {group.machines.map((machine) => (
                             <label

--- a/src/pages/admin/Machines.tsx
+++ b/src/pages/admin/Machines.tsx
@@ -59,6 +59,7 @@ type MachineSort = 'status' | 'machine' | 'account' | 'latest_sale';
 
 const setupQueryKey = ['admin-partnership-reporting-setup'];
 const initialReportingTaxStartDate = '2026-01-01';
+const hiddenFallbackLocationName = 'Unmapped Sunze Machines';
 
 const emptySetup: PartnershipReportingSetup = {
   partners: [],
@@ -116,6 +117,8 @@ export default function AdminMachinesPage() {
   const [isMachineDialogOpen, setIsMachineDialogOpen] = useState(false);
 
   const highlightedMachineId = searchParams.get('machineId');
+  const pendingSunzeMachineId = searchParams.get('sunzeMachineId');
+  const pendingSunzeMachineName = searchParams.get('sunzeMachineName');
 
   const {
     data: setup = emptySetup,
@@ -171,7 +174,6 @@ export default function AdminMachinesPage() {
         return [
           row.machine.machine_label,
           row.machine.account_name,
-          row.machine.location_name,
           row.machine.sunze_machine_id ?? '',
           row.activeAssignments.map((assignment) => assignment.partnership_name).join(' '),
         ]
@@ -182,9 +184,7 @@ export default function AdminMachinesPage() {
       .sort((left, right) => {
         if (sort === 'machine') return left.machine.machine_label.localeCompare(right.machine.machine_label);
         if (sort === 'account') {
-          return `${left.machine.account_name} ${left.machine.location_name}`.localeCompare(
-            `${right.machine.account_name} ${right.machine.location_name}`
-          );
+          return left.machine.account_name.localeCompare(right.machine.account_name);
         }
         if (sort === 'latest_sale') {
           return (right.machine.latest_sale_date ?? '').localeCompare(left.machine.latest_sale_date ?? '');
@@ -232,6 +232,11 @@ export default function AdminMachinesPage() {
 
   const openCreateMachine = () => {
     setEditingMachine(null);
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.delete('machineId');
+    nextParams.delete('sunzeMachineId');
+    nextParams.delete('sunzeMachineName');
+    setSearchParams(nextParams, { replace: true });
     setIsMachineDialogOpen(true);
   };
 
@@ -239,6 +244,8 @@ export default function AdminMachinesPage() {
     setEditingMachine(machine);
     const nextParams = new URLSearchParams(searchParams);
     nextParams.set('machineId', machine.id);
+    nextParams.delete('sunzeMachineId');
+    nextParams.delete('sunzeMachineName');
     setSearchParams(nextParams, { replace: true });
     setIsMachineDialogOpen(true);
   };
@@ -248,9 +255,17 @@ export default function AdminMachinesPage() {
     if (!open) {
       const nextParams = new URLSearchParams(searchParams);
       nextParams.delete('machineId');
+      nextParams.delete('sunzeMachineId');
+      nextParams.delete('sunzeMachineName');
       setSearchParams(nextParams, { replace: true });
     }
   };
+
+  useEffect(() => {
+    if (!pendingSunzeMachineId || isMachineDialogOpen) return;
+    setEditingMachine(null);
+    setIsMachineDialogOpen(true);
+  }, [isMachineDialogOpen, pendingSunzeMachineId]);
 
   const openTaxChangeDialog = (machine: PartnershipSetupMachine, taxRate?: ReportingMachineTaxRate) => {
     setTaxChangeForm({
@@ -428,7 +443,7 @@ export default function AdminMachinesPage() {
                     className="pl-9"
                     value={search}
                     onChange={(event) => setSearch(event.target.value)}
-                    placeholder="Machine, account, location, Sunze ID, partnership"
+                    placeholder="Machine, account, Sunze ID, partnership"
                   />
                 </div>
               </div>
@@ -456,7 +471,7 @@ export default function AdminMachinesPage() {
                 >
                   <option value="status">Tax status</option>
                   <option value="machine">Machine</option>
-                  <option value="account">Account/location</option>
+                  <option value="account">Account</option>
                   <option value="latest_sale">Latest sale</option>
                 </select>
               </div>
@@ -488,12 +503,11 @@ export default function AdminMachinesPage() {
               <div className="p-6 text-sm text-muted-foreground">No machines match this filter.</div>
             ) : (
               <div className="overflow-x-auto">
-                <table className="min-w-[1120px] w-full divide-y divide-border text-sm">
+                <table className="min-w-[1040px] w-full divide-y divide-border text-sm">
                   <thead className="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
                     <tr>
                       <th className="px-4 py-3 text-left font-semibold">Machine label / alias</th>
                       <th className="px-4 py-3 text-left font-semibold">Account</th>
-                      <th className="px-4 py-3 text-left font-semibold">Location</th>
                       <th className="px-4 py-3 text-left font-semibold">Type</th>
                       <th className="px-4 py-3 text-left font-semibold">Sunze ID</th>
                       <th className="px-4 py-3 text-left font-semibold">Assignment</th>
@@ -526,7 +540,6 @@ export default function AdminMachinesPage() {
                             )}
                           </td>
                           <td className="px-4 py-3 text-muted-foreground">{machine.account_name}</td>
-                          <td className="px-4 py-3 text-muted-foreground">{machine.location_name}</td>
                           <td className="px-4 py-3 text-muted-foreground">{formatLabel(machine.machine_type)}</td>
                           <td className="px-4 py-3 text-muted-foreground">{machine.sunze_machine_id ?? 'n/a'}</td>
                           <td className="px-4 py-3">
@@ -629,6 +642,8 @@ export default function AdminMachinesPage() {
         onOpenChange={closeMachineDialog}
         machine={editingMachine}
         machines={setup.machines}
+        initialSunzeMachineId={pendingSunzeMachineId}
+        initialSunzeMachineName={pendingSunzeMachineName}
         onSaved={refresh}
       />
       <TaxChangeDialog
@@ -788,12 +803,16 @@ function MachineDialog({
   onOpenChange,
   machine,
   machines,
+  initialSunzeMachineId,
+  initialSunzeMachineName,
   onSaved,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   machine: PartnershipSetupMachine | null;
   machines: PartnershipSetupMachine[];
+  initialSunzeMachineId: string | null;
+  initialSunzeMachineName: string | null;
   onSaved: () => Promise<unknown>;
 }) {
   const [form, setForm] = useState(emptyMachineForm);
@@ -802,7 +821,15 @@ function MachineDialog({
   useEffect(() => {
     if (!open) return;
     if (!machine) {
-      setForm(emptyMachineForm);
+      setForm({
+        ...emptyMachineForm,
+        locationName: hiddenFallbackLocationName,
+        machineLabel:
+          initialSunzeMachineName && initialSunzeMachineName !== initialSunzeMachineId
+            ? initialSunzeMachineName
+            : '',
+        sunzeMachineId: initialSunzeMachineId ?? '',
+      });
       return;
     }
 
@@ -814,36 +841,31 @@ function MachineDialog({
       machineType: machine.machine_type,
       sunzeMachineId: machine.sunze_machine_id ?? '',
     });
-  }, [machine, open]);
+  }, [initialSunzeMachineId, initialSunzeMachineName, machine, open]);
 
   const accountOptions = useMemo(
     () => Array.from(new Set(machines.map((candidate) => candidate.account_name).filter(Boolean))).sort(),
     [machines]
   );
-  const locationOptions = useMemo(
-    () => Array.from(new Set(machines.map((candidate) => candidate.location_name).filter(Boolean))).sort(),
-    [machines]
-  );
 
   const saveMachine = async () => {
-    if (!form.accountName.trim() || !form.locationName.trim() || !form.machineLabel.trim()) {
-      toast.error('Account, location, and machine label are required.');
+    if (!form.accountName.trim() || !form.machineLabel.trim()) {
+      toast.error('Account and machine label are required.');
       return;
     }
 
     const accountName = form.accountName.trim();
-    const locationName = form.locationName.trim();
+    const locationName = form.locationName.trim() || hiddenFallbackLocationName;
     const machineLabel = form.machineLabel.trim();
     const sunzeMachineId = form.sunzeMachineId.trim();
     const duplicateIdentity = machines.find(
       (candidate) =>
         candidate.id !== form.machineId &&
         normalizeComparableText(candidate.account_name) === normalizeComparableText(accountName) &&
-        normalizeComparableText(candidate.location_name) === normalizeComparableText(locationName) &&
         normalizeComparableText(candidate.machine_label) === normalizeComparableText(machineLabel)
     );
     if (duplicateIdentity) {
-      toast.error('A machine with this account, location, and label already exists.');
+      toast.error('A machine with this account and label already exists.');
       return;
     }
 
@@ -885,7 +907,7 @@ function MachineDialog({
         <DialogHeader>
           <DialogTitle>{form.machineId ? 'Edit Machine' : 'New Machine'}</DialogTitle>
           <DialogDescription>
-            Update the reporting label, account/location display, machine type, and Sunze mapping.
+            Update the reporting label, account display, machine type, and Sunze mapping.
           </DialogDescription>
         </DialogHeader>
         <div className="grid gap-4 sm:grid-cols-2">
@@ -900,20 +922,6 @@ function MachineDialog({
             <datalist id="machine-account-options">
               {accountOptions.map((accountName) => (
                 <option key={accountName} value={accountName} />
-              ))}
-            </datalist>
-          </div>
-          <div>
-            <Label htmlFor="machine-location">Location</Label>
-            <Input
-              id="machine-location"
-              list="machine-location-options"
-              value={form.locationName}
-              onChange={(event) => setForm({ ...form, locationName: event.target.value })}
-            />
-            <datalist id="machine-location-options">
-              {locationOptions.map((locationName) => (
-                <option key={locationName} value={locationName} />
               ))}
             </datalist>
           </div>
@@ -944,8 +952,9 @@ function MachineDialog({
             <Label htmlFor="sunze-id">Sunze ID</Label>
             <Input
               id="sunze-id"
-              value={form.sunzeMachineId}
-              onChange={(event) => setForm({ ...form, sunzeMachineId: event.target.value })}
+              value={form.sunzeMachineId || 'Not mapped from Sunze yet'}
+              readOnly
+              aria-readonly="true"
             />
           </div>
         </div>

--- a/src/pages/admin/Partnerships.tsx
+++ b/src/pages/admin/Partnerships.tsx
@@ -1481,7 +1481,6 @@ function MachineAssignmentsSection({
       [
         machine.machine_label,
         machine.account_name,
-        machine.location_name,
         machine.sunze_machine_id ?? '',
       ]
         .join(' ')
@@ -1657,7 +1656,7 @@ function MachineAssignmentsSection({
                 value={machineSearch}
                 onChange={(event) => setMachineSearch(event.target.value)}
                 className="pl-9"
-                placeholder="Machine, account, location, Sunze ID"
+                placeholder="Machine, account, Sunze ID"
               />
             </div>
           </div>
@@ -1709,8 +1708,7 @@ function MachineAssignmentsSection({
                     <span className="min-w-0 flex-1">
                       <span className="block font-medium text-foreground">{machine.machine_label}</span>
                       <span className="mt-1 block text-sm text-muted-foreground">
-                        {machine.account_name} / {machine.location_name} / Sunze:{' '}
-                        {machine.sunze_machine_id ?? 'n/a'}
+                        {machine.account_name} / Sunze: {machine.sunze_machine_id ?? 'n/a'}
                       </span>
                       {otherAssignments.length > 0 && (
                         <span className="mt-2 flex flex-wrap gap-1">

--- a/src/pages/admin/Reporting.tsx
+++ b/src/pages/admin/Reporting.tsx
@@ -562,7 +562,7 @@ function SyncTab({
           <EmptyRow text="No discovered Sunze machines need action." />
         ) : (
           sunzeMachineQueue.map((machine) => {
-            const mappingUrl = `/admin/partnerships?tab=machines&sunzeMachineId=${encodeURIComponent(
+            const mappingUrl = `/admin/machines?sunzeMachineId=${encodeURIComponent(
               machine.sunzeMachineId
             )}&sunzeMachineName=${encodeURIComponent(
               machine.sunzeMachineName ?? machine.sunzeMachineId

--- a/src/pages/portal/Reports.tsx
+++ b/src/pages/portal/Reports.tsx
@@ -286,7 +286,6 @@ const groupRows = <TKey extends string>(
     {
       key: TKey;
       label: string;
-      locationName: string;
       netSalesCents: number;
       grossSalesCents: number;
       refundAmountCents: number;
@@ -301,7 +300,6 @@ const groupRows = <TKey extends string>(
       {
         key,
         label: getLabel(row),
-        locationName: row.locationName,
         netSalesCents: 0,
         grossSalesCents: 0,
         refundAmountCents: 0,
@@ -399,7 +397,6 @@ function OperatorReportingView({ accessContext }: { accessContext: ReportingAcce
   const [dateTo, setDateTo] = useState(defaultRange.dateTo);
   const [grain, setGrain] = useState<ReportGrain>(defaultRange.grain);
   const [machineId, setMachineId] = useState('all');
-  const [locationId, setLocationId] = useState('all');
   const [selectedPayments, setSelectedPayments] = useState<PaymentMethod[]>([]);
   const [isExporting, setIsExporting] = useState(false);
 
@@ -413,19 +410,7 @@ function OperatorReportingView({ accessContext }: { accessContext: ReportingAcce
     staleTime: 1000 * 60,
   });
 
-  const locations = useMemo(() => {
-    const byId = new Map<string, string>();
-    dimensions.forEach((dimension) => byId.set(dimension.locationId, dimension.locationName));
-    return [...byId.entries()].map(([id, name]) => ({ id, name }));
-  }, [dimensions]);
-
-  const machineOptions = useMemo(
-    () =>
-      locationId === 'all'
-        ? dimensions
-        : dimensions.filter((dimension) => dimension.locationId === locationId),
-    [dimensions, locationId]
-  );
+  const machineOptions = useMemo(() => dimensions, [dimensions]);
 
   useEffect(() => {
     if (machineId !== 'all' && !machineOptions.some((machine) => machine.machineId === machineId)) {
@@ -439,10 +424,9 @@ function OperatorReportingView({ accessContext }: { accessContext: ReportingAcce
       dateTo,
       grain,
       machineIds: machineId === 'all' ? [] : [machineId],
-      locationIds: locationId === 'all' ? [] : [locationId],
       paymentMethods: selectedPayments,
     }),
-    [dateFrom, dateTo, grain, locationId, machineId, selectedPayments]
+    [dateFrom, dateTo, grain, machineId, selectedPayments]
   );
 
   const {
@@ -621,25 +605,7 @@ function OperatorReportingView({ accessContext }: { accessContext: ReportingAcce
             </div>
           </div>
 
-          <div className="grid gap-3 lg:grid-cols-[1fr_1fr_1.2fr]">
-            <LabeledControl label="Location">
-              <Select value={locationId} onValueChange={setLocationId}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectGroup>
-                    <SelectItem value="all">All locations</SelectItem>
-                    {locations.map((location) => (
-                      <SelectItem key={location.id} value={location.id}>
-                        {location.name}
-                      </SelectItem>
-                    ))}
-                  </SelectGroup>
-                </SelectContent>
-              </Select>
-            </LabeledControl>
-
+          <div className="grid gap-3 lg:grid-cols-[1fr_1.2fr]">
             <LabeledControl label="Machine">
               <Select value={machineId} onValueChange={setMachineId}>
                 <SelectTrigger>
@@ -778,7 +744,7 @@ function OperatorReportingView({ accessContext }: { accessContext: ReportingAcce
         <CardHeader>
           <CardTitle className="text-xl">Report rows</CardTitle>
           <CardDescription>
-            Source rows grouped by period, machine, location, and payment method.
+            Source rows grouped by period, machine, and payment method.
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -787,7 +753,6 @@ function OperatorReportingView({ accessContext }: { accessContext: ReportingAcce
               <TableRow>
                 <TableHead>Period</TableHead>
                 <TableHead>Machine</TableHead>
-                <TableHead>Location</TableHead>
                 <TableHead>Payment</TableHead>
                 <TableHead className="text-right">Net</TableHead>
                 <TableHead className="text-right">Gross</TableHead>
@@ -796,7 +761,7 @@ function OperatorReportingView({ accessContext }: { accessContext: ReportingAcce
             <TableBody>
               {reportRows.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={6} className="h-24 text-center text-muted-foreground">
+                  <TableCell colSpan={5} className="h-24 text-center text-muted-foreground">
                     No rows found for the selected filters.
                   </TableCell>
                 </TableRow>
@@ -805,7 +770,6 @@ function OperatorReportingView({ accessContext }: { accessContext: ReportingAcce
                   <TableRow key={`${row.periodStart}-${row.machineId}-${row.paymentMethod}`}>
                     <TableCell>{formatDate(row.periodStart)}</TableCell>
                     <TableCell className="font-medium">{row.machineLabel}</TableCell>
-                    <TableCell className="text-muted-foreground">{row.locationName}</TableCell>
                     <TableCell className="text-muted-foreground">
                       {paymentMethodLabels[row.paymentMethod]}
                     </TableCell>
@@ -1147,9 +1111,6 @@ function PartnerDashboardView() {
                               <TableRow key={row.current.reportingMachineId}>
                                 <TableCell>
                                   <div className="font-medium">{row.current.machineLabel}</div>
-                                  <div className="text-xs text-muted-foreground">
-                                    {row.current.locationName ?? 'No location'}
-                                  </div>
                                 </TableCell>
                                 <TableCell className="text-right">
                                   {formatCurrency(row.current.grossSalesCents)}
@@ -1573,9 +1534,6 @@ function PartnerPrintableReport({
                   <tr key={row.current.reportingMachineId} className="border-b border-border/60">
                     <td className="py-2 pr-3">
                       <div className="font-medium text-foreground">{row.current.machineLabel}</div>
-                      <div className="text-xs text-muted-foreground">
-                        {row.current.locationName ?? 'No location'}
-                      </div>
                     </td>
                     <td className="px-3 py-2 text-right">
                       {formatCurrency(row.current.grossSalesCents, true)}
@@ -1675,9 +1633,6 @@ function PartnerMachineMobileCard({
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
           <div className="font-medium text-foreground">{row.current.machineLabel}</div>
-          <div className="text-sm text-muted-foreground">
-            {row.current.locationName ?? 'No location'}
-          </div>
         </div>
         <div className="shrink-0 text-right">
           <div className="font-semibold text-foreground">


### PR DESCRIPTION
## Summary
- Hide location controls/columns from machine admin, reporting access, partnerships machine alignment, and portal reports while preserving backend location data.
- Make Sunze ID read-only in the machine modal, with pending Sunze queue links prefilled through `/admin/machines`.
- Update current status and smoke-test docs to reflect alias-first machine naming and hidden location UI.

## Files changed
- Admin machine setup, reporting sync routing, reporting access grouping, and partnership machine alignment UI.
- Portal reporting filters, report rows, partner dashboard/print/mobile machine displays.
- `Docs/CURRENT_STATUS.md` and `Docs/QA_SMOKE_TEST_CHECKLIST.md`.

## Verification commands + results
- `npm ci` - passed; npm reported 2 moderate vulnerabilities already present.
- `npm run build` - passed; Vite/prerender completed, with existing Browserslist stale-data warning.
- `npm test --if-present` - passed; no test script output.
- `npm run lint --if-present` - passed with 8 existing react-refresh warnings in shared UI/Auth files.
- `git diff --check` - passed; only Windows LF-to-CRLF working-copy warnings.

## How to test
1. From this branch, run `npm ci` then `npm run dev -- --host 127.0.0.1`.
2. Open `http://127.0.0.1:5173/admin/machines` as a super admin. Confirm Location is not visible in the table or machine modal, alias/account/type edits still save, and Sunze ID is displayed read-only.
3. Open `http://127.0.0.1:5173/admin/reporting`. In the pending Sunze machine queue, use Map and confirm it routes to machine setup with the Sunze ID prefilled but not editable.
4. Open `http://127.0.0.1:5173/admin/access`. Confirm reporting access machine grouping/search no longer exposes location labels.
5. Open `http://127.0.0.1:5173/admin/partnerships`. Confirm machine alignment search/details no longer expose location labels.
6. Open `http://127.0.0.1:5173/portal/reports`. Confirm Location filter and Location result column are gone, while machine/date/payment filters still work and report totals remain unchanged.