### PR TITLE
Add deployment security headers and CSP policy

### DIFF
--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -17,6 +17,8 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] View page source on a direct-loaded private route (for example `/portal`) and confirm robots is `noindex`
 - [ ] `https://www.bloomjoyusa.com/login`, `/reset-password`, `/portal*`, and `/admin*` redirect to `https://app.bloomjoyusa.com/...`
 - [ ] `https://app.bloomjoyusa.com/` plus public marketing/storefront paths redirect back to `https://www.bloomjoyusa.com/...`
+- [ ] Preview/production header check: representative public, `/login`, `/portal`, and `/admin` responses include `Content-Security-Policy`, `X-Frame-Options: DENY` or CSP `frame-ancestors 'none'`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, `Permissions-Policy`, and `Strict-Transport-Security`
+- [ ] CSP smoke check: Supabase auth/storage/Edge Function requests, Google sign-in, Stripe checkout/customer-portal redirects, Vimeo training embeds, Google Fonts, and analytics hooks load without browser CSP violations
 - [ ] Production/preview asset check: JS files referenced by `/admin`, `/admin/access`, `/admin/reporting`, and `/admin/partnerships` return `application/javascript`, and a bogus `/assets/__missing-admin-chunk__.js` returns `404 text/plain` instead of the SPA fallback page
 - [ ] Stale route chunk recovery check: simulate one route-level JS chunk load failure, confirm the app performs one automatic reload, then confirm a repeated failure shows the app-update refresh fallback instead of a blank page
 - [ ] `robots.txt` is reachable and includes a sitemap reference

--- a/scripts/seo-regression-check.mjs
+++ b/scripts/seo-regression-check.mjs
@@ -482,10 +482,132 @@ const hasMissingAssetFallbackGuard = (routes) => {
   );
 };
 
+const parseContentSecurityPolicy = (policy) =>
+  new Map(
+    policy
+      .split(";")
+      .map((directive) => directive.trim())
+      .filter(Boolean)
+      .map((directive) => {
+        const [name, ...values] = directive.split(/\s+/);
+        return [name, values];
+      })
+  );
+
+const directiveIncludes = (policy, directive, expectedSource) =>
+  policy.get(directive)?.includes(expectedSource) ?? false;
+
+const validateGlobalSecurityHeaders = (routes) => {
+  const securityHeaderRouteIndex = routes.findIndex(
+    (route) =>
+      route?.src === "/(.*)" &&
+      route?.continue === true &&
+      typeof route?.headers?.["Content-Security-Policy"] === "string"
+  );
+
+  if (securityHeaderRouteIndex !== 0) {
+    throw new Error(
+      "vercel.json must apply global security headers before redirects, rewrites, and fallbacks"
+    );
+  }
+
+  const headers = routes[securityHeaderRouteIndex].headers;
+  const csp = parseContentSecurityPolicy(headers["Content-Security-Policy"]);
+
+  const requiredCspSources = [
+    ["default-src", "'self'"],
+    ["base-uri", "'self'"],
+    ["object-src", "'none'"],
+    ["frame-ancestors", "'none'"],
+    ["script-src", "'self'"],
+    ["script-src", "https://accounts.google.com"],
+    ["script-src", "https://js.stripe.com"],
+    ["script-src", "https://www.googletagmanager.com"],
+    ["script-src", "https://*.posthog.com"],
+    ["style-src", "'self'"],
+    ["style-src", "'unsafe-inline'"],
+    ["style-src", "https://fonts.googleapis.com"],
+    ["img-src", "data:"],
+    ["img-src", "blob:"],
+    ["img-src", "https://*.supabase.co"],
+    ["img-src", "https://*.vimeocdn.com"],
+    ["font-src", "https://fonts.gstatic.com"],
+    ["connect-src", "https://auth.bloomjoyusa.com"],
+    ["connect-src", "wss://auth.bloomjoyusa.com"],
+    ["connect-src", "https://*.supabase.co"],
+    ["connect-src", "wss://*.supabase.co"],
+    ["connect-src", "https://api.stripe.com"],
+    ["connect-src", "https://checkout.stripe.com"],
+    ["connect-src", "https://player.vimeo.com"],
+    ["connect-src", "https://www.google-analytics.com"],
+    ["connect-src", "https://*.posthog.com"],
+    ["frame-src", "https://player.vimeo.com"],
+    ["frame-src", "https://accounts.google.com"],
+    ["frame-src", "https://js.stripe.com"],
+    ["frame-src", "https://hooks.stripe.com"],
+    ["frame-src", "https://checkout.stripe.com"],
+    ["child-src", "https://player.vimeo.com"],
+    ["media-src", "https://*.vimeocdn.com"],
+    ["worker-src", "blob:"],
+    ["manifest-src", "'self'"],
+    ["form-action", "'self'"],
+    ["form-action", "https://accounts.google.com"],
+    ["form-action", "https://checkout.stripe.com"],
+  ];
+
+  for (const [directive, expectedSource] of requiredCspSources) {
+    if (!directiveIncludes(csp, directive, expectedSource)) {
+      throw new Error(
+        `vercel.json security CSP is missing ${expectedSource} in ${directive}`
+      );
+    }
+  }
+
+  if (!csp.has("upgrade-insecure-requests")) {
+    throw new Error("vercel.json security CSP is missing upgrade-insecure-requests");
+  }
+
+  if (headers["X-Frame-Options"] !== "DENY") {
+    throw new Error("vercel.json security headers must deny third-party framing");
+  }
+
+  if (headers["X-Content-Type-Options"] !== "nosniff") {
+    throw new Error("vercel.json security headers must set X-Content-Type-Options: nosniff");
+  }
+
+  if (headers["Referrer-Policy"] !== "strict-origin-when-cross-origin") {
+    throw new Error(
+      "vercel.json security headers must set Referrer-Policy: strict-origin-when-cross-origin"
+    );
+  }
+
+  if (headers["Strict-Transport-Security"] !== "max-age=63072000") {
+    throw new Error("vercel.json security headers must preserve the deployment HSTS baseline");
+  }
+
+  const permissionsPolicy = headers["Permissions-Policy"] ?? "";
+  const requiredPermissionsPolicyTokens = [
+    "camera=()",
+    "geolocation=()",
+    "microphone=()",
+    'payment=(self "https://checkout.stripe.com")',
+    'fullscreen=(self "https://player.vimeo.com")',
+    'picture-in-picture=(self "https://player.vimeo.com")',
+  ];
+
+  for (const token of requiredPermissionsPolicyTokens) {
+    if (!permissionsPolicy.includes(token)) {
+      throw new Error(`vercel.json Permissions-Policy is missing ${token}`);
+    }
+  }
+};
+
 const validateVercelConfig = async () => {
   const raw = await readFile(VERCEL_CONFIG_PATH, "utf8");
   const parsed = JSON.parse(raw);
   const routes = Array.isArray(parsed?.routes) ? parsed.routes : [];
+
+  validateGlobalSecurityHeaders(routes);
 
   if (!hasHostRedirectRule(routes)) {
     throw new Error("vercel.json is missing apex->www 308 host redirect rule");

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,18 @@
   "routes": [
     {
       "src": "/(.*)",
+      "headers": {
+        "Content-Security-Policy": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; script-src 'self' https://accounts.google.com https://js.stripe.com https://www.googletagmanager.com https://www.google-analytics.com https://app.posthog.com https://us.i.posthog.com https://us-assets.i.posthog.com https://*.posthog.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https://auth.bloomjoyusa.com https://*.supabase.co https://i.vimeocdn.com https://f.vimeocdn.com https://*.vimeocdn.com https://vumbnail.com https://*.stripe.com https://*.googleusercontent.com https://*.gstatic.com https://www.google-analytics.com https://www.googletagmanager.com; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://auth.bloomjoyusa.com wss://auth.bloomjoyusa.com https://*.supabase.co wss://*.supabase.co https://api.stripe.com https://checkout.stripe.com https://r.stripe.com https://m.stripe.network https://accounts.google.com https://player.vimeo.com https://*.vimeocdn.com https://www.google-analytics.com https://*.google-analytics.com https://analytics.google.com https://*.analytics.google.com https://app.posthog.com https://us.i.posthog.com https://us-assets.i.posthog.com https://*.posthog.com; frame-src 'self' https://player.vimeo.com https://accounts.google.com https://js.stripe.com https://hooks.stripe.com https://checkout.stripe.com; child-src 'self' https://player.vimeo.com https://accounts.google.com https://js.stripe.com https://hooks.stripe.com https://checkout.stripe.com; media-src 'self' blob: https://*.vimeocdn.com; worker-src 'self' blob:; manifest-src 'self'; form-action 'self' https://accounts.google.com https://checkout.stripe.com; upgrade-insecure-requests",
+        "X-Frame-Options": "DENY",
+        "X-Content-Type-Options": "nosniff",
+        "Referrer-Policy": "strict-origin-when-cross-origin",
+        "Permissions-Policy": "accelerometer=(), bluetooth=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(self \"https://checkout.stripe.com\"), usb=(), fullscreen=(self \"https://player.vimeo.com\"), picture-in-picture=(self \"https://player.vimeo.com\")",
+        "Strict-Transport-Security": "max-age=63072000"
+      },
+      "continue": true
+    },
+    {
+      "src": "/(.*)",
       "has": [
         {
           "type": "host",


### PR DESCRIPTION
Fixes #294

## Summary
- Adds a global Vercel security-header route with CSP, frame blocking, nosniff, referrer, permissions, and HSTS headers while preserving existing redirects and private no-store/noindex rules.
- Extends `npm run seo:check` to validate the required security headers and CSP allowlist in `vercel.json`.
- Adds smoke checklist coverage for preview/production header verification and CSP-sensitive flows.

## Files changed
- `vercel.json`: global deployment security headers and CSP policy.
- `scripts/seo-regression-check.mjs`: Vercel security-header/CSP regression assertions.
- `Docs/QA_SMOKE_TEST_CHECKLIST.md`: header and CSP smoke checks.

## Verification commands + results
- `npm ci` - passed; npm reported 2 existing moderate audit findings.
- `npm run build` - passed; Vite build completed and prerendered 13 public routes plus 19 private route head files.
- `npm test --if-present` - passed; no test script is currently present.
- `npm run lint --if-present` - passed with 8 existing Fast Refresh warnings in shared UI/auth files.
- `npm run seo:check` - passed; 13 public routes and 19 private routes validated, including the new Vercel security-header checks.
- Local header-emulation smoke against built `dist` - passed for `/`, `/login`, `/portal`, `/admin`, and `/assets/__missing-admin-chunk__.js`; private/auth routes retained `Cache-Control: no-store` and `X-Robots-Tag: noindex, nofollow, noarchive, nosnippet`.
- Browser CSP smoke with Chromium - passed after a temporary non-secret dummy-env build and local static server applying the proposed headers; `/`, `/machines`, `/login`, `/portal`, and `/admin` loaded with no CSP violations or page errors, and the missing asset route returned the expected `404`.
- Independent sub-agent CSP integration review - no blocking issues for Supabase, Stripe, Vimeo, Google GIS/fonts/analytics, PostHog, blob/data usage, or inline style needs. A P3 inline JSON-LD concern was evaluated against Chromium in the browser smoke and did not reproduce as a CSP violation.
- Independent sub-agent Vercel route/coverage review - no blocking issues; verified global header ordering, private no-store/noindex ordering, asset cache ordering, missing-asset 404 ordering, and regression coverage. Vercel docs confirm routes are processed in array order and `continue: true` continues matching: https://vercel.com/docs/project-configuration/vercel-json
- Vercel preview header curls attempted for `/`, `/login`, `/portal`, `/admin`, and `/assets/__missing-admin-chunk__.js`; unauthenticated requests returned `401 Unauthorized` from Vercel deployment protection before app headers, so preview header verification needs an authenticated preview session or bypass token.

## Allowed CSP domains documented
- Supabase/custom auth: `https://auth.bloomjoyusa.com`, `wss://auth.bloomjoyusa.com`, `https://*.supabase.co`, `wss://*.supabase.co`.
- Stripe checkout/portal support: `https://js.stripe.com`, `https://api.stripe.com`, `https://checkout.stripe.com`, `https://hooks.stripe.com`, `https://r.stripe.com`, `https://m.stripe.network`, `https://*.stripe.com`.
- Vimeo training media: `https://player.vimeo.com`, `https://i.vimeocdn.com`, `https://f.vimeocdn.com`, `https://*.vimeocdn.com`, `https://vumbnail.com`.
- Google sign-in/fonts/analytics: `https://accounts.google.com`, `https://fonts.googleapis.com`, `https://fonts.gstatic.com`, `https://www.googletagmanager.com`, `https://www.google-analytics.com`, `https://*.google-analytics.com`, `https://analytics.google.com`, `https://*.analytics.google.com`, `https://*.googleusercontent.com`, `https://*.gstatic.com`.
- PostHog analytics hooks: `https://app.posthog.com`, `https://us.i.posthog.com`, `https://us-assets.i.posthog.com`, `https://*.posthog.com`.

## How to test
1. From this branch, run `npm ci`, `npm run build`, and `npm run seo:check`.
2. For localhost app behavior, run `npm run dev` and open `http://localhost:8080/`, `/login`, `/portal`, `/admin`, `/cart`, and `/plus`; local Vite dev does not apply Vercel deployment headers.
3. On the Vercel preview URL with preview access, run `curl -sSI <preview-url>/`, `curl -sSI <preview-url>/login`, `curl -sSI <preview-url>/portal`, and `curl -sSI <preview-url>/admin`; confirm CSP, X-Frame-Options or `frame-ancestors`, nosniff, Referrer-Policy, Permissions-Policy, and HSTS are present.
4. On the preview URL with preview access, confirm `/login`, `/portal`, and `/admin` still include `Cache-Control: no-store` and `X-Robots-Tag: noindex, nofollow, noarchive, nosnippet`.
5. Smoke CSP-sensitive flows where credentials are available: Supabase login, Stripe checkout/customer portal redirects, and a Vimeo-backed training detail page.

## Overlap / risk notes
- Open PR #155 also edits `Docs/QA_SMOKE_TEST_CHECKLIST.md`; this branch only adds two checklist bullets near existing global SEO/deployment checks.
- Current production headers were inspected before this change: production already returned HSTS and private no-store/noindex headers, but did not expose CSP, X-Frame-Options, nosniff, Referrer-Policy, or Permissions-Policy before this branch.
- Residual manual QA: production-like Vercel response headers still need to be curled with preview bypass/auth because deployment protection blocks unauthenticated preview header inspection.