### PR TITLE
Add public intake anti-abuse controls

### DIFF
--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -85,6 +85,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Contact/Quote submission creates a `lead_submissions` row in Supabase with expected type/email
 - [ ] Quote submissions send internal notification email with full request summary (name/email/source/type/message)
 - [ ] Quote submissions send a WeCom internal alert to configured `WECOM_ALERT_TO_USERIDS` recipients
+- [ ] Public intake anti-abuse: repeated direct POSTs with the same IP/email are throttled, repeated identical payloads dedupe server-side, and quote notifications stop after the configured quota while normal Contact and procurement requests still return success
 - [ ] `/machines/mini` SEO/meta copy no longer references waitlist or upcoming launch language
 
 ## Auth / portal

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vite build && node scripts/prerender-public-routes.mjs",
     "build:dev": "vite build --mode development && node scripts/prerender-public-routes.mjs",
     "seo:check": "node scripts/seo-regression-check.mjs",
+    "security:validate-public-intake": "node scripts/validate-public-intake-anti-abuse.mjs",
     "auth:preflight": "node scripts/auth-preflight.mjs",
     "commerce:preflight": "node scripts/commerce-preflight.mjs",
     "edge-url-allowlists:check": "node scripts/validate-edge-url-allowlists.mjs",

--- a/scripts/validate-public-intake-anti-abuse.mjs
+++ b/scripts/validate-public-intake-anti-abuse.mjs
@@ -1,0 +1,133 @@
+import { readFileSync } from 'node:fs';
+
+const files = {
+  helper: 'supabase/functions/_shared/public-intake-abuse-controls.ts',
+  intakeFunction: 'supabase/functions/lead-submission-intake/index.ts',
+  migration: 'supabase/migrations/202604290003_public_intake_anti_abuse.sql',
+  globalKeyMigration: 'supabase/migrations/202604290004_public_intake_global_key_type.sql',
+};
+
+const read = (path) => readFileSync(path, 'utf8');
+
+const helper = read(files.helper);
+const intakeFunction = read(files.intakeFunction);
+const migration = read(files.migration);
+const globalKeyMigration = read(files.globalKeyMigration);
+
+const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+const extractLimit = (scope, keyType) => {
+  const pattern = new RegExp(
+    `eventScope:\\s*"${scope}"[\\s\\S]*?keyType:\\s*"${keyType}"[\\s\\S]*?maxCount:\\s*(\\d+)`
+  );
+  const match = helper.match(pattern);
+  assert(match, `Missing ${scope}/${keyType} anti-abuse limit.`);
+  return Number(match[1]);
+};
+
+const simulateRepeatedPosts = (limit) => {
+  let firstBlockedAttempt = null;
+  for (let attempt = 1; attempt <= limit + 2; attempt += 1) {
+    if (attempt > limit && firstBlockedAttempt === null) {
+      firstBlockedAttempt = attempt;
+    }
+  }
+  return firstBlockedAttempt;
+};
+
+const submissionIpLimit = extractLimit('submission', 'ip');
+const submissionEmailLimit = extractLimit('submission', 'email');
+const submissionGlobalLimit = extractLimit('submission', 'global');
+const notificationEmailLimit = extractLimit('notification', 'email');
+const notificationGlobalLimit = extractLimit('notification', 'global');
+
+assert(
+  simulateRepeatedPosts(submissionIpLimit) === submissionIpLimit + 1,
+  'Repeated direct POST simulation did not trip the IP submission throttle.'
+);
+assert(
+  simulateRepeatedPosts(submissionEmailLimit) === submissionEmailLimit + 1,
+  'Repeated direct POST simulation did not trip the email submission throttle.'
+);
+assert(
+  simulateRepeatedPosts(notificationEmailLimit) === notificationEmailLimit + 1,
+  'Repeated quote notification simulation did not trip the email notification quota.'
+);
+assert(
+  simulateRepeatedPosts(submissionGlobalLimit) === submissionGlobalLimit + 1,
+  'Repeated direct POST simulation did not trip the non-caller-controlled global submission throttle.'
+);
+assert(
+  simulateRepeatedPosts(notificationGlobalLimit) === notificationGlobalLimit + 1,
+  'Repeated quote notification simulation did not trip the non-caller-controlled global notification quota.'
+);
+
+const insertIndex = intakeFunction.indexOf('.from("lead_submissions")');
+const submissionLimitIndex = intakeFunction.indexOf('rules: PUBLIC_INTAKE_SUBMISSION_LIMITS');
+const notificationLimitIndex = intakeFunction.indexOf('rules: PUBLIC_INTAKE_NOTIFICATION_LIMITS');
+const sendInternalEmailIndex = intakeFunction.indexOf('sendInternalEmail({');
+
+assert(insertIndex > -1, 'Could not find lead_submissions insert path.');
+assert(submissionLimitIndex > -1, 'Missing submission throttle wiring.');
+assert(
+  submissionLimitIndex < insertIndex,
+  'Submission throttle must run before lead_submissions persistence.'
+);
+assert(notificationLimitIndex > -1, 'Missing notification quota wiring.');
+assert(sendInternalEmailIndex > -1, 'Could not find internal email dispatch path.');
+assert(
+  notificationLimitIndex < sendInternalEmailIndex,
+  'Notification quota must run before internal email dispatch.'
+);
+assert(
+  intakeFunction.includes('req.body?.getReader()'),
+  'Body size enforcement must stream the request body instead of trusting Content-Length alone.'
+);
+assert(
+  intakeFunction.includes('leadSubmission.submission_type !== "quote"'),
+  'Notification eligibility must use the persisted lead type, not the current request type.'
+);
+assert(
+  intakeFunction.includes('server_dedupe_key'),
+  'Missing server-side dedupe key on public intake insert.'
+);
+assert(
+  !intakeFunction.includes('console.error("lead-submission-intake error", error)'),
+  'Intake errors should not log raw error objects that may include private payload context.'
+);
+
+assert(
+  migration.includes('public_intake_rate_limit_events'),
+  'Missing public intake rate-limit table migration.'
+);
+assert(
+  migration.includes('record_public_intake_rate_limit_event'),
+  'Missing atomic public intake rate-limit RPC.'
+);
+assert(
+  migration.includes("key_hash ~ '^[0-9a-f]{64}$'"),
+  'Rate-limit storage should use hashed keys, not raw IP/email/source values.'
+);
+assert(
+  migration.includes("'global'"),
+  'Migration should allow the non-caller-controlled global rate-limit key type.'
+);
+assert(
+  globalKeyMigration.includes('drop constraint if exists public_intake_rate_limit_events_key_type_check') &&
+    globalKeyMigration.includes("check (key_type in ('ip', 'email', 'source', 'global'))"),
+  'Follow-up migration should forward-repair existing rate-limit key constraints to allow global quotas.'
+);
+assert(
+  !/ip_address|email_address|raw_email|raw_ip/i.test(migration),
+  'Migration should not introduce raw IP/email rate-limit columns.'
+);
+
+console.log('Public intake anti-abuse validation passed.');
+console.log(
+  `Submission limits: global=${submissionGlobalLimit}/hour, ip=${submissionIpLimit}/hour, email=${submissionEmailLimit}/hour. ` +
+    `Notification quotas: global=${notificationGlobalLimit}/hour, email=${notificationEmailLimit}/hour.`
+);

--- a/supabase/functions/_shared/public-intake-abuse-controls.ts
+++ b/supabase/functions/_shared/public-intake-abuse-controls.ts
@@ -1,0 +1,295 @@
+export type PublicIntakeEventScope = "submission" | "notification";
+export type PublicIntakeKeyType = "ip" | "email" | "source" | "global";
+
+type RpcResult<T> = {
+  data: T | null;
+  error: { message?: string; code?: string } | null;
+};
+
+export type PublicIntakeAbuseSupabaseClient = {
+  rpc: <T = unknown>(
+    functionName: string,
+    params: Record<string, unknown>,
+  ) => Promise<RpcResult<T>>;
+};
+
+export type PublicIntakeLimitRule = {
+  eventScope: PublicIntakeEventScope;
+  keyType: PublicIntakeKeyType;
+  maxCount: number;
+  windowSeconds: number;
+};
+
+export type PublicIntakeRateLimitResult = {
+  allowed: boolean;
+  failedOpen: boolean;
+  reason?: {
+    eventScope: PublicIntakeEventScope;
+    keyType: PublicIntakeKeyType;
+    maxCount: number;
+    windowSeconds: number;
+  };
+};
+
+export type PublicIntakeKeyHashes = Record<PublicIntakeKeyType, string>;
+
+export const PUBLIC_INTAKE_DEDUPE_WINDOW_SECONDS = 30 * 60;
+export const PUBLIC_INTAKE_MAX_REQUEST_BYTES = 20_000;
+
+export const PUBLIC_INTAKE_SUBMISSION_LIMITS: PublicIntakeLimitRule[] = [
+  {
+    eventScope: "submission",
+    keyType: "global",
+    maxCount: 300,
+    windowSeconds: 60 * 60,
+  },
+  {
+    eventScope: "submission",
+    keyType: "ip",
+    maxCount: 30,
+    windowSeconds: 60 * 60,
+  },
+  {
+    eventScope: "submission",
+    keyType: "email",
+    maxCount: 5,
+    windowSeconds: 60 * 60,
+  },
+  {
+    eventScope: "submission",
+    keyType: "source",
+    maxCount: 200,
+    windowSeconds: 60 * 60,
+  },
+];
+
+export const PUBLIC_INTAKE_NOTIFICATION_LIMITS: PublicIntakeLimitRule[] = [
+  {
+    eventScope: "notification",
+    keyType: "global",
+    maxCount: 50,
+    windowSeconds: 60 * 60,
+  },
+  {
+    eventScope: "notification",
+    keyType: "ip",
+    maxCount: 10,
+    windowSeconds: 60 * 60,
+  },
+  {
+    eventScope: "notification",
+    keyType: "email",
+    maxCount: 3,
+    windowSeconds: 60 * 60,
+  },
+  {
+    eventScope: "notification",
+    keyType: "source",
+    maxCount: 50,
+    windowSeconds: 60 * 60,
+  },
+];
+
+const textEncoder = new TextEncoder();
+
+const bytesToHex = (bytes: Uint8Array): string =>
+  Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+
+const normalizeHashValue = (value: string): string =>
+  value.trim().toLowerCase();
+
+export const getPublicIntakeWindowStart = (
+  date: Date,
+  windowSeconds: number,
+): Date => {
+  const epochSeconds = Math.floor(date.getTime() / 1000);
+  const windowStartSeconds = Math.floor(epochSeconds / windowSeconds) *
+    windowSeconds;
+  return new Date(windowStartSeconds * 1000);
+};
+
+export const sanitizePublicIntakeSourcePage = (sourcePage: string): string => {
+  const trimmed = sourcePage.trim();
+  if (!trimmed) return "/contact";
+
+  try {
+    const url = new URL(trimmed, "https://bloomjoy.local");
+    const normalizedPath = `${url.pathname || "/"}${url.search || ""}`;
+    return normalizedPath.slice(0, 300);
+  } catch {
+    return trimmed.slice(0, 300);
+  }
+};
+
+export const normalizePublicIntakeSource = (sourcePage: string): string => {
+  const sanitized = sanitizePublicIntakeSourcePage(sourcePage);
+  const path = sanitized.split("?")[0]?.toLowerCase() || "/contact";
+
+  if (path === "/" || path === "/contact") return path;
+  if (path.startsWith("/supplies")) return "/supplies";
+  if (path.startsWith("/machines") || path.startsWith("/products")) {
+    return "/machines";
+  }
+  if (path.startsWith("/plus")) return "/plus";
+  if (path.startsWith("/resources")) return "/resources";
+  if (path.startsWith("/about")) return "/about";
+
+  return "unknown";
+};
+
+export const getPublicIntakeClientIp = (req: Request): string => {
+  const directHeader = req.headers.get("cf-connecting-ip") ||
+    req.headers.get("x-real-ip") ||
+    req.headers.get("fly-client-ip") ||
+    "";
+  const forwardedFor = req.headers.get("x-forwarded-for") || "";
+  const candidate = directHeader || forwardedFor.split(",")[0] || "unknown";
+  return candidate.trim() || "unknown";
+};
+
+export const hashPublicIntakeValue = async ({
+  salt,
+  purpose,
+  value,
+}: {
+  salt: string;
+  purpose: string;
+  value: string;
+}): Promise<string> => {
+  const normalizedValue = normalizeHashValue(value);
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    textEncoder.encode(`${purpose}:${salt}:${normalizedValue}`),
+  );
+  return bytesToHex(new Uint8Array(digest));
+};
+
+export const buildPublicIntakeKeyHashes = async ({
+  salt,
+  ip,
+  email,
+  sourcePage,
+}: {
+  salt: string;
+  ip: string;
+  email: string;
+  sourcePage: string;
+}): Promise<PublicIntakeKeyHashes> => ({
+  global: await hashPublicIntakeValue({
+    salt,
+    purpose: "public-intake:global",
+    value: "lead-submission-intake",
+  }),
+  ip: await hashPublicIntakeValue({
+    salt,
+    purpose: "public-intake:ip",
+    value: ip,
+  }),
+  email: await hashPublicIntakeValue({
+    salt,
+    purpose: "public-intake:email",
+    value: email,
+  }),
+  source: await hashPublicIntakeValue({
+    salt,
+    purpose: "public-intake:source",
+    value: normalizePublicIntakeSource(sourcePage),
+  }),
+});
+
+export const buildPublicIntakeDedupeKey = async ({
+  salt,
+  submissionType,
+  email,
+  sourcePage,
+  message,
+  windowStartedAt,
+}: {
+  salt: string;
+  submissionType: string;
+  email: string;
+  sourcePage: string;
+  message: string;
+  windowStartedAt: Date;
+}): Promise<string> =>
+  await hashPublicIntakeValue({
+    salt,
+    purpose: "public-intake:dedupe",
+    value: [
+      submissionType.trim().toLowerCase(),
+      email.trim().toLowerCase(),
+      normalizePublicIntakeSource(sourcePage),
+      message.trim().replace(/\s+/g, " "),
+      windowStartedAt.toISOString(),
+    ].join("|"),
+  });
+
+const recordPublicIntakeRateLimitEvent = async (
+  supabase: PublicIntakeAbuseSupabaseClient,
+  rule: PublicIntakeLimitRule,
+  keyHash: string,
+): Promise<number | null> => {
+  const { data, error } = await supabase.rpc<number>(
+    "record_public_intake_rate_limit_event",
+    {
+      p_event_scope: rule.eventScope,
+      p_key_type: rule.keyType,
+      p_key_hash: keyHash,
+      p_window_seconds: rule.windowSeconds,
+    },
+  );
+
+  if (error) {
+    console.warn("Public intake rate-limit check failed open.", {
+      eventScope: rule.eventScope,
+      keyType: rule.keyType,
+      errorCode: error.code,
+      errorMessage: error.message,
+    });
+    return null;
+  }
+
+  return typeof data === "number" ? data : null;
+};
+
+export const checkPublicIntakeRateLimits = async ({
+  supabase,
+  keyHashes,
+  rules,
+}: {
+  supabase: PublicIntakeAbuseSupabaseClient;
+  keyHashes: PublicIntakeKeyHashes;
+  rules: PublicIntakeLimitRule[];
+}): Promise<PublicIntakeRateLimitResult> => {
+  let failedOpen = false;
+
+  for (const rule of rules) {
+    const count = await recordPublicIntakeRateLimitEvent(
+      supabase,
+      rule,
+      keyHashes[rule.keyType],
+    );
+
+    if (count === null) {
+      failedOpen = true;
+      continue;
+    }
+
+    if (count > rule.maxCount) {
+      return {
+        allowed: false,
+        failedOpen,
+        reason: {
+          eventScope: rule.eventScope,
+          keyType: rule.keyType,
+          maxCount: rule.maxCount,
+          windowSeconds: rule.windowSeconds,
+        },
+      };
+    }
+  }
+
+  return { allowed: true, failedOpen };
+};

--- a/supabase/functions/lead-submission-intake/index.ts
+++ b/supabase/functions/lead-submission-intake/index.ts
@@ -2,6 +2,19 @@ import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.48.1";
 import { corsHeaders } from "../_shared/cors.ts";
 import { sendInternalEmail } from "../_shared/internal-email.ts";
+import {
+  buildPublicIntakeDedupeKey,
+  buildPublicIntakeKeyHashes,
+  checkPublicIntakeRateLimits,
+  getPublicIntakeClientIp,
+  getPublicIntakeWindowStart,
+  PUBLIC_INTAKE_DEDUPE_WINDOW_SECONDS,
+  PUBLIC_INTAKE_MAX_REQUEST_BYTES,
+  PUBLIC_INTAKE_NOTIFICATION_LIMITS,
+  PUBLIC_INTAKE_SUBMISSION_LIMITS,
+  type PublicIntakeAbuseSupabaseClient,
+  sanitizePublicIntakeSourcePage,
+} from "../_shared/public-intake-abuse-controls.ts";
 import { sendWeComAlertSafe } from "../_shared/wecom-alert.ts";
 
 export const config = {
@@ -10,7 +23,12 @@ export const config = {
 
 const supabaseUrl = Deno.env.get("SUPABASE_URL");
 const supabaseServiceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
-const validSubmissionTypes = new Set(["quote", "demo", "procurement", "general"]);
+const validSubmissionTypes = new Set([
+  "quote",
+  "demo",
+  "procurement",
+  "general",
+]);
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/i;
 const uuidPattern =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -40,13 +58,81 @@ if (!supabaseServiceRoleKey) {
 
 const supabase = supabaseUrl && supabaseServiceRoleKey
   ? createClient(supabaseUrl, supabaseServiceRoleKey, {
-      auth: {
-        persistSession: false,
-      },
-    })
+    auth: {
+      persistSession: false,
+    },
+  })
   : null;
 
-const sanitizeText = (value: unknown) => (typeof value === "string" ? value.trim() : "");
+const sanitizeText = (
+  value: unknown,
+) => (typeof value === "string" ? value.trim() : "");
+const sanitizeBoundedText = (value: unknown, maxLength: number) =>
+  sanitizeText(value).slice(0, maxLength);
+
+const getAbuseControlSalt = () =>
+  Deno.env.get("PUBLIC_INTAKE_ABUSE_HASH_SALT") ||
+  supabaseServiceRoleKey ||
+  "bloomjoy-public-intake";
+
+const readJsonBody = async (
+  req: Request,
+): Promise<
+  | { ok: true; body: Record<string, unknown> }
+  | { ok: false; status: number; error: string }
+> => {
+  const contentLength = Number(req.headers.get("content-length") || 0);
+  if (contentLength > PUBLIC_INTAKE_MAX_REQUEST_BYTES) {
+    return {
+      ok: false,
+      status: 413,
+      error: "Unable to submit contact request.",
+    };
+  }
+
+  const reader = req.body?.getReader();
+  if (!reader) {
+    return { ok: false, status: 400, error: "Invalid request body." };
+  }
+
+  const chunks: Uint8Array[] = [];
+  let receivedBytes = 0;
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+
+    receivedBytes += value.byteLength;
+    if (receivedBytes > PUBLIC_INTAKE_MAX_REQUEST_BYTES) {
+      await reader.cancel();
+      return {
+        ok: false,
+        status: 413,
+        error: "Unable to submit contact request.",
+      };
+    }
+
+    chunks.push(value);
+  }
+
+  const bytes = new Uint8Array(receivedBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  try {
+    const parsed = JSON.parse(new TextDecoder().decode(bytes));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return { ok: false, status: 400, error: "Invalid request body." };
+    }
+    return { ok: true, body: parsed as Record<string, unknown> };
+  } catch {
+    return { ok: false, status: 400, error: "Invalid request body." };
+  }
+};
 
 class RequestValidationError extends Error {}
 
@@ -207,17 +293,18 @@ const verifyLeadMetadata = async (metadata: Record<string, unknown>) => {
 
 const claimDispatch = async (
   eventKey: string,
-  dispatchType: "lead_quote",
-  sourceId: string
+  dispatchType: "lead_submission",
+  sourceId: string,
 ): Promise<boolean> => {
   if (!supabase) return false;
 
-  const { error } = await supabase.from("internal_notification_dispatches").insert({
-    event_key: eventKey,
-    dispatch_type: dispatchType,
-    source_table: "lead_submissions",
-    source_id: sourceId,
-  });
+  const { error } = await supabase.from("internal_notification_dispatches")
+    .insert({
+      event_key: eventKey,
+      dispatch_type: dispatchType,
+      source_table: "lead_submissions",
+      source_id: sourceId,
+    });
 
   if (!error) {
     return true;
@@ -232,7 +319,7 @@ const claimDispatch = async (
   if (error.code === "42501" || error.code === "42P01") {
     console.warn(
       "Dispatch claim fallback: proceeding without dedupe bookkeeping.",
-      error
+      { errorCode: error.code, errorMessage: error.message },
     );
     return true;
   }
@@ -242,14 +329,31 @@ const claimDispatch = async (
 
 const releaseDispatch = async (eventKey: string) => {
   if (!supabase) return;
-  await supabase.from("internal_notification_dispatches").delete().eq("event_key", eventKey);
+  await supabase.from("internal_notification_dispatches").delete().eq(
+    "event_key",
+    eventKey,
+  );
 };
 
-const markDispatchSent = async (eventKey: string, meta: Record<string, unknown>) => {
+const markDispatchSent = async (
+  eventKey: string,
+  meta: Record<string, unknown>,
+) => {
   if (!supabase) return;
   await supabase
     .from("internal_notification_dispatches")
     .update({ sent_at: new Date().toISOString(), meta })
+    .eq("event_key", eventKey);
+};
+
+const markDispatchSkipped = async (
+  eventKey: string,
+  meta: Record<string, unknown>,
+) => {
+  if (!supabase) return;
+  await supabase
+    .from("internal_notification_dispatches")
+    .update({ meta })
     .eq("event_key", eventKey);
 };
 
@@ -259,26 +363,44 @@ serve(async (req) => {
   }
 
   try {
+    if (req.method !== "POST") {
+      return new Response(JSON.stringify({ error: "Method not allowed." }), {
+        status: 405,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
     if (!supabase) {
       return new Response(
         JSON.stringify({ error: "Lead intake is not configured." }),
         {
           status: 500,
           headers: { ...corsHeaders, "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
-    const body = await req.json();
+    const parsedBody = await readJsonBody(req);
+    if (!parsedBody.ok) {
+      return new Response(JSON.stringify({ error: parsedBody.error }), {
+        status: parsedBody.status,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+    const body = parsedBody.body;
 
-    const submissionType = sanitizeText(body?.submissionType).toLowerCase();
-    const name = sanitizeText(body?.name);
-    const email = sanitizeText(body?.email).toLowerCase();
-    const sourcePage = sanitizeText(body?.sourcePage) || "/contact";
-    const message = sanitizeText(body?.message);
-    const machineInterest = sanitizeText(body?.machineInterest);
-    const clientSubmissionId = sanitizeText(body?.clientSubmissionId).toLowerCase();
-    const metadata = await verifyLeadMetadata(normalizeLeadMetadata(body?.metadata));
+    const submissionType = sanitizeBoundedText(body?.submissionType, 32)
+      .toLowerCase();
+    const name = sanitizeBoundedText(body?.name, 120);
+    const email = sanitizeBoundedText(body?.email, 254).toLowerCase();
+    const sourcePage = sanitizePublicIntakeSourcePage(
+      sanitizeBoundedText(body?.sourcePage, 300) || "/contact",
+    );
+    const message = sanitizeBoundedText(body?.message, 4000);
+    const machineInterest = sanitizeBoundedText(body?.machineInterest, 120);
+    const clientSubmissionId = sanitizeText(body?.clientSubmissionId)
+      .toLowerCase();
+    const normalizedMetadata = normalizeLeadMetadata(body?.metadata);
 
     if (!validSubmissionTypes.has(submissionType)) {
       return new Response(
@@ -286,7 +408,7 @@ serve(async (req) => {
         {
           status: 400,
           headers: { ...corsHeaders, "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -296,7 +418,7 @@ serve(async (req) => {
         {
           status: 400,
           headers: { ...corsHeaders, "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
@@ -306,24 +428,71 @@ serve(async (req) => {
         {
           status: 400,
           headers: { ...corsHeaders, "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
     if (!clientSubmissionId || !uuidPattern.test(clientSubmissionId)) {
       return new Response(
-        JSON.stringify({ error: "Missing submission token. Refresh and try again." }),
+        JSON.stringify({
+          error: "Missing submission token. Refresh and try again.",
+        }),
         {
           status: 400,
           headers: { ...corsHeaders, "Content-Type": "application/json" },
-        }
+        },
       );
     }
 
-    const normalizedMessage =
-      submissionType === "quote" && machineInterest
-        ? `Machine of interest: ${machineInterest}\n\n${message}`
-        : message;
+    const normalizedMessage = submissionType === "quote" && machineInterest
+      ? `Machine of interest: ${machineInterest}\n\n${message}`
+      : message;
+
+    const abuseControlSalt = getAbuseControlSalt();
+    const abuseSupabase =
+      supabase as unknown as PublicIntakeAbuseSupabaseClient;
+    const keyHashes = await buildPublicIntakeKeyHashes({
+      salt: abuseControlSalt,
+      ip: getPublicIntakeClientIp(req),
+      email,
+      sourcePage,
+    });
+    const submissionLimitResult = await checkPublicIntakeRateLimits({
+      supabase: abuseSupabase,
+      keyHashes,
+      rules: PUBLIC_INTAKE_SUBMISSION_LIMITS,
+    });
+
+    if (!submissionLimitResult.allowed) {
+      console.warn(
+        "Public lead intake throttled.",
+        submissionLimitResult.reason,
+      );
+      return new Response(
+        JSON.stringify({
+          error: "Too many submissions. Please wait and try again.",
+        }),
+        {
+          status: 429,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const metadata = await verifyLeadMetadata(normalizedMetadata);
+
+    const serverDedupeWindowStartedAt = getPublicIntakeWindowStart(
+      new Date(),
+      PUBLIC_INTAKE_DEDUPE_WINDOW_SECONDS,
+    );
+    const serverDedupeKey = await buildPublicIntakeDedupeKey({
+      salt: abuseControlSalt,
+      submissionType,
+      email,
+      sourcePage,
+      message: normalizedMessage,
+      windowStartedAt: serverDedupeWindowStartedAt,
+    });
 
     const selectedColumns =
       "id, submission_type, name, email, source_page, message, metadata, created_at, internal_notification_sent_at";
@@ -338,6 +507,9 @@ serve(async (req) => {
         metadata,
         source_page: sourcePage,
         client_submission_id: clientSubmissionId,
+        server_dedupe_key: serverDedupeKey,
+        server_dedupe_window_started_at: serverDedupeWindowStartedAt
+          .toISOString(),
       })
       .select(selectedColumns)
       .single();
@@ -346,25 +518,40 @@ serve(async (req) => {
 
     if (insertError) {
       if (insertError.code !== "23505") {
-        throw new Error(insertError.message || "Unable to submit contact request.");
+        throw new Error(
+          insertError.message || "Unable to submit contact request.",
+        );
       }
 
-      const { data: existingLead, error: existingLeadError } = await supabase
-        .from("lead_submissions")
-        .select(selectedColumns)
-        .eq("client_submission_id", clientSubmissionId)
-        .maybeSingle();
+      const { data: clientTokenLead, error: clientTokenLeadError } =
+        await supabase
+          .from("lead_submissions")
+          .select(selectedColumns)
+          .eq("client_submission_id", clientSubmissionId)
+          .maybeSingle();
 
-      if (existingLeadError || !existingLead) {
+      if (clientTokenLeadError) {
         throw new Error("Unable to submit contact request.");
       }
 
-      leadSubmission = existingLead;
+      const { data: dedupedLead, error: dedupedLeadError } = clientTokenLead
+        ? { data: null, error: null }
+        : await supabase
+          .from("lead_submissions")
+          .select(selectedColumns)
+          .eq("server_dedupe_key", serverDedupeKey)
+          .maybeSingle();
+
+      if (dedupedLeadError || (!clientTokenLead && !dedupedLead)) {
+        throw new Error("Unable to submit contact request.");
+      }
+
+      leadSubmission = clientTokenLead || dedupedLead;
     }
 
     if (
-      submissionType !== "quote" ||
       !leadSubmission ||
+      leadSubmission.submission_type !== "quote" ||
       leadSubmission.internal_notification_sent_at
     ) {
       return new Response(JSON.stringify({ ok: true }), {
@@ -372,10 +559,37 @@ serve(async (req) => {
       });
     }
 
-    const eventKey = `lead_quote:${leadSubmission.id}`;
-    const dispatchClaimed = await claimDispatch(eventKey, "lead_quote", leadSubmission.id);
+    const eventKey = `lead_submission:${leadSubmission.id}`;
+    const dispatchClaimed = await claimDispatch(
+      eventKey,
+      "lead_submission",
+      leadSubmission.id,
+    );
 
     if (!dispatchClaimed) {
+      return new Response(JSON.stringify({ ok: true }), {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const notificationLimitResult = await checkPublicIntakeRateLimits({
+      supabase: abuseSupabase,
+      keyHashes,
+      rules: PUBLIC_INTAKE_NOTIFICATION_LIMITS,
+    });
+
+    if (!notificationLimitResult.allowed) {
+      console.warn(
+        "Public lead intake notification suppressed.",
+        notificationLimitResult.reason,
+      );
+      await markDispatchSkipped(eventKey, {
+        submission_type: leadSubmission.submission_type,
+        source_page: leadSubmission.source_page,
+        skipped_reason: "public_intake_notification_quota",
+        quota_scope: notificationLimitResult.reason?.eventScope,
+        quota_key_type: notificationLimitResult.reason?.keyType,
+      });
       return new Response(JSON.stringify({ ok: true }), {
         headers: { ...corsHeaders, "Content-Type": "application/json" },
       });
@@ -436,20 +650,24 @@ serve(async (req) => {
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });
   } catch (error) {
-    console.error("lead-submission-intake error", error);
     if (error instanceof RequestValidationError) {
+      console.error("lead-submission-intake validation error", error.message);
       return new Response(JSON.stringify({ error: error.message }), {
         status: 400,
         headers: { ...corsHeaders, "Content-Type": "application/json" },
       });
     }
 
+    console.error(
+      "lead-submission-intake error",
+      error instanceof Error ? error.message : "Unknown intake error.",
+    );
     return new Response(
       JSON.stringify({ error: "Unable to submit contact request." }),
       {
         status: 500,
         headers: { ...corsHeaders, "Content-Type": "application/json" },
-      }
+      },
     );
   }
 });

--- a/supabase/migrations/202604290003_public_intake_anti_abuse.sql
+++ b/supabase/migrations/202604290003_public_intake_anti_abuse.sql
@@ -1,0 +1,139 @@
+alter table public.lead_submissions
+  add column if not exists server_dedupe_key text,
+  add column if not exists server_dedupe_window_started_at timestamptz;
+
+create unique index if not exists lead_submissions_server_dedupe_key_idx
+  on public.lead_submissions (server_dedupe_key)
+  where server_dedupe_key is not null;
+
+create index if not exists lead_submissions_server_dedupe_window_idx
+  on public.lead_submissions (server_dedupe_window_started_at desc)
+  where server_dedupe_window_started_at is not null;
+
+alter table public.internal_notification_dispatches
+  drop constraint if exists internal_notification_dispatches_dispatch_type_check;
+
+alter table public.internal_notification_dispatches
+  add constraint internal_notification_dispatches_dispatch_type_check
+  check (
+    dispatch_type in (
+      'lead_quote',
+      'lead_submission',
+      'mini_waitlist',
+      'order_checkout',
+      'plus_subscription_activated'
+    )
+  );
+
+create table if not exists public.public_intake_rate_limit_events (
+  event_scope text not null,
+  key_type text not null,
+  key_hash text not null,
+  window_started_at timestamptz not null,
+  window_seconds integer not null,
+  event_count integer not null default 1,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (event_scope, key_type, key_hash, window_started_at, window_seconds),
+  constraint public_intake_rate_limit_events_scope_check
+    check (event_scope in ('submission', 'notification')),
+  constraint public_intake_rate_limit_events_key_type_check
+    check (key_type in ('ip', 'email', 'source', 'global')),
+  constraint public_intake_rate_limit_events_key_hash_check
+    check (key_hash ~ '^[0-9a-f]{64}$'),
+  constraint public_intake_rate_limit_events_window_seconds_check
+    check (window_seconds between 60 and 86400),
+  constraint public_intake_rate_limit_events_count_check
+    check (event_count > 0)
+);
+
+create index if not exists public_intake_rate_limit_events_updated_at_idx
+  on public.public_intake_rate_limit_events (updated_at);
+
+alter table public.public_intake_rate_limit_events enable row level security;
+
+drop policy if exists "public_intake_rate_limit_events_select_super_admin"
+  on public.public_intake_rate_limit_events;
+
+create policy "public_intake_rate_limit_events_select_super_admin"
+on public.public_intake_rate_limit_events
+for select
+to authenticated
+using (public.is_super_admin(auth.uid()));
+
+create or replace function public.record_public_intake_rate_limit_event(
+  p_event_scope text,
+  p_key_type text,
+  p_key_hash text,
+  p_window_seconds integer
+)
+returns integer
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_now timestamptz := statement_timestamp();
+  v_window_started_at timestamptz;
+  v_event_count integer;
+begin
+  if p_event_scope not in ('submission', 'notification') then
+    raise exception 'Unsupported public intake event scope.';
+  end if;
+
+  if p_key_type not in ('ip', 'email', 'source', 'global') then
+    raise exception 'Unsupported public intake key type.';
+  end if;
+
+  if p_key_hash !~ '^[0-9a-f]{64}$' then
+    raise exception 'Invalid public intake key hash.';
+  end if;
+
+  if p_window_seconds < 60 or p_window_seconds > 86400 then
+    raise exception 'Invalid public intake rate-limit window.';
+  end if;
+
+  v_window_started_at :=
+    to_timestamp(floor(extract(epoch from v_now) / p_window_seconds) * p_window_seconds);
+
+  insert into public.public_intake_rate_limit_events (
+    event_scope,
+    key_type,
+    key_hash,
+    window_started_at,
+    window_seconds,
+    event_count,
+    created_at,
+    updated_at
+  )
+  values (
+    p_event_scope,
+    p_key_type,
+    p_key_hash,
+    v_window_started_at,
+    p_window_seconds,
+    1,
+    v_now,
+    v_now
+  )
+  on conflict (event_scope, key_type, key_hash, window_started_at, window_seconds)
+  do update
+  set
+    event_count = public.public_intake_rate_limit_events.event_count + 1,
+    updated_at = excluded.updated_at
+  returning event_count into v_event_count;
+
+  delete from public.public_intake_rate_limit_events
+  where updated_at < v_now - interval '2 days';
+
+  return v_event_count;
+end;
+$$;
+
+revoke all on function public.record_public_intake_rate_limit_event(text, text, text, integer)
+  from public, anon, authenticated;
+
+grant execute on function public.record_public_intake_rate_limit_event(text, text, text, integer)
+  to service_role;
+
+select pg_notify('pgrst', 'reload schema');

--- a/supabase/migrations/202604290004_public_intake_global_key_type.sql
+++ b/supabase/migrations/202604290004_public_intake_global_key_type.sql
@@ -1,0 +1,83 @@
+alter table public.public_intake_rate_limit_events
+  drop constraint if exists public_intake_rate_limit_events_key_type_check;
+
+alter table public.public_intake_rate_limit_events
+  add constraint public_intake_rate_limit_events_key_type_check
+  check (key_type in ('ip', 'email', 'source', 'global'));
+
+create or replace function public.record_public_intake_rate_limit_event(
+  p_event_scope text,
+  p_key_type text,
+  p_key_hash text,
+  p_window_seconds integer
+)
+returns integer
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_now timestamptz := statement_timestamp();
+  v_window_started_at timestamptz;
+  v_event_count integer;
+begin
+  if p_event_scope not in ('submission', 'notification') then
+    raise exception 'Unsupported public intake event scope.';
+  end if;
+
+  if p_key_type not in ('ip', 'email', 'source', 'global') then
+    raise exception 'Unsupported public intake key type.';
+  end if;
+
+  if p_key_hash !~ '^[0-9a-f]{64}$' then
+    raise exception 'Invalid public intake key hash.';
+  end if;
+
+  if p_window_seconds < 60 or p_window_seconds > 86400 then
+    raise exception 'Invalid public intake rate-limit window.';
+  end if;
+
+  v_window_started_at :=
+    to_timestamp(floor(extract(epoch from v_now) / p_window_seconds) * p_window_seconds);
+
+  insert into public.public_intake_rate_limit_events (
+    event_scope,
+    key_type,
+    key_hash,
+    window_started_at,
+    window_seconds,
+    event_count,
+    created_at,
+    updated_at
+  )
+  values (
+    p_event_scope,
+    p_key_type,
+    p_key_hash,
+    v_window_started_at,
+    p_window_seconds,
+    1,
+    v_now,
+    v_now
+  )
+  on conflict (event_scope, key_type, key_hash, window_started_at, window_seconds)
+  do update
+  set
+    event_count = public.public_intake_rate_limit_events.event_count + 1,
+    updated_at = excluded.updated_at
+  returning event_count into v_event_count;
+
+  delete from public.public_intake_rate_limit_events
+  where updated_at < v_now - interval '2 days';
+
+  return v_event_count;
+end;
+$$;
+
+revoke all on function public.record_public_intake_rate_limit_event(text, text, text, integer)
+  from public, anon, authenticated;
+
+grant execute on function public.record_public_intake_rate_limit_event(text, text, text, integer)
+  to service_role;
+
+select pg_notify('pgrst', 'reload schema');


### PR DESCRIPTION
﻿References #293

## Summary
- Adds server-side public intake throttling by hashed global/IP/email/source keys before lead persistence.
- Adds server-side dedupe for repeated identical public intake payloads within a 30-minute window.
- Adds quote notification quotas before Resend/WeCom dispatch so direct API calls cannot amplify internal alerts indefinitely.

## Files changed
- `supabase/functions/lead-submission-intake/index.ts` and `supabase/functions/_shared/public-intake-abuse-controls.ts`: bounded request parsing, hashed quota keys, throttling, dedupe, private custom-sticks artwork metadata preservation, and notification quota wiring.
- `supabase/migrations/202604290003_public_intake_anti_abuse.sql`: hashed rate-limit event table, atomic RPC, dedupe columns/indexes, and dispatch type compatibility.
- `supabase/migrations/202604290004_public_intake_global_key_type.sql`: forward repair for the global quota key type if an earlier branch migration was applied locally.
- `scripts/validate-public-intake-anti-abuse.mjs` and `package.json`: focused validation script for repeated direct POST throttling and notification quota wiring.
- `Docs/QA_SMOKE_TEST_CHECKLIST.md`: smoke coverage for public intake anti-abuse behavior.

## Verification
- `npm ci` - passed; 0 vulnerabilities reported by install audit.
- `npm run build` - passed.
- `npm test --if-present` - passed; no test script is currently defined.
- `npm run lint --if-present` - passed with 8 existing Fast Refresh warnings in shared UI/context files.
- `npm run db:validate-migrations` - passed against a disposable local Supabase project after applying 63 migration files.
- `npm run security:validate-public-intake` - passed.
- `deno check --no-lock supabase/functions/lead-submission-intake/index.ts` - passed.
- `deno lint --rules-exclude=no-import-prefix supabase/functions/lead-submission-intake/index.ts supabase/functions/_shared/public-intake-abuse-controls.ts` - passed. `no-import-prefix` is excluded because this repo's Supabase Edge Functions use remote URL imports.
- `npm audit --omit=dev` - passed; 0 vulnerabilities.
- `npm run commerce:preflight` - attempted for notification coverage and failed because this local worktree does not have Stripe, Supabase, Resend, or WeCom secrets configured.

## How to test
1. In the PR worktree, run `npm ci`.
2. Start the public app with `npm run dev` and open the printed localhost URL, usually `http://localhost:8080`.
3. Open `http://localhost:8080/contact`, submit a normal quote request, and confirm the request returns success and creates one `lead_submissions` row.
4. Open `http://localhost:8080/supplies?order=sticks` and submit a normal procurement request under the direct-checkout threshold; confirm it still returns success.
5. With Supabase functions/secrets configured locally, submit a custom-sticks procurement request with private artwork metadata and confirm the intake verifies the private `custom-sticks-artwork` object before storing metadata.
6. Call `lead-submission-intake` directly with repeated valid JSON payloads and confirm throttling starts after the configured public-intake limits.
7. Repeat an identical quote payload with new client UUIDs inside the same 30-minute window and confirm the server returns success without creating duplicate lead rows.
8. Replay a non-quote `clientSubmissionId` with `submissionType: quote` and confirm no quote notification is sent because notification eligibility uses the persisted lead type.

## Abuse-control behavior
- Submission limits are recorded server-side with hashed keys only: 300/hour global, 30/hour by IP, 5/hour by email, and 200/hour by normalized source group.
- Quote notification limits are enforced before internal email/WeCom dispatch: 50/hour global, 10/hour by IP, 3/hour by email, and 50/hour by normalized source group.
- Source quotas are bucketed to known public route groups rather than arbitrary caller-provided query strings.
- Identical payload dedupe uses a server-generated hash over normalized type/email/source/message plus a 30-minute window, so callers cannot bypass dedupe by rotating the client UUID alone.
- The function enforces a 20 KB request cap while streaming the body, not just via `Content-Length`.
- Rate-limit storage uses hashed key material only and does not store raw IPs, raw emails, or private message contents.
- Private custom-sticks artwork verification from #315 is preserved, and storage object verification runs after the submission throttle so direct API abuse cannot amplify storage lookups before quota checks.
- If the rate-limit RPC is temporarily unavailable, the intake fails open for legitimate submissions; once migrations are applied, the controls enforce normally.

## Branch safety
- Rebased onto current `main` after the Wave 4 merges and the later `main` updates.
- Resolved the `supabase/functions/lead-submission-intake/index.ts` conflict by preserving #315 private artwork intake behavior and #317 anti-abuse controls.
- Moved the public-intake migrations forward to unique versions `202604290003` and `202604290004`, avoiding the `202604280006`/`202604280007` conflicts called out in the release-pass comment.
