### PR TITLE
Close out partner reporting docs and issue state

### DIFF
--- a/Docs/BACKLOG.md
+++ b/Docs/BACKLOG.md
@@ -74,15 +74,13 @@ Guidelines:
    - Add partner-report snapshot/run records for reporting period, rule version, assumptions, generated-by user, status, recipients/download metadata, storage path, and warning state.
    - Generate a polished weekly PDF with executive summary, machine-level appendix, calculation assumptions, amount owed, generated timestamp, and snapshot ID.
    - Keep delivery manual for V1: super-admin reviews, downloads, then sends outside automation until the report is trusted.
+   - Status: weekly/monthly PDF and CSV exports are implemented and production-smoke-tested for current partner agreements; remaining trusted-settlement blocker is refund/complaint adjustment handling in `#236`.
    - Dependency: partnership setup UX and reliable Sunze sales facts.
 
 ## P1 - Reporting UX/CX follow-ups
 21. **Partner dashboard UX/CX and reporting tab design** (`#172`)
-   - Design the reporting tab so users see operator-style reporting for assigned machines by default.
-   - Add a partner dashboard concept for users with partner-dashboard permissions.
-   - Default V1 partner dashboard access to super-admins only until explicit partner-viewer permissions are implemented.
-   - Define dashboard KPIs, period controls, machine rollups, warning states, PDF export/review entry points, and mobile/desktop behavior.
-   - Dependency: corporate partner reporting model and admin partnership setup direction.
+   - Status: delivered for V1 via the reporting tab, super-admin-only Partner Dashboard, weekly/monthly period controls, machine rollups, calculation transparency, exports, and the `#239` machine-rollup label clarification.
+   - Remaining follow-ups are separate issues: explicit Partner Viewer access in `#128`, optional XLSX reconciliation export in `#205`, and operator dashboards in `#171` after partner reporting acceptance.
 
 22. **Operator performance dashboards** (`#171`)
    - Add operator dashboards only after corporate partner reporting reaches acceptance.

--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -53,6 +53,7 @@
 - Bubble Planet QA corrected the workbook's order-level fee mistake: the product source of truth is a `$0.40` stick-level cost deduction, so a paid two-stick order deducts `$0.80` and no-pay rows deduct `$0`.
 - Bubble Planet dashboard data-gap repair completed on `2026-04-26`: the production partnership's three active machine assignments and active payout rule were backdated from `2026-04-13` to `2026-02-23`, matching the first imported fact date in the current 8-week dashboard window. The partner dashboard now has nonzero weekly net-sales bars for `2026-02-23` through `2026-04-19`; the verified 8-week total is `$56,594.47` net sales after tax and configured per-stick fees.
 - Follow-up review found the partner dashboard period-preview RPC counted only the second payout-recipient share as `Amount owed`; migration `202604260017_partner_dashboard_amount_owed_repair.sql` now includes both configured non-Bloomjoy payout-recipient share fields before reporting amount owed.
+- Partner dashboard Machine rollups UX follow-up closed on `2026-04-26` via PR `#239`: Bubble Planet's `Costs $0.00` was expected because the active rule has no separate additional-cost split rule; the `$0.40` per-stick deduction is included in configured deductions before net sales. The UI now says `Tax + deductions`, hides zero-dollar additional costs, and hides the duplicate payout-basis column when payout basis equals net sales. Authenticated desktop/mobile UAT passed on `/portal/reports`.
 - Partnership Weekly Preview now supports reviewed partner-report export: PDF is the primary partner-facing artifact, and CSV is the finance reconciliation companion, both stored through `partner_report_snapshots`.
 - Manual CSV import helpers and sample files are available before production sync is enabled.
 - Sunze browser automation is now implemented as a scheduled GitHub Actions Playwright worker that exports the Orders workbook with a rolling `Last 7 Days` daily preset plus a monthly `Last Month` catch-up, deletes the raw workbook after parsing, and sends normalized rows to the locked `sunze-sales-ingest` Edge Function.
@@ -134,8 +135,7 @@
 ## Next P0 milestones
 - Complete trusted corporate partner settlement before building operator performance dashboards:
   - resolve issue `#236` so Google Sheets complaint/refund adjustments flow into net sales, split base, amount owed, and report snapshots
-  - resolve issue `#225` if partner dashboard machine-rollup cost/split-base review confirms a settlement math or presentation bug
-  - keep issue `#169` open until production UAT evidence confirms the remaining settlement math, refund handling, and partner-ready reporting expectations
+  - keep issue `#169` open until production UAT evidence confirms refund handling and partner-ready settlement expectations across current partner agreements
 - Clear the remaining WeCom production blocker:
   - confirm whether the Bloomjoy Alerts app enforces an IP allowlist or trusted network restriction in WeCom
   - update the WeCom app policy so Supabase Edge Function traffic can send messages successfully


### PR DESCRIPTION
## Summary
- Records the partner dashboard Machine rollups closeout from PR #239 in `Docs/CURRENT_STATUS.md`.
- Updates the reporting backlog to show the V1 partner dashboard/reporting UX is delivered and that #236 is the remaining trusted-settlement blocker.
- Aligns GitHub issue/project state: #225 closed/Done, #236 labeled `uat-required` and `blocked-external`, and #169 commented with the latest remaining blocker.

## Files changed
- `Docs/CURRENT_STATUS.md`: adds the machine-rollup UX closeout and removes #225 from remaining P0 blockers.
- `Docs/BACKLOG.md`: marks partner reporting exports/UX as delivered for V1 and points follow-ups to #128, #205, #171, and #236.

## Verification commands + results
- `npm ci` - PASS; existing 2 moderate npm audit vulnerabilities reported.
- `npm run build` - PASS; existing stale Browserslist warning reported.
- `npm test --if-present` - PASS; no test script output.
- `npm run lint --if-present` - PASS with existing 8 `react-refresh/only-export-components` warnings in shared UI/context files.
- `git diff --check` - PASS.

## How to test
1. Review `Docs/CURRENT_STATUS.md` and confirm the partner reporting status matches the completed PR #239/UAT outcome.
2. Review `Docs/BACKLOG.md` and confirm the remaining follow-up order is accurate: #236 before full settlement trust, then #128/#205/#171 as later reporting UX enhancements.
3. Confirm GitHub issue #225 is closed and Done on the project board, and #236 is still open with `P0`, `risky-db-change`, `uat-required`, and `blocked-external` labels.