### PR TITLE
Capture canonical machine IDs in refund intake

### DIFF
--- a/scripts/import-refund-adjustments-csv.mjs
+++ b/scripts/import-refund-adjustments-csv.mjs
@@ -231,6 +231,7 @@ try {
       source_reference: sourceReference,
       source_row_reference: input.sourceRowReference,
       source_row_hash: sourceRowHash,
+      source_reporting_machine_id: input.sourceReportingMachineId || null,
       source_location: input.sourceLocation || null,
       refund_date: input.refundDate || null,
       original_order_date: input.originalOrderDate || null,

--- a/scripts/refunds/refund-adjustment-utils.mjs
+++ b/scripts/refunds/refund-adjustment-utils.mjs
@@ -125,6 +125,31 @@ const pickNumberValue = (row, keys) => {
   return '';
 };
 
+const canonicalReportingMachineIdKeys = [
+  'source_reporting_machine_id',
+  'reporting_machine_id',
+  'canonical_reporting_machine_id',
+  'bloomjoy_reporting_machine_id',
+  'canonical_machine_id',
+  'bloomjoy_machine_id',
+  'machine_id',
+];
+
+const normalizeUuid = (value) => {
+  const text = String(value ?? '').trim().toLowerCase();
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(text)
+    ? text
+    : '';
+};
+
+const pickCanonicalReportingMachineId = (row) => {
+  const rawValue = pickText(row, canonicalReportingMachineIdKeys);
+  return {
+    rawPresent: Boolean(rawValue),
+    value: normalizeUuid(rawValue),
+  };
+};
+
 const parseCentAmount = (value) => {
   const text = String(value ?? '').trim();
   if (!text) return null;
@@ -204,6 +229,7 @@ export const normalizeAdjustmentType = (value) => {
 };
 
 export const extractRefundInput = (row, fallbackRowReference) => {
+  const canonicalMachineId = pickCanonicalReportingMachineId(row);
   const sourceLocation = pickText(row, [
     'location',
     'location_of_purchase',
@@ -246,6 +272,8 @@ export const extractRefundInput = (row, fallbackRowReference) => {
 
   return {
     sourceRowReference,
+    sourceReportingMachineId: canonicalMachineId.value,
+    hasSourceReportingMachineId: canonicalMachineId.rawPresent,
     sourceLocation,
     normalizedLocation: normalizeMatchText(sourceLocation),
     refundDate,
@@ -270,21 +298,24 @@ export const extractRefundInput = (row, fallbackRowReference) => {
   };
 };
 
-export const makeSourceRowHash = (input) =>
-  createHash('sha256')
-    .update(
-      JSON.stringify({
-        sourceRowReference: input.sourceRowReference,
-        sourceLocation: input.normalizedLocation,
-        refundDate: input.refundDate,
-        originalOrderDate: input.originalOrderDate,
-        amountCents: input.amountCents,
-        sourceStatus: input.normalizedSourceStatus,
-        sourceDecision: input.normalizedSourceDecision,
-        adjustmentType: input.adjustmentType,
-      })
-    )
-    .digest('hex');
+export const makeSourceRowHash = (input) => {
+  const hashPayload = {
+    sourceRowReference: input.sourceRowReference,
+    sourceLocation: input.normalizedLocation,
+    refundDate: input.refundDate,
+    originalOrderDate: input.originalOrderDate,
+    amountCents: input.amountCents,
+    sourceStatus: input.normalizedSourceStatus,
+    sourceDecision: input.normalizedSourceDecision,
+    adjustmentType: input.adjustmentType,
+  };
+
+  if (input.hasSourceReportingMachineId) {
+    hashPayload.sourceReportingMachineId = input.sourceReportingMachineId || null;
+  }
+
+  return createHash('sha256').update(JSON.stringify(hashPayload)).digest('hex');
+};
 
 export const buildSanitizedRefundPayload = ({
   input,
@@ -299,6 +330,8 @@ export const buildSanitizedRefundPayload = ({
   source_row_reference: input.sourceRowReference,
   source_row_hash: sourceRowHash,
   source_row_number: sourceRowNumber ? String(sourceRowNumber) : null,
+  source_reporting_machine_id: input.sourceReportingMachineId || null,
+  source_reporting_machine_id_present: Boolean(input.hasSourceReportingMachineId),
   source_location: input.sourceLocation || null,
   refund_date: input.refundDate || null,
   original_order_date: input.originalOrderDate || null,
@@ -508,7 +541,9 @@ export const countPartnerScopedRefundReviewRows = ({
 };
 
 export const matchRefundToMachine = (input, machineProfiles) => {
-  if (!input.refundDate || input.amountCents <= 0 || !input.normalizedLocation) {
+  const hasCanonicalMachineId = Boolean(input.hasSourceReportingMachineId);
+
+  if (!input.refundDate || input.amountCents <= 0 || (!input.normalizedLocation && !hasCanonicalMachineId)) {
     return {
       matchStatus: 'invalid',
       matchConfidence: 0,
@@ -539,6 +574,39 @@ export const matchRefundToMachine = (input, machineProfiles) => {
         : 'missing_source_decision',
       candidateMachineIds: [],
       matchedMachine: null,
+    };
+  }
+
+  if (hasCanonicalMachineId) {
+    if (!input.sourceReportingMachineId) {
+      return {
+        matchStatus: 'needs_review',
+        matchConfidence: 0,
+        matchReason: 'invalid_canonical_reporting_machine_id',
+        candidateMachineIds: [],
+        matchedMachine: null,
+      };
+    }
+
+    const matchedMachine =
+      machineProfiles.find((machine) => machine.id === input.sourceReportingMachineId) ?? null;
+
+    if (!matchedMachine) {
+      return {
+        matchStatus: 'needs_review',
+        matchConfidence: 0,
+        matchReason: 'canonical_reporting_machine_id_not_found',
+        candidateMachineIds: [],
+        matchedMachine: null,
+      };
+    }
+
+    return {
+      matchStatus: 'matched',
+      matchConfidence: 1,
+      matchReason: 'canonical_reporting_machine_id_match',
+      candidateMachineIds: [matchedMachine.id],
+      matchedMachine,
     };
   }
 

--- a/scripts/validate-refund-adjustments.mjs
+++ b/scripts/validate-refund-adjustments.mjs
@@ -107,6 +107,67 @@ assert.equal(exactMatch.matchStatus, 'matched');
 assert.equal(exactMatch.matchConfidence, 1);
 assert.equal(exactMatch.matchedMachine?.id, machines[0].id);
 
+const canonicalMachineInput = extractRefundInput(
+  {
+    source_reporting_machine_id: machines[1].id.toUpperCase(),
+    location_of_purchase: 'North Lobby',
+    refund_date: '2026-04-06',
+    refund_amount_usd: '12.50',
+    status: 'Closed',
+    decision: 'Approve',
+    request_id: 'SANITIZED-CANONICAL-REQ',
+  },
+  'canonical-machine-fixture'
+);
+assert.equal(canonicalMachineInput.hasSourceReportingMachineId, true);
+assert.equal(canonicalMachineInput.sourceReportingMachineId, machines[1].id);
+const canonicalMachineMatch = matchRefundToMachine(canonicalMachineInput, profiles);
+assert.equal(canonicalMachineMatch.matchStatus, 'matched');
+assert.equal(canonicalMachineMatch.matchReason, 'canonical_reporting_machine_id_match');
+assert.equal(canonicalMachineMatch.matchedMachine?.id, machines[1].id);
+assert.deepEqual(canonicalMachineMatch.candidateMachineIds, [machines[1].id]);
+
+const invalidCanonicalMachineInput = extractRefundInput(
+  {
+    source_reporting_machine_id: 'not-a-reporting-machine-id',
+    location_of_purchase: 'North Lobby',
+    refund_date: '2026-04-06',
+    refund_amount_usd: '12.50',
+    status: 'Closed',
+    decision: 'Approve',
+  },
+  'invalid-canonical-machine-fixture'
+);
+const invalidCanonicalMachineMatch = matchRefundToMachine(invalidCanonicalMachineInput, profiles);
+assert.equal(invalidCanonicalMachineMatch.matchStatus, 'needs_review');
+assert.equal(
+  invalidCanonicalMachineMatch.matchReason,
+  'invalid_canonical_reporting_machine_id'
+);
+assert.equal(invalidCanonicalMachineMatch.matchedMachine, null);
+
+const unknownCanonicalMachineInput = extractRefundInput(
+  {
+    source_reporting_machine_id: '99999999-9999-4999-8999-999999999999',
+    location_of_purchase: 'North Lobby',
+    refund_date: '2026-04-06',
+    refund_amount_usd: '12.50',
+    status: 'Closed',
+    decision: 'Approve',
+  },
+  'unknown-canonical-machine-fixture'
+);
+const unknownCanonicalMachineMatch = matchRefundToMachine(
+  unknownCanonicalMachineInput,
+  profiles
+);
+assert.equal(unknownCanonicalMachineMatch.matchStatus, 'needs_review');
+assert.equal(
+  unknownCanonicalMachineMatch.matchReason,
+  'canonical_reporting_machine_id_not_found'
+);
+assert.equal(unknownCanonicalMachineMatch.matchedMachine, null);
+
 const fuzzyMatch = matchRow({
   location: 'North entrance kiosk - manual refund',
   refund_date: '2026-04-07',
@@ -334,6 +395,17 @@ assert.equal(sanitizedPayload.source_row_reference, 'SANITIZED-REQ-2');
 assert.equal(sanitizedPayload.source_location, 'North Lobby');
 assert.equal(sanitizedPayload.amount_cents, 850);
 assert.equal(sanitizedPayload.amount_source, 'refund_amount');
+const canonicalPayload = buildSanitizedRefundPayload({
+  input: canonicalMachineInput,
+  sourceReference: 'sanitized-source',
+  sourceRowHash: makeSourceRowHash(canonicalMachineInput),
+  sourceRowNumber: 3,
+  match: canonicalMachineMatch,
+});
+assert.equal(canonicalPayload.source_reporting_machine_id, machines[1].id);
+assert.equal(canonicalPayload.source_reporting_machine_id_present, true);
+assert.equal(canonicalPayload.source_location, 'North Lobby');
+assert.equal(canonicalPayload.matched_machine_id, machines[1].id);
 assert.equal(Object.prototype.hasOwnProperty.call(sanitizedPayload, 'email_address'), false);
 assert.equal(Object.prototype.hasOwnProperty.call(sanitizedPayload, 'venmo_zelle_payment_id'), false);
 assert.equal(Object.prototype.hasOwnProperty.call(sanitizedPayload, 'last_4_digits_of_your_card'), false);
@@ -495,6 +567,9 @@ console.log(
     status: 'ok',
     fixtures: {
       exactLocationMatch: exactMatch.matchStatus,
+      canonicalMachineIdPreferred: canonicalMachineMatch.matchStatus,
+      invalidCanonicalMachineIdHeldForReview: invalidCanonicalMachineMatch.matchStatus,
+      unknownCanonicalMachineIdHeldForReview: unknownCanonicalMachineMatch.matchStatus,
       fuzzyAliasMatch: fuzzyMatch.matchStatus,
       ambiguousMatch: ambiguousMatch.matchStatus,
       unmatchedRefund: unmatched.matchStatus,

--- a/src/lib/reporting.ts
+++ b/src/lib/reporting.ts
@@ -141,6 +141,7 @@ export type AdminRefundAdjustmentReviewRow = {
   id: string;
   source_reference: string;
   source_row_reference: string;
+  source_reporting_machine_id: string | null;
   source_location: string | null;
   refund_date: string | null;
   amount_cents: number;
@@ -589,7 +590,7 @@ export const fetchAdminReportingOverview = async (): Promise<AdminReportingOverv
     supabaseClient.rpc('admin_get_sunze_machine_mapping_queue'),
     supabaseClient
       .from('refund_adjustment_review_rows')
-      .select('id, source_reference, source_row_reference, source_location, refund_date, amount_cents, source_status, match_status, match_confidence, match_reason, candidate_machine_ids, matched_machine_id, resolution_status, applied_adjustment_id, imported_at, reporting_machines(machine_label)')
+      .select('id, source_reference, source_row_reference, source_reporting_machine_id, source_location, refund_date, amount_cents, source_status, match_status, match_confidence, match_reason, candidate_machine_ids, matched_machine_id, resolution_status, applied_adjustment_id, imported_at, reporting_machines(machine_label)')
       .order('imported_at', { ascending: false })
       .limit(20),
   ]);

--- a/supabase/functions/refund-adjustment-sync/index.ts
+++ b/supabase/functions/refund-adjustment-sync/index.ts
@@ -28,6 +28,8 @@ type ImportRowsOptions = {
 
 type RefundInput = {
   sourceRowReference: string;
+  sourceReportingMachineId: string;
+  hasSourceReportingMachineId: boolean;
   sourceLocation: string;
   normalizedLocation: string;
   refundDate: string;
@@ -131,6 +133,31 @@ const pickNumberValue = (row: RefundAdjustmentRow, keys: string[]) => {
     if (value !== undefined && value !== null && String(value).trim() !== "") return value;
   }
   return "";
+};
+
+const canonicalReportingMachineIdKeys = [
+  "source_reporting_machine_id",
+  "reporting_machine_id",
+  "canonical_reporting_machine_id",
+  "bloomjoy_reporting_machine_id",
+  "canonical_machine_id",
+  "bloomjoy_machine_id",
+  "machine_id",
+];
+
+const normalizeUuid = (value: unknown) => {
+  const text = String(value ?? "").trim().toLowerCase();
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(text)
+    ? text
+    : "";
+};
+
+const pickCanonicalReportingMachineId = (row: RefundAdjustmentRow) => {
+  const rawValue = pickText(row, canonicalReportingMachineIdKeys);
+  return {
+    rawPresent: Boolean(rawValue),
+    value: normalizeUuid(rawValue),
+  };
 };
 
 const parseCentAmount = (value: unknown) => {
@@ -342,6 +369,7 @@ const fetchRefundSheetRows = async () => {
 };
 
 const extractRefundInput = (row: RefundAdjustmentRow, fallbackRowReference: string): RefundInput => {
+  const canonicalMachineId = pickCanonicalReportingMachineId(row);
   const sourceLocation = pickText(row, [
     "location",
     "location_of_purchase",
@@ -365,6 +393,8 @@ const extractRefundInput = (row: RefundAdjustmentRow, fallbackRowReference: stri
       "response_id",
       "timestamp",
     ]) || fallbackRowReference,
+    sourceReportingMachineId: canonicalMachineId.value,
+    hasSourceReportingMachineId: canonicalMachineId.rawPresent,
     sourceLocation,
     normalizedLocation: normalizeMatchText(sourceLocation),
     refundDate: normalizeDate(pickText(row, [
@@ -402,8 +432,8 @@ const extractRefundInput = (row: RefundAdjustmentRow, fallbackRowReference: stri
   };
 };
 
-const sourceRowHash = async (input: RefundInput) =>
-  sha256Hex(JSON.stringify({
+const sourceRowHash = async (input: RefundInput) => {
+  const hashPayload: Record<string, unknown> = {
     sourceRowReference: input.sourceRowReference,
     sourceLocation: input.normalizedLocation,
     refundDate: input.refundDate,
@@ -412,7 +442,14 @@ const sourceRowHash = async (input: RefundInput) =>
     sourceStatus: input.normalizedSourceStatus,
     sourceDecision: input.normalizedSourceDecision,
     adjustmentType: input.adjustmentType,
-  }));
+  };
+
+  if (input.hasSourceReportingMachineId) {
+    hashPayload.sourceReportingMachineId = input.sourceReportingMachineId || null;
+  }
+
+  return sha256Hex(JSON.stringify(hashPayload));
+};
 
 const recordRun = async ({
   status,
@@ -525,7 +562,9 @@ const buildMachineProfiles = async (): Promise<MachineProfile[]> => {
 const uniqueIds = (machines: MachineProfile[]) => [...new Set(machines.map((machine) => machine.id))];
 
 const matchRefund = (input: RefundInput, machines: MachineProfile[]) => {
-  if (!input.refundDate || input.amountCents <= 0 || !input.normalizedLocation) {
+  const hasCanonicalMachineId = Boolean(input.hasSourceReportingMachineId);
+
+  if (!input.refundDate || input.amountCents <= 0 || (!input.normalizedLocation && !hasCanonicalMachineId)) {
     return {
       status: "invalid",
       confidence: 0,
@@ -552,6 +591,38 @@ const matchRefund = (input: RefundInput, machines: MachineProfile[]) => {
       reason: input.normalizedSourceDecision ? "source_decision_requires_review" : "missing_source_decision",
       candidateMachineIds: [] as string[],
       matchedMachine: null as MachineProfile | null,
+    };
+  }
+
+  if (hasCanonicalMachineId) {
+    if (!input.sourceReportingMachineId) {
+      return {
+        status: "needs_review",
+        confidence: 0,
+        reason: "invalid_canonical_reporting_machine_id",
+        candidateMachineIds: [] as string[],
+        matchedMachine: null as MachineProfile | null,
+      };
+    }
+
+    const matchedMachine = machines.find((machine) => machine.id === input.sourceReportingMachineId) ?? null;
+
+    if (!matchedMachine) {
+      return {
+        status: "needs_review",
+        confidence: 0,
+        reason: "canonical_reporting_machine_id_not_found",
+        candidateMachineIds: [] as string[],
+        matchedMachine: null as MachineProfile | null,
+      };
+    }
+
+    return {
+      status: "matched",
+      confidence: 1,
+      reason: "canonical_reporting_machine_id_match",
+      candidateMachineIds: [matchedMachine.id],
+      matchedMachine,
     };
   }
 
@@ -634,6 +705,8 @@ const buildSanitizedRefundPayload = ({
   source_row_reference: input.sourceRowReference,
   source_row_hash: sourceRowHash,
   source_row_number: sanitizeText(sourceRowNumber) || null,
+  source_reporting_machine_id: input.sourceReportingMachineId || null,
+  source_reporting_machine_id_present: Boolean(input.hasSourceReportingMachineId),
   source_location: input.sourceLocation || null,
   refund_date: input.refundDate || null,
   original_order_date: input.originalOrderDate || null,
@@ -756,6 +829,7 @@ const importRows = async (
             source_reference: resolvedSourceReference,
             source_row_reference: input.sourceRowReference,
             source_row_hash: hash,
+            source_reporting_machine_id: input.sourceReportingMachineId || null,
             source_location: input.sourceLocation || null,
             refund_date: input.refundDate || null,
             original_order_date: input.originalOrderDate || null,

--- a/supabase/migrations/202604280001_refund_canonical_machine_identity.sql
+++ b/supabase/migrations/202604280001_refund_canonical_machine_identity.sql
@@ -1,0 +1,11 @@
+alter table public.refund_adjustment_review_rows
+  add column if not exists source_reporting_machine_id uuid;
+
+create index if not exists refund_adjustment_review_rows_source_reporting_machine_idx
+  on public.refund_adjustment_review_rows (source_reporting_machine_id, refund_date desc)
+  where source_reporting_machine_id is not null;
+
+comment on column public.refund_adjustment_review_rows.source_reporting_machine_id is
+  'Canonical Bloomjoy reporting machine ID captured from refund intake when provided; intentionally not foreign-keyed so unknown, deleted, or inactive source IDs can be retained for audit/review while source_location remains the historical source text.';
+
+select pg_notify('pgrst', 'reload schema');


### PR DESCRIPTION
## Summary
- Closes #243 by adding a forward-only `source_reporting_machine_id` audit column for refund review rows.
- Parses explicit canonical Bloomjoy reporting machine ID fields in CSV and live refund sync imports, matching by that ID before alias/location matching.
- Keeps historical source location text for audit and holds invalid or unknown canonical IDs for review instead of falling through to fuzzy matching.

## Files changed
- `supabase/migrations/202604280001_refund_canonical_machine_identity.sql`: adds the canonical source machine ID audit column, index, and schema reload notify. The column is intentionally not foreign-keyed so unknown/deleted/inactive source IDs can be retained for audit/review without failing import staging.
- `scripts/refunds/refund-adjustment-utils.mjs`, `scripts/import-refund-adjustments-csv.mjs`, `supabase/functions/refund-adjustment-sync/index.ts`: parse/store canonical IDs, prefer them in matching, and preserve alias fallback when absent.
- `scripts/validate-refund-adjustments.mjs`: adds sanitized fixture coverage for canonical match preference, invalid canonical review hold, unknown canonical review hold, and sanitized payload fields.
- `src/lib/reporting.ts`: includes the new audit column in admin reporting review row reads.

## Verification commands + results
- `npm ci`: passed; npm reported the current tree has 2 moderate audit findings.
- `npm run build`: passed; Vite build and static prerender completed. Browserslist emitted its existing stale-data warning.
- `npm test --if-present`: passed; no test script is currently configured.
- `npm run lint --if-present`: passed with the existing 8 react-refresh warnings in shared UI/auth files.
- `npm run reporting:validate-refund-adjustments`: passed with aggregate-only sanitized fixtures: canonicalMachineIdPreferred=`matched`, invalidCanonicalMachineIdHeldForReview=`needs_review`, unknownCanonicalMachineIdHeldForReview=`needs_review`, sanitizedPayloadExcludesPrivateFields=`true`.
- `npm run db:validate-migrations`: passed in a disposable Supabase project; 51 migrations applied including `202604280001_refund_canonical_machine_identity.sql`.

## How to test
1. Check out this branch in a worktree: `git checkout agent/refund-canonical-machine`.
2. Run `npm ci`.
3. Run `npm run reporting:validate-refund-adjustments` to verify the sanitized refund matching fixtures.
4. Run `npm run db:validate-migrations` to verify the forward-only migration from an empty database.
5. For local UI smoke after applying migrations to a local Supabase project, run `npm run dev` and open `http://localhost:8080/admin/reporting` with a local super-admin session. Confirm the refund review panel still loads.

## Notes
- Aggregate-only validation evidence is included above. No raw refund rows, source locations, customer data, payment identifiers, or free-text incident content are included in this PR.
- Related to #236. This does not force invalid approved refunds into settlement and does not resolve #264 or #256.
- Open PR overlap check: #194, #155, and #142 do not touch the files changed in this branch.