### PR TITLE
Harden legacy account actor RPC execution

### DIFF
--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -94,6 +94,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Google sign-in button follows official GIS rendering when `VITE_GOOGLE_CLIENT_ID` is configured locally
 - [ ] For auth launch hardening, Google consent screen shows Bloomjoy branding (name/logo/support email)
 - [ ] For auth launch hardening, Google callback host uses `auth.bloomjoyusa.com` (not `<project-ref>.supabase.co`)
+- [ ] DB/RPC security smoke for issue `#290`: as a non-admin authenticated session, direct calls fail with permission denied for legacy actor RPCs (`create_customer_account_invite_as_actor`, `record_customer_account_invite_delivery_as_actor`, `revoke_customer_account_access_as_actor`) and arbitrary-user helper RPCs (`get_portal_access_context_for_user`, `get_active_customer_account_id`, `get_active_customer_account_role`, `get_portal_access_tier_for_user`, `can_manage_customer_account_operators_for_user`, `can_access_plus_portal_for_user`, `has_active_customer_account_membership`, `is_partner_on_customer_account`) when passing any caller-supplied actor/user UUID; `get_my_portal_access_context` still returns only the current session context.
 - [ ] Logged-out visit to `/portal` redirects to login
 - [ ] App-shell routes (`/login`, `/reset-password`, `/portal*`, `/admin*`) do not render the public sales navbar or public footer
 - [ ] Dashboard loads with membership status, primary next step, and quick actions visible without excessive dead space on a desktop viewport

--- a/supabase/migrations/202604280005_rpc_actor_hardening.sql
+++ b/supabase/migrations/202604280005_rpc_actor_hardening.sql
@@ -1,0 +1,142 @@
+-- Harden legacy account/operator RPCs reported in issue #290.
+--
+-- The legacy account RPCs below are SECURITY DEFINER functions that accept
+-- caller-supplied actor/user IDs. Current browser-callable access should stay
+-- on auth.uid()-bound wrappers such as get_my_portal_access_context(),
+-- get_portal_access_context(), can_access_plus_portal(), and
+-- can_access_members_only_training().
+
+revoke execute on function public.create_customer_account_invite_as_actor(uuid, text, text, text)
+  from public, anon, authenticated;
+revoke execute on function public.record_customer_account_invite_delivery_as_actor(uuid, uuid, text)
+  from public, anon, authenticated;
+revoke execute on function public.revoke_customer_account_access_as_actor(uuid, uuid, uuid, text)
+  from public, anon, authenticated;
+
+grant execute on function public.create_customer_account_invite_as_actor(uuid, text, text, text)
+  to service_role;
+grant execute on function public.record_customer_account_invite_delivery_as_actor(uuid, uuid, text)
+  to service_role;
+grant execute on function public.revoke_customer_account_access_as_actor(uuid, uuid, uuid, text)
+  to service_role;
+
+create or replace function public.has_my_active_customer_account_membership(p_account_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, auth
+as $$
+  select public.has_active_customer_account_membership(auth.uid(), p_account_id);
+$$;
+
+create or replace function public.is_my_partner_on_customer_account(p_account_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, auth
+as $$
+  select public.is_partner_on_customer_account(auth.uid(), p_account_id);
+$$;
+
+revoke execute on function public.has_my_active_customer_account_membership(uuid)
+  from public, anon;
+revoke execute on function public.is_my_partner_on_customer_account(uuid)
+  from public, anon;
+
+grant execute on function public.has_my_active_customer_account_membership(uuid)
+  to authenticated, service_role;
+grant execute on function public.is_my_partner_on_customer_account(uuid)
+  to authenticated, service_role;
+
+drop policy if exists "customer_accounts_select_member_or_admin" on public.customer_accounts;
+create policy "customer_accounts_select_member_or_admin"
+on public.customer_accounts
+for select
+to authenticated
+using (
+  public.is_super_admin(auth.uid())
+  or public.has_my_active_customer_account_membership(id)
+);
+
+drop policy if exists "customer_account_memberships_select_partner_or_self" on public.customer_account_memberships;
+create policy "customer_account_memberships_select_partner_or_self"
+on public.customer_account_memberships
+for select
+to authenticated
+using (
+  user_id = auth.uid()
+  or public.is_super_admin(auth.uid())
+  or public.is_my_partner_on_customer_account(account_id)
+);
+
+drop policy if exists "customer_account_invites_select_partner_or_admin" on public.customer_account_invites;
+create policy "customer_account_invites_select_partner_or_admin"
+on public.customer_account_invites
+for select
+to authenticated
+using (
+  public.is_super_admin(auth.uid())
+  or public.is_my_partner_on_customer_account(account_id)
+);
+
+revoke execute on function public.has_active_customer_account_membership(uuid, uuid)
+  from public, anon, authenticated;
+revoke execute on function public.is_partner_on_customer_account(uuid, uuid)
+  from public, anon, authenticated;
+revoke execute on function public.get_active_customer_account_id(uuid)
+  from public, anon, authenticated;
+revoke execute on function public.get_active_customer_account_role(uuid)
+  from public, anon, authenticated;
+revoke execute on function public.get_portal_access_tier_for_user(uuid)
+  from public, anon, authenticated;
+revoke execute on function public.can_manage_customer_account_operators_for_user(uuid)
+  from public, anon, authenticated;
+revoke execute on function public.get_portal_access_context_for_user(uuid)
+  from public, anon, authenticated;
+revoke execute on function public.can_access_plus_portal_for_user(uuid)
+  from public, anon, authenticated;
+
+grant execute on function public.has_active_customer_account_membership(uuid, uuid)
+  to service_role;
+grant execute on function public.is_partner_on_customer_account(uuid, uuid)
+  to service_role;
+grant execute on function public.get_active_customer_account_id(uuid)
+  to service_role;
+grant execute on function public.get_active_customer_account_role(uuid)
+  to service_role;
+grant execute on function public.get_portal_access_tier_for_user(uuid)
+  to service_role;
+grant execute on function public.can_manage_customer_account_operators_for_user(uuid)
+  to service_role;
+grant execute on function public.get_portal_access_context_for_user(uuid)
+  to service_role;
+grant execute on function public.can_access_plus_portal_for_user(uuid)
+  to service_role;
+
+grant execute on function public.get_portal_access_context()
+  to authenticated, service_role;
+grant execute on function public.can_access_plus_portal()
+  to authenticated, service_role;
+grant execute on function public.can_access_members_only_training()
+  to authenticated, service_role;
+grant execute on function public.accept_customer_account_invite()
+  to authenticated, service_role;
+grant execute on function public.get_my_portal_access_context()
+  to authenticated, service_role;
+
+comment on function public.create_customer_account_invite_as_actor(uuid, text, text, text) is
+  'Legacy service-role-only account invite RPC. Browser callers must not pass actor user IDs.';
+comment on function public.record_customer_account_invite_delivery_as_actor(uuid, uuid, text) is
+  'Legacy service-role-only invite delivery RPC. Browser callers must not pass actor user IDs.';
+comment on function public.revoke_customer_account_access_as_actor(uuid, uuid, uuid, text) is
+  'Legacy service-role-only account access revoke RPC. Browser callers must not pass actor user IDs.';
+comment on function public.has_my_active_customer_account_membership(uuid) is
+  'Auth.uid-bound customer-account membership helper for browser-facing RLS checks.';
+comment on function public.is_my_partner_on_customer_account(uuid) is
+  'Auth.uid-bound customer-account partner helper for browser-facing RLS checks.';
+comment on function public.get_portal_access_context_for_user(uuid) is
+  'Service-role/internal helper for arbitrary-user portal access checks. Browser callers should use get_my_portal_access_context() or get_portal_access_context().';
+
+select pg_notify('pgrst', 'reload schema');


### PR DESCRIPTION
Closes #290.

## Summary
- Revokes browser-role execute from legacy `*_as_actor` customer account RPCs that accepted caller-supplied actor UUIDs.
- Moves arbitrary-user customer account helper RPCs to service-role/internal use and keeps browser access on `auth.uid()`-bound wrappers.
- Rewires legacy customer-account RLS policies through current-user helper wrappers, explicitly scopes those policies to `authenticated`, and adds the #290 smoke note to the QA checklist.

## Files changed
- `supabase/migrations/202604280005_rpc_actor_hardening.sql`: forward-only RPC grant hardening, current-user policy helper wrappers, RLS policy refresh, PostgREST schema reload. Timestamp was moved after syncing latest `main` to avoid a newly merged migration prefix collision.
- `Docs/QA_SMOKE_TEST_CHECKLIST.md`: targeted DB/RPC spoofing smoke note covering the full revoked actor/helper surface.

## Verification commands + results
- `npm ci`: passed. Existing npm audit output still reports 2 moderate dev dependency advisories.
- `npm run build`: passed. Build completed and prerendered static HTML; existing Browserslist staleness notice only.
- `npm test --if-present`: passed; no test script produced output.
- `npm run lint --if-present`: passed with 0 errors and the existing 8 fast-refresh warnings.
- `npm run db:validate-migrations`: passed after syncing latest `main`, applying all 53 migration files to a disposable local stack with Supabase CLI 2.67.1 and Docker Engine 29.1.3.
- `supabase db lint --local --fail-on error`: passed against the disposable stack before the final sync; existing warnings remain in `public.save_training_progress` for reserved/unused `current_timestamp`.
- Additional kept-stack privilege smoke: `authenticated` and `anon` cannot execute `create_customer_account_invite_as_actor`, `record_customer_account_invite_delivery_as_actor`, `revoke_customer_account_access_as_actor`, `get_portal_access_context_for_user`, `get_active_customer_account_id`, `get_active_customer_account_role`, `get_portal_access_tier_for_user`, `can_manage_customer_account_operators_for_user`, `can_access_plus_portal_for_user`, `has_active_customer_account_membership`, or `is_partner_on_customer_account`; `service_role` can execute them.
- Additional direct-call smoke: `SET ROLE authenticated` calls to representative revoked RPCs fail with `permission denied`; `get_my_portal_access_context` and the new `auth.uid()` RLS wrappers remain callable for authenticated callers.
- Additional RLS fixture smoke: a partner member can see the account, memberships, and pending invite for their account; an operator can see their own membership but not account invites; an unrelated authenticated user cannot see the account.
- Preflight: worktree/branch/fetch/status checks passed. `npm run auth:preflight` was run before edits and during QA and failed only because this new worktree has no `.env`/`.env.local` values for `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`.
- Independent sub-agent QA: two read-only explorer passes found no P0-P2 issues. Their P3 hardening notes were addressed by explicitly revoking `PUBLIC`/`anon` from the new wrappers, scoping recreated policies to `authenticated`, and expanding the QA smoke note to cover every revoked helper.

## How to test
1. From this branch/worktree, run `npm ci` and `npm run dev`.
2. Open `http://localhost:8080/login` and sign in with a non-admin test user.
3. Open `http://localhost:8080/portal` and confirm the portal still resolves the current session through `get_my_portal_access_context`.
4. After applying the migration to a local/preview Supabase project, use that same non-admin authenticated session to call the legacy actor/helper RPCs directly with another user's UUID. Calls to the legacy actor RPCs and arbitrary-user helpers listed in `Docs/QA_SMOKE_TEST_CHECKLIST.md` should fail with permission denied.
5. Confirm a call to `get_my_portal_access_context` still returns only the current authenticated user's context.

## Security rationale
The vulnerable surface was a `security definer` RPC set that let browser callers provide `p_actor_user_id`, causing permission checks and audit writes to evaluate against caller-supplied identity. The current app does not call those legacy actor RPCs, so this migration removes direct `authenticated`/`anon` execute and leaves them service-role-only. Arbitrary-user account helpers are likewise no longer browser-callable; browser-facing account checks now use `auth.uid()` wrappers so non-admin callers cannot spoof actor identity by passing a privileged UUID.