### PR TITLE
Add Edge Function redirect URL allowlists

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,8 @@ STRIPE_SUGAR_NON_MEMBER_PRICE_ID=
 STRIPE_STICKS_PRICE_ID=
 # Stripe recurring monthly price for Plus (set to $100/month)
 STRIPE_PLUS_PRICE_ID=
+# Optional local/dev-only support for localhost checkout, billing, and invite URLs.
+BLOOMJOY_ALLOW_LOCAL_REDIRECT_URLS=false
 SUPABASE_URL=
 SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
         run: npm run reporting:validate-provider-parser
       - name: Refund Adjustment Regression Checks
         run: npm run reporting:validate-refund-adjustments
+      - name: Edge URL Allowlist Checks
+        run: npm run edge-url-allowlists:check
       - name: Test
         run: npm test --if-present
       - name: Lint

--- a/Docs/LOCAL_DEV.md
+++ b/Docs/LOCAL_DEV.md
@@ -281,6 +281,7 @@ For production deployment order and rollback, use `Docs/PRODUCTION_RUNBOOK.md`.
    - Optional migration bridge only: `supabase secrets set STRIPE_SUGAR_PRICE_ID=...`
    - `supabase secrets set STRIPE_STICKS_PRICE_ID=...`
    - `supabase secrets set STRIPE_PLUS_PRICE_ID=...`
+   - Optional local/dev only: `supabase secrets set BLOOMJOY_ALLOW_LOCAL_REDIRECT_URLS=true` when serving commerce/invite functions locally against a non-local `SUPABASE_URL`
    - `supabase secrets set STRIPE_WEBHOOK_SECRET=...`
    - `supabase secrets set RESEND_API_KEY=...`
    - `supabase secrets set INTERNAL_NOTIFICATION_FROM_EMAIL=...`

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "seo:check": "node scripts/seo-regression-check.mjs",
     "auth:preflight": "node scripts/auth-preflight.mjs",
     "commerce:preflight": "node scripts/commerce-preflight.mjs",
+    "edge-url-allowlists:check": "node scripts/validate-edge-url-allowlists.mjs",
     "db:validate-migrations": "node scripts/validate-supabase-migrations.mjs",
     "orders:backfill": "node scripts/backfill-stripe-orders.mjs",
     "reporting:import-sales": "node scripts/import-sales-reporting-csv.mjs",

--- a/scripts/validate-edge-url-allowlists.mjs
+++ b/scripts/validate-edge-url-allowlists.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { validateBrowserUrl } from "../supabase/functions/_shared/browser-url-allowlist.mjs";
+
+const allowedLocalUrls = [
+  "http://localhost:8080/cart?checkout=success",
+  "http://127.0.0.1:8080/portal/account?billing=return",
+];
+
+const allowedProductionUrls = [
+  "https://www.bloomjoyusa.com/supplies?sticksCheckout=cancel",
+  "https://app.bloomjoyusa.com/login",
+];
+
+const rejectedUrls = [
+  "https://example.com/cart?checkout=success",
+  "https://bloomjoyusa.com/login",
+  "http://app.bloomjoyusa.com/login",
+  "javascript:alert(1)",
+  "https://www.bloomjoyusa.com.evil.test/cart",
+  "https://user:pass@app.bloomjoyusa.com/login",
+];
+
+for (const url of allowedProductionUrls) {
+  const result = validateBrowserUrl(url, { label: "test URL" });
+  assert.equal(result.ok, true, `${url} should be allowed`);
+}
+
+for (const url of allowedLocalUrls) {
+  const result = validateBrowserUrl(url, {
+    label: "test URL",
+    allowLocalUrls: true,
+  });
+  assert.equal(result.ok, true, `${url} should be allowed in local/dev mode`);
+}
+
+for (const url of allowedLocalUrls) {
+  const result = validateBrowserUrl(url, { label: "test URL" });
+  assert.equal(result.ok, false, `${url} should be rejected by default`);
+  assert.match(result.error, /Bloomjoy production origin/);
+}
+
+for (const url of rejectedUrls) {
+  const result = validateBrowserUrl(url, { label: "test URL" });
+  assert.equal(result.ok, false, `${url} should be rejected`);
+  assert.match(result.error, /Bloomjoy production|embedded credentials/);
+}
+
+const fallbackResult = validateBrowserUrl("", {
+  label: "login URL",
+  fallbackUrl: "https://app.bloomjoyusa.com/login",
+});
+assert.equal(fallbackResult.ok, true, "empty invite login URL should use the safe fallback");
+assert.equal(fallbackResult.url, "https://app.bloomjoyusa.com/login");
+
+const rejectedFallbackBypass = validateBrowserUrl("https://example.com/login", {
+  label: "login URL",
+  fallbackUrl: "https://app.bloomjoyusa.com/login",
+});
+assert.equal(
+  rejectedFallbackBypass.ok,
+  false,
+  "explicit external invite login URL should not fall back silently",
+);
+
+console.log("Edge URL allowlist checks passed");

--- a/supabase/functions/_shared/browser-url-allowlist.mjs
+++ b/supabase/functions/_shared/browser-url-allowlist.mjs
@@ -1,0 +1,126 @@
+const allowedProductionOrigins = new Set([
+  "https://www.bloomjoyusa.com",
+  "https://app.bloomjoyusa.com",
+]);
+
+const allowedLocalHosts = new Set(["localhost", "127.0.0.1"]);
+const allowedLocalProtocols = new Set(["http:", "https:"]);
+const enabledEnvValues = new Set(["1", "true", "yes", "on"]);
+
+/**
+ * @typedef {Object} BrowserUrlValidationOptions
+ * @property {string} [label]
+ * @property {string | null} [fallbackUrl]
+ * @property {boolean} [allowLocalUrls]
+ *
+ * @typedef {Object} BrowserUrlValidationSuccess
+ * @property {true} ok
+ * @property {string} url
+ * @property {boolean} isProductionOrigin
+ * @property {boolean} isLocalOrigin
+ *
+ * @typedef {Object} BrowserUrlValidationFailure
+ * @property {false} ok
+ * @property {string} error
+ *
+ * @typedef {BrowserUrlValidationSuccess | BrowserUrlValidationFailure} BrowserUrlValidationResult
+ */
+
+export const allowedBrowserUrlOrigins = Object.freeze([
+  ...allowedProductionOrigins,
+  "http://localhost:<port>",
+  "https://localhost:<port>",
+  "http://127.0.0.1:<port>",
+  "https://127.0.0.1:<port>",
+]);
+
+const getDenoEnv = (key) => {
+  if (typeof Deno === "undefined") return null;
+
+  try {
+    return Deno.env.get(key) ?? null;
+  } catch {
+    return null;
+  }
+};
+
+const isEnabledEnvValue = (value) =>
+  enabledEnvValues.has(String(value ?? "").trim().toLowerCase());
+
+const isLocalSupabaseRuntime = () => {
+  const supabaseUrl = getDenoEnv("SUPABASE_URL");
+  if (!supabaseUrl) return false;
+
+  try {
+    const url = new URL(supabaseUrl);
+    return allowedLocalHosts.has(url.hostname);
+  } catch {
+    return false;
+  }
+};
+
+export const areLocalBrowserUrlsAllowed = () =>
+  isEnabledEnvValue(getDenoEnv("BLOOMJOY_ALLOW_LOCAL_REDIRECT_URLS")) ||
+  isLocalSupabaseRuntime();
+
+/**
+ * @param {unknown} value
+ * @param {BrowserUrlValidationOptions} [options]
+ * @returns {BrowserUrlValidationResult}
+ */
+export const validateBrowserUrl = (
+  value,
+  { label = "URL", fallbackUrl = null, allowLocalUrls } = {},
+) => {
+  const raw = typeof value === "string" ? value.trim() : "";
+  const candidate = raw || fallbackUrl;
+  const localUrlsAreAllowed =
+    typeof allowLocalUrls === "boolean" ? allowLocalUrls : areLocalBrowserUrlsAllowed();
+  const allowedOriginDescription = localUrlsAreAllowed
+    ? "a Bloomjoy production or localhost/127.0.0.1 origin"
+    : "a Bloomjoy production origin";
+
+  if (!candidate) {
+    return {
+      ok: false,
+      error: `${label} is required.`,
+    };
+  }
+
+  let url;
+  try {
+    url = new URL(candidate);
+  } catch {
+    return {
+      ok: false,
+      error: `${label} must be an absolute URL using ${allowedOriginDescription}.`,
+    };
+  }
+
+  if (url.username || url.password) {
+    return {
+      ok: false,
+      error: `${label} must not include embedded credentials.`,
+    };
+  }
+
+  const isProductionOrigin = allowedProductionOrigins.has(url.origin);
+  const isLocalOrigin =
+    localUrlsAreAllowed &&
+    allowedLocalHosts.has(url.hostname) &&
+    allowedLocalProtocols.has(url.protocol);
+
+  if (!isProductionOrigin && !isLocalOrigin) {
+    return {
+      ok: false,
+      error: `${label} must use ${allowedOriginDescription}.`,
+    };
+  }
+
+  return {
+    ok: true,
+    url: url.toString(),
+    isProductionOrigin,
+    isLocalOrigin,
+  };
+};

--- a/supabase/functions/operator-training-invite/index.ts
+++ b/supabase/functions/operator-training-invite/index.ts
@@ -1,6 +1,7 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.48.1";
 import { resolveSupabaseAccessToken } from "../_shared/auth.ts";
+import { validateBrowserUrl } from "../_shared/browser-url-allowlist.mjs";
 import { corsHeaders } from "../_shared/cors.ts";
 import { sendTransactionalEmail } from "../_shared/internal-email.ts";
 
@@ -33,21 +34,6 @@ type OperatorTrainingGrantRow = {
 };
 
 const sanitizeText = (value: unknown) => (typeof value === "string" ? value.trim() : "");
-
-const sanitizeLoginUrl = (value: unknown): string => {
-  const raw = sanitizeText(value);
-  if (!raw) return fallbackLoginUrl;
-
-  try {
-    const url = new URL(raw);
-    if (url.protocol !== "https:" && url.hostname !== "localhost" && url.hostname !== "127.0.0.1") {
-      return fallbackLoginUrl;
-    }
-    return url.toString();
-  } catch {
-    return fallbackLoginUrl;
-  }
-};
 
 const escapeHtml = (value: string): string =>
   value
@@ -161,7 +147,19 @@ serve(async (req) => {
 
     const body = await req.json();
     const grantId = sanitizeText(body?.grantId);
-    const loginUrl = sanitizeLoginUrl(body?.loginUrl);
+    const loginUrlResult = validateBrowserUrl(body?.loginUrl, {
+      label: "login URL",
+      fallbackUrl: fallbackLoginUrl,
+    });
+
+    if (!loginUrlResult.ok) {
+      return new Response(JSON.stringify({ error: loginUrlResult.error }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const loginUrl = loginUrlResult.url;
 
     if (!uuidPattern.test(grantId)) {
       return new Response(JSON.stringify({ error: "Operator grant ID is required." }), {

--- a/supabase/functions/stripe-customer-portal/index.ts
+++ b/supabase/functions/stripe-customer-portal/index.ts
@@ -2,6 +2,7 @@ import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import Stripe from "https://esm.sh/stripe@12.18.0?target=deno";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.48.1";
 import { resolveSupabaseAccessToken } from "../_shared/auth.ts";
+import { validateBrowserUrl } from "../_shared/browser-url-allowlist.mjs";
 import { corsHeaders } from "../_shared/cors.ts";
 
 export const config = {
@@ -77,16 +78,6 @@ serve(async (req) => {
   }
 
   try {
-    if (!stripe) {
-      return new Response(
-        JSON.stringify({ error: "Stripe is not configured." }),
-        {
-          status: 500,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        }
-      );
-    }
-
     const authResult = await resolveAuthenticatedUser(req);
     if (!authResult.user) {
       return new Response(
@@ -99,7 +90,9 @@ serve(async (req) => {
     }
 
     const body = await req.json();
-    const returnUrl = body?.returnUrl;
+    const returnUrlResult = validateBrowserUrl(body?.returnUrl, {
+      label: "return URL",
+    });
     const email = authResult.user.email?.trim().toLowerCase() ?? null;
 
     if (!email) {
@@ -112,11 +105,23 @@ serve(async (req) => {
       );
     }
 
-    if (!returnUrl) {
+    if (!returnUrlResult.ok) {
       return new Response(
-        JSON.stringify({ error: "Missing return URL." }),
+        JSON.stringify({ error: returnUrlResult.error }),
         {
           status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    const returnUrl = returnUrlResult.url;
+
+    if (!stripe) {
+      return new Response(
+        JSON.stringify({ error: "Stripe is not configured." }),
+        {
+          status: 500,
           headers: { ...corsHeaders, "Content-Type": "application/json" },
         }
       );

--- a/supabase/functions/stripe-plus-checkout/index.ts
+++ b/supabase/functions/stripe-plus-checkout/index.ts
@@ -2,6 +2,7 @@ import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import Stripe from "https://esm.sh/stripe@12.18.0?target=deno";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.48.1";
 import { resolveSupabaseAccessToken } from "../_shared/auth.ts";
+import { validateBrowserUrl } from "../_shared/browser-url-allowlist.mjs";
 import { corsHeaders } from "../_shared/cors.ts";
 
 export const config = {
@@ -82,16 +83,6 @@ serve(async (req) => {
   }
 
   try {
-    if (!stripe || !plusPriceId) {
-      return new Response(
-        JSON.stringify({ error: "Stripe is not configured." }),
-        {
-          status: 500,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        }
-      );
-    }
-
     const authResult = await resolveAuthenticatedUser(req);
     if (!authResult.user) {
       return new Response(
@@ -104,14 +95,41 @@ serve(async (req) => {
     }
 
     const body = await req.json();
-    const successUrl = body?.successUrl;
-    const cancelUrl = body?.cancelUrl;
+    const successUrlResult = validateBrowserUrl(body?.successUrl, {
+      label: "success URL",
+    });
+    const cancelUrlResult = validateBrowserUrl(body?.cancelUrl, {
+      label: "cancel URL",
+    });
 
-    if (!successUrl || !cancelUrl) {
+    if (!successUrlResult.ok) {
       return new Response(
-        JSON.stringify({ error: "Missing success or cancel URL." }),
+        JSON.stringify({ error: successUrlResult.error }),
         {
           status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    if (!cancelUrlResult.ok) {
+      return new Response(
+        JSON.stringify({ error: cancelUrlResult.error }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    const successUrl = successUrlResult.url;
+    const cancelUrl = cancelUrlResult.url;
+
+    if (!stripe || !plusPriceId) {
+      return new Response(
+        JSON.stringify({ error: "Stripe is not configured." }),
+        {
+          status: 500,
           headers: { ...corsHeaders, "Content-Type": "application/json" },
         }
       );

--- a/supabase/functions/stripe-sticks-checkout/index.ts
+++ b/supabase/functions/stripe-sticks-checkout/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import Stripe from "https://esm.sh/stripe@12.18.0?target=deno";
+import { validateBrowserUrl } from "../_shared/browser-url-allowlist.mjs";
 import { corsHeaders } from "../_shared/cors.ts";
 
 export const config = {
@@ -36,29 +37,46 @@ serve(async (req) => {
   }
 
   try {
-    if (!stripe || !sticksPriceId) {
-      return new Response(
-        JSON.stringify({ error: "Stripe is not configured." }),
-        {
-          status: 500,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        }
-      );
-    }
-
     const body = await req.json();
-    const successUrl = body?.successUrl;
-    const cancelUrl = body?.cancelUrl;
+    const successUrlResult = validateBrowserUrl(body?.successUrl, {
+      label: "success URL",
+    });
+    const cancelUrlResult = validateBrowserUrl(body?.cancelUrl, {
+      label: "cancel URL",
+    });
     const boxCount = Number(body?.boxCount ?? 0);
     const stickSize = String(body?.stickSize ?? "");
     const addressType = String(body?.addressType ?? "");
     const variant = body?.variant ? String(body.variant) : "plain";
 
-    if (!successUrl || !cancelUrl) {
+    if (!successUrlResult.ok) {
       return new Response(
-        JSON.stringify({ error: "Missing success or cancel URL." }),
+        JSON.stringify({ error: successUrlResult.error }),
         {
           status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    if (!cancelUrlResult.ok) {
+      return new Response(
+        JSON.stringify({ error: cancelUrlResult.error }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    const successUrl = successUrlResult.url;
+    const cancelUrl = cancelUrlResult.url;
+
+    if (!stripe || !sticksPriceId) {
+      return new Response(
+        JSON.stringify({ error: "Stripe is not configured." }),
+        {
+          status: 500,
           headers: { ...corsHeaders, "Content-Type": "application/json" },
         }
       );

--- a/supabase/functions/stripe-sugar-checkout/index.ts
+++ b/supabase/functions/stripe-sugar-checkout/index.ts
@@ -4,6 +4,7 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2.48.1";
 import {
   resolveForwardedSupabaseAccessToken,
 } from "../_shared/auth.ts";
+import { validateBrowserUrl } from "../_shared/browser-url-allowlist.mjs";
 import { corsHeaders } from "../_shared/cors.ts";
 
 export const config = {
@@ -162,16 +163,6 @@ serve(async (req) => {
   }
 
   try {
-    if (!stripe || !memberSugarPriceId || !nonMemberSugarPriceId) {
-      return new Response(
-        JSON.stringify({ error: "Stripe sugar pricing is not configured." }),
-        {
-          status: 500,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        }
-      );
-    }
-
     const authResult = await resolveOptionalCheckoutUser(req);
     if (!authResult.user && authResult.error) {
       return new Response(
@@ -185,14 +176,41 @@ serve(async (req) => {
 
     const body = await req.json();
     const items = Array.isArray(body?.items) ? body.items : [];
-    const successUrl = body?.successUrl;
-    const cancelUrl = body?.cancelUrl;
+    const successUrlResult = validateBrowserUrl(body?.successUrl, {
+      label: "success URL",
+    });
+    const cancelUrlResult = validateBrowserUrl(body?.cancelUrl, {
+      label: "cancel URL",
+    });
 
-    if (!successUrl || !cancelUrl) {
+    if (!successUrlResult.ok) {
       return new Response(
-        JSON.stringify({ error: "Missing success or cancel URL." }),
+        JSON.stringify({ error: successUrlResult.error }),
         {
           status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    if (!cancelUrlResult.ok) {
+      return new Response(
+        JSON.stringify({ error: cancelUrlResult.error }),
+        {
+          status: 400,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+      );
+    }
+
+    const successUrl = successUrlResult.url;
+    const cancelUrl = cancelUrlResult.url;
+
+    if (!stripe || !memberSugarPriceId || !nonMemberSugarPriceId) {
+      return new Response(
+        JSON.stringify({ error: "Stripe sugar pricing is not configured." }),
+        {
+          status: 500,
           headers: { ...corsHeaders, "Content-Type": "application/json" },
         }
       );


### PR DESCRIPTION
Closes #291

## Summary
- Added a shared Edge Function browser URL allowlist for `https://www.bloomjoyusa.com`, `https://app.bloomjoyusa.com`, and local/dev-only localhost/127.0.0.1 origins.
- Applied URL validation to Stripe sugar, Plus, sticks, customer portal, and operator training invite URLs before using caller-supplied redirect/return/login values.
- Added `npm run edge-url-allowlists:check` and wired it into CI so allowed production/local-dev cases and rejected external hosts are covered automatically.

## Files changed
- `supabase/functions/_shared/browser-url-allowlist.mjs`: shared URL validation helper with production defaults and explicit local/dev gating via `BLOOMJOY_ALLOW_LOCAL_REDIRECT_URLS=true` or local `SUPABASE_URL`.
- `supabase/functions/stripe-sugar-checkout/index.ts`, `stripe-plus-checkout/index.ts`, `stripe-sticks-checkout/index.ts`, `stripe-customer-portal/index.ts`: validate success/cancel/return URLs before Stripe session creation.
- `supabase/functions/operator-training-invite/index.ts`: validate the invite login URL and reject explicit external hosts instead of silently using them.
- `scripts/validate-edge-url-allowlists.mjs`, `package.json`, `.github/workflows/ci.yml`: lightweight allowlist checks and CI coverage.
- `.env.example`, `Docs/LOCAL_DEV.md`: local/dev flag documentation.

## Verification commands + results
- `npm ci` - passed; install still reports the existing 2 moderate dev dependency advisories.
- `npm run edge-url-allowlists:check` - passed.
- `npm run build` - passed; Vite build and prerender completed.
- `npm test --if-present` - passed; no test script produced output.
- `npm run lint --if-present` - passed with the existing 8 fast-refresh warnings in UI/Auth files.
- `deno check --no-lock` on all five changed Edge Functions - passed.
- Deno environment-gated URL QA - passed: production-like env rejects localhost, explicit local flag allows localhost, local Supabase runtime allows `127.0.0.1`.
- `node scripts/check-supabase-migration-versions.mjs` - passed.
- `npm run seo:check` - passed.
- `npm run reporting:validate-provider-parser` - passed.
- `npm run reporting:validate-refund-adjustments` - passed.

Preflight before edits:
- `npm run commerce:preflight` - ran and failed because local Stripe/Supabase/Resend/WeCom secrets are intentionally absent in this worktree.
- `npm run auth:preflight` - ran and failed because `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` are absent in this worktree.

## How to test
1. From this branch, run `npm ci`.
2. Run `npm run edge-url-allowlists:check` to verify these cases:
   - allowed local/dev localhost with explicit local mode: `http://localhost:8080/cart?checkout=success`
   - allowed local/dev localhost IP with explicit local mode: `http://127.0.0.1:8080/portal/account?billing=return`
   - rejected localhost by default production-like mode: `http://localhost:8080/cart?checkout=success`
   - allowed production storefront: `https://www.bloomjoyusa.com/supplies?sticksCheckout=cancel`
   - allowed production app: `https://app.bloomjoyusa.com/login`
   - rejected external HTTPS host: `https://example.com/cart?checkout=success`
3. For local Edge Function smoke testing, serve the target functions locally. If `SUPABASE_URL` is not local, set server-only `BLOOMJOY_ALLOW_LOCAL_REDIRECT_URLS=true` for the local function environment.
4. Run `npm run dev` and open `http://localhost:8080`.
5. Exercise sugar checkout from `/cart`, sticks checkout from `/supplies`, Plus checkout from `/plus`, customer portal from `/portal/account`, and operator invite from `/portal/account`; local URLs should work only in the local/dev function environment.
6. With a valid auth token for Plus, customer portal, and operator invite checks, a direct function request using `https://example.com/...` for `successUrl`, `cancelUrl`, `returnUrl`, or `loginUrl` should return `400` with an allowlist error instead of creating a Stripe session or sending an invite. Unauthenticated requests to auth-required functions still return `401` first.

## QA notes
- Two read-only sub-agent reviews found that localhost needed a production gate and that CI should run the allowlist script; both were fixed in this branch.
- CORS tightening remains intentionally out of scope because shared CORS headers are used by functions beyond issue #291.

## Overlap notes
- Current open PRs #194, #155, and #142 touch overlapping config/doc files such as `package.json`, `.env.example`, and `Docs/LOCAL_DEV.md`; this branch changes those only for the allowlist script/local-dev flag.
- No current open PRs touch the Edge Function files changed here.