### PR TITLE
Add reporting highlight to login

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import {
   ArrowRight,
+  BarChart3,
   ClipboardCheck,
   GraduationCap,
   Headset,
@@ -521,6 +522,23 @@ export default function LoginPage() {
                 Use password, Google, or email-link sign-in to reach orders, account details,
                 training, onboarding, and support without bouncing through the sales shell.
               </p>
+
+              <div className="mt-5 rounded-2xl border border-primary/20 bg-primary/5 p-4 shadow-[var(--shadow-sm)]">
+                <div className="flex items-start gap-3">
+                  <div className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-background text-primary">
+                    <BarChart3 className="h-4 w-4" />
+                  </div>
+                  <div>
+                    <p className="font-semibold text-foreground">
+                      Reporting is available in the portal
+                    </p>
+                    <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                      Eligible operator accounts can review assigned-machine sales trends and
+                      exports after sign-in.
+                    </p>
+                  </div>
+                </div>
+              </div>
 
               <div className="mt-6 space-y-2.5 sm:space-y-3">
                 {operatorHighlights.map((highlight) => {


### PR DESCRIPTION
## Summary
- Adds a compact, permission-safe reporting mention to `/login` without changing the auth form.
- Keeps sign-in as the primary action and leaves password, Google, email-link, and reset entry points intact.

Closes #283.

## Files changed
- `src/pages/Login.tsx`: adds a small reporting callout and a Lucide reporting icon import.

## Verification
- `npm ci` - pass; npm reported 2 existing moderate audit findings.
- `npm run build` - pass; prerender completed for 13 public routes and 19 private route SEO tags. Browserslist stale-data warning only.
- `npm test --if-present` - pass; no test script is present, so npm exited cleanly with no output.
- `npm run lint --if-present` - pass with 8 existing fast-refresh warnings in generated/shared UI/AuthContext files.
- `npm run auth:preflight` - ran during preflight; failed because this fresh worktree has no local `VITE_SUPABASE_URL` or `VITE_SUPABASE_ANON_KEY`. No env files or secrets were committed.
- Browser smoke with Playwright on `http://127.0.0.1:5174/login` - pass on desktop `1440x1200` and mobile `390x1200`: reporting note visible; Google, password, magic-link, and reset-password entry points reachable; no horizontal overflow.
- Screenshot evidence captured locally: `output/playwright/login-reporting-desktop-full.png` and `output/playwright/login-reporting-mobile-full.png`.

## How to test
1. Check out this branch or use the worktree `C:\Repos\wt-login-reporting-highlight`.
2. Ensure local client-safe env values are set in `.env.local`: `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`.
3. Run `npm ci`.
4. Run `npm run dev` and open `http://localhost:8080/login`.
5. Confirm the reporting note is visible but secondary to sign-in.
6. Confirm the Google button, Password tab, Email Link tab, and `Forgot password? Send reset email` entry point remain reachable.
7. Open `http://localhost:8080/reset-password` to confirm the reset page route still loads.

Test credentials: none used for this copy/layout smoke.