### PR TITLE
Make custom sticks artwork uploads private

### DIFF
--- a/Docs/CUSTOM_STICKS_ARTWORK_PRIVACY.md
+++ b/Docs/CUSTOM_STICKS_ARTWORK_PRIVACY.md
@@ -2,12 +2,14 @@
 
 ## Current Handling
 - New custom sticks artwork uploads go to the private Supabase Storage bucket `custom-sticks-artwork`.
-- New browser uploads use the `private/` object prefix and keep the existing 5 MB PNG/JPG/WEBP limits.
+- New browser uploads first request a server-generated signed upload token from `custom-sticks-artwork-upload`; the browser does not get direct anonymous Storage insert permission.
+- New uploads use the `private/` object prefix and keep the existing 5 MB PNG/JPG/WEBP limits.
 - Custom sticks procurement leads store artwork details in `lead_submissions.metadata.customSticksArtwork`, including bucket, storage path, file name, MIME type, size, and private access status.
 - Procurement lead text includes the storage bucket/path for operations context, not a long-lived public URL.
+- Lead intake verifies the uploaded object exists and checks Storage metadata against the submitted MIME type and size before saving the lead.
 
 ## Admin Access
-- Operations/admin users should generate short-lived links only when they need to inspect submitted artwork.
+- Super-admin users should generate short-lived links only when they need to inspect submitted artwork.
 - The `custom-sticks-artwork-link` Edge Function requires an authenticated super-admin session through `x-supabase-auth-token`.
 - Request body:
 
@@ -19,6 +21,7 @@
 
 - The function returns a signed URL capped at 15 minutes. Do not paste the signed URL into public tickets, customer emails, or long-lived notes.
 - The service-role key remains server-side in the Edge Function environment only.
+- For localhost QA, sign in as a super-admin, copy the browser session access token from Supabase Auth debug tooling, and send it as `x-supabase-auth-token` with the local function URL.
 
 ## Existing Public Objects
 - The privacy migration changes `custom-sticks-artwork` to `public = false` and removes anonymous read policy, so old public URLs should stop being a durable access path.

--- a/Docs/CUSTOM_STICKS_ARTWORK_PRIVACY.md
+++ b/Docs/CUSTOM_STICKS_ARTWORK_PRIVACY.md
@@ -1,0 +1,42 @@
+# Custom Sticks Artwork Privacy
+
+## Current Handling
+- New custom sticks artwork uploads go to the private Supabase Storage bucket `custom-sticks-artwork`.
+- New browser uploads use the `private/` object prefix and keep the existing 5 MB PNG/JPG/WEBP limits.
+- Custom sticks procurement leads store artwork details in `lead_submissions.metadata.customSticksArtwork`, including bucket, storage path, file name, MIME type, size, and private access status.
+- Procurement lead text includes the storage bucket/path for operations context, not a long-lived public URL.
+
+## Admin Access
+- Operations/admin users should generate short-lived links only when they need to inspect submitted artwork.
+- The `custom-sticks-artwork-link` Edge Function requires an authenticated super-admin session through `x-supabase-auth-token`.
+- Request body:
+
+```json
+{
+  "storagePath": "private/<object-name>"
+}
+```
+
+- The function returns a signed URL capped at 15 minutes. Do not paste the signed URL into public tickets, customer emails, or long-lived notes.
+- The service-role key remains server-side in the Edge Function environment only.
+
+## Existing Public Objects
+- The privacy migration changes `custom-sticks-artwork` to `public = false` and removes anonymous read policy, so old public URLs should stop being a durable access path.
+- Owner review should inventory legacy `public/` objects before deletion:
+
+```sql
+select
+  name,
+  created_at,
+  updated_at,
+  metadata->>'mimetype' as mime_type,
+  metadata->>'size' as size_bytes
+from storage.objects
+where bucket_id = 'custom-sticks-artwork'
+  and (storage.foldername(name))[1] = 'public'
+order by created_at desc;
+```
+
+- Compare inventory against older `lead_submissions.message` rows containing `Artwork URL:`. Keep or migrate only artwork still needed for active procurement.
+- For retained legacy artwork, either leave it private under the existing `public/` object path and use the signed-link function, or copy it into `private/` and update the related lead metadata during owner-approved cleanup.
+- Delete abandoned or duplicate legacy artwork only after owner review confirms it is no longer needed.

--- a/Docs/LOCAL_DEV.md
+++ b/Docs/LOCAL_DEV.md
@@ -308,6 +308,8 @@ For production deployment order and rollback, use `Docs/PRODUCTION_RUNBOOK.md`.
    - `supabase functions serve stripe-customer-portal --no-verify-jwt`
    - `supabase functions serve stripe-webhook --no-verify-jwt`
    - `supabase functions serve lead-submission-intake --no-verify-jwt`
+   - `supabase functions serve custom-sticks-artwork-upload --no-verify-jwt`
+   - `supabase functions serve custom-sticks-artwork-link --no-verify-jwt`
    - `supabase functions serve support-request-intake --no-verify-jwt`
    - `supabase functions serve sales-report-export --no-verify-jwt`
    - `supabase functions serve sales-report-scheduler --no-verify-jwt`

--- a/Docs/PRODUCTION_RUNBOOK.md
+++ b/Docs/PRODUCTION_RUNBOOK.md
@@ -149,6 +149,8 @@ supabase functions deploy stripe-plus-checkout --no-verify-jwt
 supabase functions deploy stripe-customer-portal --no-verify-jwt
 supabase functions deploy stripe-webhook --no-verify-jwt
 supabase functions deploy lead-submission-intake --no-verify-jwt
+supabase functions deploy custom-sticks-artwork-upload --no-verify-jwt
+supabase functions deploy custom-sticks-artwork-link --no-verify-jwt
 supabase functions deploy support-request-intake --no-verify-jwt
 supabase functions deploy sales-report-export --no-verify-jwt
 supabase functions deploy sales-report-scheduler --no-verify-jwt

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -57,7 +57,8 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Bloomjoy branded sticks flow requires machine size selection and delivery location type selection before request/checkout
 - [ ] Bloomjoy branded sticks orders under 5 boxes submit a procurement lead with box count, size, address type, and estimated shipping summary
 - [ ] Bloomjoy branded sticks orders of 5+ boxes launch direct Stripe checkout with free shipping and do not use the shared cart
-- [ ] Custom sticks flow on `/supplies?order=custom` accepts logo/image upload and submits a procurement lead with artwork URL, requested box count, selected size, and `$750` first-order plate-fee note
+- [ ] Custom sticks flow on `/supplies?order=custom` accepts logo/image upload and submits a procurement lead with private artwork storage metadata/path, requested box count, selected size, and `$750` first-order plate-fee note; no public artwork URL is stored in the lead message
+- [ ] Super-admin artwork access can generate a signed URL for a submitted `custom-sticks-artwork` object and the link expires after the configured short window
 - [ ] Shared cart remains sugar-only and legacy stick items do not block checkout
 - [ ] Cart remains sugar-only and has no horizontal overflow on mobile viewports (`360x800`, `390x844`, `414x896`)
 - [ ] Cart line-item title, quantity controls, price, and remove action stack cleanly on mobile

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -57,7 +57,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Bloomjoy branded sticks flow requires machine size selection and delivery location type selection before request/checkout
 - [ ] Bloomjoy branded sticks orders under 5 boxes submit a procurement lead with box count, size, address type, and estimated shipping summary
 - [ ] Bloomjoy branded sticks orders of 5+ boxes launch direct Stripe checkout with free shipping and do not use the shared cart
-- [ ] Custom sticks flow on `/supplies?order=custom` accepts logo/image upload and submits a procurement lead with private artwork storage metadata/path, requested box count, selected size, and `$750` first-order plate-fee note; no public artwork URL is stored in the lead message
+- [ ] Custom sticks flow on `/supplies?order=custom` accepts logo/image upload through a signed upload token and submits a procurement lead with private artwork storage metadata/path, requested box count, selected size, and `$750` first-order plate-fee note; no public artwork URL is stored in the lead message
 - [ ] Super-admin artwork access can generate a signed URL for a submitted `custom-sticks-artwork` object and the link expires after the configured short window
 - [ ] Shared cart remains sugar-only and legacy stick items do not block checkout
 - [ ] Cart remains sugar-only and has no horizontal overflow on mobile viewports (`360x800`, `390x844`, `414x896`)

--- a/src/lib/customSticksArtwork.ts
+++ b/src/lib/customSticksArtwork.ts
@@ -1,4 +1,5 @@
 import { supabaseClient } from '@/lib/supabaseClient';
+import { invokeEdgeFunction } from '@/lib/edgeFunctions';
 
 export const CUSTOM_STICKS_ARTWORK_BUCKET = 'custom-sticks-artwork';
 export const CUSTOM_STICKS_ARTWORK_PRIVATE_PREFIX = 'private';
@@ -20,12 +21,11 @@ export type CustomSticksArtworkUpload = {
   storagePath: string;
 };
 
-const sanitizeFileName = (name: string): string =>
-  name
-    .toLowerCase()
-    .replace(/[^a-z0-9.-]+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '');
+type CustomSticksArtworkUploadTokenResponse = CustomSticksArtworkUpload & {
+  error?: string;
+  signedUploadExpiresInSeconds: number;
+  signedUploadToken: string;
+};
 
 export const validateCustomSticksArtwork = (file: File): void => {
   if (!ALLOWED_CUSTOM_STICKS_ARTWORK_TYPES.includes(file.type as (typeof ALLOWED_CUSTOM_STICKS_ARTWORK_TYPES)[number])) {
@@ -42,18 +42,22 @@ export const uploadCustomSticksArtwork = async (
 ): Promise<CustomSticksArtworkUpload> => {
   validateCustomSticksArtwork(file);
 
-  const uniqueId =
-    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
-      ? crypto.randomUUID()
-      : `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+  const uploadToken = await invokeEdgeFunction<CustomSticksArtworkUploadTokenResponse>(
+    'custom-sticks-artwork-upload',
+    {
+      contentType: file.type,
+      fileName: file.name || 'artwork',
+      sizeBytes: file.size,
+    }
+  );
 
-  const safeName = sanitizeFileName(file.name || 'artwork') || 'artwork';
-  const storagePath = `${CUSTOM_STICKS_ARTWORK_PRIVATE_PREFIX}/${uniqueId}-${safeName}`;
+  if (uploadToken.error) {
+    throw new Error(uploadToken.error);
+  }
 
   const { error: uploadError } = await supabaseClient.storage
-    .from(CUSTOM_STICKS_ARTWORK_BUCKET)
-    .upload(storagePath, file, {
-      upsert: false,
+    .from(uploadToken.bucket)
+    .uploadToSignedUrl(uploadToken.storagePath, uploadToken.signedUploadToken, file, {
       contentType: file.type || undefined,
     });
 
@@ -63,11 +67,11 @@ export const uploadCustomSticksArtwork = async (
 
   return {
     access: 'private',
-    bucket: CUSTOM_STICKS_ARTWORK_BUCKET,
-    contentType: file.type as CustomSticksArtworkUpload['contentType'],
-    fileName: file.name || safeName,
-    signedUrlTtlSeconds: CUSTOM_STICKS_ARTWORK_SIGNED_URL_TTL_SECONDS,
-    sizeBytes: file.size,
-    storagePath,
+    bucket: uploadToken.bucket,
+    contentType: uploadToken.contentType,
+    fileName: uploadToken.fileName,
+    signedUrlTtlSeconds: uploadToken.signedUrlTtlSeconds,
+    sizeBytes: uploadToken.sizeBytes,
+    storagePath: uploadToken.storagePath,
   };
 };

--- a/src/lib/customSticksArtwork.ts
+++ b/src/lib/customSticksArtwork.ts
@@ -1,12 +1,24 @@
 import { supabaseClient } from '@/lib/supabaseClient';
 
 export const CUSTOM_STICKS_ARTWORK_BUCKET = 'custom-sticks-artwork';
+export const CUSTOM_STICKS_ARTWORK_PRIVATE_PREFIX = 'private';
+export const CUSTOM_STICKS_ARTWORK_SIGNED_URL_TTL_SECONDS = 15 * 60;
 export const MAX_CUSTOM_STICKS_ARTWORK_SIZE_BYTES = 5 * 1024 * 1024;
 export const ALLOWED_CUSTOM_STICKS_ARTWORK_TYPES = [
   'image/png',
   'image/jpeg',
   'image/webp',
 ] as const;
+
+export type CustomSticksArtworkUpload = {
+  access: 'private';
+  bucket: typeof CUSTOM_STICKS_ARTWORK_BUCKET;
+  contentType: (typeof ALLOWED_CUSTOM_STICKS_ARTWORK_TYPES)[number];
+  fileName: string;
+  signedUrlTtlSeconds: typeof CUSTOM_STICKS_ARTWORK_SIGNED_URL_TTL_SECONDS;
+  sizeBytes: number;
+  storagePath: string;
+};
 
 const sanitizeFileName = (name: string): string =>
   name
@@ -27,7 +39,7 @@ export const validateCustomSticksArtwork = (file: File): void => {
 
 export const uploadCustomSticksArtwork = async (
   file: File
-): Promise<{ publicUrl: string; storagePath: string }> => {
+): Promise<CustomSticksArtworkUpload> => {
   validateCustomSticksArtwork(file);
 
   const uniqueId =
@@ -35,8 +47,8 @@ export const uploadCustomSticksArtwork = async (
       ? crypto.randomUUID()
       : `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
 
-  const safeName = sanitizeFileName(file.name || 'artwork');
-  const storagePath = `public/${uniqueId}-${safeName}`;
+  const safeName = sanitizeFileName(file.name || 'artwork') || 'artwork';
+  const storagePath = `${CUSTOM_STICKS_ARTWORK_PRIVATE_PREFIX}/${uniqueId}-${safeName}`;
 
   const { error: uploadError } = await supabaseClient.storage
     .from(CUSTOM_STICKS_ARTWORK_BUCKET)
@@ -49,16 +61,13 @@ export const uploadCustomSticksArtwork = async (
     throw new Error(uploadError.message || 'Unable to upload artwork.');
   }
 
-  const { data } = supabaseClient.storage
-    .from(CUSTOM_STICKS_ARTWORK_BUCKET)
-    .getPublicUrl(storagePath);
-
-  if (!data?.publicUrl) {
-    throw new Error('Artwork uploaded but no public URL was returned.');
-  }
-
   return {
-    publicUrl: data.publicUrl,
+    access: 'private',
+    bucket: CUSTOM_STICKS_ARTWORK_BUCKET,
+    contentType: file.type as CustomSticksArtworkUpload['contentType'],
+    fileName: file.name || safeName,
+    signedUrlTtlSeconds: CUSTOM_STICKS_ARTWORK_SIGNED_URL_TTL_SECONDS,
+    sizeBytes: file.size,
     storagePath,
   };
 };

--- a/src/lib/leadSubmissions.ts
+++ b/src/lib/leadSubmissions.ts
@@ -7,6 +7,7 @@ type CreateLeadSubmissionInput = {
   name: string;
   email: string;
   message: string;
+  metadata?: Record<string, unknown>;
   machineInterest?: string;
   sourcePage?: string;
 };
@@ -16,6 +17,7 @@ export const createLeadSubmission = async ({
   name,
   email,
   message,
+  metadata,
   machineInterest,
   sourcePage = '/contact',
 }: CreateLeadSubmissionInput) => {
@@ -26,6 +28,7 @@ export const createLeadSubmission = async ({
       name,
       email,
       message,
+      metadata,
       machineInterest,
       sourcePage,
       clientSubmissionId: crypto.randomUUID(),

--- a/src/pages/Supplies.tsx
+++ b/src/pages/Supplies.tsx
@@ -15,6 +15,7 @@ import { trackEvent } from '@/lib/analytics';
 import { useCart } from '@/lib/cart';
 import {
   ALLOWED_CUSTOM_STICKS_ARTWORK_TYPES,
+  CUSTOM_STICKS_ARTWORK_SIGNED_URL_TTL_SECONDS,
   MAX_CUSTOM_STICKS_ARTWORK_SIZE_BYTES,
   uploadCustomSticksArtwork,
   validateCustomSticksArtwork,
@@ -351,12 +352,15 @@ export default function SuppliesPage() {
     }
     setSubmittingSticksRequest(true);
     try {
-      const { publicUrl } = await uploadCustomSticksArtwork(customArtworkFile);
+      const artworkUpload = await uploadCustomSticksArtwork(customArtworkFile);
       await createLeadSubmission({
         submissionType: 'procurement',
         name: sticksContactName.trim(),
         email: sticksContactEmail.trim().toLowerCase(),
         sourcePage: '/supplies',
+        metadata: {
+          customSticksArtwork: artworkUpload,
+        },
         message: [
           'Custom Paper Sticks Request',
           `Requested boxes: ${normalizedStickBoxCount}`,
@@ -365,8 +369,12 @@ export default function SuppliesPage() {
           `Per-box price: $${STICKS_PRICE_PER_BOX}`,
           `First custom order plate fee: $${CUSTOM_STICKS_FIRST_ORDER_PLATE_FEE}`,
           `Shipping note: 1-4 boxes estimate at $35/box business or $40/box residential; ${BLANK_STICKS_FREE_SHIPPING_BOX_THRESHOLD}+ boxes ship free`,
-          `Artwork URL: ${publicUrl}`,
-          `Artwork file: ${customArtworkFile.name}`,
+          `Artwork storage bucket: ${artworkUpload.bucket}`,
+          `Artwork storage path: ${artworkUpload.storagePath}`,
+          `Artwork file: ${artworkUpload.fileName}`,
+          `Artwork content type: ${artworkUpload.contentType}`,
+          `Artwork size: ${Math.ceil(artworkUpload.sizeBytes / 1024)} KB`,
+          `Artwork access: private; admins can generate a signed URL that expires in ${Math.floor(CUSTOM_STICKS_ARTWORK_SIGNED_URL_TTL_SECONDS / 60)} minutes.`,
           `Notes: ${sticksRequestNotes.trim() || 'None'}`,
         ].join('\n'),
       });

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -16,6 +16,9 @@ verify_jwt = false
 [functions.lead-submission-intake]
 verify_jwt = false
 
+[functions.custom-sticks-artwork-link]
+verify_jwt = false
+
 [functions.support-request-intake]
 verify_jwt = false
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -16,6 +16,9 @@ verify_jwt = false
 [functions.lead-submission-intake]
 verify_jwt = false
 
+[functions.custom-sticks-artwork-upload]
+verify_jwt = false
+
 [functions.custom-sticks-artwork-link]
 verify_jwt = false
 

--- a/supabase/functions/custom-sticks-artwork-link/index.ts
+++ b/supabase/functions/custom-sticks-artwork-link/index.ts
@@ -1,0 +1,105 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.48.1";
+import { resolveSupabaseAccessToken } from "../_shared/auth.ts";
+import { corsHeaders } from "../_shared/cors.ts";
+
+export const config = {
+  verify_jwt: false,
+};
+
+const supabaseUrl = Deno.env.get("SUPABASE_URL");
+const supabaseServiceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+const artworkBucket = "custom-sticks-artwork";
+const defaultSignedUrlTtlSeconds = 15 * 60;
+const maxSignedUrlTtlSeconds = 15 * 60;
+const artworkPathPattern = /^(private|public)\/[a-z0-9][a-z0-9._/-]{0,240}$/;
+
+const supabase = supabaseUrl && supabaseServiceRoleKey
+  ? createClient(supabaseUrl, supabaseServiceRoleKey, {
+      auth: { persistSession: false },
+    })
+  : null;
+
+const jsonResponse = (body: Record<string, unknown>, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+
+const sanitizeText = (value: unknown) => (typeof value === "string" ? value.trim() : "");
+
+const normalizeTtlSeconds = (value: unknown) => {
+  const numericValue = Number(value);
+
+  if (!Number.isFinite(numericValue) || numericValue <= 0) {
+    return defaultSignedUrlTtlSeconds;
+  }
+
+  return Math.min(Math.round(numericValue), maxSignedUrlTtlSeconds);
+};
+
+const isAllowedArtworkPath = (storagePath: string) =>
+  artworkPathPattern.test(storagePath) &&
+  !storagePath.includes("..") &&
+  !storagePath.includes("//");
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    if (req.method !== "POST") {
+      return jsonResponse({ error: "Method not allowed." }, 405);
+    }
+
+    if (!supabase) {
+      return jsonResponse({ error: "Artwork link service is not configured." }, 500);
+    }
+
+    const accessToken = resolveSupabaseAccessToken(req);
+    if (!accessToken) {
+      return jsonResponse({ error: "Unauthorized." }, 401);
+    }
+
+    const { data: authData, error: authError } = await supabase.auth.getUser(accessToken);
+    const user = authData?.user;
+    if (authError || !user) {
+      return jsonResponse({ error: "Unauthorized." }, 401);
+    }
+
+    const { data: isAdmin, error: adminError } = await supabase.rpc("is_super_admin", {
+      uid: user.id,
+    });
+
+    if (adminError || !isAdmin) {
+      return jsonResponse({ error: "Access denied." }, 403);
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const storagePath = sanitizeText((body as Record<string, unknown>)?.storagePath);
+    const ttlSeconds = normalizeTtlSeconds((body as Record<string, unknown>)?.expiresInSeconds);
+
+    if (!isAllowedArtworkPath(storagePath)) {
+      return jsonResponse({ error: "Artwork storage path is invalid." }, 400);
+    }
+
+    const { data, error } = await supabase.storage
+      .from(artworkBucket)
+      .createSignedUrl(storagePath, ttlSeconds);
+
+    if (error || !data?.signedUrl) {
+      return jsonResponse({ error: "Unable to create artwork link." }, 404);
+    }
+
+    return jsonResponse({
+      bucket: artworkBucket,
+      expiresInSeconds: ttlSeconds,
+      signedUrl: data.signedUrl,
+      storagePath,
+    });
+  } catch (error) {
+    console.error("custom-sticks-artwork-link error", error);
+    return jsonResponse({ error: "Unable to create artwork link." }, 500);
+  }
+});

--- a/supabase/functions/custom-sticks-artwork-upload/index.ts
+++ b/supabase/functions/custom-sticks-artwork-upload/index.ts
@@ -1,0 +1,102 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.48.1";
+import { corsHeaders } from "../_shared/cors.ts";
+
+export const config = {
+  verify_jwt: false,
+};
+
+const supabaseUrl = Deno.env.get("SUPABASE_URL");
+const supabaseServiceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+const artworkBucket = "custom-sticks-artwork";
+const privatePrefix = "private";
+const maxArtworkSizeBytes = 5 * 1024 * 1024;
+const signedUploadExpiresInSeconds = 2 * 60 * 60;
+const signedReadUrlTtlSeconds = 15 * 60;
+const maxStorageBaseNameLength = 80;
+const allowedArtworkTypes = new Set(["image/png", "image/jpeg", "image/webp"]);
+const extensionByContentType: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+};
+
+const supabase = supabaseUrl && supabaseServiceRoleKey
+  ? createClient(supabaseUrl, supabaseServiceRoleKey, {
+      auth: { persistSession: false },
+    })
+  : null;
+
+const jsonResponse = (body: Record<string, unknown>, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+
+const sanitizeText = (value: unknown) => (typeof value === "string" ? value.trim() : "");
+
+const sanitizeFileBaseName = (name: string): string =>
+  name
+    .toLowerCase()
+    .replace(/\.[a-z0-9]+$/i, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, maxStorageBaseNameLength);
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    if (req.method !== "POST") {
+      return jsonResponse({ error: "Method not allowed." }, 405);
+    }
+
+    if (!supabase) {
+      return jsonResponse({ error: "Artwork upload service is not configured." }, 500);
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const fileName = sanitizeText((body as Record<string, unknown>)?.fileName) || "artwork";
+    const contentType = sanitizeText((body as Record<string, unknown>)?.contentType)
+      .toLowerCase();
+    const sizeBytes = Number((body as Record<string, unknown>)?.sizeBytes);
+
+    if (!allowedArtworkTypes.has(contentType)) {
+      return jsonResponse({ error: "Use PNG, JPG, or WEBP for custom sticks artwork." }, 400);
+    }
+
+    if (!Number.isFinite(sizeBytes) || sizeBytes <= 0 || sizeBytes > maxArtworkSizeBytes) {
+      return jsonResponse({ error: "Artwork must be 5MB or smaller." }, 400);
+    }
+
+    const safeBaseName = sanitizeFileBaseName(fileName) || "artwork";
+    const extension = extensionByContentType[contentType];
+    const storagePath = `${privatePrefix}/${crypto.randomUUID()}-${safeBaseName}.${extension}`;
+
+    const { data, error } = await supabase.storage
+      .from(artworkBucket)
+      .createSignedUploadUrl(storagePath, { upsert: false });
+
+    if (error || !data?.token) {
+      return jsonResponse({ error: "Unable to prepare artwork upload." }, 500);
+    }
+
+    return jsonResponse({
+      access: "private",
+      bucket: artworkBucket,
+      contentType,
+      fileName: fileName.slice(0, 160),
+      signedUploadExpiresInSeconds,
+      signedUploadToken: data.token,
+      signedUrlTtlSeconds: signedReadUrlTtlSeconds,
+      sizeBytes: Math.round(sizeBytes),
+      storagePath,
+    });
+  } catch (error) {
+    console.error("custom-sticks-artwork-upload error", error);
+    return jsonResponse({ error: "Unable to prepare artwork upload." }, 500);
+  }
+});

--- a/supabase/functions/lead-submission-intake/index.ts
+++ b/supabase/functions/lead-submission-intake/index.ts
@@ -14,6 +14,11 @@ const validSubmissionTypes = new Set(["quote", "demo", "procurement", "general"]
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/i;
 const uuidPattern =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const customSticksArtworkBucket = "custom-sticks-artwork";
+const customSticksArtworkPathPattern = /^private\/[a-z0-9][a-z0-9._/-]{0,240}$/;
+const allowedCustomSticksArtworkTypes = new Set(["image/png", "image/jpeg", "image/webp"]);
+const maxLeadMetadataBytes = 4096;
+const maxCustomSticksArtworkSizeBytes = 5 * 1024 * 1024;
 
 if (!supabaseUrl) {
   console.error("Missing SUPABASE_URL");
@@ -32,6 +37,81 @@ const supabase = supabaseUrl && supabaseServiceRoleKey
   : null;
 
 const sanitizeText = (value: unknown) => (typeof value === "string" ? value.trim() : "");
+
+class RequestValidationError extends Error {}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === "object" && !Array.isArray(value);
+
+const normalizeCustomSticksArtworkMetadata = (value: unknown) => {
+  if (!isRecord(value)) {
+    throw new RequestValidationError("Artwork metadata is invalid.");
+  }
+
+  const bucket = sanitizeText(value.bucket);
+  const storagePath = sanitizeText(value.storagePath);
+  const fileName = sanitizeText(value.fileName) || "artwork";
+  const contentType = sanitizeText(value.contentType).toLowerCase();
+  const rawSizeBytes = Number(value.sizeBytes);
+
+  if (bucket !== customSticksArtworkBucket) {
+    throw new RequestValidationError("Artwork bucket is invalid.");
+  }
+
+  if (
+    !customSticksArtworkPathPattern.test(storagePath) ||
+    storagePath.includes("..") ||
+    storagePath.includes("//")
+  ) {
+    throw new RequestValidationError("Artwork storage path is invalid.");
+  }
+
+  if (!allowedCustomSticksArtworkTypes.has(contentType)) {
+    throw new RequestValidationError("Artwork content type is invalid.");
+  }
+
+  if (
+    !Number.isFinite(rawSizeBytes) ||
+    rawSizeBytes <= 0 ||
+    rawSizeBytes > maxCustomSticksArtworkSizeBytes
+  ) {
+    throw new RequestValidationError("Artwork file size is invalid.");
+  }
+
+  return {
+    access: "private",
+    bucket: customSticksArtworkBucket,
+    contentType,
+    fileName: fileName.slice(0, 160),
+    signedUrlTtlSeconds: 15 * 60,
+    sizeBytes: Math.round(rawSizeBytes),
+    storagePath,
+  };
+};
+
+const normalizeLeadMetadata = (value: unknown): Record<string, unknown> => {
+  if (value === undefined || value === null) {
+    return {};
+  }
+
+  if (!isRecord(value)) {
+    throw new RequestValidationError("Submission metadata is invalid.");
+  }
+
+  const metadata: Record<string, unknown> = {};
+
+  if ("customSticksArtwork" in value) {
+    metadata.customSticksArtwork = normalizeCustomSticksArtworkMetadata(
+      value.customSticksArtwork
+    );
+  }
+
+  if (JSON.stringify(metadata).length > maxLeadMetadataBytes) {
+    throw new RequestValidationError("Submission metadata is too large.");
+  }
+
+  return metadata;
+};
 
 const claimDispatch = async (
   eventKey: string,
@@ -106,6 +186,7 @@ serve(async (req) => {
     const message = sanitizeText(body?.message);
     const machineInterest = sanitizeText(body?.machineInterest);
     const clientSubmissionId = sanitizeText(body?.clientSubmissionId).toLowerCase();
+    const metadata = normalizeLeadMetadata(body?.metadata);
 
     if (!validSubmissionTypes.has(submissionType)) {
       return new Response(
@@ -153,7 +234,7 @@ serve(async (req) => {
         : message;
 
     const selectedColumns =
-      "id, submission_type, name, email, source_page, message, created_at, internal_notification_sent_at";
+      "id, submission_type, name, email, source_page, message, metadata, created_at, internal_notification_sent_at";
 
     const { data: insertedLead, error: insertError } = await supabase
       .from("lead_submissions")
@@ -162,6 +243,7 @@ serve(async (req) => {
         name,
         email,
         message: normalizedMessage,
+        metadata,
         source_page: sourcePage,
         client_submission_id: clientSubmissionId,
       })
@@ -263,6 +345,13 @@ serve(async (req) => {
     });
   } catch (error) {
     console.error("lead-submission-intake error", error);
+    if (error instanceof RequestValidationError) {
+      return new Response(JSON.stringify({ error: error.message }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
     return new Response(
       JSON.stringify({ error: "Unable to submit contact request." }),
       {

--- a/supabase/functions/lead-submission-intake/index.ts
+++ b/supabase/functions/lead-submission-intake/index.ts
@@ -20,6 +20,16 @@ const allowedCustomSticksArtworkTypes = new Set(["image/png", "image/jpeg", "ima
 const maxLeadMetadataBytes = 4096;
 const maxCustomSticksArtworkSizeBytes = 5 * 1024 * 1024;
 
+type CustomSticksArtworkMetadata = {
+  access: "private";
+  bucket: string;
+  contentType: string;
+  fileName: string;
+  signedUrlTtlSeconds: number;
+  sizeBytes: number;
+  storagePath: string;
+};
+
 if (!supabaseUrl) {
   console.error("Missing SUPABASE_URL");
 }
@@ -43,7 +53,7 @@ class RequestValidationError extends Error {}
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value) && typeof value === "object" && !Array.isArray(value);
 
-const normalizeCustomSticksArtworkMetadata = (value: unknown) => {
+const normalizeCustomSticksArtworkMetadata = (value: unknown): CustomSticksArtworkMetadata => {
   if (!isRecord(value)) {
     throw new RequestValidationError("Artwork metadata is invalid.");
   }
@@ -111,6 +121,88 @@ const normalizeLeadMetadata = (value: unknown): Record<string, unknown> => {
   }
 
   return metadata;
+};
+
+const splitStoragePath = (storagePath: string) => {
+  const lastSlashIndex = storagePath.lastIndexOf("/");
+
+  return {
+    folder: storagePath.slice(0, lastSlashIndex),
+    name: storagePath.slice(lastSlashIndex + 1),
+  };
+};
+
+const readStorageMetadataValue = (
+  metadata: Record<string, unknown>,
+  keys: string[]
+): unknown => {
+  for (const key of keys) {
+    if (metadata[key] !== undefined && metadata[key] !== null) {
+      return metadata[key];
+    }
+  }
+
+  return undefined;
+};
+
+const verifyCustomSticksArtworkObject = async (
+  artwork: CustomSticksArtworkMetadata
+): Promise<CustomSticksArtworkMetadata> => {
+  if (!supabase) {
+    throw new Error("Lead intake is not configured.");
+  }
+
+  const { folder, name } = splitStoragePath(artwork.storagePath);
+  const { data, error } = await supabase.storage
+    .from(customSticksArtworkBucket)
+    .list(folder, {
+      limit: 10,
+      search: name,
+    });
+
+  if (error) {
+    throw new RequestValidationError("Uploaded artwork could not be verified.");
+  }
+
+  const storedObject = data?.find((entry) => entry.name === name);
+  if (!storedObject) {
+    throw new RequestValidationError("Uploaded artwork was not found.");
+  }
+
+  const storedMetadata = isRecord(storedObject.metadata) ? storedObject.metadata : {};
+  const storedContentType = sanitizeText(
+    readStorageMetadataValue(storedMetadata, ["mimetype", "contentType"])
+  ).toLowerCase();
+  const storedSizeBytes = Number(
+    readStorageMetadataValue(storedMetadata, ["size", "contentLength"])
+  );
+
+  if (storedContentType && storedContentType !== artwork.contentType) {
+    throw new RequestValidationError("Uploaded artwork content type does not match.");
+  }
+
+  if (Number.isFinite(storedSizeBytes) && storedSizeBytes !== artwork.sizeBytes) {
+    throw new RequestValidationError("Uploaded artwork file size does not match.");
+  }
+
+  return {
+    ...artwork,
+    contentType: storedContentType || artwork.contentType,
+    sizeBytes: Number.isFinite(storedSizeBytes) ? storedSizeBytes : artwork.sizeBytes,
+  };
+};
+
+const verifyLeadMetadata = async (metadata: Record<string, unknown>) => {
+  if (!("customSticksArtwork" in metadata)) {
+    return metadata;
+  }
+
+  return {
+    ...metadata,
+    customSticksArtwork: await verifyCustomSticksArtworkObject(
+      metadata.customSticksArtwork as CustomSticksArtworkMetadata
+    ),
+  };
 };
 
 const claimDispatch = async (
@@ -186,7 +278,7 @@ serve(async (req) => {
     const message = sanitizeText(body?.message);
     const machineInterest = sanitizeText(body?.machineInterest);
     const clientSubmissionId = sanitizeText(body?.clientSubmissionId).toLowerCase();
-    const metadata = normalizeLeadMetadata(body?.metadata);
+    const metadata = await verifyLeadMetadata(normalizeLeadMetadata(body?.metadata));
 
     if (!validSubmissionTypes.has(submissionType)) {
       return new Response(

--- a/supabase/migrations/202604280006_custom_sticks_private_artwork.sql
+++ b/supabase/migrations/202604280006_custom_sticks_private_artwork.sql
@@ -1,0 +1,46 @@
+-- Make custom sticks artwork private and store lead metadata for signed access.
+
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'custom-sticks-artwork',
+  'custom-sticks-artwork',
+  false,
+  5242880,
+  array['image/png', 'image/jpeg', 'image/webp']
+)
+on conflict (id) do update
+set
+  public = excluded.public,
+  file_size_limit = excluded.file_size_limit,
+  allowed_mime_types = excluded.allowed_mime_types;
+
+drop policy if exists "custom_sticks_artwork_insert_public" on storage.objects;
+drop policy if exists "custom_sticks_artwork_read_public" on storage.objects;
+drop policy if exists "custom_sticks_artwork_insert_private_intake" on storage.objects;
+drop policy if exists "custom_sticks_artwork_read_super_admin" on storage.objects;
+
+create policy "custom_sticks_artwork_insert_private_intake"
+on storage.objects
+for insert
+to anon, authenticated
+with check (
+  bucket_id = 'custom-sticks-artwork'
+  and (storage.foldername(name))[1] = 'private'
+);
+
+create policy "custom_sticks_artwork_read_super_admin"
+on storage.objects
+for select
+to authenticated
+using (
+  bucket_id = 'custom-sticks-artwork'
+  and public.is_super_admin((select auth.uid()))
+);
+
+alter table public.lead_submissions
+  add column if not exists metadata jsonb not null default '{}'::jsonb;
+
+comment on column public.lead_submissions.metadata is
+  'Structured lead metadata such as private custom sticks artwork bucket/path/file details. Do not store long-lived public artwork URLs here.';
+
+select pg_notify('pgrst', 'reload schema');

--- a/supabase/migrations/202604280006_custom_sticks_private_artwork.sql
+++ b/supabase/migrations/202604280006_custom_sticks_private_artwork.sql
@@ -19,15 +19,6 @@ drop policy if exists "custom_sticks_artwork_read_public" on storage.objects;
 drop policy if exists "custom_sticks_artwork_insert_private_intake" on storage.objects;
 drop policy if exists "custom_sticks_artwork_read_super_admin" on storage.objects;
 
-create policy "custom_sticks_artwork_insert_private_intake"
-on storage.objects
-for insert
-to anon, authenticated
-with check (
-  bucket_id = 'custom-sticks-artwork'
-  and (storage.foldername(name))[1] = 'private'
-);
-
 create policy "custom_sticks_artwork_read_super_admin"
 on storage.objects
 for select


### PR DESCRIPTION
Closes #292

## Summary
- Moves new custom sticks artwork uploads into the private `custom-sticks-artwork` bucket/prefix and removes public URL generation from the supplies flow.
- Replaces direct anonymous Storage writes with a server-issued signed upload token from `custom-sticks-artwork-upload`, then stores verified artwork bucket/path/file metadata on `lead_submissions.metadata.customSticksArtwork`.
- Adds an admin-only signed-link Edge Function and documents deploy/local handling plus legacy public-object owner review/migration handling.

## Files changed
- Frontend supplies flow and upload helper: `src/pages/Supplies.tsx`, `src/lib/customSticksArtwork.ts`, `src/lib/leadSubmissions.ts`
- Supabase Edge Functions/config: `lead-submission-intake`, new `custom-sticks-artwork-upload`, new `custom-sticks-artwork-link`, `supabase/config.toml`
- Database/storage migration: `202604280006_custom_sticks_private_artwork.sql`
- Docs/smoke/runbooks: `Docs/CUSTOM_STICKS_ARTWORK_PRIVACY.md`, `Docs/QA_SMOKE_TEST_CHECKLIST.md`, `Docs/LOCAL_DEV.md`, `Docs/PRODUCTION_RUNBOOK.md`

## Verification
- `npm ci`: passed; existing 2 moderate dev dependency advisories still reported by npm audit
- `npx tsc --noEmit`: passed
- `npm run build`: passed; existing Browserslist data-age warning only
- `npm test --if-present`: passed; no test script emitted output
- `npm run lint --if-present`: passed with the existing 8 fast-refresh warnings in shared UI/Auth files
- `deno check --allow-import supabase/functions/custom-sticks-artwork-upload/index.ts`: passed
- `deno check --allow-import supabase/functions/custom-sticks-artwork-link/index.ts`: passed
- `deno check --allow-import supabase/functions/lead-submission-intake/index.ts`: passed
- `npm run db:validate-migrations`: passed; 54 migrations applied in a disposable Supabase project
- Mocked Playwright browser smoke on `/supplies?order=custom`: passed; verified signed upload token request, `uploadToSignedUrl`, no direct Storage object upload, no `Artwork URL:` in lead message, and private metadata payload
- Independent sub-agent QA: initial findings fixed; follow-up review found no blocking findings

## How to test
1. From this branch/worktree, run `npm ci` and `npm run dev`.
2. Serve/deploy Supabase functions `custom-sticks-artwork-upload`, `lead-submission-intake`, and `custom-sticks-artwork-link` with server-only `SUPABASE_SERVICE_ROLE_KEY` available.
3. Open `http://localhost:8080/supplies?order=custom`.
4. Select a stick size, upload a PNG/JPG/WEBP under 5 MB, enter contact details, and submit the custom sticks request.
5. In Supabase, confirm the uploaded object is under `custom-sticks-artwork/private/...`, the bucket is private, and there is no anonymous insert/read policy on `storage.objects` for this bucket.
6. Confirm the `lead_submissions` row has `metadata.customSticksArtwork` with bucket/path/file details and the message does not contain `Artwork URL:`.
7. As a super-admin, request a signed link from `custom-sticks-artwork-link` using the submitted `storagePath`; the returned URL should expire after 15 minutes.

Example signed-link request:
```bash
curl -X POST "$VITE_SUPABASE_URL/functions/v1/custom-sticks-artwork-link" \
  -H "apikey: $VITE_SUPABASE_ANON_KEY" \
  -H "Authorization: Bearer $VITE_SUPABASE_ANON_KEY" \
  -H "x-supabase-auth-token: <super-admin-access-token>" \
  -H "Content-Type: application/json" \
  -d '{"storagePath":"private/<object-name>"}'
```

## Privacy behavior
- New artwork is uploaded to a private bucket path and is not publicly readable.
- Browser clients no longer have direct anonymous Storage insert permission; they must request a server-generated signed upload token with validated filename/type/size.
- Lead intake verifies the uploaded object exists and checks Storage metadata against the submitted MIME type and size before saving the lead.
- Super-admins can access artwork through short-lived signed URLs only; service-role credentials stay server-side.
- Legacy `public/` objects are documented for owner inventory, migration/retention review, and deletion only after approval.

## Overlap / branch safety
- `origin/main` had not moved before final verification (`HEAD...origin/main` was `2 0`, branch-only commits ahead of main).
- Open PR #155 also touches `src/lib/leadSubmissions.ts`, `supabase/functions/lead-submission-intake/index.ts`, and `Docs/QA_SMOKE_TEST_CHECKLIST.md`; if it merges first, this branch should be updated from `main` and reverified.