### PR TITLE
[codex] Fix admin asset fallback routing

### DIFF
--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -6,6 +6,11 @@
 - First priority is to **stabilize the POC** and align it to the MVP routing + docs workflow.
 - Write updates in plain language so non-technical readers can follow.
 
+## Production admin asset loading guard (2026-04-27)
+- P0 issue `#246` was traced to stale lazy-loaded chunk URLs under `/assets/*` being served through the SPA fallback as `200 text/html` after the referenced hashed files were no longer present in the active Vercel deployment.
+- Current production `/admin/access` HTML references fresh chunk hashes, and those current chunks return `application/javascript`; the repo hardening adds a Vercel guard so missing `/assets/*` files return `404` instead of `index.html`.
+- The SEO/config regression check now verifies the missing-asset guard stays between filesystem serving and the catch-all SPA fallback.
+
 ## Machine-buyer SEO static generation (2026-04-17)
 - Public marketing/legal routes now build as static HTML with rendered body content, production asset URLs, route-specific metadata, canonical tags, and JSON-LD before client JavaScript runs.
 - Route SEO data is centralized in `src/lib/seoRoutes.ts` and shared by client route metadata plus the prerender/SEO regression scripts.

--- a/Docs/PRODUCTION_RUNBOOK.md
+++ b/Docs/PRODUCTION_RUNBOOK.md
@@ -168,6 +168,7 @@ Run immediately after deploy:
 - [ ] Login works, password recovery works, and protected routes redirect correctly on `app.bloomjoyusa.com`.
 - [ ] Auth launch sign-off checklist is completed with evidence (`Docs/AUTH_PRODUCTION_SIGNOFF.md`).
 - [ ] `Docs/QA_SMOKE_TEST_CHECKLIST.md` core payment/auth checks pass.
+- [ ] Admin asset MIME smoke passes: current `/admin/access` JS chunks return `application/javascript`, and a stale or bogus `/assets/*.js` URL returns `404` instead of `index.html`.
 - [ ] Anonymous/non-member sugar checkout charges `$10/kg` and creates `orders` record in Supabase.
 - [ ] Bloomjoy Plus sugar checkout charges `$8/kg` and creates `orders` record in Supabase.
 - [ ] Sugar checkout test order stores customer contact, billing/shipping address, pricing tier, receipt URL, and color breakdown in `orders`.

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -17,6 +17,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] View page source on a direct-loaded private route (for example `/portal`) and confirm robots is `noindex`
 - [ ] `https://www.bloomjoyusa.com/login`, `/reset-password`, `/portal*`, and `/admin*` redirect to `https://app.bloomjoyusa.com/...`
 - [ ] `https://app.bloomjoyusa.com/` plus public marketing/storefront paths redirect back to `https://www.bloomjoyusa.com/...`
+- [ ] Production/preview asset check: JS files referenced by `/admin/access` return `application/javascript`, and a bogus `/assets/__missing-admin-chunk__.js` returns a non-HTML `404` instead of the SPA fallback page
 - [ ] `robots.txt` is reachable and includes a sitemap reference
 - [ ] `sitemap.xml` is reachable, lists core public routes, includes `lastmod`, and includes image sitemap entries for key machine/supplies/about URLs
 - [ ] Apex host (`https://bloomjoyusa.com`) redirects to canonical host (`https://www.bloomjoyusa.com/`) with permanent redirect behavior

--- a/scripts/seo-regression-check.mjs
+++ b/scripts/seo-regression-check.mjs
@@ -409,6 +409,26 @@ const hasStaticPrerenderRewriteRules = (routes) => {
   );
 };
 
+const hasMissingAssetFallbackGuard = (routes) => {
+  const filesystemIndex = routes.findIndex((route) => route?.handle === "filesystem");
+  const assetGuardIndex = routes.findIndex(
+    (route) =>
+      route?.src === "/assets/(.*)" &&
+      route?.status === 404 &&
+      route?.headers?.["Cache-Control"] === "no-store" &&
+      route?.headers?.["Content-Type"] === "text/plain; charset=utf-8"
+  );
+  const spaFallbackIndex = routes.findIndex(
+    (route) => route?.src === "/(.*)" && route?.dest === "/index.html"
+  );
+
+  return (
+    filesystemIndex >= 0 &&
+    assetGuardIndex > filesystemIndex &&
+    spaFallbackIndex > assetGuardIndex
+  );
+};
+
 const validateVercelConfig = async () => {
   const raw = await readFile(VERCEL_CONFIG_PATH, "utf8");
   const parsed = JSON.parse(raw);
@@ -432,6 +452,12 @@ const validateVercelConfig = async () => {
 
   if (!hasStaticPrerenderRewriteRules(routes)) {
     throw new Error("vercel.json is missing static prerender rewrite rules before SPA fallback");
+  }
+
+  if (!hasMissingAssetFallbackGuard(routes)) {
+    throw new Error(
+      "vercel.json must return a 404 for missing /assets/* files before the SPA fallback"
+    );
   }
 };
 

--- a/vercel.json
+++ b/vercel.json
@@ -105,6 +105,14 @@
       "handle": "filesystem"
     },
     {
+      "src": "/assets/(.*)",
+      "status": 404,
+      "headers": {
+        "Cache-Control": "no-store",
+        "Content-Type": "text/plain; charset=utf-8"
+      }
+    },
+    {
       "src": "/(.*)",
       "dest": "/index.html"
     }


### PR DESCRIPTION
Fixes #246

## Summary
- Add a Vercel route guard so missing `/assets/*` files return `404` with a non-HTML content type instead of falling through to `index.html`.
- Add an SEO/config regression assertion that the missing-asset guard stays after filesystem serving and before the SPA fallback.
- Document the production root cause and add admin asset MIME checks to the smoke checklist/runbook.

## Root cause
Production currently serves valid, current admin chunks as JavaScript, but stale hashed chunk URLs from an older deployment are no longer present in the active Vercel artifact. Because the catch-all SPA fallback was the next matching route after filesystem lookup, those missing `/assets/*.js` requests returned `200 text/html` with the marketing `index.html` body. Browsers then rejected the dynamic imports with strict module MIME errors.

This points to stale deployment/browser asset references plus an overly broad fallback for missing static assets, not an auth/permissions bug and not a MIME problem on current JavaScript files.

## Files changed
- `vercel.json`: added the missing `/assets/*` 404 guard before the SPA fallback.
- `scripts/seo-regression-check.mjs`: added regression coverage for the route-order guard.
- `Docs/CURRENT_STATUS.md`, `Docs/QA_SMOKE_TEST_CHECKLIST.md`, `Docs/PRODUCTION_RUNBOOK.md`: documented the incident class and production/preview smoke checks.

## Verification commands + results
After rebasing onto latest `origin/main` (`25241f0`):
- `npm ci` - pass; npm reported the existing 2 moderate audit findings.
- `npm run build` - pass; Vite build and prerender completed.
- `npm test --if-present` - pass; no test script is present.
- `npm run lint --if-present` - pass with the existing 8 fast-refresh warnings in generated/shared UI files.
- `npm run seo:check` - pass; 13 public routes and 19 private routes validated, including the new Vercel missing-asset guard.
- Targeted route QA - pass; built `/admin`, `/admin/access`, `/admin/reporting`, and `/admin/partnerships` resolve to `/admin.html`; built `Access-C9OsBSHp.js` is served by filesystem; missing `/assets/__missing-admin-chunk__.js` resolves to `404 text/plain; charset=utf-8` before the SPA fallback.
- GitHub PR checks - pass: `verify`, `Vercel`, and `Vercel Preview Comments`.

## Production validation notes
Observed before this PR:
- `https://app.bloomjoyusa.com/admin/access` returns `200 text/html` and references current assets: `framework-B0KYY4xN.js`, `index-BeHCoGW_.js`, `radix-BZKA49EU.js`, `react-query-HwQf67cs.js`, `supabase-DEvIEdQL.js`, `icons-HESiycCb.js`, and `index-CyIWWGa9.css`.
- Current admin lazy chunks referenced by the production entry return JavaScript, for example `Access-CkJ6Y1sw.js`, `tabs-ClN3-Yve.js`, `textarea-BK1FGks4.js`, `checkbox-CtRcNvmF.js`, `Reporting-BlLzFJHW.js`, and `Partnerships-C1XrqOha.js` all return `200 application/javascript`.
- Reported stale chunks (`Access-DWAWBs5U.js`, `tabs-DptTgNBn.js`, `textarea-DkrcrGRJ.js`, `checkbox-BVKxVFgU.js`) currently return `200 text/html` with the homepage body, confirming the fallback issue.
- Core admin direct loads (`/admin`, `/admin/access`, `/admin/reporting`, `/admin/partnerships`) return the same current app shell HTML in production; authenticated super-admin UI verification still needs a production login session after deployment.
- Vercel preview is protected by Vercel Authentication, so unauthenticated HTTP preview checks return the Vercel 401 page; the local build and route-order QA cover the repo-side routing behavior.

## How to test
Local/build check:
1. `npm ci`
2. `npm run build`
3. `npm run seo:check`
4. `npm test --if-present`
5. `npm run lint --if-present`

Preview or production HTTP check after Vercel deploy:
1. Open the Vercel preview or production app host.
2. Visit `/admin`, `/admin/access`, `/admin/reporting`, and `/admin/partnerships` in an authenticated super-admin session.
3. Hard refresh or use incognito on `/admin/access` and confirm there are no module MIME errors.
4. Fetch a current `/assets/*.js` URL referenced by `/admin/access` and confirm `Content-Type: application/javascript`.
5. Fetch a bogus stale chunk such as `/assets/__missing-admin-chunk__.js` and confirm it returns `404` with a non-HTML content type instead of `200 text/html`/`index.html`.

## Overlap notes
During this task, PRs #245 and #235 merged into `main`, and `main` later advanced to `25241f0`; this branch was rebased and verification was rerun after syncing. Current remaining open overlap found is docs-only with #155 and #142 on `Docs/CURRENT_STATUS.md`, `Docs/QA_SMOKE_TEST_CHECKLIST.md`, or `Docs/PRODUCTION_RUNBOOK.md`. No currently open PR was found touching `vercel.json` or `scripts/seo-regression-check.mjs`.