### PR TITLE
Fix production admin chunk recovery

### DIFF
--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -9,7 +9,10 @@
 ## Production admin asset loading guard (2026-04-27)
 - P0 issue `#246` was traced to stale lazy-loaded chunk URLs under `/assets/*` being served through the SPA fallback as `200 text/html` after the referenced hashed files were no longer present in the active Vercel deployment.
 - Current production `/admin/access` HTML references fresh chunk hashes, and those current chunks return `application/javascript`; the repo hardening adds a Vercel guard so missing `/assets/*` files return `404` instead of `index.html`.
-- The SEO/config regression check now verifies the missing-asset guard stays between filesystem serving and the catch-all SPA fallback.
+- P0 issue `#253` found the follow-on stale-tab failure: already-open admin tabs could still request old chunks such as `Dashboard-Ck3AyZbi.js`; the server correctly returned `404 text/plain`, but the SPA had no lazy-load recovery or route error boundary, so the route crashed instead of recovering.
+- The app now wraps route-level lazy imports with a one-time stale chunk reload guard and a root route error boundary. If the same chunk still fails after one reload, the user sees an app-update refresh fallback instead of a blank route.
+- Vercel config now keeps app/auth/private shell HTML (`/admin*`, `/portal*`, `/login`, `/reset-password`) on `Cache-Control: no-store`, serves existing `/assets/*` files as immutable, and leaves the missing-asset `404 text/plain` guard between filesystem serving and the catch-all SPA fallback.
+- The SEO/config regression check now verifies the asset route order, private shell cache headers, missing-asset guard, and Vite manifest asset references.
 
 ## Machine-buyer SEO static generation (2026-04-17)
 - Public marketing/legal routes now build as static HTML with rendered body content, production asset URLs, route-specific metadata, canonical tags, and JSON-LD before client JavaScript runs.

--- a/Docs/PRODUCTION_RUNBOOK.md
+++ b/Docs/PRODUCTION_RUNBOOK.md
@@ -182,7 +182,7 @@ Run immediately after deploy:
 - [ ] Login works, password recovery works, and protected routes redirect correctly on `app.bloomjoyusa.com`.
 - [ ] Auth launch sign-off checklist is completed with evidence (`Docs/AUTH_PRODUCTION_SIGNOFF.md`).
 - [ ] `Docs/QA_SMOKE_TEST_CHECKLIST.md` core payment/auth checks pass.
-- [ ] Admin asset MIME smoke passes: current `/admin/access` JS chunks return `application/javascript`, and a stale or bogus `/assets/*.js` URL returns `404` instead of `index.html`.
+- [ ] Admin asset smoke passes: current `/admin`, `/admin/access`, `/admin/reporting`, and `/admin/partnerships` JS chunks return `application/javascript`; a stale or bogus `/assets/*.js` URL returns `404 text/plain` instead of `index.html`; a hard refresh or incognito load reaches the admin app shell.
 - [ ] Anonymous/non-member sugar checkout charges `$10/kg` and creates `orders` record in Supabase.
 - [ ] Bloomjoy Plus sugar checkout charges `$8/kg` and creates `orders` record in Supabase.
 - [ ] Sugar checkout test order stores customer contact, billing/shipping address, pricing tier, receipt URL, and color breakdown in `orders`.

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -17,7 +17,8 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] View page source on a direct-loaded private route (for example `/portal`) and confirm robots is `noindex`
 - [ ] `https://www.bloomjoyusa.com/login`, `/reset-password`, `/portal*`, and `/admin*` redirect to `https://app.bloomjoyusa.com/...`
 - [ ] `https://app.bloomjoyusa.com/` plus public marketing/storefront paths redirect back to `https://www.bloomjoyusa.com/...`
-- [ ] Production/preview asset check: JS files referenced by `/admin/access` return `application/javascript`, and a bogus `/assets/__missing-admin-chunk__.js` returns a non-HTML `404` instead of the SPA fallback page
+- [ ] Production/preview asset check: JS files referenced by `/admin`, `/admin/access`, `/admin/reporting`, and `/admin/partnerships` return `application/javascript`, and a bogus `/assets/__missing-admin-chunk__.js` returns `404 text/plain` instead of the SPA fallback page
+- [ ] Stale route chunk recovery check: simulate one route-level JS chunk load failure, confirm the app performs one automatic reload, then confirm a repeated failure shows the app-update refresh fallback instead of a blank page
 - [ ] `robots.txt` is reachable and includes a sitemap reference
 - [ ] `sitemap.xml` is reachable, lists core public routes, includes `lastmod`, and includes image sitemap entries for key machine/supplies/about URLs
 - [ ] Apex host (`https://bloomjoyusa.com`) redirects to canonical host (`https://www.bloomjoyusa.com/`) with permanent redirect behavior

--- a/scripts/seo-regression-check.mjs
+++ b/scripts/seo-regression-check.mjs
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
 import path from "node:path";
 import { createServer } from "vite";
 
@@ -409,6 +409,59 @@ const hasStaticPrerenderRewriteRules = (routes) => {
   );
 };
 
+const hasPrivateNoStoreHeaders = (routes) => {
+  const privateShellHeadersIndex = routes.findIndex(
+    (route) =>
+      route?.src === "/(portal|admin)(.*)" &&
+      route?.continue === true &&
+      route?.headers?.["Cache-Control"] === "no-store" &&
+      route?.headers?.["X-Robots-Tag"] === "noindex, nofollow, noarchive, nosnippet"
+  );
+
+  const authShellHeadersIndex = routes.findIndex(
+    (route) =>
+      route?.src === "/(login(?:/operator)?|reset-password|cart)/?" &&
+      route?.continue === true &&
+      route?.headers?.["Cache-Control"] === "no-store" &&
+      route?.headers?.["X-Robots-Tag"] === "noindex, nofollow, noarchive, nosnippet"
+  );
+  const authPrivateRewriteIndex = routes.findIndex(
+    (route) =>
+      route?.src === "/(cart|login(?:/operator)?|reset-password)/?" &&
+      route?.dest === "/$1.html"
+  );
+  const portalCatchAllRewriteIndex = routes.findIndex(
+    (route) =>
+      route?.src === "/portal(?:/.*)?/?" &&
+      route?.dest === "/portal.html"
+  );
+  const adminCatchAllRewriteIndex = routes.findIndex(
+    (route) =>
+      route?.src === "/admin(?:/.*)?/?" &&
+      route?.dest === "/admin.html"
+  );
+
+  return (
+    privateShellHeadersIndex >= 0 &&
+    privateShellHeadersIndex < portalCatchAllRewriteIndex &&
+    privateShellHeadersIndex < adminCatchAllRewriteIndex &&
+    authShellHeadersIndex >= 0 &&
+    authShellHeadersIndex < authPrivateRewriteIndex
+  );
+};
+
+const hasImmutableAssetHeadersBeforeFilesystem = (routes) => {
+  const filesystemIndex = routes.findIndex((route) => route?.handle === "filesystem");
+  const immutableAssetIndex = routes.findIndex(
+    (route) =>
+      route?.src === "/assets/(.*)" &&
+      route?.continue === true &&
+      route?.headers?.["Cache-Control"] === "public, max-age=31536000, immutable"
+  );
+
+  return immutableAssetIndex >= 0 && filesystemIndex > immutableAssetIndex;
+};
+
 const hasMissingAssetFallbackGuard = (routes) => {
   const filesystemIndex = routes.findIndex((route) => route?.handle === "filesystem");
   const assetGuardIndex = routes.findIndex(
@@ -454,11 +507,75 @@ const validateVercelConfig = async () => {
     throw new Error("vercel.json is missing static prerender rewrite rules before SPA fallback");
   }
 
+  if (!hasPrivateNoStoreHeaders(routes)) {
+    throw new Error("vercel.json must mark app/auth/private shell routes with Cache-Control: no-store");
+  }
+
+  if (!hasImmutableAssetHeadersBeforeFilesystem(routes)) {
+    throw new Error("vercel.json must mark existing /assets/* files immutable before filesystem serving");
+  }
+
   if (!hasMissingAssetFallbackGuard(routes)) {
     throw new Error(
       "vercel.json must return a 404 for missing /assets/* files before the SPA fallback"
     );
   }
+};
+
+const assertDistFileExists = async (manifestPath, context) => {
+  const normalizedPath = manifestPath.replace(/^\/+/, "");
+  const resolvedPath = path.join(DIST_DIR, normalizedPath);
+
+  try {
+    await access(resolvedPath);
+  } catch {
+    throw new Error(`Vite manifest references missing ${context}: ${normalizedPath}`);
+  }
+};
+
+const validateViteManifestReferences = async () => {
+  const manifestPath = path.join(DIST_DIR, ".vite", "manifest.json");
+  const raw = await readFile(manifestPath, "utf8");
+  const manifest = JSON.parse(raw);
+  const visitedEntries = new Set();
+
+  const validateManifestEntry = async (entryKey) => {
+    if (visitedEntries.has(entryKey)) {
+      return;
+    }
+
+    const entry = manifest?.[entryKey];
+
+    if (!entry) {
+      throw new Error(`Vite manifest is missing referenced entry: ${entryKey}`);
+    }
+
+    visitedEntries.add(entryKey);
+
+    if (entry.file) {
+      await assertDistFileExists(entry.file, `${entryKey} file`);
+    }
+
+    for (const field of ["css", "assets"]) {
+      for (const referencedFile of entry[field] ?? []) {
+        await assertDistFileExists(referencedFile, `${entryKey} ${field} asset`);
+      }
+    }
+
+    for (const field of ["imports", "dynamicImports"]) {
+      for (const referencedEntry of entry[field] ?? []) {
+        if (!manifest[referencedEntry]) {
+          throw new Error(
+            `Vite manifest entry ${entryKey} references missing ${field} entry: ${referencedEntry}`
+          );
+        }
+
+        await validateManifestEntry(referencedEntry);
+      }
+    }
+  };
+
+  await Promise.all(Object.keys(manifest).map((entryKey) => validateManifestEntry(entryKey)));
 };
 
 const main = async () => {
@@ -468,6 +585,7 @@ const main = async () => {
     await validateRobots();
     await validateSitemap(seoRoutes);
     await validateVercelConfig();
+    await validateViteManifestReferences();
 
     for (const route of seoRoutes.publicRoutes) {
       await validatePublicRouteHtml(route, seoRoutes);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy, type ReactNode } from "react";
+import { Suspense, type ReactNode } from "react";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -13,42 +13,44 @@ import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
 import { MemberRoute } from "@/components/auth/MemberRoute";
 import { AdminRoute } from "@/components/auth/AdminRoute";
 import { HostRedirectGate } from "@/components/routing/HostRedirectGate";
+import { RouteErrorBoundary } from "@/components/routing/RouteErrorBoundary";
 import { RouteSeoManager } from "@/components/seo/RouteSeoManager";
+import { lazyRoute } from "@/lib/lazyRoute";
 
 import Index from "./pages/Index";
 
-const Products = lazy(() => import("./pages/Products"));
-const CommercialRobotic = lazy(() => import("./pages/products/CommercialRobotic"));
-const Mini = lazy(() => import("./pages/products/Mini"));
-const Micro = lazy(() => import("./pages/products/Micro"));
-const Supplies = lazy(() => import("./pages/Supplies"));
-const Plus = lazy(() => import("./pages/Plus"));
-const Contact = lazy(() => import("./pages/Contact"));
-const About = lazy(() => import("./pages/About"));
-const Resources = lazy(() => import("./pages/Resources"));
-const Privacy = lazy(() => import("./pages/Privacy"));
-const Terms = lazy(() => import("./pages/Terms"));
-const BillingCancellation = lazy(() => import("./pages/BillingCancellation"));
-const Cart = lazy(() => import("./pages/Cart"));
-const Login = lazy(() => import("./pages/Login"));
-const ResetPassword = lazy(() => import("./pages/ResetPassword"));
-const PortalDashboard = lazy(() => import("./pages/portal/Dashboard"));
-const PortalTraining = lazy(() => import("./pages/portal/Training"));
-const PortalTrainingDetail = lazy(() => import("./pages/portal/TrainingDetail"));
-const PortalSupport = lazy(() => import("./pages/portal/Support"));
-const PortalOnboarding = lazy(() => import("./pages/portal/Onboarding"));
-const PortalOrders = lazy(() => import("./pages/portal/Orders"));
-const PortalAccount = lazy(() => import("./pages/portal/Account"));
-const PortalReports = lazy(() => import("./pages/portal/Reports"));
-const AdminDashboard = lazy(() => import("./pages/admin/Dashboard"));
-const AdminOrders = lazy(() => import("./pages/admin/Orders"));
-const AdminSupport = lazy(() => import("./pages/admin/Support"));
-const AdminAccess = lazy(() => import("./pages/admin/Access"));
-const AdminPartnerRecords = lazy(() => import("./pages/admin/PartnerRecords"));
-const AdminMachines = lazy(() => import("./pages/admin/Machines"));
-const AdminPartnerships = lazy(() => import("./pages/admin/Partnerships"));
-const AdminReporting = lazy(() => import("./pages/admin/Reporting"));
-const NotFound = lazy(() => import("./pages/NotFound"));
+const Products = lazyRoute(() => import("./pages/Products"));
+const CommercialRobotic = lazyRoute(() => import("./pages/products/CommercialRobotic"));
+const Mini = lazyRoute(() => import("./pages/products/Mini"));
+const Micro = lazyRoute(() => import("./pages/products/Micro"));
+const Supplies = lazyRoute(() => import("./pages/Supplies"));
+const Plus = lazyRoute(() => import("./pages/Plus"));
+const Contact = lazyRoute(() => import("./pages/Contact"));
+const About = lazyRoute(() => import("./pages/About"));
+const Resources = lazyRoute(() => import("./pages/Resources"));
+const Privacy = lazyRoute(() => import("./pages/Privacy"));
+const Terms = lazyRoute(() => import("./pages/Terms"));
+const BillingCancellation = lazyRoute(() => import("./pages/BillingCancellation"));
+const Cart = lazyRoute(() => import("./pages/Cart"));
+const Login = lazyRoute(() => import("./pages/Login"));
+const ResetPassword = lazyRoute(() => import("./pages/ResetPassword"));
+const PortalDashboard = lazyRoute(() => import("./pages/portal/Dashboard"));
+const PortalTraining = lazyRoute(() => import("./pages/portal/Training"));
+const PortalTrainingDetail = lazyRoute(() => import("./pages/portal/TrainingDetail"));
+const PortalSupport = lazyRoute(() => import("./pages/portal/Support"));
+const PortalOnboarding = lazyRoute(() => import("./pages/portal/Onboarding"));
+const PortalOrders = lazyRoute(() => import("./pages/portal/Orders"));
+const PortalAccount = lazyRoute(() => import("./pages/portal/Account"));
+const PortalReports = lazyRoute(() => import("./pages/portal/Reports"));
+const AdminDashboard = lazyRoute(() => import("./pages/admin/Dashboard"));
+const AdminOrders = lazyRoute(() => import("./pages/admin/Orders"));
+const AdminSupport = lazyRoute(() => import("./pages/admin/Support"));
+const AdminAccess = lazyRoute(() => import("./pages/admin/Access"));
+const AdminPartnerRecords = lazyRoute(() => import("./pages/admin/PartnerRecords"));
+const AdminMachines = lazyRoute(() => import("./pages/admin/Machines"));
+const AdminPartnerships = lazyRoute(() => import("./pages/admin/Partnerships"));
+const AdminReporting = lazyRoute(() => import("./pages/admin/Reporting"));
+const NotFound = lazyRoute(() => import("./pages/NotFound"));
 
 const browserQueryClient = new QueryClient();
 
@@ -77,68 +79,70 @@ export const AppProviders = ({
 export const AppShell = () => (
   <HostRedirectGate>
     <RouteSeoManager />
-    <Suspense fallback={<RouteFallback />}>
-      <Routes>
-        <Route path="/" element={<Index />} />
-        <Route path="/machines" element={<Products />} />
-        <Route
-          path="/machines/commercial-robotic-machine"
-          element={<CommercialRobotic />}
-        />
-        <Route path="/machines/mini" element={<Mini />} />
-        <Route path="/machines/micro" element={<Micro />} />
-        <Route path="/products" element={<Navigate to="/machines" replace />} />
-        <Route
-          path="/products/commercial-robotic-machine"
-          element={<Navigate to="/machines/commercial-robotic-machine" replace />}
-        />
-        <Route path="/products/mini" element={<Navigate to="/machines/mini" replace />} />
-        <Route path="/products/micro" element={<Navigate to="/machines/micro" replace />} />
-        <Route path="/supplies" element={<Supplies />} />
-        <Route path="/plus" element={<Plus />} />
-        <Route path="/contact" element={<Contact />} />
-        <Route path="/about" element={<About />} />
-        <Route path="/resources" element={<Resources />} />
-        <Route path="/privacy" element={<Privacy />} />
-        <Route path="/terms" element={<Terms />} />
-        <Route path="/billing-cancellation" element={<BillingCancellation />} />
-        <Route path="/cart" element={<Cart />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/login/operator" element={<Navigate to="/login" replace />} />
-        <Route path="/reset-password" element={<ResetPassword />} />
-        <Route element={<ProtectedRoute />}>
-          <Route path="/portal" element={<PortalDashboard />} />
-          <Route element={<MemberRoute />}>
-            <Route path="/portal/orders" element={<PortalOrders />} />
-            <Route path="/portal/account" element={<PortalAccount />} />
-            <Route path="/portal/reports" element={<PortalReports />} />
-            <Route path="/portal/training" element={<PortalTraining />} />
-            <Route path="/portal/training/:id" element={<PortalTrainingDetail />} />
-            <Route path="/portal/support" element={<PortalSupport />} />
-            <Route path="/portal/onboarding" element={<PortalOnboarding />} />
+    <RouteErrorBoundary>
+      <Suspense fallback={<RouteFallback />}>
+        <Routes>
+          <Route path="/" element={<Index />} />
+          <Route path="/machines" element={<Products />} />
+          <Route
+            path="/machines/commercial-robotic-machine"
+            element={<CommercialRobotic />}
+          />
+          <Route path="/machines/mini" element={<Mini />} />
+          <Route path="/machines/micro" element={<Micro />} />
+          <Route path="/products" element={<Navigate to="/machines" replace />} />
+          <Route
+            path="/products/commercial-robotic-machine"
+            element={<Navigate to="/machines/commercial-robotic-machine" replace />}
+          />
+          <Route path="/products/mini" element={<Navigate to="/machines/mini" replace />} />
+          <Route path="/products/micro" element={<Navigate to="/machines/micro" replace />} />
+          <Route path="/supplies" element={<Supplies />} />
+          <Route path="/plus" element={<Plus />} />
+          <Route path="/contact" element={<Contact />} />
+          <Route path="/about" element={<About />} />
+          <Route path="/resources" element={<Resources />} />
+          <Route path="/privacy" element={<Privacy />} />
+          <Route path="/terms" element={<Terms />} />
+          <Route path="/billing-cancellation" element={<BillingCancellation />} />
+          <Route path="/cart" element={<Cart />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/login/operator" element={<Navigate to="/login" replace />} />
+          <Route path="/reset-password" element={<ResetPassword />} />
+          <Route element={<ProtectedRoute />}>
+            <Route path="/portal" element={<PortalDashboard />} />
+            <Route element={<MemberRoute />}>
+              <Route path="/portal/orders" element={<PortalOrders />} />
+              <Route path="/portal/account" element={<PortalAccount />} />
+              <Route path="/portal/reports" element={<PortalReports />} />
+              <Route path="/portal/training" element={<PortalTraining />} />
+              <Route path="/portal/training/:id" element={<PortalTrainingDetail />} />
+              <Route path="/portal/support" element={<PortalSupport />} />
+              <Route path="/portal/onboarding" element={<PortalOnboarding />} />
+            </Route>
+            <Route element={<AdminRoute />}>
+              <Route path="/admin" element={<AdminDashboard />} />
+              <Route path="/admin/orders" element={<AdminOrders />} />
+              <Route path="/admin/support" element={<AdminSupport />} />
+              <Route path="/admin/access" element={<AdminAccess />} />
+              <Route path="/admin/partner-records" element={<AdminPartnerRecords />} />
+              <Route path="/admin/machines" element={<AdminMachines />} />
+              <Route
+                path="/admin/accounts"
+                element={<Navigate to="/admin/access?tab=users" replace />}
+              />
+              <Route path="/admin/partnerships" element={<AdminPartnerships />} />
+              <Route path="/admin/reporting" element={<AdminReporting />} />
+              <Route
+                path="/admin/audit"
+                element={<Navigate to="/admin/access?tab=audit" replace />}
+              />
+            </Route>
           </Route>
-          <Route element={<AdminRoute />}>
-            <Route path="/admin" element={<AdminDashboard />} />
-            <Route path="/admin/orders" element={<AdminOrders />} />
-            <Route path="/admin/support" element={<AdminSupport />} />
-            <Route path="/admin/access" element={<AdminAccess />} />
-            <Route path="/admin/partner-records" element={<AdminPartnerRecords />} />
-            <Route path="/admin/machines" element={<AdminMachines />} />
-            <Route
-              path="/admin/accounts"
-              element={<Navigate to="/admin/access?tab=users" replace />}
-            />
-            <Route path="/admin/partnerships" element={<AdminPartnerships />} />
-            <Route path="/admin/reporting" element={<AdminReporting />} />
-            <Route
-              path="/admin/audit"
-              element={<Navigate to="/admin/access?tab=audit" replace />}
-            />
-          </Route>
-        </Route>
-        <Route path="*" element={<NotFound />} />
-      </Routes>
-    </Suspense>
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </Suspense>
+    </RouteErrorBoundary>
   </HostRedirectGate>
 );
 

--- a/src/components/routing/RouteErrorBoundary.tsx
+++ b/src/components/routing/RouteErrorBoundary.tsx
@@ -1,0 +1,73 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { RefreshCw } from "lucide-react";
+import { useLocation } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { clearChunkReloadMarkers, isChunkLoadError } from "@/lib/lazyRoute";
+
+type RouteErrorBoundaryProps = {
+  children: ReactNode;
+};
+
+type RouteErrorBoundaryState = {
+  error: unknown;
+};
+
+class RouteErrorBoundaryInner extends Component<
+  RouteErrorBoundaryProps,
+  RouteErrorBoundaryState
+> {
+  state: RouteErrorBoundaryState = {
+    error: null,
+  };
+
+  static getDerivedStateFromError(error: unknown): RouteErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: unknown, errorInfo: ErrorInfo) {
+    console.error("Route render failed", error, errorInfo);
+  }
+
+  handleRefresh = () => {
+    if (isChunkLoadError(this.state.error)) {
+      clearChunkReloadMarkers();
+    }
+
+    window.location.reload();
+  };
+
+  render() {
+    if (!this.state.error) {
+      return this.props.children;
+    }
+
+    const isUpdateError = isChunkLoadError(this.state.error);
+    const title = isUpdateError ? "App update required" : "Page failed to load";
+    const message = isUpdateError
+      ? "This tab needs the latest Bloomjoy app files. Refresh once to load the current version."
+      : "Refresh the page to try this route again. If it keeps failing, capture the URL and console error.";
+
+    return (
+      <div className="container-page py-10">
+        <div className="max-w-xl rounded-lg border border-border bg-background p-5 shadow-sm">
+          <p className="text-sm font-semibold text-foreground">{title}</p>
+          <p className="mt-2 text-sm text-muted-foreground">{message}</p>
+          <Button className="mt-4" size="sm" onClick={this.handleRefresh}>
+            <RefreshCw className="h-4 w-4" />
+            Refresh
+          </Button>
+        </div>
+      </div>
+    );
+  }
+}
+
+export const RouteErrorBoundary = ({ children }: RouteErrorBoundaryProps) => {
+  const location = useLocation();
+
+  return (
+    <RouteErrorBoundaryInner key={`${location.pathname}${location.search}`}>
+      {children}
+    </RouteErrorBoundaryInner>
+  );
+};

--- a/src/lib/lazyRoute.ts
+++ b/src/lib/lazyRoute.ts
@@ -1,0 +1,123 @@
+import { lazy, type ComponentType, type LazyExoticComponent } from "react";
+
+const CHUNK_RELOAD_KEY_PREFIX = "bloomjoy:chunk-reload:";
+
+type LazyRouteModule<TComponent extends ComponentType> = {
+  default: TComponent;
+};
+
+const chunkLoadPatterns = [
+  /ChunkLoadError/i,
+  /Loading chunk .+ failed/i,
+  /Failed to fetch dynamically imported module/i,
+  /error loading dynamically imported module/i,
+  /dynamically imported module/i,
+  /Failed to load module script/i,
+  /Importing a module script failed/i,
+  /module script/i,
+];
+
+const neverResolve = <TValue>() => new Promise<TValue>(() => undefined);
+
+const normalizeErrorText = (error: unknown) => {
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}`;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  return String(error);
+};
+
+const hashString = (value: string) => {
+  let hash = 5381;
+
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 33) ^ value.charCodeAt(index);
+  }
+
+  return (hash >>> 0).toString(36);
+};
+
+export const getChunkLoadFailureId = (error: unknown) => {
+  const errorText = normalizeErrorText(error);
+
+  if (!chunkLoadPatterns.some((pattern) => pattern.test(errorText))) {
+    return null;
+  }
+
+  const assetUrl = errorText.match(/(?:https?:\/\/[^"'()\s]+)?\/assets\/[^"'()\s]+\.js/i)?.[0];
+  const source = assetUrl ?? errorText;
+  const normalized = source
+    .replace(/^https?:\/\/[^/]+/i, "")
+    .replace(/[?#].*$/, "")
+    .trim()
+    .toLowerCase();
+
+  return hashString(normalized);
+};
+
+export const isChunkLoadError = (error: unknown) => getChunkLoadFailureId(error) !== null;
+
+const getSessionStorage = () => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+};
+
+const shouldAttemptReload = (failureId: string) => {
+  const storage = getSessionStorage();
+
+  if (!storage) {
+    return false;
+  }
+
+  const key = `${CHUNK_RELOAD_KEY_PREFIX}${failureId}`;
+
+  if (storage.getItem(key)) {
+    return false;
+  }
+
+  storage.setItem(key, String(Date.now()));
+  return true;
+};
+
+export const clearChunkReloadMarkers = () => {
+  const storage = getSessionStorage();
+
+  if (!storage) {
+    return;
+  }
+
+  for (let index = storage.length - 1; index >= 0; index -= 1) {
+    const key = storage.key(index);
+
+    if (key?.startsWith(CHUNK_RELOAD_KEY_PREFIX)) {
+      storage.removeItem(key);
+    }
+  }
+};
+
+export const lazyRoute = <TComponent extends ComponentType>(
+  importer: () => Promise<LazyRouteModule<TComponent>>,
+): LazyExoticComponent<TComponent> =>
+  lazy(() =>
+    importer().catch((error: unknown) => {
+      const failureId = getChunkLoadFailureId(error);
+
+      if (failureId && shouldAttemptReload(failureId)) {
+        window.location.reload();
+        return neverResolve<LazyRouteModule<TComponent>>();
+      }
+
+      throw error;
+    }),
+  );

--- a/vercel.json
+++ b/vercel.json
@@ -70,13 +70,15 @@
     {
       "src": "/(portal|admin)(.*)",
       "headers": {
+        "Cache-Control": "no-store",
         "X-Robots-Tag": "noindex, nofollow, noarchive, nosnippet"
       },
       "continue": true
     },
     {
-      "src": "/(login(?:/operator)?|reset-password|cart)",
+      "src": "/(login(?:/operator)?|reset-password|cart)/?",
       "headers": {
+        "Cache-Control": "no-store",
         "X-Robots-Tag": "noindex, nofollow, noarchive, nosnippet"
       },
       "continue": true
@@ -100,6 +102,13 @@
     {
       "src": "/admin(?:/.*)?/?",
       "dest": "/admin.html"
+    },
+    {
+      "src": "/assets/(.*)",
+      "headers": {
+        "Cache-Control": "public, max-age=31536000, immutable"
+      },
+      "continue": true
     },
     {
       "handle": "filesystem"


### PR DESCRIPTION
## Summary
- Fixes #253 by adding route-level lazy import recovery: a stale/missing chunk triggers one automatic reload per chunk/message in the current tab session, then falls through to a route error boundary if it still fails.
- Adds a root route error boundary around the existing Suspense tree so repeated chunk failures show an app-update refresh fallback instead of crashing the admin route.
- Tightens Vercel route/cache behavior so private app shells are no-store, existing hashed assets are immutable, and missing `/assets/*` files still return `404 text/plain` before the SPA fallback.

## Root cause
Fresh production `/admin` HTML currently points to valid chunks, and those chunks return JavaScript. The failing reports came from already-open tabs running older JS that tried to dynamically import stale hashed files such as `Dashboard-Ck3AyZbi.js`. The server-side `/assets/*` guard now correctly returns `404 text/plain` for those missing files, but the client had no lazy import recovery or route error boundary, so React crashed the route after the rejected dynamic import.

## Files changed
- `src/lib/lazyRoute.ts`: internal `lazyRoute()` helper, chunk-load detection, one-time session reload marker, refresh marker cleanup.
- `src/components/routing/RouteErrorBoundary.tsx` and `src/App.tsx`: route error boundary plus replacement of route-level `React.lazy()` calls with `lazyRoute()`.
- `vercel.json`: no-store headers for private/app shell routes; immutable cache header for existing `/assets/*`; keeps missing-asset 404 guard after filesystem and before SPA fallback.
- `scripts/seo-regression-check.mjs`: asserts private shell cache headers, asset route order, missing-asset guard, and Vite manifest file/import/dynamicImport references.
- `Docs/CURRENT_STATUS.md`, `Docs/PRODUCTION_RUNBOOK.md`, `Docs/QA_SMOKE_TEST_CHECKLIST.md`: document the incident, smoke checks, and production validation expectations.

## Verification commands/results
Latest run after rebasing onto `origin/main` commit `c1c783d` and addressing the QA regression-check gap:
- `npm ci` - passed; repo still reports existing 2 moderate audit findings.
- `npm run build` - passed.
- `npm run seo:check` - passed; validates 13 public and 19 private routes, Vercel asset/cache rules, private no-store header route order, and Vite manifest references.
- `npm test --if-present` - passed; no test script is present.
- `npm run lint --if-present` - passed with existing fast-refresh warnings only.
- `npm run reporting:validate-provider-parser` - passed. The older `reporting:validate-sunze-parser` command was renamed on latest `main` and now reports missing script.
- `npm run reporting:validate-refund-adjustments` - passed.
- Targeted route QA script - passed: `/admin`, `/admin/access`, `/admin/reporting`, and `/admin/partnerships` resolve to `/admin.html`; built admin chunks exist; asset cache/404 order is valid.
- Browser recovery QA - passed: intercepting one lazy route module request with 404 caused one automatic reload and then loaded; repeated 404s caused one reload and then rendered the app-update fallback.
- GitHub CI `verify` - passed on rebased head `5c6efb3`.
- Vercel preview deployment - passed, but direct unauthenticated preview HTTP checks are blocked by Vercel Authentication (`401`).

## How to test
1. In this branch worktree, run `npm ci`.
2. Create local env values for `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`, then run `npm run dev`.
3. Open `http://localhost:8080/admin`, `http://localhost:8080/admin/access`, `http://localhost:8080/admin/reporting`, and `http://localhost:8080/admin/partnerships` with a super-admin session.
4. Confirm direct route loads do not blank, and browser console does not show dynamic-import MIME or chunk-load crashes.
5. For chunk recovery, intercept one route-level module/chunk request to return 404 once; the page should reload once and recover. Repeating the failure should show the app-update refresh fallback.

## Production validation notes
- Current live HTTP check before this PR is deployed: `https://app.bloomjoyusa.com/admin`, `/admin/access`, `/admin/reporting`, and `/admin/partnerships` return `200 text/html` and reference current shell assets.
- Current live entry/admin chunks return `200 application/javascript`; the known stale `https://app.bloomjoyusa.com/assets/Dashboard-Ck3AyZbi.js` returns `404 text/plain; charset=utf-8` with `Cache-Control: no-store`.
- Current production does not yet show this PR's new private-shell `no-store` or existing-asset immutable headers because the PR is not deployed to production yet.
- After merge/deploy, validate a fresh hard refresh/incognito super-admin session on `/admin`, `/admin/access`, `/admin/reporting`, and `/admin/partnerships`. Existing already-open tabs that loaded old JavaScript before this deploy may need one manual refresh because that old JavaScript does not contain the new recovery helper.

## Open PR overlap
- The branch was rebased after #252 merged. Current open PRs no longer overlap the runtime/config files in this PR; any remaining overlap is limited to docs/checklist/runbook files.

