### PR TITLE
docs: align entitlement roadmap with implemented roles

### DIFF
--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -6,6 +6,12 @@
 - First priority is to **stabilize the POC** and align it to the MVP routing + docs workflow.
 - Write updates in plain language so non-technical readers can follow.
 
+## Entitlement roadmap alignment (2026-04-27)
+- P0 issue `#266` tracks the docs/source-of-truth gap where the entitlement persona roadmap still described Technician as a future gap after repo-side Technician entitlement work had landed.
+- `Docs/ENTITLEMENTS_PERSONA_ROADMAP.md` now separates implemented roles from schema/planning vocabulary and planned/not-live roles. Implemented repo-side roles now include Super Admin, baseline signed-in user, Plus access, training-only operator, Plus Account Owner for Technician management, Technician, and machine reporting entitlement levels.
+- Scoped Admin, customer-facing Partner Viewer, and the full custom entitlement-builder UI remain planned/not-live; this docs alignment does not implement them.
+- Caveat: repo-side Technician is implemented, but production issue `#214` remains open to verify/restore `resolve_my_technician_entitlements` before production Technician invite resolution is treated as fully verified.
+
 ## Production admin asset loading guard (2026-04-27)
 - P0 issue `#246` was traced to stale lazy-loaded chunk URLs under `/assets/*` being served through the SPA fallback as `200 text/html` after the referenced hashed files were no longer present in the active Vercel deployment.
 - Current production `/admin/access` HTML references fresh chunk hashes, and those current chunks return `application/javascript`; the repo hardening adds a Vercel guard so missing `/assets/*` files return `404` instead of `index.html`.

--- a/Docs/ENTITLEMENTS_PERSONA_ROADMAP.md
+++ b/Docs/ENTITLEMENTS_PERSONA_ROADMAP.md
@@ -1,9 +1,15 @@
 # Entitlements Persona Roadmap
 
 ## Purpose
-This document turns the current Bloomjoy entitlement brainstorm into a planning artifact for product, UAT, and future implementation work. It is intentionally documentation-only: no code, schema, RLS, route, or UI changes are introduced by this plan.
+This document is the current product source of truth for Bloomjoy entitlement personas. It separates:
 
-The near-term goal is to make the current role and entitlement direction clear enough that agents can build the next slices without blurring customer, technician, partner, and internal-admin access.
+- implemented repo-side roles and entitlement mechanisms,
+- schema/planning vocabulary that exists but is not fully productized,
+- planned roles and customer-facing flows that are not live yet.
+
+This roadmap is intentionally documentation-only: no code, schema, RLS, route, or UI changes are introduced by this plan.
+
+The near-term goal is to keep customer, technician, partner, reporting, and internal-admin access boundaries clear enough that agents do not re-open already implemented work or accidentally ship planned roles early.
 
 ## Product Guardrails
 - Corporate partner reviewed-PDF reporting remains the P0 reporting milestone.
@@ -11,64 +17,77 @@ The near-term goal is to make the current role and entitlement direction clear e
 - Customer account and team management should live under `/portal/account` or a future `/portal/team`.
 - Partner Viewer surfaces should live under `/portal/reports` once enabled, not under `/admin`.
 - Partnership setup must not grant portal access by itself.
-- Full super-admin role and entitlement builder UI remains P2.
+- Scoped Admin is not implemented in this repo yet.
+- Partner Viewer is not a live customer-facing flow yet.
+- Full custom role and entitlement builder UI is not implemented and remains under the P2 umbrella unless reprioritized.
 
-## Current Foundations
-- `super_admin` exists through `admin_roles` and is the current internal owner/admin mechanism.
-- Bloomjoy Plus access exists through paid subscriptions and free Plus grants.
-- Training-only operator grants exist and are separate from paid Plus membership.
-- Machine-level reporting entitlements exist with `viewer` and `report_manager` access levels.
-- `customer_account_memberships` already includes `partner_viewer`, but it is not yet a live customer-facing flow.
-- Current partner-dashboard planning keeps V1 partner-dashboard access super-admin-only until explicit partner-viewer permissions exist.
+## Implemented Today
+- Super Admin is implemented through `admin_roles.role = 'super_admin'` and remains the current internal owner/admin mechanism.
+- Baseline signed-in user access is implemented as basic portal access for authenticated users without Plus, training, reporting, or admin entitlements.
+- Plus access is implemented through paid `subscriptions`, free `plus_access_grants`, and admin-derived Plus access.
+- Training-only operator access is implemented through `operator_training_grants`; it grants training access without Plus benefits, billing, account-owner tools, or commerce discounts.
+- Plus Account Owner is implemented for Technician management through Plus access plus `customer_account_memberships.role = 'owner'`; owners can manage Technician grants only for controlled machines.
+- Technician is implemented repo-side through `technician_grants`, `technician_machine_assignments`, and Technician-sourced `reporting_machine_entitlements`; Technicians get training plus reporting for assigned machines only.
+- Machine reporting entitlement levels are implemented as `viewer` and `report_manager` on `reporting_machine_entitlements.access_level`.
+- Production caveat: repo-side Technician is implemented, but issue `#214` remains open to verify/restore `resolve_my_technician_entitlements` in production. Do not describe production Technician as fully verified until `#214` is resolved.
 
-## Gap Assessment
-- Scoped internal admins are not implemented yet.
-- Plus Account Owners cannot yet manage machine-scoped technician reporting access.
-- Technicians are not yet modeled as users with both training and machine-scoped reporting visibility.
-- Partner Viewer needs a first-class definition as external, non-paying, partner/reporting-only access.
-- A full role and entitlement management page for super-admins is still a lower-priority roadmap item.
+## Schema And Planning Vocabulary
+- `customer_account_memberships.role` includes role vocabulary that is not fully productized as live customer/admin flows: `account_admin`, `billing_manager`, `operator`, `support_contact`, `report_viewer`, `report_manager`, and `partner_viewer`.
+- The legacy `partner` membership role exists in the older partner/operator account migration and should be treated as legacy vocabulary, not the current Partner Viewer product flow.
+- `report_manager` as a customer account membership role is planning vocabulary; `reporting_machine_entitlements.access_level = 'report_manager'` is the implemented machine reporting entitlement level.
+
+## Planned Or Not Live
+- Scoped Admin is not implemented.
+- Partner Viewer is not a live customer-facing flow. Issue `#128` remains open unless it is explicitly superseded.
+- Full custom entitlement-builder UI is not implemented. Issue `#150` remains the umbrella/P2 item unless reprioritized.
 
 ## Persona Matrix
 | Persona | Who | Can See | Can Manage Or Grant | Explicit Exclusions | Status |
 | --- | --- | --- | --- | --- | --- |
-| Super Admin | Ethan and Ian as Bloomjoy co-owners | All Bloomjoy admin, portal, reporting, partnership, partner PDF, and audit surfaces | Roles, grants, machines, machine metadata, reporting access, partnerships, partner PDF generation/review/download, and audit review | None beyond normal production safeguards and auditability | Current owner role through `admin_roles`; continue as P0/P1 operating model |
-| Scoped Admin | Internal Bloomjoy admin such as Adam, limited to granted machines/accounts | Only machines, accounts, reports, and metadata explicitly granted by a super-admin | Future ability to manage machine metadata, reporting, and operational workflows only for entitled machines/accounts | Cannot view or manage ungranted machines, accounts, reports, partnerships, or users | Future implementation; keep in P2 umbrella until P0 reporting is trusted |
-| Plus Account Owner | Paying Bloomjoy Plus customer account owner | Their own machines, machine reporting, training, onboarding, support, account tools, and Plus benefits | Invite technicians and assign only machines the owner already controls; default V1 cap is 10 technician grants per Plus account | No internal admin setup, no unrelated customer accounts, no partner settlement access unless separately granted Partner Viewer, no global role management | P1 customer/team-management direction |
-| Technician | Customer staff member responsible for assigned machines | Training and reporting only for machines assigned by a Plus Account Owner or super-admin | No grant authority by default | No Plus discounts, billing, account-owner tools, partner settlement, admin operations, machine setup, or global reporting | P1 gap: define machine-scoped technician reporting entitlements |
-| Partner Viewer | External corporate partner or venue contact | Approved partner dashboards, report snapshots, and PDFs for granted partnerships or machines | No setup changes; may download approved artifacts only when the final product flow allows it | No Bloomjoy Plus benefits, commerce discounts, billing, technician management, admin setup, imports, tax/rule edits, schedules, or internal warning ledgers | Planned after reviewed corporate PDFs are trusted |
+| Super Admin | Ethan and Ian as Bloomjoy co-owners | All Bloomjoy admin, portal, reporting, partnership, partner PDF, and audit surfaces | Roles, grants, machines, machine metadata, reporting access, partnerships, partner PDF generation/review/download, and audit review | None beyond normal production safeguards and auditability | Implemented through `admin_roles.role = 'super_admin'` |
+| Baseline signed-in user | Authenticated customer/contact without Plus, training, reporting, or admin entitlement | Basic portal shell and baseline account/order surfaces | Own profile basics only | No Plus-gated training/onboarding/support, reporting, billing management, Technician management, partner settlement, or admin surfaces | Implemented as basic portal access |
+| Plus access holder | Paid Plus subscriber, free Plus grant recipient, or super-admin-derived Plus user | Plus-gated portal features, training, onboarding/support, and Plus benefits where applicable | Training-only operator access when allowed by access context | No unrelated customer accounts, partner settlement, global reporting, admin setup, or custom role management | Implemented through paid `subscriptions`, `plus_access_grants`, and admin-derived Plus access |
+| Training-only operator | Staff invited for operator training only | `/portal` and `/portal/training*` | No grant authority | No Plus discounts, billing, onboarding/support beyond the implemented training boundary, account-owner tools, reporting, partner settlement, or `/admin` | Implemented through `operator_training_grants` |
+| Plus Account Owner | Bloomjoy Plus customer account owner with an owner membership | Their controlled machines, training, onboarding, support, account tools, Plus benefits, and Technician management context | Invite/revoke Technicians and assign only controlled machines; default V1 cap is 10 Technician grants per Plus account | No internal admin setup, unrelated customer accounts, partner settlement access unless separately granted Partner Viewer, or global role management | Implemented for Technician management through Plus access plus `customer_account_memberships.role = 'owner'` |
+| Technician | Customer staff member responsible for assigned machines | Training and reporting only for machines assigned by a Plus Account Owner or super-admin | No grant authority by default | No Plus discounts, billing, account-owner tools, partner settlement, admin operations, machine setup, or global reporting | Implemented repo-side through Technician grants, machine assignments, and Technician-sourced machine reporting entitlements; production verification caveat remains `#214` |
+| Scoped Admin | Internal Bloomjoy admin limited to granted machines/accounts | Future: only machines, accounts, reports, and metadata explicitly granted by a super-admin | Future ability to manage machine metadata, reporting, and operational workflows only for entitled machines/accounts | Cannot view or manage ungranted machines, accounts, reports, partnerships, or users | Planned; not implemented |
+| Partner Viewer | External corporate partner or venue contact | Future: approved partner dashboards, report snapshots, and PDFs for granted partnerships or machines | No setup changes; may download approved artifacts only when the final product flow allows it | No Bloomjoy Plus benefits, commerce discounts, billing, Technician management, admin setup, imports, tax/rule edits, schedules, or internal warning ledgers | Planned; not live customer-facing flow (`#128`) |
 
 ## Permissioning Rules For Near-Term Work
 - Super Admin remains the only role that can configure partnerships, revenue-share rules, tax assumptions, partner report generation, and manual PDF review in V1.
 - Scoped Admin should be implemented only when the business is ready to support internal users with restricted machine/account visibility.
-- Plus Account Owner can grant technician access only within the machine/account boundary already granted to that owner.
-- Technician grants should compose training access with machine-scoped reporting visibility, without creating Plus benefits or account-owner permissions.
+- Plus Account Owner can grant Technician access only within the machine/account boundary already controlled by that owner.
+- Technician grants compose training access with machine-scoped reporting visibility, without creating Plus benefits or account-owner permissions.
 - Partner Viewer access must be explicit and partner/reporting-only; it must not be inherited from partnership setup or Plus membership.
 - Reporting visibility remains scoped and auditable. Do not add hidden global access paths for customer, technician, or partner personas.
-- Paid additional technician seats are a P2 commercial option; the near-term default is a 10 technician grant cap per Plus account.
+- Paid additional Technician seats are a P2 commercial option; the current default is a 10 Technician grant cap per Plus account.
+- Do not use this roadmap to imply production Technician invite resolution is fully verified until `#214` is closed.
 
 ## Recommended UX
 - Internal user and entitlement administration stays in `/admin/access`.
 - Partnership setup, revenue-share rules, machine assignment, tax assumptions, and partner PDF generation stay in `/admin/partnerships`.
-- Customer team and technician management should live under `/portal/account` or future `/portal/team`.
+- Current Technician management lives under `/portal/account`; broader customer team management may later move to a future `/portal/team`.
 - Operator and Plus Account Owner reporting should continue under `/portal/reports`.
 - Partner Viewer reporting should eventually appear under `/portal/reports` as a permissioned partner-dashboard/report-artifact view.
 - Users without partner-dashboard visibility should not see disabled partner tabs or upsell-style placeholders.
 
 ## GitHub Issue Roadmap
-- `#150` remains the P2 umbrella for scalable roles, entitlements, and a future super-admin role-management UI.
-- `#123` should carry the Plus Account Owner technician-management scope, including the 10 technician grant cap, grant-only-owned-machines rule, and paid additional seats as P2.
-- `#128` should define Partner Viewer as explicit partner/reporting-only access with no inherited Plus benefits or admin powers.
-- `#183` is the P1 issue for machine-scoped technician reporting entitlements, connecting current training-only grants with machine-specific reporting visibility. See `Docs/TECHNICIAN_ENTITLEMENTS_SPEC.md` for the detailed implementation spec.
+- `#266` tracks this P0 documentation/source-of-truth alignment.
+- `#214` remains open for production verification/restoration of `resolve_my_technician_entitlements`.
+- `#150` remains the P2 umbrella for scalable roles, entitlements, and the future custom role/entitlement builder UI unless reprioritized.
+- `#128` remains open for Partner Viewer as explicit partner/reporting-only access with no inherited Plus benefits or admin powers unless superseded.
+- `#123` and `#183` are closed definition/spec issues that informed the implemented Plus Account Owner and Technician flows.
+- See `Docs/TECHNICIAN_ENTITLEMENTS_SPEC.md` for the detailed Technician implementation reference.
 
 ## Acceptance Criteria
-- The roadmap clearly answers who can see what, who can grant what, and what is deferred.
-- Partner Viewer is first-class in the matrix and issue roadmap.
+- The roadmap clearly distinguishes implemented roles from schema/planning vocabulary and planned/not-live roles.
+- Partner Viewer remains first-class in the matrix and issue roadmap without being described as live.
 - No persona receives implicit access through partnership setup alone.
-- Plus Account Owner, Technician, and Partner Viewer boundaries are distinct and non-overlapping.
+- Plus Account Owner, Technician, Training-only operator, and Partner Viewer boundaries are distinct and non-overlapping.
 - Existing GitHub issues are updated instead of duplicated where possible.
 
 ## Assumptions
-- Partner Viewer is planned now, but implementation waits until corporate partner reviewed-PDF reporting is trusted.
+- Partner Viewer is planned, but implementation waits until corporate partner reviewed-PDF reporting is trusted.
 - `/admin` remains internal-only.
 - Partner Viewer receives reporting and partner artifacts only, not Bloomjoy Plus.
-- Full custom role and entitlement editing remains P2.
+- Scoped Admin and full custom role/entitlement editing remain planned work, not current repo functionality.

--- a/Docs/TECHNICIAN_ENTITLEMENTS_SPEC.md
+++ b/Docs/TECHNICIAN_ENTITLEMENTS_SPEC.md
@@ -1,15 +1,16 @@
 # Technician Entitlements Spec
 
 ## Status
-This is a docs-only implementation spec for GitHub issue `#183`: Define machine-scoped technician reporting entitlements.
+This document is the detailed Technician implementation reference that came out of GitHub issue `#183`: Define machine-scoped technician reporting entitlements. Issue `#183` is closed, and the repo-side Technician model has landed.
 
 Source and coordination notes:
 - `Docs/ENTITLEMENTS_PERSONA_ROADMAP.md` is the source of truth for the broader Super Admin, Scoped Admin, Plus Account Owner, Technician, and Partner Viewer persona boundaries.
 - This document is the detailed companion spec for the Technician portion of that roadmap.
-- PR `#182` is actively changing `/portal/reports`, partner dashboard UI, `src/lib/partnerDashboardReporting.ts`, and reporting preview migrations. This spec does not edit or require changes in those files.
+- Repo-side implementation lives in `technician_grants`, `technician_machine_assignments`, Technician-sourced `reporting_machine_entitlements`, the Technician RPC migrations, `src/lib/technicianEntitlements.ts`, `AuthContext`, and `TechnicianManagementPanel`.
+- Production caveat: issue `#214` remains open to verify/restore `resolve_my_technician_entitlements` in production. Do not treat production Technician invite resolution as fully verified until `#214` is resolved.
 
 ## Scope
-Define how a future Technician persona should combine existing training-only operator access with machine-scoped reporting access.
+Document how the Technician persona combines existing training-only operator access with machine-scoped reporting access.
 
 This spec does not implement partner viewer UI, partner dashboard permissions, PDF export behavior, billing behavior, dependency upgrades, or any route/code changes.
 
@@ -41,24 +42,24 @@ A Technician is not a Plus Account Owner, Partner Viewer, report manager, billin
 ### Training Relationship
 Current training-only operator grants remain valid and should continue to mean training-only access.
 
-Future Technician access should build on the training grant model rather than rename all existing operators into technicians automatically. The practical rule is:
+Technician access builds on the training grant model rather than renaming all existing operators into technicians automatically. The practical rule is:
 
 - An active `operator_training_grants` row grants training access only.
 - A Technician grant adds one or more assigned reporting machines to that training relationship.
 - Existing training-only operators with no machine assignments stay training-only.
-- If a Plus Account Owner assigns machines to an email that already has an active training grant from that owner/account, the later RPC should reuse/update that relationship instead of creating a duplicate seat.
-- If a Plus Account Owner assigns machines to a new email, the later RPC should create or update the training grant and then create machine assignments.
+- If a Plus Account Owner assigns machines to an email that already has an active training grant from that owner/account, the Technician RPCs reuse/update that relationship instead of creating a duplicate seat.
+- If a Plus Account Owner assigns machines to a new email, the Technician RPCs create or update the training grant and then create machine assignments.
 
 ### Reporting Relationship
-Technician reporting should compose with the existing reporting entitlement model, but only at machine scope.
+Technician reporting composes with the existing reporting entitlement model, but only at machine scope.
 
 Rules:
 
-- Technician reporting access should use `reporting_machine_entitlements` with `machine_id` populated.
-- Technician grants should not create account-level or location-level reporting entitlements.
-- Technician machine assignments should use `access_level = 'viewer'` by default.
-- `report_manager` should stay reserved for super-admin-managed reporting users unless a later decision explicitly delegates management authority.
-- Derived reporting entitlements should carry enough source metadata in a future schema slice to identify their Technician grant source, such as `source_type = 'technician_grant'` and `source_id = technician_grant_id`.
+- Technician reporting access uses `reporting_machine_entitlements` with `machine_id` populated.
+- Technician grants do not create account-level or location-level reporting entitlements.
+- Technician machine assignments use `access_level = 'viewer'` by default.
+- `report_manager` stays reserved for super-admin-managed reporting users unless a later decision explicitly delegates management authority.
+- Derived reporting entitlements carry Technician source metadata with `source_type = 'technician_grant'` and `source_id = technician_grant_id`.
 - Revoking a Technician grant or removing a Technician machine assignment must revoke or suspend the derived reporting entitlement for that machine.
 - A manually granted super-admin reporting entitlement should remain independent. The Technician revoke flow should not remove unrelated manual reporting access from the same user.
 
@@ -66,7 +67,7 @@ Effective Technician report visibility should be the active assigned-machine set
 
 ## Who Can Grant Or Revoke
 
-V1 grant authority:
+Implemented V1 grant authority:
 
 - Plus Account Owner: can grant, update, and revoke Technician access for their own Plus account.
 - Super Admin: can grant, update, and revoke Technician access for any account with a required audit reason.
@@ -80,7 +81,7 @@ Not V1 grant authority:
 - Reporting `report_manager`, unless a later decision explicitly expands this role.
 - Account admin or delegated team manager, unless a later decision adds delegated customer team management.
 
-The customer-facing flow should live in `/portal/account` or a future `/portal/team`, not in `/admin`. Internal override and audit review can stay in `/admin/access`.
+The current customer-facing flow lives in `/portal/account`, not in `/admin`. Future broader team management may move to `/portal/team`. Internal override and audit review can stay in `/admin/access`.
 
 ## Plus Account Owner Limits
 
@@ -169,28 +170,31 @@ Minimum audit fields:
 
 Use `admin_audit_log` if it remains the canonical audit table. If a customer-facing audit table is added later, it should still be queryable by super-admins and tied back to the same source grant IDs.
 
-## Proposed Implementation Slices
+## Implemented Repo Slices
+
+These slices have landed repo-side and remain listed here as implementation reference. Production verification for invite resolution is still tracked by issue `#214`.
 
 ### 1. Data Model And RLS
-Add a forward-only migration that introduces Technician source records and machine assignments without changing partner reporting behavior.
+Forward-only migrations introduced Technician source records and machine assignments without changing partner reporting behavior.
 
-Recommended shape:
+Implemented shape:
 
 - `technician_grants`: account, owner/sponsor, technician email/user, status, invite metadata, starts/expires, grant/revoke fields, audit reason.
 - `technician_machine_assignments`: technician grant ID, machine ID, active/revoked state, grant/revoke fields.
-- Optional source columns on `reporting_machine_entitlements`, such as `source_type` and `source_id`, so derived entitlements can be safely revoked without touching manual grants.
+- Source columns on `reporting_machine_entitlements`, including `source_type` and `source_id`, so derived entitlements can be safely revoked without touching manual grants.
 - RLS/helper functions that validate the owner controls the account and machine before allowing grants.
 - Helper that counts active unique Technician grants per Plus account and enforces the default cap of 10.
 
 Do not add account/location broad reporting inheritance for Technician in this slice.
 
 ### 2. Grant And Revoke RPCs
-Add customer-safe RPCs for the owner flow:
+Customer-safe RPCs exist for the owner flow:
 
 - `grant_technician_access(email, machine_ids, reason)`.
 - `update_technician_machines(grant_id, machine_ids, reason)`.
 - `revoke_technician_access(grant_id, reason)`.
 - `get_my_technician_grants()`.
+- `resolve_my_technician_entitlements(reason)`.
 
 RPC requirements:
 
@@ -202,14 +206,12 @@ RPC requirements:
 - Reuse or create the underlying operator training grant.
 - Create, update, or revoke derived machine-level reporting entitlements.
 - Write audit rows.
-- Send or queue invite email without blocking the database transaction on email delivery failure.
-
-Add super-admin override RPCs only if the internal UI needs them in the same slice. Otherwise keep internal override as a later PR.
+- Resolve pending Technician invites on sign-in and upsert derived machine-level reporting entitlements.
 
 ### 3. Customer UX
-Add the customer flow under `/portal/account` or a future `/portal/team`.
+The customer flow is under `/portal/account`.
 
-V1 UX should show:
+V1 UX shows:
 
 - Technician list with email, invite/status, assigned machine count, and last updated timestamp.
 - Seat usage: `used / 10`.
@@ -222,16 +224,16 @@ V1 UX should show:
 Do not add partner dashboard UI, partner viewer UI, PDF/report export behavior, or `/admin` customer team management.
 
 ### 4. Portal Reporting Integration
-Keep `/portal/reports` behavior machine-scoped.
+`/portal/reports` behavior remains machine-scoped.
 
-The reporting route should continue to rely on effective machine access, but future Technician implementation should ensure effective access excludes unassigned machines and suspended source grants. If source-aware entitlement filtering requires a helper change, make that change in a narrow PR with targeted tests.
+The reporting route relies on effective machine access. Technician-sourced access must exclude unassigned machines and suspended/revoked source grants.
 
 Do not edit partner dashboard behavior for this Technician slice.
 
 ### 5. QA And Smoke Tests
-Add smoke checklist items when implementation begins, not in this docs-only PR.
+Smoke checklist items now exist in `Docs/QA_SMOKE_TEST_CHECKLIST.md`.
 
-Future checks:
+Checks:
 
 - Plus Account Owner can add a Technician with one assigned machine.
 - Technician can open `/portal/training*`.
@@ -253,7 +255,7 @@ Backfill should be conservative:
 - Existing manual `reporting_machine_entitlements` remain manual reporting grants.
 - Do not reinterpret existing account/location reporting entitlements as Technician assignments.
 
-## Acceptance Criteria For Later Implementation
+## Acceptance Criteria For Implemented Repo-Side Model
 
 - Current training-only access continues to work unchanged.
 - A Technician with assigned machines has training plus reporting only for those machines.


### PR DESCRIPTION
## Summary
- Aligns the entitlement persona roadmap with the repo-side implemented role model.
- Marks Technician as implemented repo-side while preserving the production `resolve_my_technician_entitlements` caveat in #214.
- Separates implemented roles from schema/planning vocabulary and planned/not-live roles.

## Files changed
- `Docs/ENTITLEMENTS_PERSONA_ROADMAP.md`: reframes the roadmap as the current source of truth and updates the persona/status matrix.
- `Docs/TECHNICIAN_ENTITLEMENTS_SPEC.md`: marks the Technician spec as implemented repo-side reference instead of future-only planning.
- `Docs/CURRENT_STATUS.md`: records the P0 documentation alignment and caveat.

## Verification commands/results
- `npm ci` - passed; reported existing 2 moderate audit findings, no dependency upgrades made.
- `npm run build` - passed; Vite build and static prerender completed.
- `npm test --if-present` - passed; no test script is configured.
- `npm run lint --if-present` - passed with 8 existing fast-refresh warnings in UI/Auth files.

## How to test
1. Check out this branch: `git checkout agent/entitlement-roadmap-alignment`.
2. Run `npm ci`.
3. Run `npm run dev` and open the printed localhost URL, usually `http://localhost:8080`.
4. Review the docs changes in `Docs/ENTITLEMENTS_PERSONA_ROADMAP.md`, `Docs/TECHNICIAN_ENTITLEMENTS_SPEC.md`, and `Docs/CURRENT_STATUS.md`.
5. Optional unchanged surface sanity check, with local auth/Supabase configured: open `http://localhost:8080/portal/account` and `http://localhost:8080/portal/reports`.

## Issue created/updated
- Created and added to Bloomjoy Hub Priorities: Closes #266.
- #214 remains open for production verification/restoration of `resolve_my_technician_entitlements`.
- #128 remains open for Partner Viewer unless superseded.
- #150 remains the P2 umbrella unless reprioritized.

## Scope note
This PR aligns documentation/source of truth only. It does not implement Scoped Admin, Partner Viewer, or the full custom entitlement-builder UI.

## Open PR overlap
- Open PRs #260 and #261 also touch `Docs/CURRENT_STATUS.md`; this PR is docs-only and should be rebased if either merges first.
## Potential supersession note
The roadmap is being edited against broader entitlements best practices. This draft PR may need to be discarded or replaced if that best-practices pass changes the roadmap direction.