### PR TITLE
Add Supabase migration parse/apply validation

### DIFF
--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -1,0 +1,29 @@
+name: Supabase Migrations
+
+on:
+  pull_request:
+    paths:
+      - 'supabase/migrations/**'
+      - 'scripts/validate-supabase-migrations.mjs'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/supabase-migrations.yml'
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v2
+        with:
+          version: 2.67.1
+      - name: Validate Supabase Migration Apply
+        run: npm run db:validate-migrations

--- a/Docs/LOCAL_DEV.md
+++ b/Docs/LOCAL_DEV.md
@@ -67,7 +67,9 @@
 
 Migration notes:
 - Supabase will not replay an edited migration after production has marked that version applied. Add a later forward-only repair migration when production schema drift needs to be fixed.
-- After migrations that add or replace frontend-facing RPCs, verify `supabase db push --dry-run` is clean and confirm the live REST endpoint does not return `404` or `PGRST202` for the changed RPCs.
+- Before production pushes for any migration branch, run `npm run db:validate-migrations`. This creates a temporary local Supabase project, copies `supabase/migrations`, starts a disposable local Postgres container on random ports, applies every migration from an empty database, and then tears it down. It requires Docker plus the Supabase CLI, but it does not require secrets or production data.
+- `supabase db push --dry-run` is still useful after linking a project because it checks local/remote migration history and shows which migrations would be pushed. It does not execute the SQL, so it can miss parse/apply failures inside SQL scripts or function bodies. `npm run db:validate-migrations` performs the actual local parse/apply validation.
+- After migrations that add or replace frontend-facing RPCs, run `npm run db:validate-migrations`, verify `supabase db push --dry-run` is clean, and confirm the live REST endpoint does not return `404` or `PGRST202` for the changed RPCs.
 
 ## Sales reporting import helpers
 Use these after the sales reporting migration has been applied.
@@ -229,7 +231,8 @@ To use all login methods in local dev:
 4) Run `git status -sb` and make sure it looks clean
 5) Run `npm run auth:preflight` when working on auth/OAuth launch tasks
 6) Run `npm run commerce:preflight` when working on Stripe/order/notification changes
-7) If you are in `C:\Repos\Bloomjoy_hub`, stop and switch to a worktree
+7) Run `npm run db:validate-migrations` when working on Supabase migrations
+8) If you are in `C:\Repos\Bloomjoy_hub`, stop and switch to a worktree
 
 ## Post-merge hygiene (2 minutes)
 Use this after a PR is merged or intentionally closed. Do not remove a worktree that still has uncommitted work.

--- a/Docs/PRODUCTION_RUNBOOK.md
+++ b/Docs/PRODUCTION_RUNBOOK.md
@@ -62,6 +62,7 @@ Security rule:
   - [ ] `npm run build`
   - [ ] `npm test --if-present`
   - [ ] `npm run lint --if-present`
+- [ ] `npm run db:validate-migrations` passes before any production Supabase migration push.
 - [ ] `npm run commerce:preflight -- --project-ref <project-ref>` passes
 - [ ] Supabase production backup/snapshot confirmed before applying new migrations.
 - [ ] Stripe products/prices verified (`STRIPE_SUGAR_MEMBER_PRICE_ID`, `STRIPE_SUGAR_NON_MEMBER_PRICE_ID`, `STRIPE_STICKS_PRICE_ID`, `STRIPE_PLUS_PRICE_ID`).
@@ -76,13 +77,20 @@ Use this order exactly.
 Apply all `supabase/migrations/*.sql` not already applied, oldest to newest.
 
 Recommended:
-1) Link Supabase project:
+1) Validate migration SQL against a disposable local database:
+   - `npm run db:validate-migrations`
+2) Link Supabase project:
    - `supabase link --project-ref <project-ref>`
-2) Push migrations:
+3) Preview pending migration history:
+   - `supabase db push --dry-run`
+4) Push migrations:
    - `supabase db push`
-3) If a migration adds or replaces frontend-facing RPCs, confirm PostgREST schema visibility:
+5) If a migration adds or replaces frontend-facing RPCs, confirm PostgREST schema visibility:
    - Changed RPCs do not return `404` or `PGRST202`.
    - Admin/reporting examples: `admin_get_account_summaries`, `admin_set_user_machine_reporting_access`, and `admin_get_partnership_reporting_setup`.
+
+Validation note:
+- `supabase db push --dry-run` checks migration history and lists what would be pushed to the linked project, but it does not execute the SQL. Use `npm run db:validate-migrations` first because it actually applies repo migrations to disposable local Postgres and catches SQL parse/apply errors without production data or secrets.
 
 Migration repair rule:
 - Do not edit an already-applied migration and expect production to replay it.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "seo:check": "node scripts/seo-regression-check.mjs",
     "auth:preflight": "node scripts/auth-preflight.mjs",
     "commerce:preflight": "node scripts/commerce-preflight.mjs",
+    "db:validate-migrations": "node scripts/validate-supabase-migrations.mjs",
     "orders:backfill": "node scripts/backfill-stripe-orders.mjs",
     "reporting:import-sales": "node scripts/import-sales-reporting-csv.mjs",
     "reporting:import-refunds": "node scripts/import-refund-adjustments-csv.mjs",

--- a/scripts/validate-supabase-migrations.mjs
+++ b/scripts/validate-supabase-migrations.mjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const migrationsDir = path.join(repoRoot, 'supabase', 'migrations');
+
+function printHelp() {
+  console.log(`Usage: npm run db:validate-migrations [-- --keep-temp] [-- --debug]
+
+Validates Supabase migrations by applying them to a disposable local database.
+
+Options:
+  --debug      Pass --debug to Supabase CLI commands.
+  --keep-temp  Leave the temporary Supabase project on disk for troubleshooting.
+  --help       Show this help text.
+`);
+}
+
+function log(message = '') {
+  process.stderr.write(`${message}\n`);
+}
+
+function parseArgs(argv) {
+  const options = {
+    debug: false,
+    keepTemp: false,
+    help: false,
+  };
+
+  for (const arg of argv) {
+    if (arg === '--debug') {
+      options.debug = true;
+      continue;
+    }
+
+    if (arg === '--keep-temp') {
+      options.keepTemp = true;
+      continue;
+    }
+
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  return options;
+}
+
+function run(command, args, { allowFailure = false, stdio = 'pipe' } = {}) {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio,
+    shell: false,
+  });
+
+  if (result.error) {
+    if (allowFailure) {
+      return result;
+    }
+
+    throw result.error;
+  }
+
+  if (!allowFailure && result.status !== 0) {
+    const error = new Error(`${command} ${args.join(' ')} failed with exit code ${result.status}`);
+    error.result = result;
+    throw error;
+  }
+
+  return result;
+}
+
+function requireCommand(command, args, installHint) {
+  const result = run(command, args, { allowFailure: true });
+
+  if (result.error && result.error.code === 'ENOENT') {
+    throw new Error(`${command} is not installed or is not on PATH. ${installHint}`);
+  }
+
+  if (result.status !== 0) {
+    const stderr = result.stderr ? `\n${result.stderr.trim()}` : '';
+    throw new Error(`${command} check failed.${stderr}`);
+  }
+
+  return result.stdout.trim();
+}
+
+function getMigrationFiles() {
+  if (!fs.existsSync(migrationsDir)) {
+    throw new Error(`Supabase migrations directory not found: ${migrationsDir}`);
+  }
+
+  return fs
+    .readdirSync(migrationsDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.sql'))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      server.close(() => {
+        if (typeof address === 'object' && address?.port) {
+          resolve(address.port);
+        } else {
+          reject(new Error('Unable to allocate a local port.'));
+        }
+      });
+    });
+  });
+}
+
+async function getDistinctPorts(count) {
+  const ports = new Set();
+
+  while (ports.size < count) {
+    ports.add(await getFreePort());
+  }
+
+  return [...ports];
+}
+
+function writeTempSupabaseProject(tempRoot, projectId, dbPort, shadowPort) {
+  const tempSupabaseDir = path.join(tempRoot, 'supabase');
+  fs.mkdirSync(tempSupabaseDir, { recursive: true });
+
+  fs.cpSync(migrationsDir, path.join(tempSupabaseDir, 'migrations'), {
+    recursive: true,
+  });
+
+  const config = `project_id = "${projectId}"
+
+[db]
+port = ${dbPort}
+shadow_port = ${shadowPort}
+major_version = 15
+`;
+
+  fs.writeFileSync(path.join(tempSupabaseDir, 'config.toml'), config, 'utf8');
+  fs.writeFileSync(path.join(tempSupabaseDir, 'seed.sql'), '', 'utf8');
+}
+
+function stopSupabase(tempRoot, debug) {
+  const args = ['stop', '--workdir', tempRoot, '--no-backup'];
+
+  if (debug) {
+    args.push('--debug');
+  }
+
+  const result = run('supabase', args, { allowFailure: true });
+
+  if (result.error || result.status !== 0) {
+    log('WARN: Unable to stop the disposable Supabase stack cleanly.');
+    if (result.stdout) {
+      log(result.stdout.trim());
+    }
+    if (result.stderr) {
+      log(result.stderr.trim());
+    }
+  }
+
+  return result;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  if (options.help) {
+    printHelp();
+    return;
+  }
+
+  const migrationFiles = getMigrationFiles();
+  if (migrationFiles.length === 0) {
+    throw new Error('No Supabase migration files found.');
+  }
+
+  const supabaseVersion = requireCommand(
+    'supabase',
+    ['--version'],
+    'Install the Supabase CLI before running migration validation.'
+  );
+  const dockerVersion = requireCommand(
+    'docker',
+    ['info', '--format', '{{.ServerVersion}}'],
+    'Install Docker and start the Docker daemon before running migration validation.'
+  );
+
+  const [dbPort, shadowPort] = await getDistinctPorts(2);
+  const projectId = `bj-migrations-${crypto.randomBytes(4).toString('hex')}`;
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'bloomjoy-supabase-migrations-'));
+
+  log(`Supabase CLI: ${supabaseVersion}`);
+  log(`Docker Engine: ${dockerVersion}`);
+  log(`Validating ${migrationFiles.length} migration file(s) in disposable project ${projectId}.`);
+  log(`Temporary workdir: ${tempRoot}`);
+
+  let validationError;
+
+  try {
+    writeTempSupabaseProject(tempRoot, projectId, dbPort, shadowPort);
+
+    const args = ['db', 'start', '--workdir', tempRoot];
+    if (options.debug) {
+      args.push('--debug');
+    }
+
+    run('supabase', args, { stdio: 'inherit' });
+    log('\nSupabase migration apply validation passed.');
+  } catch (error) {
+    validationError = error;
+  } finally {
+    if (options.keepTemp) {
+      log(`Keeping temporary workdir for troubleshooting: ${tempRoot}`);
+      log(`Stop the disposable stack with: supabase stop --workdir "${tempRoot}" --no-backup`);
+    } else {
+      stopSupabase(tempRoot, options.debug);
+      fs.rmSync(tempRoot, { recursive: true, force: true });
+    }
+  }
+
+  if (validationError) {
+    throw validationError;
+  }
+}
+
+main().catch((error) => {
+  console.error('\nSupabase migration apply validation failed.');
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
Closes #276.

## Summary
- Adds `npm run db:validate-migrations` to apply repo migrations against a disposable local Supabase/Postgres database before production pushes.
- Adds a focused `Supabase Migrations` GitHub Actions workflow for migration/tooling/package changes.
- Documents why `supabase db push --dry-run` is not the same as SQL parse/apply validation.

## Files changed
- `scripts/validate-supabase-migrations.mjs`: creates a temporary Supabase project, copies `supabase/migrations`, starts local Postgres on random ports, applies migrations, and cleans up without secrets or production data.
- `package.json`: adds the `db:validate-migrations` npm script.
- `.github/workflows/supabase-migrations.yml`: runs the migration apply validator on PRs that touch migrations or the validation tooling.
- `Docs/LOCAL_DEV.md`: adds local agent instructions and dry-run vs apply-validation guidance.
- `Docs/PRODUCTION_RUNBOOK.md`: adds the validation command to the pre-launch checklist and database deploy sequence.

## Verification commands + results
- `npm ci` - passed. NPM reported existing 2 moderate vulnerabilities.
- `npm run build` - passed. Build reported the existing stale Browserslist data warning.
- `npm test --if-present` - passed; no test script is present.
- `npm run lint --if-present` - passed with 8 existing fast-refresh warnings in generated/UI files.
- `npm run db:validate-migrations` - passed. Applied 48 migrations to a disposable local Supabase/Postgres database using Supabase CLI 2.67.1 and Docker Engine 29.1.3.
- `node --check scripts/validate-supabase-migrations.mjs` - passed.
- GitHub checks - passed: `CI / verify`, `Supabase Migrations / validate` (2m26s), Vercel, and Vercel Preview Comments.

## How to test
1. From a clean worktree on this branch, make sure Docker is running and Supabase CLI is installed.
2. Run `npm ci`.
3. Run `npm run db:validate-migrations`.
4. Confirm the command creates a temporary workdir, applies all migrations, prints `Supabase migration apply validation passed.`, and leaves no `bj-migrations-*` containers running afterward.

Key URLs: none. This is migration tooling only; it uses a disposable local Postgres container on random localhost ports and does not require app credentials.

## CI runtime
The new workflow is path-scoped to Supabase migration/tooling/package changes. Expected runtime is roughly 1-3 minutes when Docker images are warm and up to about 5 minutes on a cold GitHub-hosted runner. First PR run completed in 2m26s.

## Overlap / branch safety
Open PRs #155 and #142 also touch `Docs/LOCAL_DEV.md`, `Docs/PRODUCTION_RUNBOOK.md`, and `package.json`; Dependabot PR #194 touches `package.json`/`package-lock.json`. Rebase this branch from `main` and rerun verification if any of those merge first.