### PR TITLE
Add live refund sheet ingestion

### DIFF
--- a/.github/workflows/refund-adjustment-sync.yml
+++ b/.github/workflows/refund-adjustment-sync.yml
@@ -1,0 +1,107 @@
+name: Refund Adjustment Sync
+
+on:
+  schedule:
+    # Daily private-source sync. Avoid the top of the hour because scheduled Actions can be delayed or dropped under load.
+    - cron: '17 15 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Fetch and validate rows without writing review or adjustment records'
+        required: false
+        default: 'false'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: refund-adjustment-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      REFUND_ADJUSTMENT_SYNC_URL: ${{ secrets.REFUND_ADJUSTMENT_SYNC_URL }}
+      REFUND_ADJUSTMENT_SYNC_TOKEN: ${{ secrets.REFUND_ADJUSTMENT_SYNC_TOKEN }}
+      DRY_RUN: ${{ inputs.dry_run || 'false' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate refund adjustment fixtures
+        run: npm run reporting:validate-refund-adjustments
+
+      - name: Sync refund adjustments
+        shell: bash
+        run: |
+          if [[ -z "$REFUND_ADJUSTMENT_SYNC_URL" || -z "$REFUND_ADJUSTMENT_SYNC_TOKEN" ]]; then
+            echo "Missing REFUND_ADJUSTMENT_SYNC_URL or REFUND_ADJUSTMENT_SYNC_TOKEN."
+            exit 1
+          fi
+
+          payload='{"dryRun":false}'
+          if [[ "$DRY_RUN" == "true" ]]; then
+            payload='{"dryRun":true}'
+          fi
+
+          response_file="$(mktemp)"
+          status_code="$(
+            curl -sS \
+              -o "$response_file" \
+              -w "%{http_code}" \
+              -X POST "$REFUND_ADJUSTMENT_SYNC_URL" \
+              -H "Authorization: Bearer $REFUND_ADJUSTMENT_SYNC_TOKEN" \
+              -H "Content-Type: application/json" \
+              --data "$payload"
+          )"
+
+          node --input-type=module - "$response_file" "$status_code" <<'NODE'
+          import { readFileSync } from 'node:fs';
+
+          const [responseFile, statusCodeText] = process.argv.slice(2);
+          const statusCode = Number(statusCodeText);
+          const raw = readFileSync(responseFile, 'utf8');
+          let body = {};
+          try {
+            body = raw ? JSON.parse(raw) : {};
+          } catch {
+            body = { error: 'Refund sync returned a non-JSON response.' };
+          }
+
+          const summary = {
+            httpStatus: statusCode,
+            status: body.status ?? null,
+            dryRun: body.dryRun ?? null,
+            reviewSource: body.reviewSource ?? null,
+            runId: body.runId ?? null,
+            rowsSeen: body.rowsSeen ?? 0,
+            rowsStaged: body.rowsStaged ?? 0,
+            rowsApplied: body.rowsApplied ?? 0,
+            rowsReview: body.rowsReview ?? 0,
+            rowsDuplicate: body.rowsDuplicate ?? 0,
+            rowsInvalid: body.rowsInvalid ?? 0,
+            rowsAmbiguous: body.rowsAmbiguous ?? 0,
+            rowsUnmatched: body.rowsUnmatched ?? 0,
+            rowsUnapplied: body.rowsUnapplied ?? 0,
+          };
+
+          console.log(JSON.stringify(summary, null, 2));
+
+          if (statusCode >= 400 || body.error || body.status === 'failed') {
+            console.error(body.error || 'Refund adjustment sync failed.');
+            process.exit(1);
+          }
+          NODE

--- a/.github/workflows/refund-adjustment-sync.yml
+++ b/.github/workflows/refund-adjustment-sync.yml
@@ -48,6 +48,10 @@ jobs:
         shell: bash
         run: |
           if [[ -z "$REFUND_ADJUSTMENT_SYNC_URL" || -z "$REFUND_ADJUSTMENT_SYNC_TOKEN" ]]; then
+            if [[ "$GITHUB_EVENT_NAME" == "schedule" ]]; then
+              echo "Skipping scheduled refund sync because REFUND_ADJUSTMENT_SYNC_URL or REFUND_ADJUSTMENT_SYNC_TOKEN is not configured."
+              exit 0
+            fi
             echo "Missing REFUND_ADJUSTMENT_SYNC_URL or REFUND_ADJUSTMENT_SYNC_TOKEN."
             exit 1
           fi

--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -69,7 +69,7 @@
 - Follow-up `#174` should simplify machine mapping into a focused admin flow from `/admin/reporting`: admins should only need to confirm the canonical machine name, Sunze ID, machine type, and user access, with site/location grouping optional and able to contain multiple machines.
 - `Docs/SUNZE_SALES_DISCOVERY.md` records the validated Sunze routes, export headers, payment/status mappings, and remaining open questions without storing credentials or raw order data.
 - Refund adjustment imports now use a safe review layer: rows are staged with source-row audit fields, deterministic machine-alias matching, match confidence/status, and applied adjustment links before they can affect partner settlement. Approved uniquely matched refunds reduce partner net sales, split base, and amount owed while gross sales remains the imported sales basis.
-- Google Sheets complaints/refunds ingestion still needs service-account access before live API fetching is enabled. A local XLSX export confirmed the current customer service sheet contract: `Location of Purchase`, `Decision Date`, `Date and Time of Incident`, `Refund Amount`, `Status`, `Decision`, and `Request ID`. The importer handles those headers with sanitized fixtures; production live reads still wait on the service-account path.
+- Refund source ingestion now has a service-account API path for production: `refund-adjustment-sync` can read the private sheet with a read-only Google service account, stage rows as review records, and auto-apply only uniquely matched `Status=Closed` plus approve-style `Decision` rows. The current customer service sheet contract is `Location of Purchase`, `Decision Date`, `Date and Time of Incident`, `Refund Amount`, `Status`, `Decision`, and `Request ID`; raw customer/payment/free-text source rows are not stored in reporting payloads.
 - Account/entitlement follow-up is tracked in issue `#150`; stale PR `#143` was closed instead of carrying forward older partner/operator schema work.
 
 ## Partner reporting PM roadmap (2026-04-25)
@@ -140,7 +140,7 @@
 
 ## Next P0 milestones
 - Complete trusted corporate partner settlement before building operator performance dashboards:
-  - resolve issue `#244` so the live Google Sheet service-account ingestion path is confirmed for production refund imports
+  - complete issue `#244` by deploying the refund service-account secrets, sharing the source sheet with the service account, and confirming the first dry-run/live sync in production
   - keep issue `#169` open until production UAT evidence confirms reviewed refund handling and partner-ready settlement expectations across current partner agreements
 - Clear the remaining WeCom production blocker:
   - confirm whether the Bloomjoy Alerts app enforces an IP allowlist or trusted network restriction in WeCom

--- a/Docs/LOCAL_DEV.md
+++ b/Docs/LOCAL_DEV.md
@@ -84,7 +84,7 @@ Use these after the sales reporting migration has been applied.
    - Only approved/completed/refunded-style statuses with one conservative machine match auto-apply. For the current customer service export, `Status=Closed` must pair with an approve-style `Decision`; `Open`, `Deny`, ambiguous, unmatched, duplicate, invalid, missing-status, or low-confidence rows stay in the admin review ledger and do not change partner settlement.
 4) Run the live refund source sync through the Supabase Edge Function after secrets are configured:
    - Local dry run: `curl -X POST http://127.0.0.1:54321/functions/v1/refund-adjustment-sync -H "Authorization: Bearer $REPORT_SCHEDULER_SECRET" -H "Content-Type: application/json" --data "{\"dryRun\":true}"`
-   - Production trigger: run the `Refund Adjustment Sync` GitHub Action first with `dry_run=true`, then without dry run after aggregate counts look right.
+   - Production trigger: run the `Refund Adjustment Sync` GitHub Action first with `dry_run=true`, then without dry run after aggregate counts look right. Scheduled runs skip until the required GitHub secrets are configured; manual runs fail fast if they are missing.
    - The live sync reads the configured sheet range, stages all rows, applies only safe rows, and returns aggregate counts only.
 5) Validate sanitized reporting parser/matching fixtures:
    - `npm run reporting:validate-sunze-parser`

--- a/Docs/LOCAL_DEV.md
+++ b/Docs/LOCAL_DEV.md
@@ -57,6 +57,7 @@
    - Reporting partnership participant remove RPC: `supabase/migrations/202604260018_reporting_partnership_party_remove_rpc.sql`
    - Partner report weekly/monthly export metadata: `supabase/migrations/202604260019_partner_report_period_exports.sql`
    - Refund adjustment review/matching: `supabase/migrations/202604270001_refund_adjustment_review_matching.sql`
+   - Live refund sheet ingestion source marker: `supabase/migrations/202604270002_live_refund_sheet_ingestion.sql`
 2) Seed data (optional for local dev): `supabase/seed/20260122_training_seed.sql`
 3) Populate Vimeo fields after account setup:
    - `provider_video_id`
@@ -79,12 +80,16 @@ Use these after the sales reporting migration has been applied.
 3) Import or dry-run refund/complaint adjustments from a sanitized CSV/export:
    - `npm run reporting:import-refunds -- --file scripts/sample-refund-adjustments.csv --dry-run`
    - `npm run reporting:import-refunds -- --file path/to/refunds.csv --source-reference <refund-export-id>`
-   - Required/referrable columns are `location` / `Location of Purchase`, `refund_date` / `Decision Date`, `refund_amount_usd` / `Refund Amount`, and `status` / `Status`. Optional audit columns include `order_date` / `Date and Time of Incident`, `reason` / `Incident Description`, `source_row_reference` / `Request ID`, `decision` / `Refund Decision`, and `complaint_count`.
+   - Required/referrable columns are `location` / `Location of Purchase`, `refund_date` / `Decision Date`, `refund_amount_usd` / `Refund Amount`, and `status` / `Status`. Optional fields include `order_date` / `Date and Time of Incident`, `source_row_reference` / `Request ID`, `decision` / `Refund Decision`, and `complaint_count`. Free-text reason/incident fields are recognized for change detection only and are not stored in reporting payloads.
    - Only approved/completed/refunded-style statuses with one conservative machine match auto-apply. For the current customer service export, `Status=Closed` must pair with an approve-style `Decision`; `Open`, `Deny`, ambiguous, unmatched, duplicate, invalid, missing-status, or low-confidence rows stay in the admin review ledger and do not change partner settlement.
-4) Validate sanitized reporting parser/matching fixtures:
+4) Run the live refund source sync through the Supabase Edge Function after secrets are configured:
+   - Local dry run: `curl -X POST http://127.0.0.1:54321/functions/v1/refund-adjustment-sync -H "Authorization: Bearer $REPORT_SCHEDULER_SECRET" -H "Content-Type: application/json" --data "{\"dryRun\":true}"`
+   - Production trigger: run the `Refund Adjustment Sync` GitHub Action first with `dry_run=true`, then without dry run after aggregate counts look right.
+   - The live sync reads the configured sheet range, stages all rows, applies only safe rows, and returns aggregate counts only.
+5) Validate sanitized reporting parser/matching fixtures:
    - `npm run reporting:validate-sunze-parser`
    - `npm run reporting:validate-refund-adjustments`
-5) Dry-run the Sunze browser export locally:
+6) Dry-run the Sunze browser export locally:
    - `npm run reporting:sunze-sync -- --env-file path/to/local.env --dry-run`
    - Historical backfill dry run with a supported Sunze preset:
      `npm run reporting:sunze-sync -- --env-file path/to/local.env --date-preset "Last Month" --dry-run`
@@ -103,11 +108,12 @@ Use these after the sales reporting migration has been applied.
 
 Notes:
 - Sales CSV rows must map to configured reporting machines by `machine_id`/`reporting_machine_id` or `sunze_machine_id`.
-- Refund CSV rows are staged first and map through `reporting_machine_aliases`; do not paste raw private refund exports into repo files, issues, PRs, or chat.
+- Refund CSV and live source rows are staged first and map through `reporting_machine_aliases`; do not paste raw private refund exports into repo files, issues, PRs, or chat. Reporting payloads keep calculation/audit fields only and omit customer names, emails, payment identifiers, card digits, and free-text incident descriptions.
 - `machine_sales_facts` stores Sunze/manual sales as net sales. `sales_adjustment_facts` stores approved refund adjustments separately so partner gross sales remains the imported sales basis while refund impact reduces net sales and split base.
 - `sunze-sales-ingest` requires `REPORTING_INGEST_TOKEN` and `REPORTING_ROW_HASH_SALT` as Supabase function secrets. The GitHub worker receives only `REPORTING_INGEST_TOKEN`, never the Supabase service-role key.
 - GitHub encrypted secrets for the Sunze worker are `SUNZE_LOGIN_URL`, `SUNZE_REPORTING_EMAIL`, `SUNZE_REPORTING_PASSWORD`, `REPORTING_INGEST_URL`, and `REPORTING_INGEST_TOKEN`.
-- Server-only Supabase function secrets for reporting are `REPORT_SCHEDULER_SECRET`, `REPORTING_INGEST_TOKEN`, `REPORTING_ROW_HASH_SALT`, `GOOGLE_REFUNDS_SHEET_ID`, and `GOOGLE_SERVICE_ACCOUNT_JSON`.
+- GitHub encrypted secrets for the refund sync worker are `REFUND_ADJUSTMENT_SYNC_URL` and `REFUND_ADJUSTMENT_SYNC_TOKEN`; the GitHub workflow does not receive the Google service-account JSON or Supabase service-role key.
+- Server-only Supabase function secrets for reporting are `REPORT_SCHEDULER_SECRET`, `REPORTING_INGEST_TOKEN`, `REPORTING_ROW_HASH_SALT`, `GOOGLE_REFUNDS_SHEET_ID`, optional `GOOGLE_REFUNDS_SHEET_RANGE`, and `GOOGLE_SERVICE_ACCOUNT_JSON`.
 - Sunze sync controls use optional `SUNZE_EXPECTED_MACHINE_COUNT`, `SUNZE_SYNC_STALE_HOURS=30`, and `SUNZE_REPORTING_TIMEZONE=America/Los_Angeles` by default. The scheduled sync workflow uses `Last 7 Days` daily for rolling overlap and `Last Month` monthly as a safety sweep, then performs a post-import freshness check. The separate Sunze health workflow checks again later for missed/stale imports. Set the expected count only after confirming how many machines the workflow Sunze account exposes in the top-level Machine Center; new visible machines are placed in the `/admin/reporting` mapping queue instead of blocking already mapped sales.
 - Admins map newly discovered Sunze IDs from `/admin/reporting`; the current PR flow pre-fills the broader `/admin/partnerships` machine form. Pending rows for unmapped machines are quarantined in normalized form and replayed into `machine_sales_facts` after the Sunze ID is mapped to a canonical reporting machine. Follow-up `#174` tracks a simpler machine-first mapping flow so new Sunze machines do not become recurring engineering blockers.
 - Never prefix Sunze, Google, service-role, or scheduler secrets with `VITE_`.
@@ -283,6 +289,7 @@ For production deployment order and rollback, use `Docs/PRODUCTION_RUNBOOK.md`.
    - `supabase secrets set REPORTING_ROW_HASH_SALT=...`
    - `supabase secrets set SUNZE_SYNC_STALE_HOURS=30`
    - `supabase secrets set GOOGLE_REFUNDS_SHEET_ID=...`
+   - `supabase secrets set GOOGLE_REFUNDS_SHEET_RANGE="'Form Responses 1'!A:T"`
    - `supabase secrets set GOOGLE_SERVICE_ACCOUNT_JSON=...`
    - Ensure `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and `SUPABASE_SERVICE_ROLE_KEY` are available to functions
 3) Run the commerce release preflight before deploy:

--- a/Docs/PRODUCTION_RUNBOOK.md
+++ b/Docs/PRODUCTION_RUNBOOK.md
@@ -35,11 +35,14 @@ Set the following values before launch.
 | `SUPABASE_URL` | Server-only | Stripe/order/support Edge Functions | Supabase project URL | Technical owner |
 | `SUPABASE_ANON_KEY` | Server-only | `stripe-sugar-checkout`, `stripe-plus-checkout`, `stripe-customer-portal` | Supabase project anon key | Technical owner |
 | `SUPABASE_SERVICE_ROLE_KEY` | Server-only | `stripe-webhook`, `stripe-sugar-checkout`, `lead-submission-intake`, `support-request-intake` | Supabase service role key | Technical owner |
-| `REPORT_SCHEDULER_SECRET` | Server-only | `sales-report-scheduler` | Generated secret stored in function secrets | Technical owner |
+| `REPORT_SCHEDULER_SECRET` | Server-only | `sales-report-scheduler`, `refund-adjustment-sync` | Generated secret stored in function secrets | Technical owner |
 | `REPORTING_INGEST_TOKEN` | Server-only + GitHub Actions secret | `sunze-sales-ingest`, Sunze sync workflow | Generated ingest token | Technical owner |
 | `REPORTING_ROW_HASH_SALT` | Server-only | `sunze-sales-ingest` | Generated secret stored in function secrets | Technical owner |
 | `GOOGLE_REFUNDS_SHEET_ID` | Server-only | `refund-adjustment-sync` | Google Sheet ID for refunds/complaints | Operations owner |
+| `GOOGLE_REFUNDS_SHEET_RANGE` | Server-only | `refund-adjustment-sync` | Optional A1 range, default `'Form Responses 1'!A:T` | Technical owner |
 | `GOOGLE_SERVICE_ACCOUNT_JSON` | Server-only | `refund-adjustment-sync` | Google service account JSON | Technical owner |
+| `REFUND_ADJUSTMENT_SYNC_URL` | GitHub Actions secret | Refund sync workflow | Supabase Edge Function URL | Technical owner |
+| `REFUND_ADJUSTMENT_SYNC_TOKEN` | GitHub Actions secret | Refund sync workflow | Same scheduler token value, never a service-role key | Technical owner |
 | `SUNZE_LOGIN_URL` | GitHub Actions secret | Sunze sync workflow | Sunze service-account login URL | Technical owner |
 | `SUNZE_REPORTING_EMAIL` | GitHub Actions secret | Sunze sync workflow | Sunze service-account email | Technical owner |
 | `SUNZE_REPORTING_PASSWORD` | GitHub Actions secret | Sunze sync workflow | Sunze service-account password | Technical owner |
@@ -109,6 +112,7 @@ supabase secrets set REPORT_SCHEDULER_SECRET=...
 supabase secrets set REPORTING_INGEST_TOKEN=...
 supabase secrets set REPORTING_ROW_HASH_SALT=...
 supabase secrets set GOOGLE_REFUNDS_SHEET_ID=...
+supabase secrets set GOOGLE_REFUNDS_SHEET_RANGE="'Form Responses 1'!A:T"
 supabase secrets set GOOGLE_SERVICE_ACCOUNT_JSON=...
 ```
 
@@ -120,6 +124,11 @@ npm run commerce:preflight -- --project-ref <project-ref>
 
 WeCom note:
 - If token auth succeeds but live sends fail with `60020: not allow to access from your ip`, the remaining issue is WeCom-side network/IP policy, not the secret values. Fix the app/network restriction in WeCom admin, then re-run a live smoke order.
+
+Refund source note:
+- Enable Google Sheets API for the service account project, share the refund source sheet with the service account email as Viewer, and keep `GOOGLE_SERVICE_ACCOUNT_JSON` only in Supabase function secrets.
+- Add GitHub secrets `REFUND_ADJUSTMENT_SYNC_URL` and `REFUND_ADJUSTMENT_SYNC_TOKEN` before enabling the scheduled workflow. The token should match `REPORT_SCHEDULER_SECRET`; do not use the Supabase service-role key.
+- First run the `Refund Adjustment Sync` workflow manually with `dry_run=true`. The workflow should print aggregate counts only. Then run it without dry run and confirm `/admin/reporting` shows the completed refund import run plus any review-only rows.
 
 ### Step C: Deploy Supabase Edge Functions
 Deploy all current checkout, submission, and reporting functions:

--- a/Docs/PRODUCTION_RUNBOOK.md
+++ b/Docs/PRODUCTION_RUNBOOK.md
@@ -127,7 +127,7 @@ WeCom note:
 
 Refund source note:
 - Enable Google Sheets API for the service account project, share the refund source sheet with the service account email as Viewer, and keep `GOOGLE_SERVICE_ACCOUNT_JSON` only in Supabase function secrets.
-- Add GitHub secrets `REFUND_ADJUSTMENT_SYNC_URL` and `REFUND_ADJUSTMENT_SYNC_TOKEN` before enabling the scheduled workflow. The token should match `REPORT_SCHEDULER_SECRET`; do not use the Supabase service-role key.
+- Add GitHub secrets `REFUND_ADJUSTMENT_SYNC_URL` and `REFUND_ADJUSTMENT_SYNC_TOKEN`. The token should match `REPORT_SCHEDULER_SECRET`; do not use the Supabase service-role key. Scheduled runs skip until these secrets exist, while manual runs fail fast if they are missing.
 - First run the `Refund Adjustment Sync` workflow manually with `dry_run=true`. The workflow should print aggregate counts only. Then run it without dry run and confirm `/admin/reporting` shows the completed refund import run plus any review-only rows.
 
 ### Step C: Deploy Supabase Edge Functions

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -180,7 +180,8 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Portal Reports > Partner Dashboard shows gross sales, refund impact, net sales, split base, and amount owed as separate values when applied refund adjustments exist
 - [ ] `/portal/reports` export creates a private signed PDF link that matches the selected filters
 - [ ] `npm run reporting:validate-sunze-parser` passes with the sanitized Sunze `.xlsx` fixture
-- [ ] `npm run reporting:validate-refund-adjustments` passes with sanitized exact-match, fuzzy-alias, ambiguous, unmatched, duplicate, current customer-service export header, and partner-settlement fixtures
+- [ ] `npm run reporting:validate-refund-adjustments` passes with sanitized exact-match, fuzzy-alias, ambiguous, unmatched, duplicate, current customer-service export header, live sheet-shaped rows, sanitized-payload, and partner-settlement fixtures
+- [ ] Refund Adjustment Sync GitHub Action can be run manually with `dry_run=true` and returns aggregate counts only, with no customer names, emails, payment IDs, card digits, or free-text incident descriptions in logs
 - [ ] `npm run reporting:sunze-sync -- --dry-run` downloads the Sunze Orders export, reconciles parsed row count/revenue against the Sunze UI, checks top-level machine discovery, deletes the raw workbook, and validates Supabase ingest/machine mappings without writing sales facts when ingest env vars are present
 - [ ] `npm run reporting:sunze-health -- --event freshness_check --stale-hours 30` reports the latest completed Sunze import or sends a stale-data ops alert
 
@@ -306,6 +307,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Admin can create a weekly partner PDF schedule with recipients and sees it in active schedules
 - [ ] Admin reporting shows report export archive, partner report exports, recent sales/refund import runs, and stale/failed sync status clearly
 - [ ] Admin Reporting > Sync shows a refund adjustment review summary/list where ambiguous, unmatched, duplicate, invalid, and missing-status rows require review and do not silently affect settlement
+- [ ] Admin Reporting > Sync shows the latest live refund sync run after the scheduled workflow runs, and open/denied rows remain review-only
 - [ ] Admin reporting does not mark Sunze freshness as failed solely because an unrelated historical backfill failed when a recent daily import is fresh
 - [ ] Admin can open discovered Sunze machine IDs from `/admin/reporting`, map them in `/admin/machines`, ignore them, and reopen them
 - [ ] Failed, stale, or mapping-needed Sunze ingest runs appear in `/admin/reporting` without changing existing mapped sales facts incorrectly

--- a/scripts/import-refund-adjustments-csv.mjs
+++ b/scripts/import-refund-adjustments-csv.mjs
@@ -2,6 +2,7 @@
 import { readFile } from 'node:fs/promises';
 import { createClient } from '@supabase/supabase-js';
 import {
+  buildSanitizedRefundPayload,
   buildMachineProfiles,
   extractRefundInput,
   makeSourceRowHash,
@@ -69,10 +70,20 @@ const loadMachineProfiles = async () => {
 
 const loadExistingAdjustmentHashes = async () => {
   const rows = requireNoError(
-    await supabase.from('sales_adjustment_facts').select('source_row_hash').eq('source', 'google_sheets'),
+    await supabase
+      .from('sales_adjustment_facts')
+      .select('source_reference, source_row_reference, source_row_hash')
+      .eq('source', 'google_sheets'),
     'Unable to load existing refund adjustment hashes'
   );
-  return new Set((rows ?? []).map((row) => row.source_row_hash).filter(Boolean));
+  const hashOwners = new Map();
+  for (const row of rows ?? []) {
+    if (!row.source_row_hash || !row.source_row_reference) continue;
+    const owners = hashOwners.get(row.source_row_hash) ?? new Set();
+    owners.add(`${row.source_reference ?? ''}\u0000${row.source_row_reference}`);
+    hashOwners.set(row.source_row_hash, owners);
+  }
+  return hashOwners;
 };
 
 const createImportRun = async (rowsSeen) => {
@@ -129,7 +140,7 @@ const applyAdjustment = async ({
   reviewRowId,
   matchedMachine,
   matchConfidence,
-  row,
+  rawPayload,
 }) => {
   if (dryRun) return { id: null };
 
@@ -152,8 +163,8 @@ const applyAdjustment = async ({
           refund_review_row_id: reviewRowId,
           match_status: 'applied',
           match_confidence: matchConfidence,
-          notes: input.reason || null,
-          raw_payload: row,
+          notes: null,
+          raw_payload: rawPayload,
         },
         { onConflict: 'source,source_reference,source_row_reference' }
       )
@@ -167,7 +178,7 @@ const applyAdjustment = async ({
 
 const rows = parseCsv(await readFile(filePath, 'utf8'));
 const machineProfiles = await loadMachineProfiles();
-const existingHashes = await loadExistingAdjustmentHashes();
+const existingHashOwners = await loadExistingAdjustmentHashes();
 const seenHashes = new Set();
 const counts = {
   rowsSeen: rows.length,
@@ -178,6 +189,7 @@ const counts = {
   rowsInvalid: 0,
   rowsAmbiguous: 0,
   rowsUnmatched: 0,
+  rowsUnapplied: 0,
 };
 const runId = await createImportRun(rows.length);
 
@@ -185,7 +197,10 @@ try {
   for (const { row, rowNumber } of rows) {
     const input = extractRefundInput(row, `row-${rowNumber}`);
     const sourceRowHash = makeSourceRowHash(input);
-    const duplicate = seenHashes.has(sourceRowHash) || existingHashes.has(sourceRowHash);
+    const currentOwnerKey = `${sourceReference}\u0000${input.sourceRowReference}`;
+    const duplicateFromExisting = [...(existingHashOwners.get(sourceRowHash) ?? new Set())]
+      .some((ownerKey) => ownerKey !== currentOwnerKey);
+    const duplicate = seenHashes.has(sourceRowHash) || duplicateFromExisting;
     seenHashes.add(sourceRowHash);
 
     const match = duplicate
@@ -199,6 +214,13 @@ try {
       : matchRefundToMachine(input, machineProfiles);
     const canApply = match.matchStatus === 'matched' && match.matchedMachine;
     const reviewStatus = canApply ? 'approved' : 'unresolved';
+    const rawPayload = buildSanitizedRefundPayload({
+      input,
+      sourceReference,
+      sourceRowHash,
+      sourceRowNumber: row.source_sheet_row_number ?? rowNumber,
+      match,
+    });
     const staged = await stageReviewRow({
       import_run_id: runId,
       source: 'sheet_export',
@@ -211,9 +233,9 @@ try {
       amount_cents: input.amountCents,
       adjustment_type: input.adjustmentType,
       complaint_count: input.complaintCount,
-      reason: input.reason || null,
+      reason: null,
       source_status: [input.sourceStatus, input.sourceDecision].filter(Boolean).join(' / ') || null,
-      raw_payload: row,
+      raw_payload: rawPayload,
       match_status: canApply ? 'matched' : match.matchStatus,
       match_confidence: match.matchConfidence,
       match_reason: match.matchReason,
@@ -232,7 +254,7 @@ try {
         reviewRowId: staged.id,
         matchedMachine: match.matchedMachine,
         matchConfidence: match.matchConfidence,
-        row,
+        rawPayload,
       });
       if (!dryRun && staged.id && adjustment.id) {
         requireNoError(
@@ -247,9 +269,44 @@ try {
           'Unable to mark refund review row applied'
         );
       }
-      existingHashes.add(sourceRowHash);
+      const owners = existingHashOwners.get(sourceRowHash) ?? new Set();
+      owners.add(currentOwnerKey);
+      existingHashOwners.set(sourceRowHash, owners);
       counts.rowsApplied += 1;
       continue;
+    }
+
+    if (!dryRun) {
+      const existingAdjustment = requireNoError(
+        await supabase
+          .from('sales_adjustment_facts')
+          .select('id')
+          .eq('source', 'google_sheets')
+          .eq('source_reference', sourceReference)
+          .eq('source_row_reference', input.sourceRowReference)
+          .maybeSingle(),
+        'Unable to check existing refund adjustment'
+      );
+
+      if (existingAdjustment?.id) {
+        requireNoError(
+          await supabase
+            .from('sales_adjustment_facts')
+            .delete()
+            .eq('id', existingAdjustment.id),
+          'Unable to remove refund adjustment that no longer qualifies for auto-apply'
+        );
+        if (staged.id) {
+          requireNoError(
+            await supabase
+              .from('refund_adjustment_review_rows')
+              .update({ applied_adjustment_id: null })
+              .eq('id', staged.id),
+            'Unable to clear stale applied refund link'
+          );
+        }
+        counts.rowsUnapplied += 1;
+      }
     }
 
     counts.rowsReview += 1;
@@ -272,6 +329,7 @@ try {
       rows_invalid: counts.rowsInvalid,
       rows_ambiguous: counts.rowsAmbiguous,
       rows_unmatched: counts.rowsUnmatched,
+      rows_unapplied: counts.rowsUnapplied,
     },
     completed_at: new Date().toISOString(),
   });

--- a/scripts/refunds/refund-adjustment-utils.mjs
+++ b/scripts/refunds/refund-adjustment-utils.mjs
@@ -23,7 +23,7 @@ export const AUTO_APPLY_DECISIONS = new Set([
   'refund approve',
 ]);
 
-const normalizeHeader = (value) =>
+export const normalizeHeader = (value) =>
   String(value ?? '')
     .normalize('NFKD')
     .toLowerCase()
@@ -85,6 +85,34 @@ export const parseCsv = (text) => {
     rowNumber: rowIndex + 2,
     row: Object.fromEntries(headers.map((header, index) => [header, cells[index]?.trim() ?? ''])),
   }));
+};
+
+export const parseSheetValues = (values) => {
+  if (!Array.isArray(values) || values.length === 0) return [];
+
+  const headers = values[0].map((header) => normalizeHeader(header));
+  return values
+    .slice(1)
+    .map((cells, rowIndex) => {
+      const rowNumber = rowIndex + 2;
+      const row = Object.fromEntries(
+        headers.map((header, cellIndex) => [
+          header,
+          String(cells?.[cellIndex] ?? '').trim(),
+        ])
+      );
+
+      if (!row.source_sheet_row_number) {
+        row.source_sheet_row_number = String(rowNumber);
+      }
+
+      return { rowNumber, row };
+    })
+    .filter(({ row }) =>
+      Object.entries(row).some(
+        ([key, value]) => key !== 'source_sheet_row_number' && String(value).trim() !== ''
+      )
+    );
 };
 
 export const normalizeMatchText = (value) =>
@@ -237,6 +265,35 @@ export const makeSourceRowHash = (input) =>
       })
     )
     .digest('hex');
+
+export const buildSanitizedRefundPayload = ({
+  input,
+  sourceReference,
+  sourceRowHash,
+  sourceRowNumber,
+  match,
+  appliedAdjustmentId = null,
+}) => ({
+  payload_schema: 'refund_adjustment.v1',
+  source_reference: sourceReference || null,
+  source_row_reference: input.sourceRowReference,
+  source_row_hash: sourceRowHash,
+  source_row_number: sourceRowNumber ? String(sourceRowNumber) : null,
+  source_location: input.sourceLocation || null,
+  refund_date: input.refundDate || null,
+  original_order_date: input.originalOrderDate || null,
+  amount_cents: input.amountCents,
+  adjustment_type: input.adjustmentType,
+  complaint_count: input.complaintCount,
+  source_status: input.sourceStatus || null,
+  source_decision: input.sourceDecision || null,
+  match_status: match?.matchStatus ?? null,
+  match_confidence: match?.matchConfidence ?? null,
+  match_reason: match?.matchReason ?? null,
+  candidate_machine_count: match?.candidateMachineIds?.length ?? 0,
+  matched_machine_id: match?.matchedMachine?.id ?? null,
+  applied_adjustment_id: appliedAdjustmentId,
+});
 
 export const buildMachineProfiles = ({ machines, aliases = [] }) => {
   const aliasesByMachineId = new Map();

--- a/scripts/validate-refund-adjustments.mjs
+++ b/scripts/validate-refund-adjustments.mjs
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
 import assert from 'node:assert/strict';
 import {
+  buildSanitizedRefundPayload,
   buildMachineProfiles,
   calculatePartnerSettlementTotals,
   extractRefundInput,
   makeSourceRowHash,
   matchRefundToMachine,
   parseCsv,
+  parseSheetValues,
 } from './refunds/refund-adjustment-utils.mjs';
 
 const machines = [
@@ -175,6 +177,60 @@ const parsed = parseCsv(
 assert.equal(parsed.length, 1);
 assert.equal(parsed[0].row.refund_amount_usd, '12.50');
 
+const sheetRows = parseSheetValues([
+  [
+    'Timestamp',
+    'Your Name',
+    'Email Address',
+    'Location of Purchase',
+    'Date and Time of Incident',
+    'Incident Description',
+    'Venmo/Zelle Payment ID',
+    'Last 4 digits of your card',
+    'Request ID',
+    'Status',
+    'Refund Amount',
+    'Decision',
+    'Decision Date',
+  ],
+  [
+    '2026-04-11 09:00:00',
+    'Customer Name',
+    'customer@example.com',
+    'North Lobby',
+    '2026-04-10 10:30 AM',
+    'Private fixture detail',
+    'private-payment-id',
+    '1234',
+    'SANITIZED-REQ-2',
+    'Closed',
+    '8.50',
+    'Approve',
+    '2026-04-11',
+  ],
+]);
+assert.equal(sheetRows.length, 1);
+assert.equal(sheetRows[0].row.location_of_purchase, 'North Lobby');
+assert.equal(sheetRows[0].row.source_sheet_row_number, '2');
+
+const sheetInput = extractRefundInput(sheetRows[0].row, 'sheet-row-2');
+const sheetMatch = matchRefundToMachine(sheetInput, profiles);
+assert.equal(sheetMatch.matchStatus, 'matched');
+const sanitizedPayload = buildSanitizedRefundPayload({
+  input: sheetInput,
+  sourceReference: 'sanitized-source',
+  sourceRowHash: makeSourceRowHash(sheetInput),
+  sourceRowNumber: sheetRows[0].row.source_sheet_row_number,
+  match: sheetMatch,
+});
+assert.equal(sanitizedPayload.source_row_reference, 'SANITIZED-REQ-2');
+assert.equal(sanitizedPayload.source_location, 'North Lobby');
+assert.equal(sanitizedPayload.amount_cents, 850);
+assert.equal(Object.prototype.hasOwnProperty.call(sanitizedPayload, 'email_address'), false);
+assert.equal(Object.prototype.hasOwnProperty.call(sanitizedPayload, 'venmo_zelle_payment_id'), false);
+assert.equal(Object.prototype.hasOwnProperty.call(sanitizedPayload, 'last_4_digits_of_your_card'), false);
+assert.equal(Object.prototype.hasOwnProperty.call(sanitizedPayload, 'incident_description'), false);
+
 const withoutRefund = calculatePartnerSettlementTotals({
   grossSalesCents: 10000,
   taxCents: 800,
@@ -220,6 +276,8 @@ console.log(
       openStatusReviewOnly: openFormContractMatch.matchStatus,
       deniedDecisionReviewOnly: deniedFormContractMatch.matchStatus,
       duplicateHashDetected: true,
+      liveSheetValuesParsed: true,
+      sanitizedPayloadExcludesPrivateFields: true,
       refundReducesPartnerSettlement: true,
     },
   })

--- a/supabase/functions/refund-adjustment-sync/index.ts
+++ b/supabase/functions/refund-adjustment-sync/index.ts
@@ -6,6 +6,7 @@ const supabaseUrl = Deno.env.get("SUPABASE_URL");
 const supabaseServiceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
 const schedulerSecret = Deno.env.get("REPORT_SCHEDULER_SECRET");
 const googleRefundsSheetId = Deno.env.get("GOOGLE_REFUNDS_SHEET_ID");
+const googleRefundsSheetRange = Deno.env.get("GOOGLE_REFUNDS_SHEET_RANGE") || "'Form Responses 1'!A:T";
 const googleServiceAccountJson = Deno.env.get("GOOGLE_SERVICE_ACCOUNT_JSON");
 const encoder = new TextEncoder();
 
@@ -17,6 +18,11 @@ const supabase =
     : null;
 
 type RefundAdjustmentRow = Record<string, unknown>;
+
+type ImportRowsOptions = {
+  dryRun?: boolean;
+  reviewSource?: "api_payload" | "sheet_api";
+};
 
 type RefundInput = {
   sourceRowReference: string;
@@ -39,6 +45,12 @@ type MachineProfile = {
   locationId: string;
   machineLabel: string;
   labels: Array<{ kind: string; normalized: string }>;
+};
+
+type GoogleServiceAccount = {
+  client_email?: string;
+  private_key?: string;
+  token_uri?: string;
 };
 
 const autoApplyStatuses = new Set([
@@ -80,8 +92,21 @@ const normalizeMatchText = (value: unknown) =>
     .replace(/\s+/g, " ")
     .trim();
 
+const normalizeHeader = (value: unknown) =>
+  String(value ?? "")
+    .normalize("NFKD")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+
 const normalizeStatus = (value: unknown) =>
   sanitizeText(value).toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ");
+
+const parseBoolean = (value: unknown) => {
+  if (value === true) return true;
+  if (typeof value === "string") return normalizeStatus(value) === "true";
+  return false;
+};
 
 const normalizeDate = (value: unknown) => {
   const text = sanitizeText(value);
@@ -145,6 +170,141 @@ const parseCount = (value: unknown) => {
 const sha256Hex = async (value: string) => {
   const digest = await crypto.subtle.digest("SHA-256", encoder.encode(value));
   return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+};
+
+const base64Url = (value: string | Uint8Array) => {
+  const bytes = typeof value === "string" ? encoder.encode(value) : value;
+  const binary = [...bytes].map((byte) => String.fromCharCode(byte)).join("");
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+};
+
+const pemToArrayBuffer = (pem: string) => {
+  const base64 = pem
+    .replace(/-----BEGIN PRIVATE KEY-----/g, "")
+    .replace(/-----END PRIVATE KEY-----/g, "")
+    .replace(/\s+/g, "");
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes.buffer;
+};
+
+const createGoogleAccessToken = async () => {
+  if (!googleServiceAccountJson) {
+    throw new Error("Live refund source credentials are not configured.");
+  }
+
+  let credentials: GoogleServiceAccount;
+  try {
+    credentials = JSON.parse(googleServiceAccountJson) as GoogleServiceAccount;
+  } catch {
+    throw new Error("Live refund source credentials are not valid JSON.");
+  }
+
+  const clientEmail = sanitizeText(credentials.client_email);
+  const privateKey = sanitizeText(credentials.private_key);
+  const tokenUri = sanitizeText(credentials.token_uri) || "https://oauth2.googleapis.com/token";
+
+  if (!clientEmail || !privateKey) {
+    throw new Error("Live refund source credentials are missing service account fields.");
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: "RS256", typ: "JWT" };
+  const claimSet = {
+    iss: clientEmail,
+    scope: "https://www.googleapis.com/auth/spreadsheets.readonly",
+    aud: tokenUri,
+    exp: now + 3600,
+    iat: now,
+  };
+  const unsignedJwt = `${base64Url(JSON.stringify(header))}.${base64Url(JSON.stringify(claimSet))}`;
+  const key = await crypto.subtle.importKey(
+    "pkcs8",
+    pemToArrayBuffer(privateKey),
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = new Uint8Array(await crypto.subtle.sign("RSASSA-PKCS1-v1_5", key, encoder.encode(unsignedJwt)));
+  const assertion = `${unsignedJwt}.${base64Url(signature)}`;
+
+  const response = await fetch(tokenUri, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Unable to authenticate to live refund source. Status: ${response.status}`);
+  }
+
+  const body = await response.json().catch(() => ({})) as Record<string, unknown>;
+  const accessToken = sanitizeText(body.access_token);
+  if (!accessToken) {
+    throw new Error("Live refund source did not return an access token.");
+  }
+  return accessToken;
+};
+
+const sheetValuesToRows = (values: unknown[][]) => {
+  if (!Array.isArray(values) || values.length === 0) return [] as RefundAdjustmentRow[];
+
+  const headers = (values[0] ?? []).map((header) => normalizeHeader(header));
+  return values
+    .slice(1)
+    .map((cells, rowIndex) => {
+      const rowNumber = rowIndex + 2;
+      const row = Object.fromEntries(
+        headers.map((header, cellIndex) => [
+          header,
+          String((cells ?? [])[cellIndex] ?? "").trim(),
+        ]),
+      ) as RefundAdjustmentRow;
+      if (!sanitizeText(row.source_sheet_row_number)) {
+        row.source_sheet_row_number = String(rowNumber);
+      }
+      return row;
+    })
+    .filter((row) =>
+      Object.entries(row).some(
+        ([key, value]) => key !== "source_sheet_row_number" && sanitizeText(value),
+      )
+    );
+};
+
+const fetchRefundSheetRows = async () => {
+  if (!googleRefundsSheetId) {
+    throw new Error("Live refund source sheet ID is not configured.");
+  }
+
+  const accessToken = await createGoogleAccessToken();
+  const url = new URL(
+    `https://sheets.googleapis.com/v4/spreadsheets/${encodeURIComponent(googleRefundsSheetId)}/values/${encodeURIComponent(googleRefundsSheetRange)}`,
+  );
+  url.searchParams.set("majorDimension", "ROWS");
+  url.searchParams.set("valueRenderOption", "FORMATTED_VALUE");
+  url.searchParams.set("dateTimeRenderOption", "FORMATTED_STRING");
+
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Unable to fetch live refund source rows. Status: ${response.status}`);
+  }
+
+  const body = await response.json().catch(() => ({})) as Record<string, unknown>;
+  const values = Array.isArray(body.values) ? (body.values as unknown[][]) : [];
+  return {
+    rows: sheetValuesToRows(values),
+    sourceReference: `sheet:${googleRefundsSheetId}:${googleRefundsSheetRange}`,
+  };
 };
 
 const extractRefundInput = (row: RefundAdjustmentRow, fallbackRowReference: string): RefundInput => {
@@ -418,29 +578,90 @@ const matchRefund = (input: RefundInput, machines: MachineProfile[]) => {
   };
 };
 
-const loadExistingHashes = async () => {
-  if (!supabase) return new Set<string>();
+const buildSanitizedRefundPayload = ({
+  input,
+  sourceReference,
+  sourceRowHash,
+  sourceRowNumber,
+  match,
+  appliedAdjustmentId = null,
+}: {
+  input: RefundInput;
+  sourceReference: string | null;
+  sourceRowHash: string;
+  sourceRowNumber?: unknown;
+  match: ReturnType<typeof matchRefund>;
+  appliedAdjustmentId?: string | null;
+}) => ({
+  payload_schema: "refund_adjustment.v1",
+  source_reference: sourceReference || null,
+  source_row_reference: input.sourceRowReference,
+  source_row_hash: sourceRowHash,
+  source_row_number: sanitizeText(sourceRowNumber) || null,
+  source_location: input.sourceLocation || null,
+  refund_date: input.refundDate || null,
+  original_order_date: input.originalOrderDate || null,
+  amount_cents: input.amountCents,
+  adjustment_type: input.adjustmentType,
+  complaint_count: input.complaintCount,
+  source_status: input.sourceStatus || null,
+  source_decision: input.sourceDecision || null,
+  match_status: match.status,
+  match_confidence: match.confidence,
+  match_reason: match.reason,
+  candidate_machine_count: match.candidateMachineIds.length,
+  matched_machine_id: match.matchedMachine?.id ?? null,
+  applied_adjustment_id: appliedAdjustmentId,
+});
+
+const existingAdjustmentKey = (sourceReference: string | null, sourceRowReference: string) =>
+  `${sourceReference ?? ""}\u0000${sourceRowReference}`;
+
+const loadExistingAdjustments = async () => {
+  const hashOwners = new Map<string, Set<string>>();
+  if (!supabase) return hashOwners;
   const { data, error } = await supabase
     .from("sales_adjustment_facts")
-    .select("source_row_hash")
+    .select("source_reference, source_row_reference, source_row_hash")
     .eq("source", "google_sheets");
   if (error) throw new Error(error.message || "Unable to load existing refund adjustments.");
-  return new Set(((data ?? []) as Array<Record<string, unknown>>).map((row) => sanitizeText(row.source_row_hash)).filter(Boolean));
+
+  ((data ?? []) as Array<Record<string, unknown>>).forEach((row) => {
+    const hash = sanitizeText(row.source_row_hash);
+    const sourceReference = sanitizeText(row.source_reference);
+    const sourceRowReference = sanitizeText(row.source_row_reference);
+    if (!hash || !sourceRowReference) return;
+    const owners = hashOwners.get(hash) ?? new Set<string>();
+    owners.add(existingAdjustmentKey(sourceReference, sourceRowReference));
+    hashOwners.set(hash, owners);
+  });
+
+  return hashOwners;
 };
 
 const importRows = async (
   rows: RefundAdjustmentRow[],
   sourceReference: string | null,
+  options: ImportRowsOptions = {},
 ) => {
   if (!supabase) throw new Error("Supabase is not configured.");
 
-  const runId = await recordRun({
-    status: "running",
-    sourceReference,
-    rowsSeen: rows.length,
-  });
+  const dryRun = Boolean(options.dryRun);
+  const reviewSource = options.reviewSource ?? "api_payload";
+  const runId = dryRun
+    ? null
+    : await recordRun({
+      status: "running",
+      sourceReference,
+      rowsSeen: rows.length,
+      meta: {
+        dry_run: false,
+        review_source: reviewSource,
+        sheet_range: reviewSource === "sheet_api" ? googleRefundsSheetRange : null,
+      },
+    });
   const machines = await buildMachineProfiles();
-  const existingHashes = await loadExistingHashes();
+  const existingHashOwners = await loadExistingAdjustments();
   const seenHashes = new Set<string>();
   const counts = {
     rowsSeen: rows.length,
@@ -451,13 +672,21 @@ const importRows = async (
     rowsInvalid: 0,
     rowsAmbiguous: 0,
     rowsUnmatched: 0,
+    rowsUnapplied: 0,
   };
 
   try {
     for (const [index, row] of rows.entries()) {
-      const input = extractRefundInput(row, `row-${index + 1}`);
+      const fallbackRowReference = sanitizeText(row.source_sheet_row_number)
+        ? `sheet-row-${sanitizeText(row.source_sheet_row_number)}`
+        : `row-${index + 1}`;
+      const input = extractRefundInput(row, fallbackRowReference);
       const hash = await sourceRowHash(input);
-      const duplicate = seenHashes.has(hash) || existingHashes.has(hash);
+      const resolvedSourceReference = sourceReference ?? googleRefundsSheetId ?? "refund-source-export";
+      const currentOwnerKey = existingAdjustmentKey(resolvedSourceReference, input.sourceRowReference);
+      const duplicateFromExisting = [...(existingHashOwners.get(hash) ?? new Set<string>())]
+        .some((ownerKey) => ownerKey !== currentOwnerKey);
+      const duplicate = seenHashes.has(hash) || duplicateFromExisting;
       seenHashes.add(hash);
       const match = duplicate
         ? {
@@ -469,85 +698,137 @@ const importRows = async (
         }
         : matchRefund(input, machines);
       const canApply = match.status === "matched" && match.matchedMachine;
+      const rawPayload = buildSanitizedRefundPayload({
+        input,
+        sourceReference: resolvedSourceReference,
+        sourceRowHash: hash,
+        sourceRowNumber: row.source_sheet_row_number,
+        match,
+      });
+      let staged: { id: string | null } = { id: null };
 
-      const { data: staged, error: stageError } = await supabase
-        .from("refund_adjustment_review_rows")
-        .upsert({
-          import_run_id: runId,
-          source: "api_payload",
-          source_reference: sourceReference ?? googleRefundsSheetId ?? "refund-source-export",
-          source_row_reference: input.sourceRowReference,
-          source_row_hash: hash,
-          source_location: input.sourceLocation || null,
-          refund_date: input.refundDate || null,
-          original_order_date: input.originalOrderDate || null,
-          amount_cents: input.amountCents,
-          adjustment_type: input.adjustmentType,
-          complaint_count: input.complaintCount,
-          reason: input.reason || null,
-          source_status: [input.sourceStatus, input.sourceDecision].filter(Boolean).join(" / ") || null,
-          raw_payload: row,
-          match_status: canApply ? "matched" : match.status,
-          match_confidence: match.confidence,
-          match_reason: match.reason,
-          candidate_machine_ids: match.candidateMachineIds,
-          matched_machine_id: match.matchedMachine?.id ?? null,
-          matched_location_id: match.matchedMachine?.locationId ?? null,
-          resolution_status: canApply ? "approved" : "unresolved",
-        }, { onConflict: "source,source_reference,source_row_reference" })
-        .select("id")
-        .single();
+      if (!dryRun) {
+        const { data, error: stageError } = await supabase
+          .from("refund_adjustment_review_rows")
+          .upsert({
+            import_run_id: runId,
+            source: reviewSource,
+            source_reference: resolvedSourceReference,
+            source_row_reference: input.sourceRowReference,
+            source_row_hash: hash,
+            source_location: input.sourceLocation || null,
+            refund_date: input.refundDate || null,
+            original_order_date: input.originalOrderDate || null,
+            amount_cents: input.amountCents,
+            adjustment_type: input.adjustmentType,
+            complaint_count: input.complaintCount,
+            reason: null,
+            source_status: [input.sourceStatus, input.sourceDecision].filter(Boolean).join(" / ") || null,
+            raw_payload: rawPayload,
+            match_status: canApply ? "matched" : match.status,
+            match_confidence: match.confidence,
+            match_reason: match.reason,
+            candidate_machine_ids: match.candidateMachineIds,
+            matched_machine_id: match.matchedMachine?.id ?? null,
+            matched_location_id: match.matchedMachine?.locationId ?? null,
+            resolution_status: canApply ? "approved" : "unresolved",
+          }, { onConflict: "source,source_reference,source_row_reference" })
+          .select("id")
+          .single();
 
-      if (stageError || !staged) {
-        throw new Error(stageError?.message || "Unable to stage refund review row.");
+        if (stageError || !data) {
+          throw new Error(stageError?.message || "Unable to stage refund review row.");
+        }
+        staged = data;
       }
 
       counts.rowsStaged += 1;
 
       if (canApply && match.matchedMachine) {
-        const { data: adjustment, error: adjustmentError } = await supabase
-          .from("sales_adjustment_facts")
-          .upsert({
-            reporting_machine_id: match.matchedMachine.id,
-            reporting_location_id: match.matchedMachine.locationId,
-            adjustment_date: input.refundDate,
-            adjustment_type: input.adjustmentType,
-            amount_cents: input.amountCents,
-            complaint_count: input.complaintCount,
-            source: "google_sheets",
-            source_reference: sourceReference ?? googleRefundsSheetId ?? "refund-source-export",
-            source_row_reference: input.sourceRowReference,
-            source_row_hash: hash,
-            import_run_id: runId,
-            refund_review_row_id: staged.id,
-            match_status: "applied",
-            match_confidence: match.confidence,
-            notes: input.reason || null,
-            raw_payload: row,
-          }, { onConflict: "source,source_reference,source_row_reference" })
-          .select("id")
-          .single();
+        if (!dryRun) {
+          const { data: adjustment, error: adjustmentError } = await supabase
+            .from("sales_adjustment_facts")
+            .upsert({
+              reporting_machine_id: match.matchedMachine.id,
+              reporting_location_id: match.matchedMachine.locationId,
+              adjustment_date: input.refundDate,
+              adjustment_type: input.adjustmentType,
+              amount_cents: input.amountCents,
+              complaint_count: input.complaintCount,
+              source: "google_sheets",
+              source_reference: resolvedSourceReference,
+              source_row_reference: input.sourceRowReference,
+              source_row_hash: hash,
+              import_run_id: runId,
+              refund_review_row_id: staged.id,
+              match_status: "applied",
+              match_confidence: match.confidence,
+              notes: null,
+              raw_payload: rawPayload,
+            }, { onConflict: "source,source_reference,source_row_reference" })
+            .select("id")
+            .single();
 
-        if (adjustmentError || !adjustment) {
-          throw new Error(adjustmentError?.message || "Unable to apply refund adjustment.");
+          if (adjustmentError || !adjustment) {
+            throw new Error(adjustmentError?.message || "Unable to apply refund adjustment.");
+          }
+
+          const { error: reviewUpdateError } = await supabase
+            .from("refund_adjustment_review_rows")
+            .update({
+              match_status: "applied",
+              applied_adjustment_id: adjustment.id,
+              resolution_status: "approved",
+            })
+            .eq("id", staged.id);
+
+          if (reviewUpdateError) {
+            throw new Error(reviewUpdateError.message || "Unable to mark refund row applied.");
+          }
         }
 
-        const { error: reviewUpdateError } = await supabase
-          .from("refund_adjustment_review_rows")
-          .update({
-            match_status: "applied",
-            applied_adjustment_id: adjustment.id,
-            resolution_status: "approved",
-          })
-          .eq("id", staged.id);
-
-        if (reviewUpdateError) {
-          throw new Error(reviewUpdateError.message || "Unable to mark refund row applied.");
-        }
-
-        existingHashes.add(hash);
+        const owners = existingHashOwners.get(hash) ?? new Set<string>();
+        owners.add(currentOwnerKey);
+        existingHashOwners.set(hash, owners);
         counts.rowsApplied += 1;
       } else {
+        if (!dryRun) {
+          const { data: existingAdjustment, error: existingAdjustmentError } = await supabase
+            .from("sales_adjustment_facts")
+            .select("id")
+            .eq("source", "google_sheets")
+            .eq("source_reference", resolvedSourceReference)
+            .eq("source_row_reference", input.sourceRowReference)
+            .maybeSingle();
+
+          if (existingAdjustmentError) {
+            throw new Error(existingAdjustmentError.message || "Unable to check existing refund adjustment.");
+          }
+
+          const existingAdjustmentId = sanitizeText(existingAdjustment?.id);
+          if (existingAdjustmentId) {
+            const { error: deleteError } = await supabase
+              .from("sales_adjustment_facts")
+              .delete()
+              .eq("id", existingAdjustmentId);
+
+            if (deleteError) {
+              throw new Error(deleteError.message || "Unable to remove refund adjustment that no longer qualifies for auto-apply.");
+            }
+
+            if (staged.id) {
+              const { error: clearReviewError } = await supabase
+                .from("refund_adjustment_review_rows")
+                .update({ applied_adjustment_id: null })
+                .eq("id", staged.id);
+
+              if (clearReviewError) {
+                throw new Error(clearReviewError.message || "Unable to clear stale applied refund link.");
+              }
+            }
+            counts.rowsUnapplied += 1;
+          }
+        }
         counts.rowsReview += 1;
         if (match.status === "duplicate") counts.rowsDuplicate += 1;
         if (match.status === "invalid") counts.rowsInvalid += 1;
@@ -556,7 +837,7 @@ const importRows = async (
       }
     }
 
-    await updateRun(runId, {
+    if (!dryRun) await updateRun(runId, {
       status: "completed",
       rows_seen: counts.rowsSeen,
       rows_imported: counts.rowsApplied,
@@ -569,13 +850,14 @@ const importRows = async (
         rows_invalid: counts.rowsInvalid,
         rows_ambiguous: counts.rowsAmbiguous,
         rows_unmatched: counts.rowsUnmatched,
+        rows_unapplied: counts.rowsUnapplied,
       },
       completed_at: new Date().toISOString(),
     });
 
     return { runId, ...counts };
   } catch (error) {
-    await updateRun(runId, {
+    if (!dryRun) await updateRun(runId, {
       status: "failed",
       rows_imported: counts.rowsApplied,
       rows_skipped: counts.rowsSeen - counts.rowsApplied,
@@ -609,31 +891,48 @@ serve(async (req) => {
     }
 
     const body = (await req.json().catch(() => ({}))) as Record<string, unknown>;
-    const rows = Array.isArray(body.rows) ? (body.rows as RefundAdjustmentRow[]) : [];
-    const sourceReference = sanitizeText(body.sourceReference) || googleRefundsSheetId || "refund-source-export";
+    let rows = Array.isArray(body.rows) ? (body.rows as RefundAdjustmentRow[]) : [];
+    let sourceReference = sanitizeText(body.sourceReference) || googleRefundsSheetId || "refund-source-export";
+    const dryRun = parseBoolean(body.dryRun ?? body.dry_run);
+    let reviewSource: ImportRowsOptions["reviewSource"] = "api_payload";
 
     if (rows.length === 0) {
-      const runId = await recordRun({
-        status: "failed",
-        sourceReference,
-        errorMessage:
-          googleRefundsSheetId && googleServiceAccountJson
-            ? "External refund source fetch is blocked until the header and status contract is confirmed."
-            : "External refund source credentials are not configured.",
-      });
-      return jsonResponse({
-        status: "blocked",
-        runId,
-        message:
-          "Send sanitized rows in the request body for now. Live refund-source ingestion is a follow-up after the sheet contract is confirmed.",
-      });
+      try {
+        const fetched = await fetchRefundSheetRows();
+        rows = fetched.rows;
+        sourceReference = sanitizeText(body.sourceReference) || fetched.sourceReference;
+        reviewSource = "sheet_api";
+      } catch (error) {
+        const errorMessage = error instanceof Error && error.message
+          ? error.message
+          : "Unable to fetch live refund source rows.";
+        const runId = dryRun
+          ? null
+          : await recordRun({
+            status: "failed",
+            sourceReference,
+            errorMessage,
+            meta: {
+              dry_run: false,
+              review_source: "sheet_api",
+              sheet_range: googleRefundsSheetRange,
+            },
+          });
+        return jsonResponse({
+          status: "failed",
+          runId,
+          error: errorMessage,
+        }, 500);
+      }
     }
 
-    const result = await importRows(rows, sourceReference);
+    const result = await importRows(rows, sourceReference, { dryRun, reviewSource });
 
     return jsonResponse({
       status: "completed",
       source: "refund_adjustments",
+      dryRun,
+      reviewSource,
       ...result,
     });
   } catch (error) {

--- a/supabase/migrations/202604270002_live_refund_sheet_ingestion.sql
+++ b/supabase/migrations/202604270002_live_refund_sheet_ingestion.sql
@@ -1,0 +1,12 @@
+-- Allow live private-sheet refund rows to be distinguished from uploaded exports
+-- while reusing the existing refund review ledger and applied adjustment facts.
+
+alter table public.refund_adjustment_review_rows
+  drop constraint if exists refund_adjustment_review_rows_source_check;
+
+alter table public.refund_adjustment_review_rows
+  add constraint refund_adjustment_review_rows_source_check
+  check (source in ('sheet_export', 'sheet_api', 'api_payload', 'manual_csv'));
+
+comment on constraint refund_adjustment_review_rows_source_check on public.refund_adjustment_review_rows is
+  'Tracks whether a refund review row came from an uploaded sheet export, live sheet API sync, API payload, or manual CSV import.';


### PR DESCRIPTION
## Summary
- Implements live private refund-source ingestion in `refund-adjustment-sync` using Google service-account OAuth and the Sheets `values.get` API.
- Adds a daily/manual GitHub Actions workflow that calls the Edge Function with aggregate-only output and optional `dry_run`.
- Tightens refund import privacy/idempotency: staged/applied payloads now keep calculation/audit fields only, same-row re-runs stay idempotent, and rows that no longer qualify for auto-apply remove stale applied adjustments.

Refs #236. Updates #244.

## Files changed
- `supabase/functions/refund-adjustment-sync/index.ts`: live sheet fetch, dry-run mode, `sheet_api` staging source, sanitized payloads, safer duplicate/idempotency handling.
- `.github/workflows/refund-adjustment-sync.yml`: daily `15:17 UTC` sync plus manual `dry_run` dispatch.
- `supabase/migrations/202604270002_live_refund_sheet_ingestion.sql`: allows `sheet_api` rows in the existing refund review ledger.
- `scripts/refunds/*`, `scripts/import-refund-adjustments-csv.mjs`, `scripts/validate-refund-adjustments.mjs`: sheet-shaped fixtures, sanitized-payload validation, and CSV parity.
- Docs/runbooks/checklist: production secrets, dry-run rollout, smoke checks, and current status.

## Verification commands/results
- `npm ci` - passed; npm reports 2 existing moderate vulnerabilities on default dependency tree.
- `node scripts/check-supabase-migration-versions.mjs` - passed, 46 migrations checked with no duplicate versions.
- `npm run reporting:validate-refund-adjustments` - passed, including exact match, fuzzy alias, ambiguous, unmatched, duplicate, current export headers, live sheet-shaped rows, sanitized payload, and settlement math.
- `npm run reporting:validate-sunze-parser` - passed.
- `npm run build` - passed.
- `npm test --if-present` - passed; no test script is configured.
- `npm run lint --if-present` - passed with existing Fast Refresh warnings only.
- `npm run seo:check` - passed.
- `deno check --no-lock supabase/functions/refund-adjustment-sync/index.ts` - passed.
- `supabase db push --dry-run` - passed; linked DB would apply `202604270001_refund_adjustment_review_matching.sql` and `202604270002_live_refund_sheet_ingestion.sql`.

## How to test
1. Apply pending Supabase migrations and deploy `refund-adjustment-sync`.
2. Create/confirm a Google service account with Sheets API enabled and share the refund source sheet with the service account email as Viewer.
3. Set Supabase secrets: `REPORT_SCHEDULER_SECRET`, `GOOGLE_REFUNDS_SHEET_ID`, optional `GOOGLE_REFUNDS_SHEET_RANGE`, and `GOOGLE_SERVICE_ACCOUNT_JSON`.
4. Set GitHub secrets: `REFUND_ADJUSTMENT_SYNC_URL` and `REFUND_ADJUSTMENT_SYNC_TOKEN` where the token matches `REPORT_SCHEDULER_SECRET`.
5. Run the `Refund Adjustment Sync` GitHub Action manually with `dry_run=true`; confirm aggregate counts only.
6. Run the workflow without dry run; then check `/admin/reporting` for the completed refund run and review-only rows.
7. Spot-check a partner preview/export where an approved, uniquely matched refund exists: gross sales should stay separate while refund impact reduces net sales, split base, and amount owed.

## Google Sheet access/data privacy
- No raw private sheet rows, customer names, emails, payment IDs, card digits, or free-text incident descriptions are committed, logged, or included in the PR.
- The GitHub workflow never receives the Google service-account JSON or Supabase service-role key.
- Live sync stores only calculation/audit payload fields; open, denied, ambiguous, duplicate, unmatched, invalid, or missing-status rows stay review-only.

## Open PR overlap
- Open PR #194 is dependency-only and this PR does not touch package files.
- Draft PR #155 may overlap docs, so this branch should be refreshed if that draft merges first.
