### PR TITLE
Support current refund export headers

### DIFF
--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -69,7 +69,7 @@
 - Follow-up `#174` should simplify machine mapping into a focused admin flow from `/admin/reporting`: admins should only need to confirm the canonical machine name, Sunze ID, machine type, and user access, with site/location grouping optional and able to contain multiple machines.
 - `Docs/SUNZE_SALES_DISCOVERY.md` records the validated Sunze routes, export headers, payment/status mappings, and remaining open questions without storing credentials or raw order data.
 - Refund adjustment imports now use a safe review layer: rows are staged with source-row audit fields, deterministic machine-alias matching, match confidence/status, and applied adjustment links before they can affect partner settlement. Approved uniquely matched refunds reduce partner net sales, split base, and amount owed while gross sales remains the imported sales basis.
-- Google Sheets complaints/refunds ingestion still needs source clarification before live API fetching is enabled. Connector read tools were not exposed in the agent session for issue `#236`, so the branch uses sanitized fixtures and requires a sanitized CSV/header export or service-account sheet contract confirmation before production ingestion reads the live sheet.
+- Google Sheets complaints/refunds ingestion still needs service-account access before live API fetching is enabled. A local XLSX export confirmed the current customer service sheet contract: `Location of Purchase`, `Decision Date`, `Date and Time of Incident`, `Refund Amount`, `Status`, `Decision`, and `Request ID`. The importer handles those headers with sanitized fixtures; production live reads still wait on the service-account path.
 - Account/entitlement follow-up is tracked in issue `#150`; stale PR `#143` was closed instead of carrying forward older partner/operator schema work.
 
 ## Partner reporting PM roadmap (2026-04-25)
@@ -140,7 +140,7 @@
 
 ## Next P0 milestones
 - Complete trusted corporate partner settlement before building operator performance dashboards:
-  - resolve issue `#244` so the live Google Sheet contract/service-account ingestion path is confirmed for production refund imports
+  - resolve issue `#244` so the live Google Sheet service-account ingestion path is confirmed for production refund imports
   - keep issue `#169` open until production UAT evidence confirms reviewed refund handling and partner-ready settlement expectations across current partner agreements
 - Clear the remaining WeCom production blocker:
   - confirm whether the Bloomjoy Alerts app enforces an IP allowlist or trusted network restriction in WeCom

--- a/Docs/LOCAL_DEV.md
+++ b/Docs/LOCAL_DEV.md
@@ -79,8 +79,8 @@ Use these after the sales reporting migration has been applied.
 3) Import or dry-run refund/complaint adjustments from a sanitized CSV/export:
    - `npm run reporting:import-refunds -- --file scripts/sample-refund-adjustments.csv --dry-run`
    - `npm run reporting:import-refunds -- --file path/to/refunds.csv --source-reference <refund-export-id>`
-   - Required/referrable columns are `location` or `source_location`, `refund_date` or `processed_date`, `refund_amount_usd` or `refund_amount_cents`, and `status`. Optional audit columns include `order_date`, `reason`, `source_row_reference`, and `complaint_count`.
-   - Only approved/completed/refunded-style statuses with one conservative machine match auto-apply. Ambiguous, unmatched, duplicate, invalid, missing-status, or low-confidence rows stay in the admin review ledger and do not change partner settlement.
+   - Required/referrable columns are `location` / `Location of Purchase`, `refund_date` / `Decision Date`, `refund_amount_usd` / `Refund Amount`, and `status` / `Status`. Optional audit columns include `order_date` / `Date and Time of Incident`, `reason` / `Incident Description`, `source_row_reference` / `Request ID`, `decision` / `Refund Decision`, and `complaint_count`.
+   - Only approved/completed/refunded-style statuses with one conservative machine match auto-apply. For the current customer service export, `Status=Closed` must pair with an approve-style `Decision`; `Open`, `Deny`, ambiguous, unmatched, duplicate, invalid, missing-status, or low-confidence rows stay in the admin review ledger and do not change partner settlement.
 4) Validate sanitized reporting parser/matching fixtures:
    - `npm run reporting:validate-sunze-parser`
    - `npm run reporting:validate-refund-adjustments`

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -180,7 +180,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Portal Reports > Partner Dashboard shows gross sales, refund impact, net sales, split base, and amount owed as separate values when applied refund adjustments exist
 - [ ] `/portal/reports` export creates a private signed PDF link that matches the selected filters
 - [ ] `npm run reporting:validate-sunze-parser` passes with the sanitized Sunze `.xlsx` fixture
-- [ ] `npm run reporting:validate-refund-adjustments` passes with sanitized exact-match, fuzzy-alias, ambiguous, unmatched, duplicate, and partner-settlement fixtures
+- [ ] `npm run reporting:validate-refund-adjustments` passes with sanitized exact-match, fuzzy-alias, ambiguous, unmatched, duplicate, current customer-service export header, and partner-settlement fixtures
 - [ ] `npm run reporting:sunze-sync -- --dry-run` downloads the Sunze Orders export, reconciles parsed row count/revenue against the Sunze UI, checks top-level machine discovery, deletes the raw workbook, and validates Supabase ingest/machine mappings without writing sales facts when ingest env vars are present
 - [ ] `npm run reporting:sunze-health -- --event freshness_check --stale-hours 30` reports the latest completed Sunze import or sends a stale-data ops alert
 

--- a/scripts/import-refund-adjustments-csv.mjs
+++ b/scripts/import-refund-adjustments-csv.mjs
@@ -212,7 +212,7 @@ try {
       adjustment_type: input.adjustmentType,
       complaint_count: input.complaintCount,
       reason: input.reason || null,
-      source_status: input.sourceStatus || null,
+      source_status: [input.sourceStatus, input.sourceDecision].filter(Boolean).join(' / ') || null,
       raw_payload: row,
       match_status: canApply ? 'matched' : match.matchStatus,
       match_confidence: match.matchConfidence,

--- a/scripts/refunds/refund-adjustment-utils.mjs
+++ b/scripts/refunds/refund-adjustment-utils.mjs
@@ -16,6 +16,13 @@ export const AUTO_APPLY_STATUSES = new Set([
   'settled',
 ]);
 
+export const AUTO_APPLY_DECISIONS = new Set([
+  'approve',
+  'approved',
+  'refund approved',
+  'refund approve',
+]);
+
 const normalizeHeader = (value) =>
   String(value ?? '')
     .normalize('NFKD')
@@ -153,6 +160,7 @@ export const normalizeAdjustmentType = (value) => {
 export const extractRefundInput = (row, fallbackRowReference) => {
   const sourceLocation = pickText(row, [
     'location',
+    'location_of_purchase',
     'source_location',
     'machine_location',
     'refund_location',
@@ -162,15 +170,31 @@ export const extractRefundInput = (row, fallbackRowReference) => {
     'machine',
   ]);
   const refundDate = normalizeDate(
-    pickText(row, ['refund_date', 'processed_date', 'adjustment_date', 'date'])
+    pickText(row, ['refund_date', 'decision_date', 'processed_date', 'adjustment_date', 'date'])
   );
   const originalOrderDate = normalizeDate(
-    pickText(row, ['original_order_date', 'order_date', 'sale_date', 'transaction_date'])
+    pickText(row, [
+      'original_order_date',
+      'date_and_time_of_incident',
+      'incident_date',
+      'order_date',
+      'sale_date',
+      'transaction_date',
+    ])
   );
   const sourceStatus = pickText(row, ['status', 'refund_status', 'source_status']);
+  const sourceDecision = pickText(row, ['decision', 'refund_decision']);
   const normalizedSourceStatus = normalizeStatus(sourceStatus);
+  const normalizedSourceDecision = normalizeStatus(sourceDecision);
   const sourceRowReference =
-    pickText(row, ['source_row_reference', 'row_reference', 'row_id', 'response_id', 'timestamp']) ||
+    pickText(row, [
+      'source_row_reference',
+      'request_id',
+      'row_reference',
+      'row_id',
+      'response_id',
+      'timestamp',
+    ]) ||
     fallbackRowReference;
 
   return {
@@ -180,9 +204,19 @@ export const extractRefundInput = (row, fallbackRowReference) => {
     refundDate,
     originalOrderDate,
     amountCents: parseCents(row),
-    reason: pickText(row, ['reason', 'notes', 'complaint_reason', 'refund_reason']),
+    reason: pickText(row, [
+      'reason',
+      'incident_description',
+      'mgr_commentary',
+      'commentary',
+      'notes',
+      'complaint_reason',
+      'refund_reason',
+    ]),
     sourceStatus,
     normalizedSourceStatus,
+    sourceDecision,
+    normalizedSourceDecision,
     adjustmentType: normalizeAdjustmentType(row.adjustment_type || row.type || row.reason),
     complaintCount: Math.max(0, Math.round(Number(row.complaint_count || row.complaints || 0))),
   };
@@ -198,6 +232,7 @@ export const makeSourceRowHash = (input) =>
         amountCents: input.amountCents,
         reason: normalizeMatchText(input.reason),
         sourceStatus: input.normalizedSourceStatus,
+        sourceDecision: input.normalizedSourceDecision,
         adjustmentType: input.adjustmentType,
       })
     )
@@ -262,6 +297,19 @@ export const matchRefundToMachine = (input, machineProfiles) => {
       matchReason: input.normalizedSourceStatus
         ? 'source_status_requires_review'
         : 'missing_source_status',
+      candidateMachineIds: [],
+      matchedMachine: null,
+    };
+  }
+
+  if (
+    input.normalizedSourceDecision &&
+    !AUTO_APPLY_DECISIONS.has(input.normalizedSourceDecision)
+  ) {
+    return {
+      matchStatus: 'needs_review',
+      matchConfidence: 0,
+      matchReason: 'source_decision_requires_review',
       candidateMachineIds: [],
       matchedMachine: null,
     };

--- a/scripts/validate-refund-adjustments.mjs
+++ b/scripts/validate-refund-adjustments.mjs
@@ -111,6 +111,47 @@ const statusReview = matchRow({
 assert.equal(statusReview.matchStatus, 'needs_review');
 assert.equal(statusReview.matchReason, 'missing_source_status');
 
+const currentFormContractInput = extractRefundInput(
+  {
+    location_of_purchase: 'North Lobby',
+    decision_date: '2026-04-11',
+    date_and_time_of_incident: '2026-04-10 10:30 AM',
+    refund_amount: '7.25',
+    status: 'Closed',
+    decision: 'Approve',
+    request_id: 'SANITIZED-REQ-1',
+    incident_description: 'Sanitized fixture reason',
+  },
+  'current-form-contract-fixture'
+);
+assert.equal(currentFormContractInput.sourceRowReference, 'SANITIZED-REQ-1');
+assert.equal(currentFormContractInput.refundDate, '2026-04-11');
+assert.equal(currentFormContractInput.originalOrderDate, '2026-04-10');
+assert.equal(currentFormContractInput.amountCents, 725);
+const currentFormContractMatch = matchRefundToMachine(currentFormContractInput, profiles);
+assert.equal(currentFormContractMatch.matchStatus, 'matched');
+assert.equal(currentFormContractMatch.matchedMachine?.id, machines[0].id);
+
+const openFormContractMatch = matchRow({
+  location_of_purchase: 'North Lobby',
+  decision_date: '2026-04-11',
+  refund_amount: '7.25',
+  status: 'Open',
+  decision: 'Approve',
+});
+assert.equal(openFormContractMatch.matchStatus, 'needs_review');
+assert.equal(openFormContractMatch.matchReason, 'source_status_requires_review');
+
+const deniedFormContractMatch = matchRow({
+  location_of_purchase: 'North Lobby',
+  decision_date: '2026-04-11',
+  refund_amount: '7.25',
+  status: 'Closed',
+  decision: 'Deny',
+});
+assert.equal(deniedFormContractMatch.matchStatus, 'needs_review');
+assert.equal(deniedFormContractMatch.matchReason, 'source_decision_requires_review');
+
 const duplicateInput = extractRefundInput(
   {
     location: 'North Lobby',
@@ -175,6 +216,9 @@ console.log(
       fuzzyAliasMatch: fuzzyMatch.matchStatus,
       ambiguousMatch: ambiguousMatch.matchStatus,
       unmatchedRefund: unmatched.matchStatus,
+      currentFormContract: currentFormContractMatch.matchStatus,
+      openStatusReviewOnly: openFormContractMatch.matchStatus,
+      deniedDecisionReviewOnly: deniedFormContractMatch.matchStatus,
       duplicateHashDetected: true,
       refundReducesPartnerSettlement: true,
     },

--- a/supabase/functions/refund-adjustment-sync/index.ts
+++ b/supabase/functions/refund-adjustment-sync/index.ts
@@ -28,6 +28,8 @@ type RefundInput = {
   reason: string;
   sourceStatus: string;
   normalizedSourceStatus: string;
+  sourceDecision: string;
+  normalizedSourceDecision: string;
   adjustmentType: "refund" | "complaint_refund" | "manual_adjustment";
   complaintCount: number;
 };
@@ -53,6 +55,13 @@ const autoApplyStatuses = new Set([
   "refunded",
   "resolved",
   "settled",
+]);
+
+const autoApplyDecisions = new Set([
+  "approve",
+  "approved",
+  "refund approved",
+  "refund approve",
 ]);
 
 const jsonResponse = (body: Record<string, unknown>, status = 200) =>
@@ -141,6 +150,7 @@ const sha256Hex = async (value: string) => {
 const extractRefundInput = (row: RefundAdjustmentRow, fallbackRowReference: string): RefundInput => {
   const sourceLocation = pickText(row, [
     "location",
+    "location_of_purchase",
     "source_location",
     "machine_location",
     "refund_location",
@@ -150,9 +160,11 @@ const extractRefundInput = (row: RefundAdjustmentRow, fallbackRowReference: stri
     "machine",
   ]);
   const sourceStatus = pickText(row, ["status", "refund_status", "source_status"]);
+  const sourceDecision = pickText(row, ["decision", "refund_decision"]);
   return {
     sourceRowReference: pickText(row, [
       "source_row_reference",
+      "request_id",
       "row_reference",
       "row_id",
       "response_id",
@@ -160,17 +172,35 @@ const extractRefundInput = (row: RefundAdjustmentRow, fallbackRowReference: stri
     ]) || fallbackRowReference,
     sourceLocation,
     normalizedLocation: normalizeMatchText(sourceLocation),
-    refundDate: normalizeDate(pickText(row, ["refund_date", "processed_date", "adjustment_date", "date"])),
+    refundDate: normalizeDate(pickText(row, [
+      "refund_date",
+      "decision_date",
+      "processed_date",
+      "adjustment_date",
+      "date",
+    ])),
     originalOrderDate: normalizeDate(pickText(row, [
       "original_order_date",
+      "date_and_time_of_incident",
+      "incident_date",
       "order_date",
       "sale_date",
       "transaction_date",
     ])),
     amountCents: parseCents(row),
-    reason: pickText(row, ["reason", "notes", "complaint_reason", "refund_reason"]),
+    reason: pickText(row, [
+      "reason",
+      "incident_description",
+      "mgr_commentary",
+      "commentary",
+      "notes",
+      "complaint_reason",
+      "refund_reason",
+    ]),
     sourceStatus,
     normalizedSourceStatus: normalizeStatus(sourceStatus),
+    sourceDecision,
+    normalizedSourceDecision: normalizeStatus(sourceDecision),
     adjustmentType: normalizeAdjustmentType(row.adjustment_type ?? row.type ?? row.reason),
     complaintCount: parseCount(row.complaint_count ?? row.complaints),
   };
@@ -184,6 +214,7 @@ const sourceRowHash = async (input: RefundInput) =>
     amountCents: input.amountCents,
     reason: normalizeMatchText(input.reason),
     sourceStatus: input.normalizedSourceStatus,
+    sourceDecision: input.normalizedSourceDecision,
     adjustmentType: input.adjustmentType,
   }));
 
@@ -318,6 +349,16 @@ const matchRefund = (input: RefundInput, machines: MachineProfile[]) => {
     };
   }
 
+  if (input.normalizedSourceDecision && !autoApplyDecisions.has(input.normalizedSourceDecision)) {
+    return {
+      status: "needs_review",
+      confidence: 0,
+      reason: "source_decision_requires_review",
+      candidateMachineIds: [] as string[],
+      matchedMachine: null as MachineProfile | null,
+    };
+  }
+
   const exactMatches = machines.filter((machine) =>
     machine.labels.some((label) => label.normalized === input.normalizedLocation)
   );
@@ -444,7 +485,7 @@ const importRows = async (
           adjustment_type: input.adjustmentType,
           complaint_count: input.complaintCount,
           reason: input.reason || null,
-          source_status: input.sourceStatus || null,
+          source_status: [input.sourceStatus, input.sourceDecision].filter(Boolean).join(" / ") || null,
           raw_payload: row,
           match_status: canApply ? "matched" : match.status,
           match_confidence: match.confidence,


### PR DESCRIPTION
## Summary
- Confirms the current customer service XLSX export header contract without committing private row data.
- Adds aliases for `Location of Purchase`, `Decision Date`, `Date and Time of Incident`, `Request ID`, and incident/commentary reason fields.
- Requires approve-style `Decision` values when that column is present, so `Open` or `Deny` rows remain review-only and do not affect settlement.

## Files changed
- Refund import helpers and `refund-adjustment-sync` header/status/decision mapping.
- Sanitized refund validation fixtures for the current export header shape.
- Docs and smoke checklist for the confirmed export contract and remaining service-account blocker.

## Verification commands + results
- `npm ci` - passed; npm reported existing 2 moderate vulnerabilities.
- `node scripts/check-supabase-migration-versions.mjs` - passed, 45 migrations checked.
- `npm run reporting:validate-refund-adjustments` - passed, including current customer-service export header fixture, `Open` review-only, and `Deny` review-only cases.
- `deno check supabase/functions/refund-adjustment-sync/index.ts` - passed.
- `npm run build` - passed.
- `npm run lint --if-present` - passed with existing fast-refresh warnings only.
- `npm test --if-present` - passed/no test script present.
- `npm run reporting:validate-sunze-parser` - passed after `npm ci` completed.

## How to test
1. Run `npm run reporting:validate-refund-adjustments` and confirm the `currentFormContract`, `openStatusReviewOnly`, and `deniedDecisionReviewOnly` fixture results pass.
2. Dry-run a sanitized refund export that uses the current customer service headers: `Location of Purchase`, `Decision Date`, `Date and Time of Incident`, `Refund Amount`, `Status`, `Decision`, and `Request ID`.
3. Confirm rows with `Status=Closed` and approve-style `Decision` can proceed only when machine matching is unique.
4. Confirm `Status=Open`, `Decision=Deny`, unmatched, ambiguous, duplicate, or invalid rows stay in review and do not apply adjustments.

## Data privacy
- The local XLSX export was used only to inspect workbook structure, headers, and aggregate status/decision counts.
- No customer names, emails, payment identifiers, incident descriptions, row data, or raw private sheet data were committed, pasted, or added to this PR.
- Live Google Sheet API ingestion still remains blocked on service-account access tracked by #244.