### PR TITLE
docs: clarify issue hygiene for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,13 @@ PR description includes:
 - Helpful repo plugins/skills: GitHub for issues/PRs/CI, Browser Use or Vercel browser verification for localhost UI checks, Build Web Apps/shadcn/React skills for UI work, Supabase Postgres guidance for migrations/RLS/reporting SQL, Stripe guidance for checkout/billing/webhooks, and Vercel guidance for redirects/domains/deploy config.
 - Use Gmail, Google Drive, or Sheets only when the task explicitly depends on connected business source material. Never move secrets or private operational data into repo files.
 
+### Issue hygiene
+- When you find a meaningful bug, blocker, gap, risk, or follow-up opportunity that is not fixed in the current PR, create or update a GitHub Issue.
+- Search open issues first and update the existing issue when possible instead of duplicating it.
+- Label tracked issues with `P0`, `P1`, `P2`, or `P3`, and add them to the Bloomjoy Hub Priorities Project board.
+- Do not create issues for tiny notes that are fully resolved in the current PR.
+- Mention new or updated issues in the PR description or final status update.
+
 ## Operational safeguards (must follow)
 - Work only in a worktree (never edit `C:\Repos\Bloomjoy_hub` directly).
 - Run the preflight check in `Docs/LOCAL_DEV.md` before making edits.


### PR DESCRIPTION
## Summary
- Adds a lean `Issue hygiene` section to `AGENTS.md`.
- Clarifies that agents should create or update GitHub Issues for meaningful gaps, blockers, bugs, risks, or follow-ups not fixed in the current PR.
- Keeps overhead low by requiring issue search first, P0-P3 labels, project-board tracking, and no issues for tiny notes fully resolved in the PR.

## Files changed
- `AGENTS.md` - adds five issue-hygiene guardrails for agent-discovered follow-up work.

## Verification commands + results
- `npm ci` - passed; npm reported existing lockfile audit warnings.
- `npm run build` - passed; existing Browserslist data-age warning reported.
- `npm test --if-present` - passed.
- `npm run lint --if-present` - passed with 8 existing fast-refresh warnings and 0 errors.

## How to test
- Docs-only guardrail change; no localhost runtime behavior changed.
- Review `AGENTS.md` and confirm the new `Issue hygiene` section is clear, lean, and does not require issues for work already resolved in the current PR.
