### PR TITLE
Add Supabase migration version CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
+      - name: Supabase Migration Version Check
+        run: node scripts/check-supabase-migration-versions.mjs
       - name: Build
         run: npm run build
       - name: SEO Regression Checks

--- a/scripts/check-supabase-migration-versions.mjs
+++ b/scripts/check-supabase-migration-versions.mjs
@@ -1,0 +1,60 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const migrationsDir = path.resolve(process.cwd(), 'supabase', 'migrations');
+
+if (!fs.existsSync(migrationsDir)) {
+  console.error(`Supabase migrations directory not found: ${migrationsDir}`);
+  process.exit(1);
+}
+
+const migrationFiles = fs
+  .readdirSync(migrationsDir, { withFileTypes: true })
+  .filter((entry) => entry.isFile() && entry.name.endsWith('.sql'))
+  .map((entry) => entry.name)
+  .sort();
+
+const versions = new Map();
+const invalidNames = [];
+
+for (const fileName of migrationFiles) {
+  const match = fileName.match(/^(\d+)_.*\.sql$/);
+
+  if (!match) {
+    invalidNames.push(fileName);
+    continue;
+  }
+
+  const version = match[1];
+  const filesForVersion = versions.get(version) ?? [];
+  filesForVersion.push(fileName);
+  versions.set(version, filesForVersion);
+}
+
+const duplicateVersions = [...versions.entries()].filter(([, files]) => files.length > 1);
+
+if (invalidNames.length > 0 || duplicateVersions.length > 0) {
+  console.error('Supabase migration version check failed.');
+
+  if (invalidNames.length > 0) {
+    console.error('\nMigration files must start with a numeric version followed by an underscore:');
+    for (const fileName of invalidNames) {
+      console.error(`- ${fileName}`);
+    }
+  }
+
+  if (duplicateVersions.length > 0) {
+    console.error('\nDuplicate migration versions:');
+    for (const [version, files] of duplicateVersions) {
+      console.error(`- ${version}`);
+      for (const fileName of files) {
+        console.error(`  - ${fileName}`);
+      }
+    }
+  }
+
+  process.exit(1);
+}
+
+console.log(`Checked ${migrationFiles.length} Supabase migrations; no duplicate versions found.`);


### PR DESCRIPTION
﻿## Summary
- Adds a CI guard that fails when two Supabase migration files share the same numeric version prefix.
- Wires the guard into the existing CI verify job before build.
- Keeps scope away from active reporting UI, dependency, and draft marketing/WeCom PR files.

## Files changed
- `.github/workflows/ci.yml`: runs the migration-version check after `npm ci`.
- `scripts/check-supabase-migration-versions.mjs`: scans `supabase/migrations/*.sql` for invalid names and duplicate version prefixes.

## Verification commands/results
- `node scripts/check-supabase-migration-versions.mjs` - passed; checked 43 migrations with no duplicate versions.
- `npm ci` - passed; existing 2 moderate audit warnings and existing `glob` deprecation warning remain.
- `npm run build` - passed.
- `npm test --if-present` - passed.
- `npm run lint --if-present` - passed with existing 8 fast-refresh warnings.

## How to test
1. Check out this branch locally.
2. Run `node scripts/check-supabase-migration-versions.mjs`.
3. To confirm the guard behavior manually, temporarily create a local-only duplicate migration filename with the same numeric prefix as an existing migration, rerun the script, and confirm it exits nonzero with the duplicate version listed. Remove the temporary file before committing.

## Coordination notes
- Open PR #228 touches reporting UI and smoke checklist docs; this PR does not touch those files.
- Open PR #194 touches dependency files; this PR does not change dependencies.
- Draft PRs #155 and #142 touch `package.json`, so this PR avoids adding an npm script and calls the Node script directly from CI.
- Production/preview Weekly Preview UAT is still pending because no Supabase/reporting environment variables are present in this shell.
