### PR TITLE
Fix refund warning migration SQL quote

### DIFF
--- a/supabase/migrations/202604270003_partner_scoped_refund_review_warnings.sql
+++ b/supabase/migrations/202604270003_partner_scoped_refund_review_warnings.sql
@@ -514,7 +514,7 @@ begin
     select jsonb_build_object(
       'warning_type', 'refund_adjustment_review_needed',
       'severity', 'non_blocking',
-      'message', 'Refund adjustment rows for this report's machines need admin review before they affect partner settlement.'
+      'message', 'Refund adjustment rows for this report''s machines need admin review before they affect partner settlement.'
     ) as warning
     from unresolved_refund_review review
     where review.row_count > 0


### PR DESCRIPTION
## Summary
- Fixes the SQL string escape in migration `202604270003_partner_scoped_refund_review_warnings.sql` after the corrected file was successfully applied to production.
- Keeps repository `main` aligned with the migration text now recorded in Supabase.

## Files changed
- `supabase/migrations/202604270003_partner_scoped_refund_review_warnings.sql`: escapes the apostrophe in the partner-scoped refund warning message.

## Verification commands + results
- `node scripts/check-supabase-migration-versions.mjs` - passed; 47 migrations checked, no duplicate versions.
- `supabase db push --dry-run` - passed; remote database is up to date.
- `git diff --check` / `git diff --cached --check` - passed.

## How to test
1. Confirm `supabase db push --dry-run` reports the remote database is up to date.
2. In a fresh environment, applying migration `202604270003` should parse the warning string correctly.

## Production note
- Production already has migration `202604270003` applied successfully from this corrected migration text.