### PR TITLE
Enhance Resources startup cost FAQ

### DIFF
--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -61,6 +61,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Cart line-item title, quantity controls, price, and remove action stack cleanly on mobile
 - [ ] Plus page: pricing and boundaries are visible and clear
 - [ ] Resources page shows Bloomjoy Plus teaser content for locked downloads (procedure docs, daily checklists, frequent updates)
+- [ ] `/resources#faq` opens to the FAQ section, shows startup-cost guidance without exact all-in-cost/ROI/profit claims, and keeps the quote/contact path clear on desktop and mobile
 - [ ] `/machines`, `/resources`, `/plus`, and `/contact` show primary content without excessive dead space on desktop and mobile
 - [ ] Footer legal links open `/privacy`, `/terms`, and `/billing-cancellation`
 - [ ] Footer support links navigate to valid Resources anchors (`/resources#faq` and `/resources#support-boundaries`)

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -61,7 +61,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Cart line-item title, quantity controls, price, and remove action stack cleanly on mobile
 - [ ] Plus page: pricing and boundaries are visible and clear
 - [ ] Resources page shows Bloomjoy Plus teaser content for locked downloads (procedure docs, daily checklists, frequent updates)
-- [ ] `/resources#faq` opens to the FAQ section, shows startup-cost guidance without exact all-in-cost/ROI/profit claims, and keeps the quote/contact path clear on desktop and mobile
+- [ ] `/resources#faq` opens to the FAQ section, shows startup-cost guidance without exact all-in-cost/ROI/profit claims, keeps the quote/contact path clear on desktop and mobile, and `/resources` page source includes matching FAQPage JSON-LD
 - [ ] `/machines`, `/resources`, `/plus`, and `/contact` show primary content without excessive dead space on desktop and mobile
 - [ ] Footer legal links open `/privacy`, `/terms`, and `/billing-cancellation`
 - [ ] Footer support links navigate to valid Resources anchors (`/resources#faq` and `/resources#support-boundaries`)

--- a/src/lib/seoRoutes.ts
+++ b/src/lib/seoRoutes.ts
@@ -80,6 +80,12 @@ export const machineBuyerFaqs = [
 
 export const resourcesFaqs = [
   {
+    q: "What startup costs should I expect to launch an operation?",
+    a: "Plan for several setup categories rather than one fixed all-in number: the machine purchase, opening consumables like sugar and paper sticks, shipping or freight, optional Bloomjoy Plus membership, venue or site setup needs, payment and operations supplies, and permits, insurance, or other local requirements where applicable. Bloomjoy uses the quote/contact flow to confirm machine fit, delivery assumptions, opening supplies, and support options so you can get a personalized launch estimate before invoicing.",
+    ctaLabel: "Request a personalized quote",
+    ctaHref: "/contact?type=quote&source=%2Fresources%23faq",
+  },
+  {
     q: "What support is included with machine purchase?",
     a: "The manufacturer support team provides 24/7 first-line technical support via WeChat. Bloomjoy provides onboarding guidance and Plus concierge support during US business hours.",
   },

--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -61,11 +61,17 @@ export default function ResourcesPage() {
       return;
     }
 
-    const frameId = window.requestAnimationFrame(() => {
+    const scrollToTarget = () => {
       document.getElementById(targetId)?.scrollIntoView({ block: 'start' });
-    });
+    };
 
-    return () => window.cancelAnimationFrame(frameId);
+    const frameId = window.requestAnimationFrame(scrollToTarget);
+    const timeoutIds = [100, 300].map((delay) => window.setTimeout(scrollToTarget, delay));
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      timeoutIds.forEach((timeoutId) => window.clearTimeout(timeoutId));
+    };
   }, [location.hash]);
 
   return (

--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -1,4 +1,5 @@
-import { Link } from 'react-router-dom';
+import { useEffect } from 'react';
+import { Link, useLocation } from 'react-router-dom';
 import { ArrowRight, Download, Lock } from 'lucide-react';
 import { Layout } from '@/components/layout/Layout';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
@@ -46,8 +47,26 @@ const resourceGroups = [
 ];
 
 export default function ResourcesPage() {
+  const location = useLocation();
   const currentLocation = typeof window === 'undefined' ? undefined : window.location;
   const operatorLoginUrl = getCanonicalUrlForSurface('app', '/login', '', '', currentLocation);
+
+  useEffect(() => {
+    if (!location.hash) {
+      return;
+    }
+
+    const targetId = decodeURIComponent(location.hash.slice(1));
+    if (!targetId) {
+      return;
+    }
+
+    const frameId = window.requestAnimationFrame(() => {
+      document.getElementById(targetId)?.scrollIntoView({ block: 'start' });
+    });
+
+    return () => window.cancelAnimationFrame(frameId);
+  }, [location.hash]);
 
   return (
     <Layout>
@@ -98,7 +117,18 @@ export default function ResourcesPage() {
               {resourcesFaqs.map((faq, i) => (
                 <AccordionItem key={i} value={`faq-${i}`}>
                   <AccordionTrigger className="text-left font-medium">{faq.q}</AccordionTrigger>
-                  <AccordionContent className="text-muted-foreground">{faq.a}</AccordionContent>
+                  <AccordionContent className="text-muted-foreground">
+                    <p>{faq.a}</p>
+                    {faq.ctaHref && faq.ctaLabel && (
+                      <Link
+                        to={faq.ctaHref}
+                        className="mt-3 inline-flex items-center gap-2 font-semibold text-primary hover:underline"
+                      >
+                        {faq.ctaLabel}
+                        <ArrowRight className="h-4 w-4" />
+                      </Link>
+                    )}
+                  </AccordionContent>
                 </AccordionItem>
               ))}
             </Accordion>


### PR DESCRIPTION
﻿Closes #288.

## Summary
- Added a startup-cost FAQ answer that covers expected launch cost categories without making all-in-cost, ROI, payback, profit, or legal claims.
- Added an inline quote CTA from the startup-cost answer and hardened Resources hash scrolling so `/resources#faq` and `/resources#support-boundaries` land correctly after the React route renders, including mobile preview loads.
- Updated the sponsor smoke checklist for the Resources FAQ anchor, mobile layout, unsupported-claim guardrails, and matching FAQPage JSON-LD.

## Files changed
- `src/lib/seoRoutes.ts`: adds the startup-cost FAQ copy and quote CTA metadata used by visible FAQ content and FAQ structured data.
- `src/pages/Resources.tsx`: renders optional FAQ CTAs and scrolls to Resources hash anchors after render with short retries for mobile/layout timing.
- `Docs/QA_SMOKE_TEST_CHECKLIST.md`: adds the new `/resources#faq` smoke check, including page-source FAQPage JSON-LD coverage.

## Verification
- `npm ci` - passed. npm reported 2 moderate audit findings already present on the default dependency set.
- `npm run build` - passed.
- `npm test --if-present` - passed; no test script output.
- `npm run lint --if-present` - passed with the existing 8 `react-refresh/only-export-components` warnings in shared UI/auth files.
- `npm run seo:check` - passed: 13 public routes and 19 private routes validated.
- Built-preview browser smoke on `http://127.0.0.1:8091` - passed on desktop `1280x900`, mobile `390x844`, and mobile `360x800`:
  - `/resources#faq` scrolled into safe view.
  - startup-cost answer included all requested categories.
  - no ROI/payback/profit/all-in/legal-advice claim language appeared.
  - quote CTA opened `/contact?type=quote&source=%2Fresources%23faq` and mounted the quote form.
  - `/resources#support-boundaries` scrolled to the support section heading.
  - no horizontal overflow, console errors, or page errors.
  - visible Resources FAQ names matched FAQPage JSON-LD names; startup-cost FAQ was present in structured data and CTA text did not leak into the answer text.
- Sub-agent QA lanes - completed; no code UX/SEO issues found. One P3 smoke-check coverage gap was addressed in this branch.
- `npm exec -- tsc -p tsconfig.app.json --noEmit --pretty false` - fails on existing unrelated project errors in reporting/training/admin/product files; no diagnostics were reported for touched Resources FAQ files.

## How to test
1. From this branch, run `npm ci`.
2. Start local dev with `npm run dev`.
3. Open `http://localhost:8080/resources#faq`.
4. Confirm the startup-cost FAQ is visible, includes the expected categories, avoids exact all-in-cost/ROI/profit claims, and shows the personalized quote link.
5. Check a mobile viewport around `390x844` and confirm the accordion text and CTA do not overflow or clip.
6. Click `Request a personalized quote` and confirm it opens `/contact?type=quote&source=%2Fresources%23faq` with inquiry type set to `Request a Quote`.
7. View page source for `/resources` and confirm FAQPage JSON-LD includes the Resources FAQ entries.

## Open PR overlap
- PR #155 (`agent/autonomous-marketing-foundation`) also touches `Docs/QA_SMOKE_TEST_CHECKLIST.md`; this PR's overlap is limited to one checklist line.
