### PR TITLE
Launch Business Playbook resources

### DIFF
--- a/Docs/BUSINESS_PLAYBOOK_CONTENT_BRIEF.md
+++ b/Docs/BUSINESS_PLAYBOOK_CONTENT_BRIEF.md
@@ -12,6 +12,8 @@ The content should help a serious buyer make a better business decision before t
 - Use official sources for business setup topics, especially SBA and IRS pages.
 - Make each article visually scannable with real Bloomjoy imagery plus at least one useful visual block.
 - Keep public articles indexable. Save downloadable templates, calculators, and deeper operator assets for future Plus work.
+- Flagship public articles should usually land around 1,000-1,800 words. Shorter pieces need a clear reason.
+- Include operator-led narrative: field notes, first-launch scenes, common mistakes, and "what this means in practice" guidance.
 
 ## Article Template
 Each article should include:
@@ -20,6 +22,7 @@ Each article should include:
 - 3 key takeaways
 - Real Bloomjoy image or approved branded visual
 - At least one useful visual block: table, checklist, scorecard, pitch script, worksheet preview, or comparison chart
+- At least one concrete operator example, sample scenario, script, filled-in worksheet, or decision rule
 - Primary CTA and optional secondary CTA
 - Sources and related articles
 
@@ -40,4 +43,5 @@ Each article should include:
 - For general startup sequencing, cite SBA startup guidance.
 - For business structure topics, cite SBA business structure guidance.
 - For EIN topics, cite IRS EIN guidance and note that EIN applications are free through the IRS.
+- For licenses and permits, cite SBA license/permit guidance and remind readers that state, county, city, and venue requirements can vary.
 - For SEO/content quality standards, follow Google Search Central's people-first content guidance.

--- a/Docs/BUSINESS_PLAYBOOK_CONTENT_BRIEF.md
+++ b/Docs/BUSINESS_PLAYBOOK_CONTENT_BRIEF.md
@@ -1,0 +1,43 @@
+# Bloomjoy Business Playbook Content Brief
+
+## Purpose
+The Bloomjoy Business Playbook is the public resource hub for people exploring cotton candy vending, event service, catering, and machine ownership.
+
+The content should help a serious buyer make a better business decision before they request a quote. It should feel practical, visual, operator-led, and enjoyable to read.
+
+## Editorial Standard
+- Be useful first. Every article needs specific examples, checklists, tables, scripts, scorecards, or decision frameworks.
+- Keep the voice practical, confident, clear, and lightly playful where natural.
+- Avoid generic SEO filler, vague entrepreneurship advice, unrealistic ROI/profit claims, and legal/tax overconfidence.
+- Use official sources for business setup topics, especially SBA and IRS pages.
+- Make each article visually scannable with real Bloomjoy imagery plus at least one useful visual block.
+- Keep public articles indexable. Save downloadable templates, calculators, and deeper operator assets for future Plus work.
+
+## Article Template
+Each article should include:
+- Title and short title
+- Audience and machine-fit label
+- 3 key takeaways
+- Real Bloomjoy image or approved branded visual
+- At least one useful visual block: table, checklist, scorecard, pitch script, worksheet preview, or comparison chart
+- Primary CTA and optional secondary CTA
+- Sources and related articles
+
+## Content Categories
+- Start the Business: business model, launch path, machine fit, and first 30 days.
+- Find Locations: venue scoring, owner pitch, site walks, and commercial terms.
+- Budget and Plan: startup costs, supplies, reserves, and practical worksheets.
+- Events and Catering: Mini/Micro event operations, packages, staffing, and event-day kit.
+- Business Setup: LLC, EIN, banking, insurance, permits, and local research prompts.
+
+## Visual Rules
+- Prefer real Bloomjoy machine, supply, or operator photography already in the repo.
+- Use branded diagrams, tables, scorecards, and checklists before adding decorative imagery.
+- Avoid stock-looking photos and purely atmospheric images.
+- Tables must remain readable on mobile or sit inside horizontal scroll containers.
+
+## Source Rules
+- For general startup sequencing, cite SBA startup guidance.
+- For business structure topics, cite SBA business structure guidance.
+- For EIN topics, cite IRS EIN guidance and note that EIN applications are free through the IRS.
+- For SEO/content quality standards, follow Google Search Central's people-first content guidance.

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -22,7 +22,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Production/preview asset check: JS files referenced by `/admin`, `/admin/access`, `/admin/reporting`, and `/admin/partnerships` return `application/javascript`, and a bogus `/assets/__missing-admin-chunk__.js` returns `404 text/plain` instead of the SPA fallback page
 - [ ] Stale route chunk recovery check: simulate one route-level JS chunk load failure, confirm the app performs one automatic reload, then confirm a repeated failure shows the app-update refresh fallback instead of a blank page
 - [ ] `robots.txt` is reachable and includes a sitemap reference
-- [ ] `sitemap.xml` is reachable, lists core public routes, includes `lastmod`, and includes image sitemap entries for key machine/supplies/about URLs
+- [ ] `sitemap.xml` is reachable, lists core public routes plus public Business Playbook article routes, includes `lastmod`, and includes image sitemap entries for key machine/supplies/about/playbook URLs
 - [ ] Apex host (`https://bloomjoyusa.com`) redirects to canonical host (`https://www.bloomjoyusa.com/`) with permanent redirect behavior
 - [ ] Legacy paths (`/products`, `/products/mini`, `/products/micro`, `/products/commercial-robotic-machine`) return permanent redirects to `/machines*`
 - [ ] No console errors on home page load
@@ -64,6 +64,11 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Cart line-item title, quantity controls, price, and remove action stack cleanly on mobile
 - [ ] Plus page: pricing and boundaries are visible and clear
 - [ ] Resources page shows Bloomjoy Plus teaser content for locked downloads (procedure docs, daily checklists, frequent updates)
+- [ ] Resources page leads with the Bloomjoy Business Playbook, shows visual article cards, and still exposes FAQ and Support Boundaries anchors
+- [ ] `/resources/business-playbook` direct-loads and shows category navigation plus all public playbook guides
+- [ ] Business Playbook article routes direct-load, show a real Bloomjoy image, useful visual blocks (tables/checklists/scorecards/scripts), source links, related articles, and quote/machine CTAs
+- [ ] Business Playbook article routes are readable on mobile widths (`360x800`, `390x844`, `414x896`) with no clipped tables or horizontal page overflow
+- [ ] Commercial, Mini, Micro, Machines listing, Plus, and Contact success states link to relevant Business Playbook guides
 - [ ] `/resources#faq` opens to the FAQ section, shows startup-cost guidance without exact all-in-cost/ROI/profit claims, keeps the quote/contact path clear on desktop and mobile, and `/resources` page source includes matching FAQPage JSON-LD
 - [ ] `/machines`, `/resources`, `/plus`, and `/contact` show primary content without excessive dead space on desktop and mobile
 - [ ] Footer legal links open `/privacy`, `/terms`, and `/billing-cancellation`

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   <url>
     <loc>https://www.bloomjoyusa.com/</loc>
-    <lastmod>2026-04-28</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <image:image>
       <image:loc>https://www.bloomjoyusa.com/seo/home-machine.jpg</image:loc>
       <image:title>Bloomjoy robotic cotton candy machine</image:title>
@@ -10,7 +10,7 @@
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/machines</loc>
-    <lastmod>2026-04-28</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <image:image>
       <image:loc>https://www.bloomjoyusa.com/seo/machines-lineup.jpg</image:loc>
       <image:title>Bloomjoy robotic cotton candy machines</image:title>
@@ -18,7 +18,7 @@
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/machines/commercial-robotic-machine</loc>
-    <lastmod>2026-04-28</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <image:image>
       <image:loc>https://www.bloomjoyusa.com/seo/commercial-machine.jpg</image:loc>
       <image:title>Bloomjoy Commercial Machine</image:title>
@@ -26,7 +26,7 @@
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/machines/mini</loc>
-    <lastmod>2026-04-28</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <image:image>
       <image:loc>https://www.bloomjoyusa.com/seo/mini-machine.jpg</image:loc>
       <image:title>Bloomjoy Mini Machine</image:title>
@@ -34,7 +34,7 @@
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/machines/micro</loc>
-    <lastmod>2026-04-28</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <image:image>
       <image:loc>https://www.bloomjoyusa.com/seo/micro-machine.jpg</image:loc>
       <image:title>Bloomjoy Micro Machine</image:title>
@@ -42,7 +42,7 @@
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/supplies</loc>
-    <lastmod>2026-04-28</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <image:image>
       <image:loc>https://www.bloomjoyusa.com/seo/supplies.jpg</image:loc>
       <image:title>Bloomjoy cotton candy machine sugar and paper sticks</image:title>
@@ -50,19 +50,19 @@
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/plus</loc>
-    <lastmod>2026-04-28</lastmod>
+    <lastmod>2026-04-29</lastmod>
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/resources</loc>
-    <lastmod>2026-04-28</lastmod>
+    <lastmod>2026-04-29</lastmod>
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/resources/business-playbook</loc>
-    <lastmod>2026-04-28</lastmod>
+    <lastmod>2026-04-29</lastmod>
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/resources/business-playbook/how-to-start-cotton-candy-vending-business</loc>
-    <lastmod>2026-04-28</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <image:image>
       <image:loc>https://www.bloomjoyusa.com/seo/commercial-machine.jpg</image:loc>
       <image:title>How to Start a Cotton Candy Vending Business</image:title>
@@ -70,7 +70,7 @@
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/resources/business-playbook/best-locations-for-cotton-candy-vending-machines</loc>
-    <lastmod>2026-04-28</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <image:image>
       <image:loc>https://www.bloomjoyusa.com/seo/home-machine.jpg</image:loc>
       <image:title>How to Find Good Locations for a Cotton Candy Vending Machine</image:title>
@@ -78,7 +78,7 @@
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/resources/business-playbook/mini-micro-event-catering-business-guide</loc>
-    <lastmod>2026-04-28</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <image:image>
       <image:loc>https://www.bloomjoyusa.com/seo/mini-machine.jpg</image:loc>
       <image:title>How to Start a Cotton Candy Event or Catering Business with Mini or Micro</image:title>
@@ -86,7 +86,7 @@
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/resources/business-playbook/startup-budget-checklist-cotton-candy-machine-business</loc>
-    <lastmod>2026-04-28</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <image:image>
       <image:loc>https://www.bloomjoyusa.com/seo/supplies.jpg</image:loc>
       <image:title>Startup Budget Checklist for a Cotton Candy Machine Business</image:title>
@@ -94,7 +94,7 @@
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/resources/business-playbook/how-to-pitch-location-owners</loc>
-    <lastmod>2026-04-28</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <image:image>
       <image:loc>https://www.bloomjoyusa.com/seo/about.jpg</image:loc>
       <image:title>How to Pitch a Location Owner on a Cotton Candy Vending Machine</image:title>
@@ -102,7 +102,7 @@
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/resources/business-playbook/commercial-vending-vs-event-catering</loc>
-    <lastmod>2026-04-28</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <image:image>
       <image:loc>https://www.bloomjoyusa.com/seo/micro-machine.jpg</image:loc>
       <image:title>Commercial Vending vs. Event Catering: Which Cotton Candy Business Fits You?</image:title>
@@ -110,7 +110,7 @@
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/resources/business-playbook/business-setup-basics-llc-ein-insurance-permits</loc>
-    <lastmod>2026-04-28</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <image:image>
       <image:loc>https://www.bloomjoyusa.com/seo/about.jpg</image:loc>
       <image:title>Business Setup Basics: LLC, EIN, Bank Account, Insurance, and Permits</image:title>
@@ -118,11 +118,11 @@
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/contact</loc>
-    <lastmod>2026-04-28</lastmod>
+    <lastmod>2026-04-29</lastmod>
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/about</loc>
-    <lastmod>2026-04-28</lastmod>
+    <lastmod>2026-04-29</lastmod>
     <image:image>
       <image:loc>https://www.bloomjoyusa.com/seo/about.jpg</image:loc>
       <image:title>Bloomjoy operator experience</image:title>
@@ -130,14 +130,14 @@
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/privacy</loc>
-    <lastmod>2026-04-28</lastmod>
+    <lastmod>2026-04-29</lastmod>
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/terms</loc>
-    <lastmod>2026-04-28</lastmod>
+    <lastmod>2026-04-29</lastmod>
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/billing-cancellation</loc>
-    <lastmod>2026-04-28</lastmod>
+    <lastmod>2026-04-29</lastmod>
   </url>
 </urlset>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   <url>
     <loc>https://www.bloomjoyusa.com/</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-04-28</lastmod>
     <image:image>
       <image:loc>https://www.bloomjoyusa.com/seo/home-machine.jpg</image:loc>
       <image:title>Bloomjoy robotic cotton candy machine</image:title>
@@ -10,7 +10,7 @@
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/machines</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-04-28</lastmod>
     <image:image>
       <image:loc>https://www.bloomjoyusa.com/seo/machines-lineup.jpg</image:loc>
       <image:title>Bloomjoy robotic cotton candy machines</image:title>
@@ -18,7 +18,7 @@
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/machines/commercial-robotic-machine</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-04-28</lastmod>
     <image:image>
       <image:loc>https://www.bloomjoyusa.com/seo/commercial-machine.jpg</image:loc>
       <image:title>Bloomjoy Commercial Machine</image:title>
@@ -26,7 +26,7 @@
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/machines/mini</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-04-28</lastmod>
     <image:image>
       <image:loc>https://www.bloomjoyusa.com/seo/mini-machine.jpg</image:loc>
       <image:title>Bloomjoy Mini Machine</image:title>
@@ -34,7 +34,7 @@
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/machines/micro</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-04-28</lastmod>
     <image:image>
       <image:loc>https://www.bloomjoyusa.com/seo/micro-machine.jpg</image:loc>
       <image:title>Bloomjoy Micro Machine</image:title>
@@ -42,7 +42,7 @@
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/supplies</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-04-28</lastmod>
     <image:image>
       <image:loc>https://www.bloomjoyusa.com/seo/supplies.jpg</image:loc>
       <image:title>Bloomjoy cotton candy machine sugar and paper sticks</image:title>
@@ -50,19 +50,79 @@
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/plus</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-04-28</lastmod>
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/resources</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-04-28</lastmod>
+  </url>
+  <url>
+    <loc>https://www.bloomjoyusa.com/resources/business-playbook</loc>
+    <lastmod>2026-04-28</lastmod>
+  </url>
+  <url>
+    <loc>https://www.bloomjoyusa.com/resources/business-playbook/how-to-start-cotton-candy-vending-business</loc>
+    <lastmod>2026-04-28</lastmod>
+    <image:image>
+      <image:loc>https://www.bloomjoyusa.com/seo/commercial-machine.jpg</image:loc>
+      <image:title>How to Start a Cotton Candy Vending Business</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://www.bloomjoyusa.com/resources/business-playbook/best-locations-for-cotton-candy-vending-machines</loc>
+    <lastmod>2026-04-28</lastmod>
+    <image:image>
+      <image:loc>https://www.bloomjoyusa.com/seo/home-machine.jpg</image:loc>
+      <image:title>How to Find Good Locations for a Cotton Candy Vending Machine</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://www.bloomjoyusa.com/resources/business-playbook/mini-micro-event-catering-business-guide</loc>
+    <lastmod>2026-04-28</lastmod>
+    <image:image>
+      <image:loc>https://www.bloomjoyusa.com/seo/mini-machine.jpg</image:loc>
+      <image:title>How to Start a Cotton Candy Event or Catering Business with Mini or Micro</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://www.bloomjoyusa.com/resources/business-playbook/startup-budget-checklist-cotton-candy-machine-business</loc>
+    <lastmod>2026-04-28</lastmod>
+    <image:image>
+      <image:loc>https://www.bloomjoyusa.com/seo/supplies.jpg</image:loc>
+      <image:title>Startup Budget Checklist for a Cotton Candy Machine Business</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://www.bloomjoyusa.com/resources/business-playbook/how-to-pitch-location-owners</loc>
+    <lastmod>2026-04-28</lastmod>
+    <image:image>
+      <image:loc>https://www.bloomjoyusa.com/seo/about.jpg</image:loc>
+      <image:title>How to Pitch a Location Owner on a Cotton Candy Vending Machine</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://www.bloomjoyusa.com/resources/business-playbook/commercial-vending-vs-event-catering</loc>
+    <lastmod>2026-04-28</lastmod>
+    <image:image>
+      <image:loc>https://www.bloomjoyusa.com/seo/micro-machine.jpg</image:loc>
+      <image:title>Commercial Vending vs. Event Catering: Which Cotton Candy Business Fits You?</image:title>
+    </image:image>
+  </url>
+  <url>
+    <loc>https://www.bloomjoyusa.com/resources/business-playbook/business-setup-basics-llc-ein-insurance-permits</loc>
+    <lastmod>2026-04-28</lastmod>
+    <image:image>
+      <image:loc>https://www.bloomjoyusa.com/seo/about.jpg</image:loc>
+      <image:title>Business Setup Basics: LLC, EIN, Bank Account, Insurance, and Permits</image:title>
+    </image:image>
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/contact</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-04-28</lastmod>
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/about</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-04-28</lastmod>
     <image:image>
       <image:loc>https://www.bloomjoyusa.com/seo/about.jpg</image:loc>
       <image:title>Bloomjoy operator experience</image:title>
@@ -70,14 +130,14 @@
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/privacy</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-04-28</lastmod>
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/terms</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-04-28</lastmod>
   </url>
   <url>
     <loc>https://www.bloomjoyusa.com/billing-cancellation</loc>
-    <lastmod>2026-04-17</lastmod>
+    <lastmod>2026-04-28</lastmod>
   </url>
 </urlset>

--- a/scripts/seo-regression-check.mjs
+++ b/scripts/seo-regression-check.mjs
@@ -49,7 +49,8 @@ const expectedH1TextByRoute = {
   "/machines/micro": "Bloomjoy Sweets Micro Machine",
   "/supplies": "Cotton Candy Machine Sugar and Paper Sticks",
   "/plus": "Onboarding + Playbooks + Concierge",
-  "/resources": "Resources",
+  "/resources": "Guides, FAQs, and operator playbooks for starting smart",
+  "/resources/business-playbook": "Practical startup guides for cotton candy operators",
   "/contact": "Contact Us",
   "/about": "About Bloomjoy",
   "/privacy": "Privacy Policy",
@@ -169,6 +170,37 @@ const validatePublicRouteHtml = async (route, seoRoutes) => {
     assertIncludes(html, `"@type":"Offer"`, "Supplies route is missing Offer JSON-LD");
     assertIncludes(html, `"price":"10.00"`, "Supplies route is missing sugar price Offer");
     assertIncludes(html, `"price":"130.00"`, "Supplies route is missing sticks price Offer");
+  }
+
+  if (route.path === "/resources/business-playbook") {
+    assertIncludes(
+      html,
+      `"@type":"CollectionPage"`,
+      "Business Playbook index is missing CollectionPage JSON-LD"
+    );
+    assertIncludes(
+      html,
+      "Bloomjoy Business Playbook",
+      "Business Playbook index is missing visible playbook branding"
+    );
+  }
+
+  if (route.path.startsWith("/resources/business-playbook/")) {
+    assertIncludes(
+      html,
+      `"@type":"Article"`,
+      `Business Playbook article ${route.path} is missing Article JSON-LD`
+    );
+    assertIncludes(
+      html,
+      `"@type":"BreadcrumbList"`,
+      `Business Playbook article ${route.path} is missing BreadcrumbList JSON-LD`
+    );
+    assertIncludes(
+      html,
+      "What you will take away",
+      `Business Playbook article ${route.path} is missing prerendered article body`
+    );
   }
 
   if (route.path === "/machines/mini") {
@@ -357,7 +389,7 @@ const hasAppToWwwRedirectRules = (routes) => {
 
   const groupedRedirect = routes.some(
     (route) =>
-      route?.src === "/(machines(?:/.*)?|products(?:/.*)?|supplies|plus|resources|about|contact|privacy|terms|billing-cancellation|cart)" &&
+      route?.src === "/(machines(?:/.*)?|products(?:/.*)?|supplies|plus|resources(?:/.*)?|about|contact|privacy|terms|billing-cancellation|cart)" &&
       route?.status === 308 &&
       route?.headers?.Location === "https://www.bloomjoyusa.com/$1" &&
       Array.isArray(route?.has) &&
@@ -382,6 +414,18 @@ const hasStaticPrerenderRewriteRules = (routes) => {
       route?.dest === "/$1.html"
   );
 
+  const playbookIndexRewrite = routes.some(
+    (route) =>
+      route?.src === "/resources/business-playbook/?" &&
+      route?.dest === "/resources/business-playbook.html"
+  );
+
+  const playbookArticleRewrite = routes.some(
+    (route) =>
+      route?.src === "/resources/business-playbook/([^/]+)/?" &&
+      route?.dest === "/resources/business-playbook/$1.html"
+  );
+
   const authPrivateRewrite = routes.some(
     (route) =>
       route?.src === "/(cart|login(?:/operator)?|reset-password)/?" &&
@@ -402,6 +446,8 @@ const hasStaticPrerenderRewriteRules = (routes) => {
 
   return (
     machineDetailRewrite &&
+    playbookIndexRewrite &&
+    playbookArticleRewrite &&
     publicRewrite &&
     authPrivateRewrite &&
     portalCatchAllRewrite &&

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,12 @@ const Plus = lazyRoute(() => import("./pages/Plus"));
 const Contact = lazyRoute(() => import("./pages/Contact"));
 const About = lazyRoute(() => import("./pages/About"));
 const Resources = lazyRoute(() => import("./pages/Resources"));
+const BusinessPlaybookIndex = lazyRoute(
+  () => import("./pages/resources/BusinessPlaybookIndex")
+);
+const BusinessPlaybookArticle = lazyRoute(
+  () => import("./pages/resources/BusinessPlaybookArticle")
+);
 const Privacy = lazyRoute(() => import("./pages/Privacy"));
 const Terms = lazyRoute(() => import("./pages/Terms"));
 const BillingCancellation = lazyRoute(() => import("./pages/BillingCancellation"));
@@ -132,6 +138,11 @@ export const AppShell = () => (
           <Route path="/contact" element={<Contact />} />
           <Route path="/about" element={<About />} />
           <Route path="/resources" element={<Resources />} />
+          <Route path="/resources/business-playbook" element={<BusinessPlaybookIndex />} />
+          <Route
+            path="/resources/business-playbook/:slug"
+            element={<BusinessPlaybookArticle />}
+          />
           <Route path="/privacy" element={<Privacy />} />
           <Route path="/terms" element={<Terms />} />
           <Route path="/billing-cancellation" element={<BillingCancellation />} />

--- a/src/data/businessPlaybook.ts
+++ b/src/data/businessPlaybook.ts
@@ -1,0 +1,1037 @@
+import commercialMachineImage from "@/assets/real/commercial-main.jpg";
+import miniMachineImage from "@/assets/real/mini-main.webp";
+import microMachineImage from "@/assets/real/micro-main.webp";
+import suppliesImage from "@/assets/real/sugar-product.jpg";
+import aboutFoundersImage from "@/assets/real/about-founders.webp";
+import aboutHeroImage from "@/assets/real/about-hero.jpg";
+import landingHeroImage from "@/assets/real/landing-hero.jpg";
+
+export type PlaybookCategoryId =
+  | "start"
+  | "locations"
+  | "budget"
+  | "events"
+  | "setup";
+
+export type PlaybookTable = {
+  caption?: string;
+  columns: string[];
+  rows: string[][];
+};
+
+export type PlaybookScorecardItem = {
+  label: string;
+  score: string;
+  guidance: string;
+};
+
+export type PlaybookStep = {
+  title: string;
+  body: string;
+};
+
+export type PlaybookSection = {
+  heading: string;
+  body: string[];
+  bullets?: string[];
+  callout?: {
+    title: string;
+    body: string;
+  };
+  checklist?: string[];
+  table?: PlaybookTable;
+  scorecard?: {
+    title: string;
+    items: PlaybookScorecardItem[];
+  };
+  steps?: PlaybookStep[];
+  script?: {
+    title: string;
+    lines: string[];
+  };
+};
+
+export type PlaybookCitation = {
+  label: string;
+  source: string;
+  url: string;
+};
+
+export type BusinessPlaybookArticle = {
+  slug: string;
+  title: string;
+  shortTitle: string;
+  description: string;
+  category: PlaybookCategoryId;
+  audience: string;
+  machineFit: string;
+  updatedAt: string;
+  readingTime: string;
+  heroImage: string;
+  heroImageAlt: string;
+  seoImagePath: string;
+  visualLabel: string;
+  keyTakeaways: string[];
+  visualSummary: {
+    title: string;
+    items: Array<{
+      label: string;
+      value: string;
+      description: string;
+    }>;
+  };
+  primaryCta: {
+    label: string;
+    href: string;
+  };
+  secondaryCta?: {
+    label: string;
+    href: string;
+  };
+  sections: PlaybookSection[];
+  citations: PlaybookCitation[];
+  relatedSlugs: string[];
+};
+
+export const playbookCategories: Array<{
+  id: PlaybookCategoryId;
+  title: string;
+  description: string;
+  colorClass: string;
+}> = [
+  {
+    id: "start",
+    title: "Start the Business",
+    description:
+      "The first-principles guides: model fit, startup path, buyer questions, and launch sequence.",
+    colorClass: "bg-primary/10 text-primary",
+  },
+  {
+    id: "locations",
+    title: "Find Locations",
+    description:
+      "How to evaluate venues, pitch owners, and build a location pipeline without sounding generic.",
+    colorClass: "bg-sage-light text-sage",
+  },
+  {
+    id: "budget",
+    title: "Budget and Plan",
+    description:
+      "Startup cost categories, opening supplies, operating reserves, and practical planning worksheets.",
+    colorClass: "bg-amber/10 text-amber",
+  },
+  {
+    id: "events",
+    title: "Events and Catering",
+    description:
+      "Mini and Micro planning for pop-ups, parties, fairs, staffing, booking, and event-day flow.",
+    colorClass: "bg-rose/10 text-rose",
+  },
+  {
+    id: "setup",
+    title: "Business Setup",
+    description:
+      "LLC, EIN, bank account, insurance, permits, and the admin basics new operators should research.",
+    colorClass: "bg-charcoal/10 text-charcoal",
+  },
+];
+
+const sbaStartup: PlaybookCitation = {
+  label: "10 steps to start your business",
+  source: "U.S. Small Business Administration",
+  url: "https://www.sba.gov/business-guide/10-steps-start-your-business",
+};
+
+const sbaStructure: PlaybookCitation = {
+  label: "Choose a business structure",
+  source: "U.S. Small Business Administration",
+  url: "https://www.sba.gov/starting-business/choose-your-business-structure/",
+};
+
+const irsEin: PlaybookCitation = {
+  label: "Employer Identification Number guidance",
+  source: "Internal Revenue Service",
+  url: "https://www.irs.gov/businesses/employer-identification-number",
+};
+
+const googleHelpfulContent: PlaybookCitation = {
+  label: "Creating helpful, reliable, people-first content",
+  source: "Google Search Central",
+  url: "https://developers.google.com/search/docs/fundamentals/creating-helpful-content",
+};
+
+export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
+  {
+    slug: "how-to-start-cotton-candy-vending-business",
+    title: "How to Start a Cotton Candy Vending Business",
+    shortTitle: "Start a Vending Business",
+    description:
+      "A practical launch guide for choosing a machine, planning your first locations, budgeting, supplies, setup, and operator rhythm.",
+    category: "start",
+    audience: "New commercial operators",
+    machineFit: "Commercial Machine first, Mini for mobile tests",
+    updatedAt: "2026-04-28",
+    readingTime: "9 min read",
+    heroImage: commercialMachineImage,
+    heroImageAlt: "Bloomjoy Commercial Machine ready for a venue placement",
+    seoImagePath: "/seo/commercial-machine.jpg",
+    visualLabel: "Launch roadmap",
+    keyTakeaways: [
+      "Start with the business model, not the machine alone.",
+      "The best early plan has one target venue type, one launch budget, and one service rhythm.",
+      "Bloomjoy can help with machine fit, but local business setup and permits require local research.",
+    ],
+    visualSummary: {
+      title: "A clean first launch has six moving parts",
+      items: [
+        {
+          label: "1",
+          value: "Model",
+          description: "Choose vending, events, or a hybrid path before comparing machines.",
+        },
+        {
+          label: "2",
+          value: "Location",
+          description: "Pick a venue type where families already slow down and spend.",
+        },
+        {
+          label: "3",
+          value: "Operations",
+          description: "Plan refills, cleaning, support, payment, and owner check-ins.",
+        },
+      ],
+    },
+    primaryCta: {
+      label: "Request a machine quote",
+      href: "/contact?type=quote&source=%2Fresources%2Fbusiness-playbook%2Fhow-to-start-cotton-candy-vending-business",
+    },
+    secondaryCta: {
+      label: "Compare machines",
+      href: "/machines",
+    },
+    sections: [
+      {
+        heading: "Start with the business model",
+        body: [
+          "A cotton candy machine can be a vending placement, an event attraction, a catering add-on, or a test of a larger venue strategy. The machine is the fun part. The business is the repeatable system around it.",
+          "For most new operators, the simplest first question is: do you want a machine that earns from a fixed location, or do you want a portable offer that you bring to events?",
+        ],
+        table: {
+          caption: "Use this to avoid buying for the wrong job.",
+          columns: ["Path", "Best machine fit", "What you need to prove"],
+          rows: [
+            [
+              "Fixed-location vending",
+              "Commercial Machine",
+              "Foot traffic, power access, venue agreement, service schedule",
+            ],
+            [
+              "Events and pop-ups",
+              "Mini Machine",
+              "Booking demand, staffing flow, transport plan, event pricing",
+            ],
+            [
+              "Low-volume testing",
+              "Micro Machine",
+              "Basic-shape demand, simple operation, smaller budget fit",
+            ],
+          ],
+        },
+      },
+      {
+        heading: "Build the first 30-day launch plan",
+        body: [
+          "Do not wait until the machine arrives to figure out where it goes, who checks it, how supplies are ordered, or what happens when something needs support. A calm launch is planned before the crate shows up.",
+          "The right v1 plan is not fancy. It is a short operating routine you can actually follow.",
+        ],
+        steps: [
+          {
+            title: "Week 1: pick your target venue",
+            body: "Choose one primary venue type, like family entertainment centers, tourist retail, malls, arcades, skating rinks, or event venues.",
+          },
+          {
+            title: "Week 2: price the full launch",
+            body: "Estimate machine, shipping, opening supplies, insurance, payment setup, permits, signage, and a maintenance reserve.",
+          },
+          {
+            title: "Week 3: secure the first site or booking lane",
+            body: "Start outreach with a simple pitch, photos, the service plan, and the reason the machine helps the venue.",
+          },
+          {
+            title: "Week 4: prepare the operating rhythm",
+            body: "Write the refill, cleaning, check-in, and issue-escalation routine before your first customer order.",
+          },
+        ],
+      },
+      {
+        heading: "Choose support before you need support",
+        body: [
+          "A vending business is easier to run when support boundaries are clear. Technical troubleshooting belongs with manufacturer first-line support. Bloomjoy Plus adds onboarding, playbooks, operator guidance, and concierge help during business hours.",
+          "That split matters because it keeps your plan honest. You are not buying a magic box. You are building a small operating system around a very eye-catching machine.",
+        ],
+        callout: {
+          title: "Operator rule of thumb",
+          body: "If a task affects machine uptime, write down who owns it before launch: venue staff, your team, manufacturer support, or Bloomjoy concierge.",
+        },
+        checklist: [
+          "Machine placement and power confirmed",
+          "Opening sugar and sticks ordered",
+          "Payment setup planned",
+          "Cleaning and refill owner assigned",
+          "WeChat/manufacturer support path understood",
+          "Local permits, insurance, and business registration researched",
+        ],
+      },
+      {
+        heading: "Use official startup guidance for the admin layer",
+        body: [
+          "Bloomjoy can help you think through machine fit and operations, but business registration, tax, insurance, and permits vary by location. Treat those as a real part of launch, not a paperwork chore for later.",
+          "The SBA recommends thinking through market research, business planning, funding, location, structure, tax IDs, licenses, permits, and banking as part of starting a business. Use that as your admin checklist, then layer your machine plan on top.",
+        ],
+        bullets: [
+          "Decide whether the business will be a solo venture, partnership, LLC, or another structure.",
+          "Research state and local registration requirements before applying for an EIN.",
+          "Open a business bank account once your registration paperwork is ready.",
+          "Ask a local professional about tax, insurance, and permit requirements for your state and venue type.",
+        ],
+      },
+    ],
+    citations: [sbaStartup, sbaStructure, irsEin, googleHelpfulContent],
+    relatedSlugs: [
+      "startup-budget-checklist-cotton-candy-machine-business",
+      "best-locations-for-cotton-candy-vending-machines",
+      "commercial-vending-vs-event-catering",
+    ],
+  },
+  {
+    slug: "best-locations-for-cotton-candy-vending-machines",
+    title: "How to Find Good Locations for a Cotton Candy Vending Machine",
+    shortTitle: "Find Good Locations",
+    description:
+      "A practical location scorecard for malls, family entertainment centers, arcades, tourist venues, and other high-attention placements.",
+    category: "locations",
+    audience: "Commercial vending operators",
+    machineFit: "Commercial Machine",
+    updatedAt: "2026-04-28",
+    readingTime: "8 min read",
+    heroImage: landingHeroImage,
+    heroImageAlt: "Bloomjoy robotic cotton candy machine in a colorful public setting",
+    seoImagePath: "/seo/home-machine.jpg",
+    visualLabel: "Venue scorecard",
+    keyTakeaways: [
+      "The best location is not just busy. It is busy with the right people in the right mood.",
+      "Family dwell time, power access, operator access, and venue enthusiasm matter more than raw foot traffic.",
+      "A simple scoring rubric helps you compare locations without falling in love with the first yes.",
+    ],
+    visualSummary: {
+      title: "Score locations before you pitch them",
+      items: [
+        {
+          label: "High",
+          value: "Dwell time",
+          description: "Families pause, browse, wait, or line up nearby.",
+        },
+        {
+          label: "Clean",
+          value: "Operations",
+          description: "Power, service access, and machine visibility are realistic.",
+        },
+        {
+          label: "Aligned",
+          value: "Venue upside",
+          description: "The owner sees entertainment value, not just rent.",
+        },
+      ],
+    },
+    primaryCta: {
+      label: "Explore the Commercial Machine",
+      href: "/machines/commercial-robotic-machine",
+    },
+    secondaryCta: {
+      label: "Read the pitch guide",
+      href: "/resources/business-playbook/how-to-pitch-location-owners",
+    },
+    sections: [
+      {
+        heading: "Look for attention, not just traffic",
+        body: [
+          "A cotton candy machine is a small show. It works best where people already have permission to be delighted: family entertainment centers, arcades, skating rinks, tourist retail, malls, resorts, cinemas, birthday-party venues, and seasonal attractions.",
+          "Raw foot traffic can fool you. A commuter hallway may be packed, but nobody wants to stop. A family entertainment lobby with fewer people can be better because parents are waiting, kids are watching, and the venue already sells fun.",
+        ],
+        scorecard: {
+          title: "Quick location scorecard",
+          items: [
+            {
+              label: "Audience fit",
+              score: "1-5",
+              guidance: "Families, kids, tourists, or celebration buyers are already present.",
+            },
+            {
+              label: "Dwell time",
+              score: "1-5",
+              guidance: "People wait, browse, or gather long enough to notice the machine.",
+            },
+            {
+              label: "Visibility",
+              score: "1-5",
+              guidance: "The machine can face traffic without being tucked behind a corner.",
+            },
+            {
+              label: "Operations",
+              score: "1-5",
+              guidance: "Power, refill access, cleaning access, and service visits are practical.",
+            },
+            {
+              label: "Venue motivation",
+              score: "1-5",
+              guidance: "The owner wants a guest experience upgrade, not only a rent check.",
+            },
+          ],
+        },
+      },
+      {
+        heading: "Prioritize these venue types first",
+        body: [
+          "Start where the product already makes emotional sense. Cotton candy is visual, nostalgic, and kid-friendly. The best placements turn that into a small moment of theater.",
+          "If you are new, build a short list by category instead of contacting every business in town.",
+        ],
+        table: {
+          columns: ["Venue type", "Why it can work", "Question to ask"],
+          rows: [
+            [
+              "Family entertainment center",
+              "Kids, birthdays, wait time, arcade energy",
+              "Where do families wait before or after activities?",
+            ],
+            [
+              "Mall or tourist retail",
+              "Foot traffic plus impulse purchases",
+              "Can the machine be visible without blocking flow?",
+            ],
+            [
+              "Skating rink or trampoline park",
+              "Repeat family visits and party traffic",
+              "Who manages party packages and lobby concessions?",
+            ],
+            [
+              "Cinema or attraction lobby",
+              "Pre-show waiting and treat mindset",
+              "Can the machine operate near existing concessions?",
+            ],
+          ],
+        },
+      },
+      {
+        heading: "Do a site walk before you promise anything",
+        body: [
+          "A location can sound perfect by email and fail in person. Before signing anything, walk the site like an operator.",
+          "Stand where the machine would go. Watch the traffic. Look for outlets. Ask how staff access the area after hours. Find the closest cleaning path. If the machine needs service, can someone reach it without a scavenger hunt?",
+        ],
+        checklist: [
+          "Power access is real, safe, and approved by the venue.",
+          "The machine can be serviced without interrupting customers.",
+          "The placement is visible from a natural waiting or browsing area.",
+          "Venue staff know who to call if there is an issue.",
+          "Revenue share, rent, or other commercial terms are clear in writing.",
+        ],
+      },
+    ],
+    citations: [sbaStartup],
+    relatedSlugs: [
+      "how-to-pitch-location-owners",
+      "startup-budget-checklist-cotton-candy-machine-business",
+      "how-to-start-cotton-candy-vending-business",
+    ],
+  },
+  {
+    slug: "mini-micro-event-catering-business-guide",
+    title: "How to Start a Cotton Candy Event or Catering Business with Mini or Micro",
+    shortTitle: "Event Business Guide",
+    description:
+      "How to think about bookings, equipment, staffing, packages, transport, and event-day operations for portable cotton candy service.",
+    category: "events",
+    audience: "Event operators and mobile sellers",
+    machineFit: "Mini Machine and Micro Machine",
+    updatedAt: "2026-04-28",
+    readingTime: "8 min read",
+    heroImage: miniMachineImage,
+    heroImageAlt: "Bloomjoy Mini Machine for portable event operators",
+    seoImagePath: "/seo/mini-machine.jpg",
+    visualLabel: "Event-day kit",
+    keyTakeaways: [
+      "Events are a logistics business with a dessert show attached.",
+      "Mini is the stronger fit when pattern capability and event volume matter.",
+      "Your offer should be packaged clearly so customers know what they are buying.",
+    ],
+    visualSummary: {
+      title: "Event operators need a portable system",
+      items: [
+        {
+          label: "Offer",
+          value: "Packages",
+          description: "Sell clear booking packages, not vague hourly availability.",
+        },
+        {
+          label: "Flow",
+          value: "Queue",
+          description: "Plan the table, line, toppings, sticks, and payment path.",
+        },
+        {
+          label: "Kit",
+          value: "Backup",
+          description: "Bring supplies, cleaning tools, extension plan, and a recovery checklist.",
+        },
+      ],
+    },
+    primaryCta: {
+      label: "Explore the Mini Machine",
+      href: "/machines/mini",
+    },
+    secondaryCta: {
+      label: "Compare Mini and Micro",
+      href: "/resources/business-playbook/commercial-vending-vs-event-catering",
+    },
+    sections: [
+      {
+        heading: "Think like an event operator",
+        body: [
+          "A portable cotton candy business is not only about making candy. It is about showing up on time, setting up cleanly, managing a line, and leaving the customer glad they booked you.",
+          "Mini is usually the better event-minded machine when you want more pattern capability and a stronger visual moment. Micro can make sense for smaller, lower-volume, basic-shape use cases.",
+        ],
+        table: {
+          columns: ["Question", "Mini", "Micro"],
+          rows: [
+            [
+              "Do you need complex patterns?",
+              "Better fit for more visual variety",
+              "Basic shapes only",
+            ],
+            [
+              "Do you expect party or fair volume?",
+              "Better fit for more serious event use",
+              "Better for smaller, simpler use",
+            ],
+            [
+              "Is budget the main constraint?",
+              "Higher machine cost, more capability",
+              "Lower entry cost, simpler output",
+            ],
+          ],
+        },
+      },
+      {
+        heading: "Package the offer so buyers understand it",
+        body: [
+          "People book event vendors when the offer is easy to understand. Instead of saying, 'We have a machine,' build simple packages around time, serving estimate, setup needs, travel, and add-ons.",
+          "Keep your first menu short. Too many choices make buyers slower, and slow buyers do not help a new business.",
+        ],
+        bullets: [
+          "Birthday package: fixed service window, simple color menu, local travel radius.",
+          "Corporate or school event package: longer service window, invoice-friendly process, setup requirements.",
+          "Festival package: booth layout, queue plan, weather policy, staff coverage, and restock plan.",
+        ],
+        callout: {
+          title: "Make the booking page boring in the best way",
+          body: "A buyer should know what is included, what costs extra, what you need from them, and what happens if the event changes.",
+        },
+      },
+      {
+        heading: "Build the event-day kit",
+        body: [
+          "The machine is only one part of the setup. Your event kit should make the job feel repeatable even when the venue is chaotic.",
+          "Pack like the person who has to solve problems in a parking lot with ten minutes to spare.",
+        ],
+        checklist: [
+          "Sugar and sticks for the expected serving count plus buffer",
+          "Cleaning towels and approved cleaning supplies",
+          "Table, signage, menu, and line-control plan",
+          "Extension/power plan approved by the venue",
+          "Payment backup, charger, and printed QR code if used",
+          "Trash plan and end-of-event cleanup supplies",
+        ],
+      },
+    ],
+    citations: [sbaStartup],
+    relatedSlugs: [
+      "commercial-vending-vs-event-catering",
+      "startup-budget-checklist-cotton-candy-machine-business",
+      "business-setup-basics-llc-ein-insurance-permits",
+    ],
+  },
+  {
+    slug: "startup-budget-checklist-cotton-candy-machine-business",
+    title: "Startup Budget Checklist for a Cotton Candy Machine Business",
+    shortTitle: "Startup Budget Checklist",
+    description:
+      "A practical budget framework for machine cost, supplies, freight, insurance, permits, payment setup, marketing, and operating reserve.",
+    category: "budget",
+    audience: "Budget-conscious buyers",
+    machineFit: "Commercial, Mini, and Micro",
+    updatedAt: "2026-04-28",
+    readingTime: "7 min read",
+    heroImage: suppliesImage,
+    heroImageAlt: "Bloomjoy cotton candy sugar and paper sticks for launch planning",
+    seoImagePath: "/seo/supplies.jpg",
+    visualLabel: "Budget worksheet",
+    keyTakeaways: [
+      "A launch budget should include more than the machine price.",
+      "Opening supplies and a maintenance reserve keep small problems from becoming big surprises.",
+      "Your budget should match the business path: fixed vending, events, or a hybrid.",
+    ],
+    visualSummary: {
+      title: "Budget by category, not vibes",
+      items: [
+        {
+          label: "Core",
+          value: "Machine",
+          description: "The machine plus quoted configuration, shipping, and install assumptions.",
+        },
+        {
+          label: "Launch",
+          value: "Supplies",
+          description: "Sugar, sticks, cleaning basics, signage, and payment setup.",
+        },
+        {
+          label: "Buffer",
+          value: "Reserve",
+          description: "Cash set aside for early restock, travel, maintenance, and surprises.",
+        },
+      ],
+    },
+    primaryCta: {
+      label: "Request a personalized quote",
+      href: "/contact?type=quote&source=%2Fresources%2Fbusiness-playbook%2Fstartup-budget-checklist-cotton-candy-machine-business",
+    },
+    secondaryCta: {
+      label: "Shop opening supplies",
+      href: "/supplies",
+    },
+    sections: [
+      {
+        heading: "The machine price is not the full launch price",
+        body: [
+          "The fastest way to under-budget is to stop at the machine number. A realistic budget includes everything required to open, operate, restock, and stay compliant.",
+          "Your exact numbers depend on machine model, shipping, location, venue terms, supplies, local requirements, and whether you are fixed-location or event-based.",
+        ],
+        table: {
+          caption: "Use this as a planning worksheet, then replace estimates with real quotes.",
+          columns: ["Category", "What to include", "Planning note"],
+          rows: [
+            [
+              "Machine",
+              "Machine price, add-ons, wrap choices, payment hardware if applicable",
+              "Quote-led so final configuration is confirmed before invoicing",
+            ],
+            [
+              "Freight and setup",
+              "Shipping, delivery access, liftgate or install assumptions",
+              "Ask early if the venue has access constraints",
+            ],
+            [
+              "Opening supplies",
+              "Sugar, paper sticks, cleaning basics, backup consumables",
+              "Order enough for launch plus buffer",
+            ],
+            [
+              "Business setup",
+              "Registration, bank account, insurance, permits, tax support",
+              "Varies by state and local rules",
+            ],
+            [
+              "Sales and marketing",
+              "Pitch materials, signage, menu, local outreach, event listing",
+              "Keep it practical and venue-specific",
+            ],
+            [
+              "Operating reserve",
+              "Early restocks, travel, replacement items, support needs",
+              "Protects the first few months",
+            ],
+          ],
+        },
+      },
+      {
+        heading: "Match the budget to the path",
+        body: [
+          "A fixed-location vending budget usually spends more time on venue agreement, placement, service access, payment setup, and reliable restock. An event budget usually spends more time on transport, staffing, table setup, signage, and booking materials.",
+          "Do not copy a budget from a different business model unless you want their problems too.",
+        ],
+        bullets: [
+          "Commercial vending: prioritize placement quality, uptime, supplies, and clear service responsibility.",
+          "Event business: prioritize transport, event kit, booking workflow, and staff flow.",
+          "Hybrid model: budget for both location service and event-day portability before committing.",
+        ],
+      },
+      {
+        heading: "Keep a reserve for the unglamorous stuff",
+        body: [
+          "A reserve is not pessimism. It is how you keep a launch from getting knocked sideways by normal early-business surprises.",
+          "Set aside money for the first restock, a missed shipment, extra supplies for a better-than-expected weekend, travel, cleaning replacements, or a venue setup change.",
+        ],
+        checklist: [
+          "Opening sugar and sticks",
+          "Cleaning and maintenance supplies",
+          "Venue signage or table setup",
+          "Payment device or checkout backup",
+          "Travel, delivery, or storage costs",
+          "Local permits, insurance, or professional advice",
+        ],
+      },
+    ],
+    citations: [sbaStartup, sbaStructure],
+    relatedSlugs: [
+      "how-to-start-cotton-candy-vending-business",
+      "business-setup-basics-llc-ein-insurance-permits",
+      "mini-micro-event-catering-business-guide",
+    ],
+  },
+  {
+    slug: "how-to-pitch-location-owners",
+    title: "How to Pitch a Location Owner on a Cotton Candy Vending Machine",
+    shortTitle: "Pitch Location Owners",
+    description:
+      "A practical pitch framework for venue owners: guest experience, space needs, service plan, revenue model, and follow-up script.",
+    category: "locations",
+    audience: "Operators doing venue outreach",
+    machineFit: "Commercial Machine",
+    updatedAt: "2026-04-28",
+    readingTime: "7 min read",
+    heroImage: aboutFoundersImage,
+    heroImageAlt: "Bloomjoy team preparing operator materials",
+    seoImagePath: "/seo/about.jpg",
+    visualLabel: "Pitch script",
+    keyTakeaways: [
+      "Venue owners care about guest experience, reliability, and operational simplicity.",
+      "A good pitch explains the machine, the benefit, the requirements, and the service plan.",
+      "Follow-up matters. Many good locations are won after the second useful touch.",
+    ],
+    visualSummary: {
+      title: "A venue pitch needs four proofs",
+      items: [
+        {
+          label: "1",
+          value: "Guest draw",
+          description: "Show why the machine adds a moment people notice.",
+        },
+        {
+          label: "2",
+          value: "Low friction",
+          description: "Explain space, power, service visits, and who owns what.",
+        },
+        {
+          label: "3",
+          value: "Commercial upside",
+          description: "Make the revenue or amenity case simple.",
+        },
+      ],
+    },
+    primaryCta: {
+      label: "Explore Commercial Machine details",
+      href: "/machines/commercial-robotic-machine",
+    },
+    secondaryCta: {
+      label: "Find good locations first",
+      href: "/resources/business-playbook/best-locations-for-cotton-candy-vending-machines",
+    },
+    sections: [
+      {
+        heading: "Lead with the venue's benefit",
+        body: [
+          "A location owner is not buying your excitement. They are deciding whether this machine improves their space without creating operational headaches.",
+          "Lead with the guest experience and the operating plan. The cotton candy part is memorable, but the owner needs to know it will not become their problem.",
+        ],
+        script: {
+          title: "Simple opening email",
+          lines: [
+            "Hi [Name], I operate robotic cotton candy machines for family-friendly venues.",
+            "I think [Venue] could be a strong fit because guests already spend time near [specific area].",
+            "The machine creates a visual treat moment, and I handle the service routine, supplies, and owner check-ins.",
+            "Would you be open to a quick walkthrough next week to see if the space, power, and guest flow make sense?",
+          ],
+        },
+      },
+      {
+        heading: "Bring a one-page plan",
+        body: [
+          "Do not show up with only enthusiasm. Bring a short plan the venue can react to. The goal is to make the next step obvious.",
+          "Your one-pager should be clean enough for the owner to forward to a partner, manager, or landlord without needing you to translate it.",
+        ],
+        checklist: [
+          "Photo of the machine and example placement",
+          "Space, power, and access requirements",
+          "Service schedule and contact owner",
+          "Proposed commercial terms or pilot structure",
+          "Why this venue's audience is a good fit",
+          "Next step: site walk, pilot date, or decision meeting",
+        ],
+      },
+      {
+        heading: "Offer a pilot when the owner is interested but cautious",
+        body: [
+          "Some venues need to see the machine in context before committing. A pilot can reduce perceived risk if the site logistics are realistic.",
+          "Define the pilot terms before you start: duration, placement, service responsibilities, reporting, revenue share or rent, and what success means.",
+        ],
+        table: {
+          columns: ["Owner concern", "Your answer should cover"],
+          rows: [
+            [
+              "Will it take too much staff time?",
+              "Who services it, how often, and what staff should do if there is an issue",
+            ],
+            [
+              "Will it fit the space?",
+              "Footprint, visibility, customer flow, power, and cleaning access",
+            ],
+            [
+              "Will guests use it?",
+              "Audience fit, nearby dwell time, and a short pilot success metric",
+            ],
+            [
+              "How do we make money?",
+              "Revenue share, rent, or amenity logic stated simply",
+            ],
+          ],
+        },
+      },
+    ],
+    citations: [sbaStartup],
+    relatedSlugs: [
+      "best-locations-for-cotton-candy-vending-machines",
+      "how-to-start-cotton-candy-vending-business",
+      "commercial-vending-vs-event-catering",
+    ],
+  },
+  {
+    slug: "commercial-vending-vs-event-catering",
+    title: "Commercial Vending vs. Event Catering: Which Cotton Candy Business Fits You?",
+    shortTitle: "Vending vs. Events",
+    description:
+      "Compare fixed-location vending with event and catering operations so you can choose the right machine, budget, and daily workflow.",
+    category: "start",
+    audience: "Buyers choosing a business path",
+    machineFit: "Commercial, Mini, and Micro",
+    updatedAt: "2026-04-28",
+    readingTime: "6 min read",
+    heroImage: microMachineImage,
+    heroImageAlt: "Bloomjoy Micro Machine with cotton candy output for smaller setups",
+    seoImagePath: "/seo/micro-machine.jpg",
+    visualLabel: "Business model comparison",
+    keyTakeaways: [
+      "Commercial vending is about placement quality and service consistency.",
+      "Events are about bookings, logistics, staffing, and guest flow.",
+      "The right machine follows the business model, not the other way around.",
+    ],
+    visualSummary: {
+      title: "Two paths, different muscles",
+      items: [
+        {
+          label: "Vending",
+          value: "Place",
+          description: "Win a site, keep it stocked, keep it clean, keep it earning.",
+        },
+        {
+          label: "Events",
+          value: "Move",
+          description: "Book dates, show up prepared, serve smoothly, pack out clean.",
+        },
+        {
+          label: "Hybrid",
+          value: "Focus",
+          description: "Possible later, but harder as a first operating model.",
+        },
+      ],
+    },
+    primaryCta: {
+      label: "Compare all machines",
+      href: "/machines",
+    },
+    secondaryCta: {
+      label: "Read the event guide",
+      href: "/resources/business-playbook/mini-micro-event-catering-business-guide",
+    },
+    sections: [
+      {
+        heading: "Vending and events are different businesses",
+        body: [
+          "Both models can use the same basic product category, but they feel very different day to day.",
+          "Fixed-location vending rewards patient location development, clear service routes, and reliable restocking. Events reward booking, setup speed, customer flow, and a polished live experience.",
+        ],
+        table: {
+          columns: ["Decision", "Commercial vending", "Event or catering"],
+          rows: [
+            [
+              "Primary challenge",
+              "Winning and keeping a good location",
+              "Winning bookings and executing event days",
+            ],
+            [
+              "Best machine direction",
+              "Commercial Machine",
+              "Mini for serious events, Micro for simple low-volume use",
+            ],
+            [
+              "Sales motion",
+              "Venue owner outreach and site walks",
+              "Event planners, parents, schools, companies, fairs",
+            ],
+            [
+              "Operations rhythm",
+              "Scheduled service, restock, cleaning, owner reporting",
+              "Transport, setup, line management, teardown",
+            ],
+          ],
+        },
+      },
+      {
+        heading: "Choose the model that fits your personality",
+        body: [
+          "If you like recurring locations, repeatable service routes, and business-to-business selling, fixed vending may fit you. If you like live events, weekends, direct customer energy, and moving parts, events may feel more natural.",
+          "Neither path is automatically easier. They are just different flavors of work.",
+        ],
+        bullets: [
+          "Choose vending if you want to build a location portfolio over time.",
+          "Choose events if you are comfortable selling, scheduling, transporting, and staffing.",
+          "Choose a hybrid only after the first path is stable enough to not collapse when you add the second.",
+        ],
+      },
+      {
+        heading: "Let the business model choose the machine",
+        body: [
+          "A Commercial Machine is designed for high-throughput, fixed or serious venue use. Mini is designed for operators who need a more portable footprint and still want stronger pattern capability. Micro is the simpler entry point for basic-shape, lower-volume use.",
+          "If you are stuck, write down your first ten target customers. The list usually tells you which model you are really building.",
+        ],
+      },
+    ],
+    citations: [sbaStartup],
+    relatedSlugs: [
+      "how-to-start-cotton-candy-vending-business",
+      "mini-micro-event-catering-business-guide",
+      "best-locations-for-cotton-candy-vending-machines",
+    ],
+  },
+  {
+    slug: "business-setup-basics-llc-ein-insurance-permits",
+    title: "Business Setup Basics: LLC, EIN, Bank Account, Insurance, and Permits",
+    shortTitle: "Business Setup Basics",
+    description:
+      "A plain-English checklist for the admin side of starting a cotton candy machine business, with official SBA and IRS links.",
+    category: "setup",
+    audience: "New business owners",
+    machineFit: "All machine paths",
+    updatedAt: "2026-04-28",
+    readingTime: "8 min read",
+    heroImage: aboutHeroImage,
+    heroImageAlt: "Bloomjoy operations team context for business setup planning",
+    seoImagePath: "/seo/about.jpg",
+    visualLabel: "Admin checklist",
+    keyTakeaways: [
+      "Business setup rules vary by state, city, entity type, and venue model.",
+      "Form the entity first if you are creating an LLC, partnership, or corporation, then apply for an EIN.",
+      "Use official SBA and IRS resources, then confirm local requirements with a qualified professional.",
+    ],
+    visualSummary: {
+      title: "The admin stack has a sequence",
+      items: [
+        {
+          label: "1",
+          value: "Structure",
+          description: "Choose the business structure and register where required.",
+        },
+        {
+          label: "2",
+          value: "EIN",
+          description: "Apply directly through the IRS when your entity is ready.",
+        },
+        {
+          label: "3",
+          value: "Operate",
+          description: "Banking, insurance, permits, and local compliance come next.",
+        },
+      ],
+    },
+    primaryCta: {
+      label: "Request a quote when ready",
+      href: "/contact?type=quote&source=%2Fresources%2Fbusiness-playbook%2Fbusiness-setup-basics-llc-ein-insurance-permits",
+    },
+    secondaryCta: {
+      label: "Read the startup budget checklist",
+      href: "/resources/business-playbook/startup-budget-checklist-cotton-candy-machine-business",
+    },
+    sections: [
+      {
+        heading: "This is not legal or tax advice",
+        body: [
+          "Bloomjoy can share an operator-minded checklist, but your legal, tax, insurance, and permit requirements depend on where and how you operate. Use this article to get organized, then confirm the details with your state, city, venue, accountant, insurance broker, or attorney.",
+          "That said, a little admin planning goes a long way. It is much easier to open a bank account, sign a venue agreement, and collect payments when your paperwork is not a mystery.",
+        ],
+        callout: {
+          title: "Important sequence",
+          body: "The IRS says that if you are forming a legal entity such as an LLC, partnership, or corporation, you should form the entity with your state before applying for an EIN.",
+        },
+      },
+      {
+        heading: "Work through the basics in order",
+        body: [
+          "The SBA frames business startup as a sequence: research the market, write a plan, fund the business, pick a location, choose a structure, register, get tax IDs, apply for licenses and permits, and open a business bank account.",
+          "For a cotton candy machine business, the practical version is simple: know what you are selling, where you are selling it, who owns the business, how money flows, and what local rules apply.",
+        ],
+        steps: [
+          {
+            title: "Choose a structure",
+            body: "Common options include sole proprietorship, partnership, LLC, and corporation. Liability, taxes, and filing requirements vary.",
+          },
+          {
+            title: "Register the business",
+            body: "State and local rules vary. Confirm name, entity, and doing-business-as requirements.",
+          },
+          {
+            title: "Apply for an EIN when appropriate",
+            body: "The IRS offers free EIN applications directly through its official site.",
+          },
+          {
+            title: "Open business banking",
+            body: "Keep business money separate and make venue, tax, and supplier workflows cleaner.",
+          },
+          {
+            title: "Research insurance and permits",
+            body: "Food service, vending, sales tax, event, and local business requirements can vary by location and venue.",
+          },
+        ],
+      },
+      {
+        heading: "Questions to ask before your first placement",
+        body: [
+          "The right questions save time. Ask them before you sign a venue agreement or book a paid event.",
+          "If a venue already hosts food vendors, concessions, or entertainment machines, ask who manages approval and what documentation they require.",
+        ],
+        checklist: [
+          "Do I need a local business license?",
+          "Do I need food vending, event, or temporary seller permits?",
+          "Do I need sales tax registration?",
+          "What insurance does the venue require?",
+          "Who is responsible for power, placement, cleaning access, and after-hours access?",
+          "Can I provide invoices, W-9, certificate of insurance, or other requested documents?",
+        ],
+      },
+    ],
+    citations: [sbaStartup, sbaStructure, irsEin],
+    relatedSlugs: [
+      "startup-budget-checklist-cotton-candy-machine-business",
+      "how-to-start-cotton-candy-vending-business",
+      "commercial-vending-vs-event-catering",
+    ],
+  },
+];
+
+export const getPlaybookCategory = (id: PlaybookCategoryId) =>
+  playbookCategories.find((category) => category.id === id);
+
+export const getBusinessPlaybookArticle = (slug: string | undefined) =>
+  businessPlaybookArticles.find((article) => article.slug === slug);
+
+export const getRelatedBusinessPlaybookArticles = (article: BusinessPlaybookArticle) =>
+  article.relatedSlugs
+    .map((slug) => getBusinessPlaybookArticle(slug))
+    .filter((related): related is BusinessPlaybookArticle => Boolean(related));
+
+export const featuredBusinessPlaybookArticles = businessPlaybookArticles.slice(0, 3);

--- a/src/data/businessPlaybook.ts
+++ b/src/data/businessPlaybook.ts
@@ -148,6 +148,12 @@ const sbaStructure: PlaybookCitation = {
   url: "https://www.sba.gov/starting-business/choose-your-business-structure/",
 };
 
+const sbaLicensesPermits: PlaybookCitation = {
+  label: "Apply for licenses and permits",
+  source: "U.S. Small Business Administration",
+  url: "https://www.sba.gov/business-guide/launch-your-business/apply-licenses-and-permits",
+};
+
 const irsEin: PlaybookCitation = {
   label: "Employer Identification Number guidance",
   source: "Internal Revenue Service",
@@ -170,8 +176,8 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
     category: "start",
     audience: "New commercial operators",
     machineFit: "Commercial Machine first, Mini for mobile tests",
-    updatedAt: "2026-04-28",
-    readingTime: "9 min read",
+    updatedAt: "2026-04-29",
+    readingTime: "13 min read",
     heroImage: commercialMachineImage,
     heroImageAlt: "Bloomjoy Commercial Machine ready for a venue placement",
     seoImagePath: "/seo/commercial-machine.jpg",
@@ -179,7 +185,7 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
     keyTakeaways: [
       "Start with the business model, not the machine alone.",
       "The best early plan has one target venue type, one launch budget, and one service rhythm.",
-      "Bloomjoy can help with machine fit, but local business setup and permits require local research.",
+      "The first 30 days should feel like a small operating plan, not a scramble after delivery.",
     ],
     visualSummary: {
       title: "A clean first launch has six moving parts",
@@ -211,10 +217,23 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
     },
     sections: [
       {
+        heading: "Before you buy, picture the first Tuesday",
+        body: [
+          "The most useful way to plan a vending business is to imagine an ordinary operating day, not the launch announcement. The machine is already placed. The first rush has passed. Someone needs to check supplies, wipe the area, confirm payments, answer the venue manager, and decide whether the machine is earning the right spot.",
+          "That is where good operators separate themselves. They do not only ask, 'Can this machine make cotton candy?' They ask, 'Who owns the refill routine, what happens when a venue calls, where do supplies live, and how will I know this location is working?'",
+          "Bloomjoy sells equipment, but we also operate machines. That changes how we think about the purchase. A machine is exciting. A repeatable operating rhythm is what gives it a real chance to become a business.",
+        ],
+        callout: {
+          title: "What we would tell a first-time operator",
+          body: "Do not start with ten possible ideas. Start with one target customer, one venue type, one machine fit, and one weekly routine you can actually keep.",
+        },
+      },
+      {
         heading: "Start with the business model",
         body: [
           "A cotton candy machine can be a vending placement, an event attraction, a catering add-on, or a test of a larger venue strategy. The machine is the fun part. The business is the repeatable system around it.",
-          "For most new operators, the simplest first question is: do you want a machine that earns from a fixed location, or do you want a portable offer that you bring to events?",
+          "For most new operators, the simplest first question is: do you want a machine that earns from a fixed location, or do you want a portable offer that you bring to events? Those are both good businesses, but they ask different things from you.",
+          "A fixed-location operator spends more time on site selection, owner relationships, uptime, restock, and reporting. An event operator spends more time on booking, transport, setup, line flow, staffing, and cleanup. If you pick the wrong model, the machine can still be good, but the work around it will feel wrong.",
         ],
         table: {
           caption: "Use this to avoid buying for the wrong job.",
@@ -242,7 +261,7 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
         heading: "Build the first 30-day launch plan",
         body: [
           "Do not wait until the machine arrives to figure out where it goes, who checks it, how supplies are ordered, or what happens when something needs support. A calm launch is planned before the crate shows up.",
-          "The right v1 plan is not fancy. It is a short operating routine you can actually follow.",
+          "The right v1 plan is not fancy. It is a short operating routine you can actually follow. A buyer who knows the first venue, the first supply order, the service owner, and the support path is in a much better position than a buyer who only knows the machine model.",
         ],
         steps: [
           {
@@ -261,6 +280,62 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
             title: "Week 4: prepare the operating rhythm",
             body: "Write the refill, cleaning, check-in, and issue-escalation routine before your first customer order.",
           },
+          {
+            title: "Delivery week: slow down on purpose",
+            body: "Confirm access, placement, power, supplies, and who is present before the machine shows up. A rushed delivery creates avoidable stress.",
+          },
+          {
+            title: "First week live: inspect more often than you think",
+            body: "Check customer flow, cleanliness, supply use, and venue feedback closely. The first week teaches you what the spreadsheet missed.",
+          },
+        ],
+      },
+      {
+        heading: "Write the weekly operator rhythm",
+        body: [
+          "A small vending business becomes easier when the week has a pattern. You do not need a corporate operations manual, but you do need a rhythm that tells you what happens every week, who does it, and what proof you look at.",
+          "For a single machine, that rhythm may be simple. For multiple machines, it becomes the difference between feeling organized and feeling like every text is an emergency.",
+        ],
+        table: {
+          caption: "A starter rhythm you can adapt before launch.",
+          columns: ["Operator moment", "What to check", "Why it matters"],
+          rows: [
+            [
+              "Start of week",
+              "Supply levels, upcoming venue hours, service schedule",
+              "Prevents avoidable stockouts and missed access windows",
+            ],
+            [
+              "Service visit",
+              "Cleanliness, sugar/stick levels, payment flow, visible placement",
+              "Keeps the machine guest-ready and venue-friendly",
+            ],
+            [
+              "Venue check-in",
+              "Staff feedback, guest questions, placement concerns, upcoming events",
+              "Turns the venue into a partner instead of a landlord",
+            ],
+            [
+              "End of week",
+              "Sales trend, issues, supply use, next restock order",
+              "Helps you decide whether to adjust placement, pitch, or routine",
+            ],
+          ],
+        },
+      },
+      {
+        heading: "Avoid the first-launch mistakes we see most often",
+        body: [
+          "New operators usually do not fail because they forgot to be excited. They struggle because they skipped the boring pieces that make the exciting part repeatable.",
+          "Use this as a pre-launch honesty check. If any item makes you pause, that is not a bad sign. It is exactly the kind of gap you want to find before money, freight, and venue expectations are involved.",
+        ],
+        checklist: [
+          "Buying before choosing the first business model",
+          "Assuming the busiest location is automatically the best location",
+          "Planning supplies only for opening day instead of the first operating cycle",
+          "Leaving venue communication vague until there is a problem",
+          "Forgetting that delivery, access, power, and cleaning are part of the business",
+          "Treating legal, tax, insurance, and permit research as something to solve later",
         ],
       },
       {
@@ -296,7 +371,7 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
         ],
       },
     ],
-    citations: [sbaStartup, sbaStructure, irsEin, googleHelpfulContent],
+    citations: [sbaStartup, sbaStructure, sbaLicensesPermits, irsEin, googleHelpfulContent],
     relatedSlugs: [
       "startup-budget-checklist-cotton-candy-machine-business",
       "best-locations-for-cotton-candy-vending-machines",
@@ -312,8 +387,8 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
     category: "locations",
     audience: "Commercial vending operators",
     machineFit: "Commercial Machine",
-    updatedAt: "2026-04-28",
-    readingTime: "8 min read",
+    updatedAt: "2026-04-29",
+    readingTime: "12 min read",
     heroImage: landingHeroImage,
     heroImageAlt: "Bloomjoy robotic cotton candy machine in a colorful public setting",
     seoImagePath: "/seo/home-machine.jpg",
@@ -357,6 +432,7 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
         body: [
           "A cotton candy machine is a small show. It works best where people already have permission to be delighted: family entertainment centers, arcades, skating rinks, tourist retail, malls, resorts, cinemas, birthday-party venues, and seasonal attractions.",
           "Raw foot traffic can fool you. A commuter hallway may be packed, but nobody wants to stop. A family entertainment lobby with fewer people can be better because parents are waiting, kids are watching, and the venue already sells fun.",
+          "When we think about locations, we look for the pause. Where do families slow down? Where does a kid have time to point? Where is a parent already in treat mode? The best spot is often not the entrance. It might be near party check-in, an arcade prize counter, a concession line, or a lobby where families wait between activities.",
         ],
         scorecard: {
           title: "Quick location scorecard",
@@ -422,6 +498,71 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
         },
       },
       {
+        heading: "Turn the scorecard into a decision",
+        body: [
+          "A scorecard only helps if you decide what the score means before you fall in love with a location. Use the total to decide the next move, not to create a false sense of certainty.",
+          "If a location scores high but has one serious operational problem, treat it as a maybe until that problem is solved. A beautiful spot with bad access, unsafe power, or unclear ownership can become expensive quickly.",
+        ],
+        table: {
+          caption: "A simple way to interpret a 25-point location score.",
+          columns: ["Score", "Read", "Next move"],
+          rows: [
+            [
+              "21-25",
+              "Strong candidate",
+              "Request a site walk, confirm power/access, and discuss pilot or terms",
+            ],
+            [
+              "16-20",
+              "Promising but needs proof",
+              "Identify the weak score and ask targeted questions before pitching hard",
+            ],
+            [
+              "11-15",
+              "Probably not first",
+              "Keep in the pipeline only if one fix would materially improve the site",
+            ],
+            [
+              "10 or below",
+              "Pass for now",
+              "Do not spend early launch energy trying to rescue the wrong location",
+            ],
+          ],
+        },
+      },
+      {
+        heading: "Compare real-feeling venue scenarios",
+        body: [
+          "The point is not to find a perfect venue. The point is to understand why one venue deserves your attention before another.",
+          "Here is how we would think about a few common situations before spending time on a pitch.",
+        ],
+        table: {
+          columns: ["Scenario", "What looks good", "What to verify before yes"],
+          rows: [
+            [
+              "Family entertainment center lobby",
+              "Birthday traffic, parents waiting, kids already asking for treats",
+              "Party schedule, staff contact, power, after-hours access, and cleaning expectations",
+            ],
+            [
+              "Mall corridor near a food court",
+              "Impulse traffic and visibility from multiple directions",
+              "Lease rules, utility access, security hours, rent structure, and whether people actually pause",
+            ],
+            [
+              "Tourist retail shop",
+              "Vacation mindset, novelty products, gift/treat behavior",
+              "Available footprint, staff burden, owner enthusiasm, and seasonal traffic swings",
+            ],
+            [
+              "Busy commuter hallway",
+              "Large raw traffic number",
+              "Whether anyone is willing to stop. Often this is weaker than it looks.",
+            ],
+          ],
+        },
+      },
+      {
         heading: "Do a site walk before you promise anything",
         body: [
           "A location can sound perfect by email and fail in person. Before signing anything, walk the site like an operator.",
@@ -435,8 +576,52 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
           "Revenue share, rent, or other commercial terms are clear in writing.",
         ],
       },
+      {
+        heading: "Build a location pipeline, not a wish list",
+        body: [
+          "One promising conversation is not a pipeline. A pipeline means you know which venues you want, where each conversation stands, and what the next useful action is.",
+          "This keeps you from sounding generic. A venue owner can tell when you copied the same pitch to everyone. A good pipeline forces you to write down why each location might work.",
+        ],
+        steps: [
+          {
+            title: "Make a target list by category",
+            body: "Group venues by FEC, mall, tourist retail, cinema, resort, school/event venue, or seasonal attraction.",
+          },
+          {
+            title: "Research the specific pause point",
+            body: "Write down where families wait, browse, celebrate, or line up before you send the first message.",
+          },
+          {
+            title: "Start outreach with the venue benefit",
+            body: "Lead with guest experience, not with a machine brochure.",
+          },
+          {
+            title: "Use the site walk to qualify the deal",
+            body: "Confirm visibility, power, service access, staff expectations, and commercial terms.",
+          },
+          {
+            title: "Track the first 30 days",
+            body: "If the venue says yes, define what you will review after launch: sales, service issues, staff feedback, and guest response.",
+          },
+        ],
+      },
+      {
+        heading: "Watch for red flags early",
+        body: [
+          "A no is not a failure. Sometimes it is a gift. The wrong location can take more energy than it returns, especially when you are still learning the business.",
+          "If you see several of these signs, slow down and either solve them in writing or move on.",
+        ],
+        checklist: [
+          "The venue wants the machine hidden away from customer flow",
+          "No one can clearly approve power, placement, and service access",
+          "The owner only talks about rent and not guest experience",
+          "Staff are expected to manage issues but have not agreed to that responsibility",
+          "Access hours make restock or cleaning unrealistic",
+          "Commercial terms are vague or change conversation to conversation",
+        ],
+      },
     ],
-    citations: [sbaStartup],
+    citations: [sbaStartup, sbaLicensesPermits],
     relatedSlugs: [
       "how-to-pitch-location-owners",
       "startup-budget-checklist-cotton-candy-machine-business",
@@ -452,8 +637,8 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
     category: "events",
     audience: "Event operators and mobile sellers",
     machineFit: "Mini Machine and Micro Machine",
-    updatedAt: "2026-04-28",
-    readingTime: "8 min read",
+    updatedAt: "2026-04-29",
+    readingTime: "12 min read",
     heroImage: miniMachineImage,
     heroImageAlt: "Bloomjoy Mini Machine for portable event operators",
     seoImagePath: "/seo/mini-machine.jpg",
@@ -497,6 +682,7 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
         body: [
           "A portable cotton candy business is not only about making candy. It is about showing up on time, setting up cleanly, managing a line, and leaving the customer glad they booked you.",
           "Mini is usually the better event-minded machine when you want more pattern capability and a stronger visual moment. Micro can make sense for smaller, lower-volume, basic-shape use cases.",
+          "Picture the morning of a birthday party or school fundraiser. You are loading supplies, confirming the address, checking power, packing backup tools, and thinking through where the line will form. The guests will remember the cotton candy. The buyer will remember whether you were calm, clean, and easy to work with.",
         ],
         table: {
           columns: ["Question", "Mini", "Micro"],
@@ -536,6 +722,67 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
         },
       },
       {
+        heading: "Use sample packages before inventing custom quotes",
+        body: [
+          "Custom work is fine later. Early on, packages make the business easier to sell and easier to operate. They also keep you from accidentally promising three different businesses to three different customers.",
+          "These are planning examples, not fixed prices. Replace the serving counts, travel radius, staffing, and policy details with what fits your machine, market, and comfort level.",
+        ],
+        table: {
+          caption: "Starter package structure for event operators.",
+          columns: ["Package", "Best for", "What to define"],
+          rows: [
+            [
+              "Birthday pop-up",
+              "Backyard parties, play spaces, smaller private events",
+              "Service window, estimated servings, color/menu choices, travel radius, setup space",
+            ],
+            [
+              "School or corporate event",
+              "Longer guest flow, invoice-friendly buyers, planned schedule",
+              "COI needs, arrival time, staff contact, power, payment/invoicing process",
+            ],
+            [
+              "Festival or fair booth",
+              "Public traffic, longer day, more unknowns",
+              "Booth layout, weather plan, restock plan, line control, staffing shifts",
+            ],
+          ],
+        },
+      },
+      {
+        heading: "Plan serving counts like an operator",
+        body: [
+          "Serving estimates are not promises. They are planning tools that help you avoid under-packing, under-staffing, or setting up in a way that makes the line harder than it needs to be.",
+          "Start with the buyer's expected attendance, then discount for who will actually want cotton candy, the event length, competing food, and whether people arrive all at once or slowly over time.",
+        ],
+        table: {
+          caption: "A simple serving-planning worksheet.",
+          columns: ["Planning input", "Question to answer", "Operator note"],
+          rows: [
+            [
+              "Guest count",
+              "How many people are expected, and how many are kids or treat buyers?",
+              "Do not pack only for the invitation count. Pack for realistic demand plus buffer.",
+            ],
+            [
+              "Service window",
+              "Will demand hit all at once or spread across the event?",
+              "A two-hour party and a six-hour fair need different queue plans.",
+            ],
+            [
+              "Menu complexity",
+              "How many colors, shapes, or choices are you offering?",
+              "More options can slow the line, especially with children choosing.",
+            ],
+            [
+              "Staffing",
+              "Who greets, manages the line, handles payment, and resets supplies?",
+              "If one person owns everything, keep the offer simpler.",
+            ],
+          ],
+        },
+      },
+      {
         heading: "Build the event-day kit",
         body: [
           "The machine is only one part of the setup. Your event kit should make the job feel repeatable even when the venue is chaotic.",
@@ -550,8 +797,52 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
           "Trash plan and end-of-event cleanup supplies",
         ],
       },
+      {
+        heading: "Run the event day from a checklist",
+        body: [
+          "The best event operators make the day feel boring in the best possible way. They know when to arrive, what gets unpacked first, how the line works, and what happens if the venue contact is busy.",
+          "Write this down before your first paid booking. When the event is loud, hot, crowded, or running late, a checklist is kinder than memory.",
+        ],
+        steps: [
+          {
+            title: "Day before",
+            body: "Confirm address, contact, arrival window, power, parking, load-in path, weather, and expected attendance.",
+          },
+          {
+            title: "Arrival",
+            body: "Find the venue contact, inspect power, choose the line direction, and keep walkways clear before unpacking fully.",
+          },
+          {
+            title: "Setup",
+            body: "Place table/signage, stage supplies, test the machine, prepare payment backup if needed, and take a clean setup photo.",
+          },
+          {
+            title: "Service",
+            body: "Keep the menu simple, watch the line, restock before you are empty, and clean small messes before they look like messes.",
+          },
+          {
+            title: "Teardown",
+            body: "Pack cleanly, remove trash, thank the buyer, note supply use, and write one improvement for the next booking.",
+          },
+        ],
+      },
+      {
+        heading: "Put policies in writing before money changes hands",
+        body: [
+          "Policies are not about being difficult. They protect the customer, the operator, and the event. A friendly business can still be clear.",
+          "At minimum, your booking flow should explain what is included, what the customer provides, when payment is due, and what happens if conditions change.",
+        ],
+        checklist: [
+          "Deposit and final payment timing",
+          "Travel radius and extra travel fees",
+          "Indoor/outdoor and weather policy",
+          "Power, table, tent, or space requirements",
+          "Cancellation or reschedule policy",
+          "Certificate of insurance or vendor paperwork timing",
+        ],
+      },
     ],
-    citations: [sbaStartup],
+    citations: [sbaStartup, sbaLicensesPermits],
     relatedSlugs: [
       "commercial-vending-vs-event-catering",
       "startup-budget-checklist-cotton-candy-machine-business",
@@ -567,8 +858,8 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
     category: "budget",
     audience: "Budget-conscious buyers",
     machineFit: "Commercial, Mini, and Micro",
-    updatedAt: "2026-04-28",
-    readingTime: "7 min read",
+    updatedAt: "2026-04-29",
+    readingTime: "12 min read",
     heroImage: suppliesImage,
     heroImageAlt: "Bloomjoy cotton candy sugar and paper sticks for launch planning",
     seoImagePath: "/seo/supplies.jpg",
@@ -612,6 +903,7 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
         body: [
           "The fastest way to under-budget is to stop at the machine number. A realistic budget includes everything required to open, operate, restock, and stay compliant.",
           "Your exact numbers depend on machine model, shipping, location, venue terms, supplies, local requirements, and whether you are fixed-location or event-based.",
+          "Think about the first 90 days, not just purchase day. You may need opening supplies, a second supply order, travel, storage, signage, payment setup, venue paperwork, insurance documentation, and a reserve for normal early surprises.",
         ],
         table: {
           caption: "Use this as a planning worksheet, then replace estimates with real quotes.",
@@ -651,6 +943,49 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
         },
       },
       {
+        heading: "Build a worksheet with formulas, not guesses",
+        body: [
+          "A good budget lets you replace assumptions with real quotes over time. Start with placeholders, then mark each line as estimated, quoted, paid, or recurring.",
+          "Avoid using someone else's budget as a shortcut. Freight, local permits, insurance, venue terms, and event setup needs can change the picture quickly.",
+        ],
+        table: {
+          caption: "Public-safe worksheet structure. Replace blanks with your actual quotes.",
+          columns: ["Line item", "Planning formula", "Status to track"],
+          rows: [
+            [
+              "Core equipment",
+              "Machine quote + selected configuration + payment hardware if applicable",
+              "Quoted before deposit",
+            ],
+            [
+              "Freight and delivery",
+              "Freight quote + access requirements + liftgate/install assumptions",
+              "Quoted after delivery location is known",
+            ],
+            [
+              "Opening supplies",
+              "Expected first operating cycle x supply buffer",
+              "Ordered before launch",
+            ],
+            [
+              "Venue or event setup",
+              "Signage + table/display needs + extension/power plan + storage/transport",
+              "Estimated, then confirmed by site walk",
+            ],
+            [
+              "Admin and compliance",
+              "Registration + insurance + permits + professional advice as needed",
+              "Confirmed locally",
+            ],
+            [
+              "Operating reserve",
+              "One to three months of known fixed obligations, adjusted for risk",
+              "Set aside before launch when possible",
+            ],
+          ],
+        },
+      },
+      {
         heading: "Match the budget to the path",
         body: [
           "A fixed-location vending budget usually spends more time on venue agreement, placement, service access, payment setup, and reliable restock. An event budget usually spends more time on transport, staffing, table setup, signage, and booking materials.",
@@ -661,6 +996,39 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
           "Event business: prioritize transport, event kit, booking workflow, and staff flow.",
           "Hybrid model: budget for both location service and event-day portability before committing.",
         ],
+      },
+      {
+        heading: "Stress-test the first few months",
+        body: [
+          "Planning is not the same as promising profit. The point of a stress test is to understand what has to be true for the business to feel healthy.",
+          "Use conservative assumptions first. If the plan only works when every location is perfect, every weekend is busy, and nothing breaks your schedule, it is probably too fragile.",
+        ],
+        table: {
+          caption: "Simple questions to pressure-test your plan.",
+          columns: ["Question", "Formula or check", "What it tells you"],
+          rows: [
+            [
+              "What are my fixed monthly obligations?",
+              "Rent, subscriptions, insurance, storage, financing, or other fixed costs",
+              "The baseline the business must cover before it feels comfortable",
+            ],
+            [
+              "How many orders cover fixed obligations?",
+              "Fixed obligations divided by expected contribution per order",
+              "A rough break-even order count, not a profit promise",
+            ],
+            [
+              "What if demand is 25% lower than expected?",
+              "Reduce expected orders and rerun the worksheet",
+              "Whether the launch still has breathing room",
+            ],
+            [
+              "What if restock or service costs are higher?",
+              "Increase supplies, travel, or labor assumptions",
+              "Whether your reserve is large enough for normal variance",
+            ],
+          ],
+        },
       },
       {
         heading: "Keep a reserve for the unglamorous stuff",
@@ -677,8 +1045,27 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
           "Local permits, insurance, or professional advice",
         ],
       },
+      {
+        heading: "Bring better questions into the quote conversation",
+        body: [
+          "A good quote conversation is not just, 'What does the machine cost?' It is a fit conversation. The more context you bring, the better the answer can be.",
+          "Before you talk to Bloomjoy or any equipment provider, write down the business model, target venues, launch timing, budget constraints, and what you need the machine to do on day one.",
+        ],
+        checklist: [
+          "Which model am I building first: fixed vending, events, or hybrid?",
+          "Do I have a target venue type or event buyer already in mind?",
+          "Do I need complex patterns, higher throughput, portability, or a lower-cost test?",
+          "Where will the machine live, and what delivery/access constraints exist?",
+          "Which costs are fixed, quoted, estimated, or still unknown?",
+          "What reserve can I set aside after buying the machine and opening supplies?",
+        ],
+        callout: {
+          title: "What this means in practice",
+          body: "The cheapest plan is not always the safest plan. The right plan gives the machine enough support, supplies, and breathing room to operate well after the excitement of launch day.",
+        },
+      },
     ],
-    citations: [sbaStartup, sbaStructure],
+    citations: [sbaStartup, sbaStructure, sbaLicensesPermits],
     relatedSlugs: [
       "how-to-start-cotton-candy-vending-business",
       "business-setup-basics-llc-ein-insurance-permits",
@@ -694,8 +1081,8 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
     category: "locations",
     audience: "Operators doing venue outreach",
     machineFit: "Commercial Machine",
-    updatedAt: "2026-04-28",
-    readingTime: "7 min read",
+    updatedAt: "2026-04-29",
+    readingTime: "12 min read",
     heroImage: aboutFoundersImage,
     heroImageAlt: "Bloomjoy team preparing operator materials",
     seoImagePath: "/seo/about.jpg",
@@ -739,6 +1126,7 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
         body: [
           "A location owner is not buying your excitement. They are deciding whether this machine improves their space without creating operational headaches.",
           "Lead with the guest experience and the operating plan. The cotton candy part is memorable, but the owner needs to know it will not become their problem.",
+          "The best pitch sounds like you have already thought through their day. Where does the machine sit? Who services it? What happens if a guest has a question? How do they make money or improve the guest experience without adding staff chaos?",
         ],
         script: {
           title: "Simple opening email",
@@ -747,6 +1135,21 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
             "I think [Venue] could be a strong fit because guests already spend time near [specific area].",
             "The machine creates a visual treat moment, and I handle the service routine, supplies, and owner check-ins.",
             "Would you be open to a quick walkthrough next week to see if the space, power, and guest flow make sense?",
+          ],
+        },
+      },
+      {
+        heading: "Use the right script for the moment",
+        body: [
+          "A cold email, warm intro, follow-up, and site-walk recap should not sound identical. Keep the same core promise, but match the message to the relationship.",
+          "The goal is not to win the whole deal in one note. The goal is to earn a short conversation or walkthrough.",
+        ],
+        script: {
+          title: "Three useful outreach scripts",
+          lines: [
+            "Cold email: Hi [Name], I operate robotic cotton candy machines for family-friendly venues. I noticed [specific reason the venue has family dwell time], and I think there may be a guest-experience fit worth exploring.",
+            "Warm intro: [Referrer] mentioned you manage guest experience at [Venue]. I help place and service robotic cotton candy machines, and I would love to see whether a small pilot could add a fun treat moment without adding staff work.",
+            "Site-walk follow-up: Thanks for walking the space today. Based on what we saw, the strongest potential placement is [area] because [reason]. The open questions are [power/access/terms]. If those check out, I suggest a short pilot with clear success metrics.",
           ],
         },
       },
@@ -764,6 +1167,43 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
           "Why this venue's audience is a good fit",
           "Next step: site walk, pilot date, or decision meeting",
         ],
+      },
+      {
+        heading: "Prepare for owner objections",
+        body: [
+          "Objections are not bad. They usually mean the owner is picturing the machine in their space. Treat each concern as a chance to show that you are an operator, not just a salesperson.",
+          "If you do not know the answer yet, say so and follow up. Guessing creates more risk than pausing.",
+        ],
+        table: {
+          columns: ["Owner concern", "Helpful answer angle", "Proof to bring"],
+          rows: [
+            [
+              "Will this make a mess?",
+              "Explain cleaning routine, service schedule, and who owns cleanup",
+              "Checklist, supply plan, and service contact",
+            ],
+            [
+              "Will staff have to manage it?",
+              "Clarify what staff do and do not own",
+              "Simple issue path and operator contact",
+            ],
+            [
+              "Will it take too much space?",
+              "Show footprint, flow, and placement options",
+              "Photos, measurements, and site-walk notes",
+            ],
+            [
+              "What about insurance or paperwork?",
+              "Ask what documents the venue requires and confirm timing",
+              "Business setup packet or document checklist",
+            ],
+            [
+              "How do we know guests will use it?",
+              "Offer a pilot with simple success metrics",
+              "Location scorecard and proposed review date",
+            ],
+          ],
+        },
       },
       {
         heading: "Offer a pilot when the owner is interested but cautious",
@@ -793,8 +1233,52 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
           ],
         },
       },
+      {
+        heading: "Run the site walk like a professional",
+        body: [
+          "A site walk is not a tour. It is a qualification meeting. You are checking whether the venue, machine, owner, and operating routine can all work together.",
+          "Bring a short agenda so the owner feels you are making the decision easier, not creating another project for them.",
+        ],
+        checklist: [
+          "Confirm the decision maker and day-to-day staff contact",
+          "Stand in the proposed placement and watch guest flow",
+          "Verify power, cleaning access, restock access, and security hours",
+          "Discuss commercial terms: rent, revenue share, pilot length, or amenity logic",
+          "Agree on what staff should do if there is a question or issue",
+          "Set a follow-up date and define the next decision",
+        ],
+      },
+      {
+        heading: "Report back after launch",
+        body: [
+          "Winning the location is only the first part. Keeping it means proving that you are paying attention.",
+          "A simple owner update can be enough: what happened, what you checked, what you are adjusting, and what you need from the venue. This is especially helpful after the first week and first month.",
+        ],
+        table: {
+          caption: "Simple owner update structure.",
+          columns: ["Update line", "Example"],
+          rows: [
+            [
+              "Guest response",
+              "Families are stopping most often before/after birthday check-in.",
+            ],
+            [
+              "Operations",
+              "Service visit completed Monday; supplies are stocked and area was cleaned.",
+            ],
+            [
+              "Adjustment",
+              "We recommend turning the machine slightly toward the waiting area for better visibility.",
+            ],
+            [
+              "Ask",
+              "Please tell staff to text [contact] if they notice a supply or guest question.",
+            ],
+          ],
+        },
+      },
     ],
-    citations: [sbaStartup],
+    citations: [sbaStartup, sbaLicensesPermits],
     relatedSlugs: [
       "best-locations-for-cotton-candy-vending-machines",
       "how-to-start-cotton-candy-vending-business",
@@ -810,8 +1294,8 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
     category: "start",
     audience: "Buyers choosing a business path",
     machineFit: "Commercial, Mini, and Micro",
-    updatedAt: "2026-04-28",
-    readingTime: "6 min read",
+    updatedAt: "2026-04-29",
+    readingTime: "11 min read",
     heroImage: microMachineImage,
     heroImageAlt: "Bloomjoy Micro Machine with cotton candy output for smaller setups",
     seoImagePath: "/seo/micro-machine.jpg",
@@ -855,6 +1339,7 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
         body: [
           "Both models can use the same basic product category, but they feel very different day to day.",
           "Fixed-location vending rewards patient location development, clear service routes, and reliable restocking. Events reward booking, setup speed, customer flow, and a polished live experience.",
+          "This is why the question is not simply, 'Which machine is best?' The better question is, 'Which operating life am I willing to build?' A machine can support the business, but it cannot make you love the work around it.",
         ],
         table: {
           columns: ["Decision", "Commercial vending", "Event or catering"],
@@ -883,6 +1368,38 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
         },
       },
       {
+        heading: "Compare a normal week in each model",
+        body: [
+          "The daily work is where the decision becomes clear. Imagine doing the business on an average week, not just on the day you announce it.",
+          "If one column sounds energizing and the other sounds draining, pay attention. That is useful data.",
+        ],
+        table: {
+          columns: ["Work moment", "Commercial vending", "Event or catering"],
+          rows: [
+            [
+              "Selling",
+              "Research venues, pitch owners, schedule site walks, negotiate terms",
+              "Answer inquiries, quote packages, follow up with planners and parents",
+            ],
+            [
+              "Operations",
+              "Service route, restock, clean, check payments, update owner",
+              "Pack, transport, set up, serve, manage line, tear down",
+            ],
+            [
+              "Schedule shape",
+              "More repeatable once locations are active",
+              "More weekend and event-date driven",
+            ],
+            [
+              "Main risk",
+              "Weak placement or unclear service responsibility",
+              "Underpriced events, poor logistics, or too much custom work",
+            ],
+          ],
+        },
+      },
+      {
         heading: "Choose the model that fits your personality",
         body: [
           "If you like recurring locations, repeatable service routes, and business-to-business selling, fixed vending may fit you. If you like live events, weekends, direct customer energy, and moving parts, events may feel more natural.",
@@ -895,14 +1412,64 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
         ],
       },
       {
+        heading: "Choose this path if",
+        body: [
+          "Neither path is automatically better. The right choice depends on your goals, schedule, sales comfort, budget, and appetite for operational complexity.",
+          "Use these prompts as a decision tree before you compare machine specs.",
+        ],
+        table: {
+          columns: ["Choose", "If this sounds like you", "Be honest about"],
+          rows: [
+            [
+              "Commercial vending",
+              "You like B2B selling, repeat locations, and building a small route over time",
+              "Venue outreach can be slow, and a bad location can waste months",
+            ],
+            [
+              "Events and catering",
+              "You like live customer energy, weekend work, and booking-based revenue",
+              "Every event has logistics, policies, and customer communication",
+            ],
+            [
+              "Mini/Micro testing",
+              "You want a smaller first step before committing to a larger placement strategy",
+              "Lower complexity can also mean lower throughput or simpler output",
+            ],
+            [
+              "Hybrid later",
+              "You already have one path stable and want to add another channel",
+              "Hybrid too early can split attention before either model is strong",
+            ],
+          ],
+        },
+      },
+      {
         heading: "Let the business model choose the machine",
         body: [
           "A Commercial Machine is designed for high-throughput, fixed or serious venue use. Mini is designed for operators who need a more portable footprint and still want stronger pattern capability. Micro is the simpler entry point for basic-shape, lower-volume use.",
           "If you are stuck, write down your first ten target customers. The list usually tells you which model you are really building.",
         ],
+        callout: {
+          title: "The first ten customer test",
+          body: "If your list is mostly venue owners, mall managers, FEC operators, and attraction managers, you are probably building a vending placement business. If it is parents, schools, event planners, companies, and festival organizers, you are probably building an event business. If the list is half and half, pick the side you can sell and operate first.",
+        },
+      },
+      {
+        heading: "Know when not to choose a path",
+        body: [
+          "Good operators say no to the wrong first move. That does not mean the idea is bad forever. It means the timing, resources, or operating model may not be ready yet.",
+          "A clear no can protect your budget and your energy.",
+        ],
+        checklist: [
+          "Do not choose vending first if you have no realistic venue pipeline and do not want to pitch owners.",
+          "Do not choose events first if weekend work, transport, setup, and customer communication sound exhausting.",
+          "Do not choose hybrid first if you have not proven either location service or event execution.",
+          "Do not choose solely by machine price if the cheaper path cannot do the work your business model needs.",
+          "Do not ignore admin basics because the machine itself feels fun and tangible.",
+        ],
       },
     ],
-    citations: [sbaStartup],
+    citations: [sbaStartup, sbaLicensesPermits],
     relatedSlugs: [
       "how-to-start-cotton-candy-vending-business",
       "mini-micro-event-catering-business-guide",
@@ -918,8 +1485,8 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
     category: "setup",
     audience: "New business owners",
     machineFit: "All machine paths",
-    updatedAt: "2026-04-28",
-    readingTime: "8 min read",
+    updatedAt: "2026-04-29",
+    readingTime: "12 min read",
     heroImage: aboutHeroImage,
     heroImageAlt: "Bloomjoy operations team context for business setup planning",
     seoImagePath: "/seo/about.jpg",
@@ -963,6 +1530,7 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
         body: [
           "Bloomjoy can share an operator-minded checklist, but your legal, tax, insurance, and permit requirements depend on where and how you operate. Use this article to get organized, then confirm the details with your state, city, venue, accountant, insurance broker, or attorney.",
           "That said, a little admin planning goes a long way. It is much easier to open a bank account, sign a venue agreement, and collect payments when your paperwork is not a mystery.",
+          "Think of this as an admin day. Put the boring documents in one folder before the venue asks for them. It is not the most photogenic part of a cotton candy business, but it can make you look serious when a good location is ready to move.",
         ],
         callout: {
           title: "Important sequence",
@@ -999,6 +1567,22 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
         ],
       },
       {
+        heading: "Create a venue-ready document packet",
+        body: [
+          "Venues vary, but many professional conversations eventually become a paperwork conversation. If you can answer calmly, you feel less like a hobbyist and more like a partner.",
+          "Do not fabricate or rush documents. Build the packet as each item becomes real and verified for your business.",
+        ],
+        checklist: [
+          "Business formation or registration confirmation, if applicable",
+          "EIN confirmation letter or tax ID documentation, if applicable",
+          "W-9 for U.S. venue or vendor onboarding workflows",
+          "Certificate of insurance, if the venue requires one",
+          "Local business license, seller's permit, food/vendor permit, or event permit where required",
+          "Simple venue agreement or pilot agreement",
+          "Machine/service contact sheet for day-to-day questions",
+        ],
+      },
+      {
         heading: "Questions to ask before your first placement",
         body: [
           "The right questions save time. Ask them before you sign a venue agreement or book a paid event.",
@@ -1013,8 +1597,59 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
           "Can I provide invoices, W-9, certificate of insurance, or other requested documents?",
         ],
       },
+      {
+        heading: "Track renewals before they become urgent",
+        body: [
+          "Some licenses and permits expire. Insurance renews. Venue paperwork may need updates. A small renewal calendar can save you from a last-minute scramble.",
+          "The SBA notes that license and permit requirements and fees can vary by business activity, location, and government rules, and that vending machines are commonly regulated at the local level. That is your cue to check locally and keep dates organized.",
+        ],
+        table: {
+          caption: "Simple compliance calendar fields.",
+          columns: ["Item", "Who to confirm with", "Date to track"],
+          rows: [
+            [
+              "Business registration",
+              "State or local registration office",
+              "Annual report, renewal, or filing deadline",
+            ],
+            [
+              "Sales tax or seller permit",
+              "State tax agency or local authority",
+              "Filing dates and renewal date if applicable",
+            ],
+            [
+              "Food, vending, or event permit",
+              "City, county, health department, or event organizer",
+              "Expiration date and event-specific deadlines",
+            ],
+            [
+              "Insurance",
+              "Insurance broker or carrier",
+              "Policy renewal and certificate request timing",
+            ],
+            [
+              "Venue agreement",
+              "Venue owner or property manager",
+              "Pilot review, renewal, or termination dates",
+            ],
+          ],
+        },
+      },
+      {
+        heading: "Ask better questions of professionals",
+        body: [
+          "A professional advisor can help more when you bring a specific business model. Saying 'I might sell cotton candy somehow' is hard to advise. Saying 'I plan to place a machine in family entertainment venues in this county' is much better.",
+          "Bring your planned locations, sales model, ownership structure, and first launch timeline into the conversation.",
+        ],
+        bullets: [
+          "Ask an accountant how to handle sales tax, income tracking, expenses, and entity choice for your situation.",
+          "Ask an insurance broker what coverage venues commonly require for vending or event work.",
+          "Ask the city, county, health department, or event organizer which permits apply to your planned activity.",
+          "Ask venues what vendor documents they need before you sign or launch.",
+        ],
+      },
     ],
-    citations: [sbaStartup, sbaStructure, irsEin],
+    citations: [sbaStartup, sbaStructure, sbaLicensesPermits, irsEin],
     relatedSlugs: [
       "startup-budget-checklist-cotton-candy-machine-business",
       "how-to-start-cotton-candy-vending-business",

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -35,6 +35,7 @@ type EventName =
   | 'add_to_cart'
   | 'remove_from_cart'
   | 'view_cart'
+  | 'view_business_playbook_article'
   | 'admin_support_request_updated'
   | 'admin_order_fulfillment_updated'
   | 'admin_machine_inventory_updated'

--- a/src/lib/seoRoutes.ts
+++ b/src/lib/seoRoutes.ts
@@ -44,7 +44,7 @@ export const PUBLIC_ROBOTS =
   "index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1";
 export const PRIVATE_ROBOTS = "noindex,nofollow,noarchive,nosnippet";
 
-const LASTMOD = "2026-04-28";
+const LASTMOD = "2026-04-29";
 
 export const commercialMachineFaqs = [
   {

--- a/src/lib/seoRoutes.ts
+++ b/src/lib/seoRoutes.ts
@@ -1,4 +1,5 @@
 import type { AppSurface } from "@/lib/appSurface";
+import { businessPlaybookArticles } from "@/data/businessPlaybook";
 
 export type RouteSeo = {
   path: string;
@@ -15,7 +16,12 @@ export type RouteSeo = {
     title: string;
   }>;
   lastmod: string;
-  structuredDataKind?: "machine-product" | "supplies" | "faq";
+  structuredDataKind?:
+    | "machine-product"
+    | "supplies"
+    | "faq"
+    | "business-playbook-index"
+    | "business-playbook-article";
 };
 
 export type PrivateRouteSeo = RouteSeo & {
@@ -38,7 +44,7 @@ export const PUBLIC_ROBOTS =
   "index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1";
 export const PRIVATE_ROBOTS = "noindex,nofollow,noarchive,nosnippet";
 
-const LASTMOD = "2026-04-17";
+const LASTMOD = "2026-04-28";
 
 export const commercialMachineFaqs = [
   {
@@ -109,6 +115,42 @@ export const resourcesFaqs = [
     q: "Which sugar and stick supplies are available?",
     a: "Bloomjoy sells bulk cotton candy sugar in core colors, Bloomjoy branded paper sticks by box, and custom stick requests with artwork proofing.",
   },
+];
+
+const businessPlaybookSeoRoutes: RouteSeo[] = [
+  {
+    path: "/resources/business-playbook",
+    title: "Bloomjoy Business Playbook | Cotton Candy Business Guides",
+    description:
+      "Read practical Bloomjoy guides for starting a cotton candy vending, event, or catering business with operator-led tips, visuals, budget planning, and location strategy.",
+    robots: PUBLIC_ROBOTS,
+    surface: "marketing",
+    ogType: "website",
+    ogImagePath: DEFAULT_SHARE_IMAGE_PATH,
+    ogImageAlt: "Bloomjoy Business Playbook for cotton candy machine operators",
+    lastmod: LASTMOD,
+    structuredDataKind: "business-playbook-index",
+  },
+  ...businessPlaybookArticles.map(
+    (article): RouteSeo => ({
+      path: `/resources/business-playbook/${article.slug}`,
+      title: `${article.title} | Bloomjoy Business Playbook`,
+      description: article.description,
+      robots: PUBLIC_ROBOTS,
+      surface: "marketing",
+      ogType: "article",
+      ogImagePath: article.seoImagePath,
+      ogImageAlt: article.heroImageAlt,
+      sitemapImages: [
+        {
+          loc: `${MARKETING_ORIGIN}${article.seoImagePath}`,
+          title: article.title,
+        },
+      ],
+      lastmod: article.updatedAt,
+      structuredDataKind: "business-playbook-article",
+    })
+  ),
 ];
 
 export const publicRoutes: RouteSeo[] = [
@@ -233,9 +275,9 @@ export const publicRoutes: RouteSeo[] = [
   },
   {
     path: "/resources",
-    title: "Robotic Cotton Candy Machine FAQs and Resources | Bloomjoy",
+    title: "Business Playbook and Robotic Cotton Candy Machine Resources | Bloomjoy",
     description:
-      "Get practical answers about Bloomjoy robotic cotton candy machines, supplies, training, support boundaries, maintenance, and quote preparation.",
+      "Explore the Bloomjoy Business Playbook, FAQs, operator resources, supplies guidance, support boundaries, and machine quote preparation.",
     robots: PUBLIC_ROBOTS,
     surface: "marketing",
     ogImagePath: DEFAULT_SHARE_IMAGE_PATH,
@@ -243,6 +285,7 @@ export const publicRoutes: RouteSeo[] = [
     lastmod: LASTMOD,
     structuredDataKind: "faq",
   },
+  ...businessPlaybookSeoRoutes,
   {
     path: "/contact",
     title: "Request a Robotic Cotton Candy Machine Quote | Bloomjoy",
@@ -430,6 +473,11 @@ const getRouteFaqs = (route: RouteSeo) => {
   return [];
 };
 
+const getBusinessPlaybookArticleByPath = (path: string) => {
+  const slug = path.replace("/resources/business-playbook/", "");
+  return businessPlaybookArticles.find((article) => article.slug === slug);
+};
+
 const machineProductDataByPath: Record<string, Record<string, unknown>> = {
   "/machines/commercial-robotic-machine": {
     "@type": "Product",
@@ -563,6 +611,81 @@ export const buildStructuredData = ({
         },
       ],
     });
+  }
+
+  if (route.path === "/resources/business-playbook") {
+    graph.push({
+      "@type": "CollectionPage",
+      "@id": `${canonicalUrl}#collection`,
+      name: "Bloomjoy Business Playbook",
+      description: route.description,
+      url: canonicalUrl,
+      isPartOf: {
+        "@id": `${MARKETING_ORIGIN}/#website`,
+      },
+      mainEntity: {
+        "@type": "ItemList",
+        itemListElement: businessPlaybookArticles.map((article, index) => ({
+          "@type": "ListItem",
+          position: index + 1,
+          name: article.title,
+          url: `${MARKETING_ORIGIN}/resources/business-playbook/${article.slug}`,
+        })),
+      },
+    });
+  }
+
+  if (route.structuredDataKind === "business-playbook-article") {
+    const article = getBusinessPlaybookArticleByPath(route.path);
+
+    if (article) {
+      graph.push(
+        {
+          "@type": "BreadcrumbList",
+          "@id": `${canonicalUrl}#breadcrumb`,
+          itemListElement: [
+            {
+              "@type": "ListItem",
+              position: 1,
+              name: "Resources",
+              item: `${MARKETING_ORIGIN}/resources`,
+            },
+            {
+              "@type": "ListItem",
+              position: 2,
+              name: "Business Playbook",
+              item: `${MARKETING_ORIGIN}/resources/business-playbook`,
+            },
+            {
+              "@type": "ListItem",
+              position: 3,
+              name: article.title,
+              item: canonicalUrl,
+            },
+          ],
+        },
+        {
+          "@type": "Article",
+          "@id": `${canonicalUrl}#article`,
+          headline: article.title,
+          description: article.description,
+          image: `${MARKETING_ORIGIN}${article.seoImagePath}`,
+          datePublished: article.updatedAt,
+          dateModified: article.updatedAt,
+          author: {
+            "@id": `${MARKETING_ORIGIN}/#organization`,
+          },
+          publisher: {
+            "@id": `${MARKETING_ORIGIN}/#organization`,
+          },
+          mainEntityOfPage: {
+            "@id": `${canonicalUrl}#webpage`,
+          },
+          about: article.keyTakeaways,
+          citation: article.citations.map((citation) => citation.url),
+        }
+      );
+    }
   }
 
   if (route.structuredDataKind === "machine-product" && machineProductDataByPath[route.path]) {

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
+import { ArrowRight, BookOpen } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
@@ -14,6 +15,45 @@ const machineInterestOptions = [
   ...MACHINE_INTEREST_OPTIONS,
   'Not sure yet',
 ];
+
+const getPostSubmitPlaybookLinks = (interest: string) => {
+  if (interest === 'Commercial Machine') {
+    return [
+      {
+        label: 'Read the Commercial location guide',
+        href: '/resources/business-playbook/best-locations-for-cotton-candy-vending-machines',
+      },
+      {
+        label: 'Prep your location-owner pitch',
+        href: '/resources/business-playbook/how-to-pitch-location-owners',
+      },
+    ];
+  }
+
+  if (interest === 'Mini Machine' || interest === 'Micro Machine') {
+    return [
+      {
+        label: 'Read the event business guide',
+        href: '/resources/business-playbook/mini-micro-event-catering-business-guide',
+      },
+      {
+        label: 'Compare vending vs. events',
+        href: '/resources/business-playbook/commercial-vending-vs-event-catering',
+      },
+    ];
+  }
+
+  return [
+    {
+      label: 'Start with the business launch guide',
+      href: '/resources/business-playbook/how-to-start-cotton-candy-vending-business',
+    },
+    {
+      label: 'Review the startup budget checklist',
+      href: '/resources/business-playbook/startup-budget-checklist-cotton-candy-machine-business',
+    },
+  ];
+};
 
 export default function ContactPage() {
   const [searchParams] = useSearchParams();
@@ -31,6 +71,7 @@ export default function ContactPage() {
     website: '',
   });
   const [submitting, setSubmitting] = useState(false);
+  const [lastSubmittedInterest, setLastSubmittedInterest] = useState('');
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -60,6 +101,7 @@ export default function ContactPage() {
         machineInterest: formData.type === 'quote' ? formData.interest.trim() : undefined,
         sourcePage: querySource?.trim() || '/contact',
       });
+      setLastSubmittedInterest(formData.interest || 'Not sure yet');
       toast.success('Message sent! We\'ll be in touch soon.');
       setFormData({
         name: '',
@@ -77,6 +119,10 @@ export default function ContactPage() {
     }
   };
 
+  const postSubmitPlaybookLinks = lastSubmittedInterest
+    ? getPostSubmitPlaybookLinks(lastSubmittedInterest)
+    : [];
+
   return (
     <Layout>
       <section className="bg-gradient-to-b from-cream to-background py-12 sm:py-14 lg:py-16">
@@ -93,6 +139,34 @@ export default function ContactPage() {
       <section className="py-10 sm:py-12 lg:py-16">
         <div className="container-page">
           <div className="mx-auto max-w-2xl">
+            {postSubmitPlaybookLinks.length > 0 && (
+              <div className="mb-6 rounded-xl border border-primary/20 bg-primary/5 p-5">
+                <div className="flex items-start gap-3">
+                  <BookOpen className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
+                  <div>
+                    <h2 className="font-display text-xl font-bold text-foreground">
+                      While we review your request
+                    </h2>
+                    <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                      These playbook guides can help you tighten your launch plan before the
+                      quote conversation.
+                    </p>
+                    <div className="mt-4 grid gap-2">
+                      {postSubmitPlaybookLinks.map((link) => (
+                        <Link
+                          key={link.href}
+                          to={link.href}
+                          className="inline-flex items-center gap-2 text-sm font-semibold text-primary hover:underline"
+                        >
+                          {link.label}
+                          <ArrowRight className="h-4 w-4" />
+                        </Link>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
             <div className="card-elevated p-8">
               <form onSubmit={handleSubmit} className="space-y-6">
                 <div className="hidden" aria-hidden="true">
@@ -207,7 +281,7 @@ export default function ContactPage() {
                   />
                 </div>
                 <Button type="submit" variant="hero" size="lg" className="w-full" disabled={submitting}>
-                  {submitting ? 'Sending…' : 'Send Message'}
+                  {submitting ? 'Sending...' : 'Send Message'}
                 </Button>
               </form>
             </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -200,6 +200,7 @@ export default function HomePage() {
                 {[
                   'Onboarding checklist & WeChat setup assistance',
                   'Training library access with video guides',
+                  'Assigned-machine reporting when connected',
                   'Member community access',
                   'Concierge support (triage, best-practices, escalation)',
                 ].map((benefit) => (

--- a/src/pages/Plus.tsx
+++ b/src/pages/Plus.tsx
@@ -22,6 +22,10 @@ const benefits = [
     description: 'Complete the Operator Essentials path and unlock a lightweight Bloomjoy completion certificate.',
   },
   {
+    title: 'Reporting Access',
+    description: 'Review assigned-machine sales, trends, and exports when reporting is connected to your account.',
+  },
+  {
     title: 'Concierge Support',
     description: 'Triage assistance, best-practice guidance, and translation/escalation with manufacturer support.',
   },
@@ -204,7 +208,8 @@ export default function PlusPage() {
             </p>
             <div className="mt-6 rounded-xl border border-border bg-background p-5 text-sm text-muted-foreground">
               Plus training now focuses on operator outcomes: quick-start setup, software and payment settings,
-              daily operation, cleaning and hygiene, troubleshooting, and a lightweight completion certificate path.
+              daily operation, cleaning and hygiene, reporting access where available, troubleshooting,
+              and a lightweight completion certificate path.
             </div>
             <div className="mt-10 grid gap-6 md:grid-cols-2">
               <div className="rounded-xl border border-border bg-background p-6">

--- a/src/pages/Plus.tsx
+++ b/src/pages/Plus.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { Check, ArrowRight } from 'lucide-react';
+import { Check, ArrowRight, BookOpen } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Layout } from '@/components/layout/Layout';
 import { trackEvent } from '@/lib/analytics';
@@ -142,7 +142,7 @@ export default function PlusPage() {
                   disabled={isStartingCheckout}
                 >
                   {isStartingCheckout
-                    ? 'Redirecting…'
+                    ? 'Redirecting...'
                     : user
                       ? 'Start Membership'
                       : 'Log In to Start Membership'}
@@ -162,6 +162,32 @@ export default function PlusPage() {
                 </p>
               </div>
             </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-y border-border bg-background py-8">
+        <div className="container-page">
+          <div className="mx-auto flex max-w-4xl flex-col gap-4 rounded-xl border border-primary/20 bg-primary/5 p-5 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-start gap-3">
+              <BookOpen className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
+              <div>
+                <h2 className="font-display text-xl font-bold text-foreground">
+                  Planning before you join Plus?
+                </h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  The public Business Playbook covers startup budgeting, locations, pitches,
+                  and business setup. Plus adds the operator training layer after launch.
+                </p>
+              </div>
+            </div>
+            <Link
+              to="/resources/business-playbook"
+              className="inline-flex items-center gap-2 text-sm font-semibold text-primary hover:underline"
+            >
+              Open Playbook
+              <ArrowRight className="h-4 w-4" />
+            </Link>
           </div>
         </div>
       </section>
@@ -200,7 +226,7 @@ export default function PlusPage() {
                   </li>
                   <li className="flex items-start gap-2">
                     <Check className="mt-0.5 h-4 w-4 shrink-0 text-sage" />
-                    US business hours (Mon–Fri, 9am–5pm EST)
+                    US business hours (Mon-Fri, 9am-5pm EST)
                   </li>
                 </ul>
                 <p className="mt-4 rounded-lg bg-amber/10 p-3 text-xs text-amber">

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -87,6 +87,28 @@ export default function ProductsPage() {
         </div>
       </section>
 
+      <section className="border-b border-border bg-background py-6">
+        <div className="container-page">
+          <div className="flex flex-col gap-3 rounded-xl border border-primary/20 bg-primary/5 p-5 sm:flex-row sm:items-center sm:justify-between">
+            <div className="min-w-0">
+              <h2 className="font-display text-xl font-bold text-foreground">
+                Still choosing the right business model?
+              </h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Read the Bloomjoy Business Playbook before you compare machines by price alone.
+              </p>
+            </div>
+            <Link
+              to="/resources/business-playbook/commercial-vending-vs-event-catering"
+              className="inline-flex items-center gap-2 text-sm font-semibold text-primary hover:underline"
+            >
+              Compare vending and events
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+          </div>
+        </div>
+      </section>
+
       {/* Machines */}
       <section className="py-10 sm:py-12 lg:py-16">
         <div className="container-page">
@@ -148,7 +170,7 @@ export default function ProductsPage() {
       <section className="border-y border-border bg-muted/25 py-10 sm:py-12 lg:py-16">
         <div className="container-page">
           <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_22rem]">
-            <div>
+            <div className="min-w-0">
               <h2 className="font-display text-2xl font-bold text-foreground">
                 Machine buyer comparison
               </h2>
@@ -183,7 +205,7 @@ export default function ProductsPage() {
                 </div>
               </div>
             </div>
-            <aside className="rounded-lg border border-border bg-background p-5">
+            <aside className="min-w-0 rounded-lg border border-border bg-background p-5">
               <h3 className="font-display text-lg font-semibold text-foreground">
                 Quote expectations
               </h3>

--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -1,55 +1,62 @@
-import { useEffect } from 'react';
-import { Link, useLocation } from 'react-router-dom';
-import { ArrowRight, Download, Lock } from 'lucide-react';
-import { Layout } from '@/components/layout/Layout';
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
-import { Button } from '@/components/ui/button';
-import { getCanonicalUrlForSurface } from '@/lib/appSurface';
-import { resourcesFaqs } from '@/lib/seoRoutes';
+import { useEffect } from "react";
+import { Link, useLocation } from "react-router-dom";
+import {
+  ArrowRight,
+  BookOpen,
+  ClipboardCheck,
+  Download,
+  Lock,
+  MapPinned,
+  Sparkles,
+} from "lucide-react";
+import { Layout } from "@/components/layout/Layout";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Button } from "@/components/ui/button";
+import { getCanonicalUrlForSurface } from "@/lib/appSurface";
+import { resourcesFaqs } from "@/lib/seoRoutes";
+import {
+  businessPlaybookArticles,
+  featuredBusinessPlaybookArticles,
+  getPlaybookCategory,
+  playbookCategories,
+} from "@/data/businessPlaybook";
+import landingHeroImage from "@/assets/real/landing-hero.jpg";
 
 const plusTeasers = [
   {
-    title: 'Operator Guides',
+    title: "Operator Guides",
     description:
-      'Task-first setup, pricing, timer, and payment guides so operators can find answers fast.',
+      "Task-first setup, pricing, timer, and payment guides so operators can find answers fast.",
   },
   {
-    title: 'Maintenance Checklists',
+    title: "Maintenance Checklists",
     description:
-      'Cleaning, hygiene, and function-check references pulled from Bloomjoy training materials.',
+      "Cleaning, hygiene, and function-check references pulled from Bloomjoy training materials.",
   },
   {
-    title: 'Operator Certificate',
+    title: "Operator Certificate",
     description:
-      'Plus members can complete the Operator Essentials path and unlock a lightweight completion certificate.',
+      "Plus members can complete the Operator Essentials path and unlock a lightweight completion certificate.",
   },
 ];
 
-const resourceGroups = [
-  {
-    title: 'Machine Buyers',
-    description:
-      'Compare the Commercial, Mini, and Micro machines by venue fit, footprint, pattern capability, and quote expectations.',
-    href: '/machines',
-  },
-  {
-    title: 'Supplies Planning',
-    description:
-      'Review sugar, Bloomjoy branded paper sticks, custom sticks, pricing, and order paths before launch.',
-    href: '/supplies',
-  },
-  {
-    title: 'Support Boundaries',
-    description:
-      'Understand manufacturer first-line support, Bloomjoy concierge guidance, and Plus training resources.',
-    href: '#support-boundaries',
-  },
-];
+const categoryIcons = {
+  start: BookOpen,
+  locations: MapPinned,
+  budget: ClipboardCheck,
+  events: Sparkles,
+  setup: ClipboardCheck,
+};
 
 export default function ResourcesPage() {
   const location = useLocation();
-  const currentLocation = typeof window === 'undefined' ? undefined : window.location;
-  const operatorLoginUrl = getCanonicalUrlForSurface('app', '/login', '', '', currentLocation);
+  const currentLocation = typeof window === "undefined" ? undefined : window.location;
+  const operatorLoginUrl = getCanonicalUrlForSurface("app", "/login", "", "", currentLocation);
 
   useEffect(() => {
     if (!location.hash) {
@@ -62,7 +69,7 @@ export default function ResourcesPage() {
     }
 
     const scrollToTarget = () => {
-      document.getElementById(targetId)?.scrollIntoView({ block: 'start' });
+      document.getElementById(targetId)?.scrollIntoView({ block: "start" });
     };
 
     const frameId = window.requestAnimationFrame(scrollToTarget);
@@ -76,52 +83,165 @@ export default function ResourcesPage() {
 
   return (
     <Layout>
-      <section className="bg-gradient-to-b from-cream to-background py-12 sm:py-14 lg:py-16">
-        <div className="container-page text-center">
-          <h1 className="font-display text-4xl font-bold text-foreground">Resources</h1>
-          <p className="mx-auto mt-4 max-w-2xl text-lg text-muted-foreground">
-            Practical FAQs for robotic cotton candy machine buyers, venue operators, supplies,
-            maintenance, support, and Bloomjoy Plus.
-          </p>
-        </div>
-      </section>
-      <section className="border-b border-border bg-background py-10 sm:py-12 lg:py-16">
+      <section className="border-b border-border bg-gradient-to-b from-cream to-background py-12 sm:py-14 lg:py-16">
         <div className="container-page">
-          <div className="grid gap-4 md:grid-cols-3">
-            {resourceGroups.map((group) => (
-              <Link
-                key={group.title}
-                to={group.href}
-                className="rounded-lg border border-border bg-muted/10 p-5 transition-colors hover:border-primary/60"
-              >
-                <h2 className="font-display text-xl font-semibold text-foreground">
-                  {group.title}
-                </h2>
-                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-                  {group.description}
-                </p>
-                <span className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-primary">
-                  Open resource
-                  <ArrowRight className="h-4 w-4" />
-                </span>
-              </Link>
-            ))}
+          <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(22rem,0.82fr)] lg:items-center">
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-[0.14em] text-primary">
+                Resources
+              </p>
+              <h1 className="mt-4 max-w-4xl font-display text-4xl font-bold leading-tight text-foreground sm:text-5xl">
+                Guides, FAQs, and operator playbooks for starting smart
+              </h1>
+              <p className="mt-5 max-w-2xl text-lg leading-relaxed text-muted-foreground">
+                The Bloomjoy Business Playbook turns common buyer questions into practical,
+                visual guides for vending locations, event service, budgeting, business setup,
+                supplies, support, and machine fit.
+              </p>
+              <div className="mt-7 flex flex-wrap gap-3">
+                <Button asChild size="lg">
+                  <Link to="/resources/business-playbook">
+                    Open Business Playbook
+                    <ArrowRight className="ml-2 h-4 w-4" />
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" size="lg">
+                  <Link to="#faq">Read FAQs</Link>
+                </Button>
+              </div>
+            </div>
+
+            <figure className="overflow-hidden rounded-2xl border border-border bg-background shadow-elevated">
+              <img
+                src={landingHeroImage}
+                alt="Bloomjoy robotic cotton candy machine creating a colorful product moment"
+                width={720}
+                height={520}
+                loading="eager"
+                decoding="async"
+                className="aspect-[4/3] w-full object-cover"
+              />
+              <figcaption className="border-t border-border px-5 py-4 text-sm text-muted-foreground">
+                Operator-led guidance for turning machine interest into a real launch plan.
+              </figcaption>
+            </figure>
           </div>
         </div>
       </section>
+
+      <section className="border-b border-border bg-background py-10 sm:py-12 lg:py-16">
+        <div className="container-page">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <h2 className="font-display text-3xl font-bold text-foreground">
+                Bloomjoy Business Playbook
+              </h2>
+              <p className="mt-2 max-w-3xl text-muted-foreground">
+                Useful, well-researched, easy-to-read guides for people evaluating a cotton
+                candy vending, event, or catering business.
+              </p>
+            </div>
+            <Button asChild variant="outline">
+              <Link to="/resources/business-playbook">
+                View all guides
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </Link>
+            </Button>
+          </div>
+
+          <div className="mt-8 grid gap-5 lg:grid-cols-3">
+            {featuredBusinessPlaybookArticles.map((article) => {
+              const category = getPlaybookCategory(article.category);
+              return (
+                <Link
+                  key={article.slug}
+                  to={`/resources/business-playbook/${article.slug}`}
+                  className="group overflow-hidden rounded-xl border border-border bg-background transition-[box-shadow,transform,border-color] duration-200 hover:-translate-y-1 hover:border-primary/50 hover:shadow-elevated"
+                >
+                  <div className="aspect-[16/10] overflow-hidden bg-muted">
+                    <img
+                      src={article.heroImage}
+                      alt={article.heroImageAlt}
+                      width={640}
+                      height={400}
+                      loading="lazy"
+                      decoding="async"
+                      className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+                    />
+                  </div>
+                  <div className="p-5">
+                    <div className="flex flex-wrap items-center gap-2 text-xs font-semibold">
+                      {category && (
+                        <span className={`rounded-full px-2.5 py-1 ${category.colorClass}`}>
+                          {category.title}
+                        </span>
+                      )}
+                      <span className="text-muted-foreground">{article.readingTime}</span>
+                    </div>
+                    <h3 className="mt-3 font-display text-xl font-bold leading-tight text-foreground group-hover:text-primary">
+                      {article.shortTitle}
+                    </h3>
+                    <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                      {article.description}
+                    </p>
+                    <div className="mt-4 flex items-center text-sm font-semibold text-primary">
+                      Read guide
+                      <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
+                    </div>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+
+          <div className="mt-8 grid gap-4 md:grid-cols-5">
+            {playbookCategories.map((category) => {
+              const Icon = categoryIcons[category.id];
+              const count = businessPlaybookArticles.filter(
+                (article) => article.category === category.id
+              ).length;
+
+              return (
+                <Link
+                  key={category.id}
+                  to={`/resources/business-playbook#${category.id}`}
+                  className="rounded-lg border border-border bg-muted/10 p-4 transition-colors hover:border-primary/60"
+                >
+                  <span
+                    className={`flex h-10 w-10 items-center justify-center rounded-lg ${category.colorClass}`}
+                  >
+                    <Icon className="h-5 w-5" />
+                  </span>
+                  <h3 className="mt-4 font-display text-lg font-semibold text-foreground">
+                    {category.title}
+                  </h3>
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    {count} guide{count === 1 ? "" : "s"}
+                  </p>
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
       <section id="faq" className="scroll-mt-24 py-10 sm:py-12 lg:py-16">
         <div className="container-page">
-          <div className="mx-auto max-w-2xl">
+          <div className="mx-auto max-w-3xl">
             <h2 className="font-display text-2xl font-bold text-foreground">
               Robotic cotton candy machine FAQs
             </h2>
+            <p className="mt-2 text-muted-foreground">
+              Fast answers for buyers who need support boundaries, machine fit, supplies, and
+              quote prep before a deeper playbook read.
+            </p>
             <Accordion
               type="multiple"
               defaultValue={resourcesFaqs.map((_, index) => `faq-${index}`)}
               className="mt-6"
             >
               {resourcesFaqs.map((faq, i) => (
-                <AccordionItem key={i} value={`faq-${i}`}>
+                <AccordionItem key={faq.q} value={`faq-${i}`}>
                   <AccordionTrigger className="text-left font-medium">{faq.q}</AccordionTrigger>
                   <AccordionContent className="text-muted-foreground">
                     <p>{faq.a}</p>
@@ -141,6 +261,7 @@ export default function ResourcesPage() {
           </div>
         </div>
       </section>
+
       <section className="border-y border-border bg-muted/20 py-10 sm:py-12 lg:py-16">
         <div className="container-page">
           <div className="mx-auto max-w-4xl">
@@ -152,8 +273,9 @@ export default function ResourcesPage() {
                 Premium resources unlocked with Plus
               </h2>
               <p className="text-muted-foreground">
-                Plus includes task-based operator guides, maintenance checklists, troubleshooting references,
-                and the Bloomjoy Operator Essentials certificate path.
+                Public playbooks help you plan. Plus adds the operator layer: task-based
+                guides, maintenance checklists, troubleshooting references, and the Bloomjoy
+                Operator Essentials certificate path.
               </p>
             </div>
 
@@ -161,7 +283,9 @@ export default function ResourcesPage() {
               {plusTeasers.map((item) => (
                 <div key={item.title} className="rounded-xl border border-border bg-background p-5">
                   <div className="flex items-center justify-between">
-                    <h3 className="font-display text-lg font-semibold text-foreground">{item.title}</h3>
+                    <h3 className="font-display text-lg font-semibold text-foreground">
+                      {item.title}
+                    </h3>
                     <Lock className="h-4 w-4 text-muted-foreground" />
                   </div>
                   <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
@@ -189,9 +313,10 @@ export default function ResourcesPage() {
           </div>
         </div>
       </section>
-      <section id="support-boundaries" className="pb-16 scroll-mt-24">
+
+      <section id="support-boundaries" className="scroll-mt-24 py-10 sm:py-12 lg:py-16">
         <div className="container-page">
-          <div className="mx-auto max-w-2xl rounded-lg border border-border bg-muted/30 p-6">
+          <div className="mx-auto max-w-3xl rounded-xl border border-border bg-background p-6 shadow-sm">
             <h2 className="font-display text-2xl font-bold text-foreground">Support Boundaries</h2>
             <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
               The manufacturer support team provides 24/7 first-line technical support via WeChat

--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import {
   ArrowRight,
+  BarChart3,
   BookOpen,
   ClipboardCheck,
   Download,
@@ -32,16 +33,29 @@ const plusTeasers = [
     title: "Operator Guides",
     description:
       "Task-first setup, pricing, timer, and payment guides so operators can find answers fast.",
+    metaLabel: "Plus download",
+    MetaIcon: Download,
   },
   {
     title: "Maintenance Checklists",
     description:
       "Cleaning, hygiene, and function-check references pulled from Bloomjoy training materials.",
+    metaLabel: "Plus download",
+    MetaIcon: Download,
+  },
+  {
+    title: "Reporting Dashboard",
+    description:
+      "Assigned-machine sales, trends, and exports for accounts with reporting access.",
+    metaLabel: "Portal feature",
+    MetaIcon: BarChart3,
   },
   {
     title: "Operator Certificate",
     description:
       "Plus members can complete the Operator Essentials path and unlock a lightweight completion certificate.",
+    metaLabel: "Plus download",
+    MetaIcon: Download,
   },
 ];
 
@@ -264,7 +278,7 @@ export default function ResourcesPage() {
 
       <section className="border-y border-border bg-muted/20 py-10 sm:py-12 lg:py-16">
         <div className="container-page">
-          <div className="mx-auto max-w-4xl">
+          <div className="mx-auto max-w-6xl">
             <div className="flex flex-col gap-3 text-center">
               <p className="text-xs font-semibold uppercase tracking-[0.14em] text-primary">
                 Bloomjoy Plus Preview
@@ -274,29 +288,33 @@ export default function ResourcesPage() {
               </h2>
               <p className="text-muted-foreground">
                 Public playbooks help you plan. Plus adds the operator layer: task-based
-                guides, maintenance checklists, troubleshooting references, and the Bloomjoy
-                Operator Essentials certificate path.
+                guides, maintenance checklists, eligible reporting access, troubleshooting
+                references, and the Bloomjoy Operator Essentials certificate path.
               </p>
             </div>
 
-            <div className="mt-8 grid gap-4 md:grid-cols-3">
-              {plusTeasers.map((item) => (
-                <div key={item.title} className="rounded-xl border border-border bg-background p-5">
-                  <div className="flex items-center justify-between">
-                    <h3 className="font-display text-lg font-semibold text-foreground">
-                      {item.title}
-                    </h3>
-                    <Lock className="h-4 w-4 text-muted-foreground" />
+            <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              {plusTeasers.map((item) => {
+                const MetaIcon = item.MetaIcon;
+
+                return (
+                  <div key={item.title} className="rounded-xl border border-border bg-background p-5">
+                    <div className="flex items-center justify-between">
+                      <h3 className="font-display text-lg font-semibold text-foreground">
+                        {item.title}
+                      </h3>
+                      <Lock className="h-4 w-4 text-muted-foreground" />
+                    </div>
+                    <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                      {item.description}
+                    </p>
+                    <div className="mt-4 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                      <MetaIcon className="h-3.5 w-3.5" />
+                      {item.metaLabel}
+                    </div>
                   </div>
-                  <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-                    {item.description}
-                  </p>
-                  <div className="mt-4 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
-                    <Download className="h-3.5 w-3.5" />
-                    Plus download
-                  </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
 
             <div className="mt-8 flex flex-wrap justify-center gap-3">

--- a/src/pages/products/CommercialRobotic.tsx
+++ b/src/pages/products/CommercialRobotic.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Check, ArrowRight, AlertCircle } from 'lucide-react';
+import { Check, ArrowRight, AlertCircle, BookOpen } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
@@ -157,6 +157,22 @@ export default function CommercialRoboticPage() {
                 <p className="text-center text-sm text-muted-foreground">
                   Custom wrap artwork is finalized offline with the Bloomjoy design team.
                 </p>
+              </div>
+
+              <div className="mt-5 rounded-lg border border-primary/20 bg-primary/5 p-4">
+                <div className="flex items-start gap-3">
+                  <BookOpen className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
+                  <div>
+                    <p className="font-semibold text-foreground">Planning a location?</p>
+                    <Link
+                      to="/resources/business-playbook/best-locations-for-cotton-candy-vending-machines"
+                      className="mt-1 inline-flex items-center gap-2 text-sm font-semibold text-primary hover:underline"
+                    >
+                      Read the Commercial location guide
+                      <ArrowRight className="h-4 w-4" />
+                    </Link>
+                  </div>
+                </div>
               </div>
 
               {/* Features */}

--- a/src/pages/products/Micro.tsx
+++ b/src/pages/products/Micro.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { AlertCircle, ArrowRight, Check } from 'lucide-react';
+import { AlertCircle, ArrowRight, BookOpen, Check } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Layout } from '@/components/layout/Layout';
 import { ProductImageGallery } from '@/components/products/ProductImageGallery';
@@ -92,6 +92,22 @@ export default function MicroPage() {
                     Reorder Sugar
                   </Link>
                 </Button>
+              </div>
+
+              <div className="mt-5 rounded-lg border border-primary/20 bg-primary/5 p-4">
+                <div className="flex items-start gap-3">
+                  <BookOpen className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
+                  <div>
+                    <p className="font-semibold text-foreground">Starting small?</p>
+                    <Link
+                      to="/resources/business-playbook/commercial-vending-vs-event-catering"
+                      className="mt-1 inline-flex items-center gap-2 text-sm font-semibold text-primary hover:underline"
+                    >
+                      Compare vending, events, and Micro fit
+                      <ArrowRight className="h-4 w-4" />
+                    </Link>
+                  </div>
+                </div>
               </div>
 
               {/* Features */}

--- a/src/pages/products/Mini.tsx
+++ b/src/pages/products/Mini.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import { Check, ArrowRight, AlertCircle } from 'lucide-react';
+import { Check, ArrowRight, AlertCircle, BookOpen } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Layout } from '@/components/layout/Layout';
 import { ProductImageGallery } from '@/components/products/ProductImageGallery';
@@ -93,6 +93,22 @@ export default function MiniPage() {
                   Mini orders are handled through our quote flow so we can confirm fit, shipping,
                   and operator handoff details before invoicing.
                 </p>
+              </div>
+
+              <div className="mt-5 rounded-lg border border-primary/20 bg-primary/5 p-4">
+                <div className="flex items-start gap-3">
+                  <BookOpen className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
+                  <div>
+                    <p className="font-semibold text-foreground">Thinking events or catering?</p>
+                    <Link
+                      to="/resources/business-playbook/mini-micro-event-catering-business-guide"
+                      className="mt-1 inline-flex items-center gap-2 text-sm font-semibold text-primary hover:underline"
+                    >
+                      Read the Mini event business guide
+                      <ArrowRight className="h-4 w-4" />
+                    </Link>
+                  </div>
+                </div>
               </div>
 
               <div className="mt-10">

--- a/src/pages/resources/BusinessPlaybookArticle.tsx
+++ b/src/pages/resources/BusinessPlaybookArticle.tsx
@@ -1,0 +1,434 @@
+import { useEffect } from "react";
+import { Link, useParams } from "react-router-dom";
+import {
+  ArrowLeft,
+  ArrowRight,
+  BookOpen,
+  Check,
+  ExternalLink,
+  Sparkles,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Layout } from "@/components/layout/Layout";
+import { trackEvent } from "@/lib/analytics";
+import {
+  type BusinessPlaybookArticle,
+  type PlaybookSection,
+  getBusinessPlaybookArticle,
+  getPlaybookCategory,
+  getRelatedBusinessPlaybookArticles,
+} from "@/data/businessPlaybook";
+
+const renderTable = (section: PlaybookSection) => {
+  if (!section.table) return null;
+
+  return (
+    <div className="mt-6 overflow-hidden rounded-lg border border-border bg-background">
+      {section.table.caption && (
+        <p className="border-b border-border bg-muted/30 px-4 py-3 text-sm font-medium text-muted-foreground">
+          {section.table.caption}
+        </p>
+      )}
+      <div className="overflow-x-auto">
+        <table className="min-w-full border-collapse text-sm">
+          <thead className="bg-muted/40 text-left">
+            <tr>
+              {section.table.columns.map((column) => (
+                <th key={column} className="px-4 py-3 font-semibold text-foreground">
+                  {column}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {section.table.rows.map((row) => (
+              <tr key={row.join("|")} className="border-t border-border">
+                {row.map((cell, index) => (
+                  <td
+                    key={`${cell}-${index}`}
+                    className={
+                      index === 0
+                        ? "px-4 py-3 font-semibold text-foreground"
+                        : "px-4 py-3 text-muted-foreground"
+                    }
+                  >
+                    {cell}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+const renderSectionVisuals = (section: PlaybookSection) => (
+  <>
+    {section.callout && (
+      <div className="mt-6 rounded-lg border border-primary/20 bg-primary/5 p-5">
+        <div className="flex items-start gap-3">
+          <Sparkles className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
+          <div>
+            <p className="font-semibold text-foreground">{section.callout.title}</p>
+            <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+              {section.callout.body}
+            </p>
+          </div>
+        </div>
+      </div>
+    )}
+
+    {section.bullets && (
+      <ul className="mt-5 grid gap-3">
+        {section.bullets.map((item) => (
+          <li key={item} className="flex items-start gap-3 text-muted-foreground">
+            <span className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-sage-light">
+              <Check className="h-3 w-3 text-sage" />
+            </span>
+            <span>{item}</span>
+          </li>
+        ))}
+      </ul>
+    )}
+
+    {section.checklist && (
+      <div className="mt-6 rounded-lg border border-border bg-muted/20 p-5">
+        <p className="font-display text-lg font-semibold text-foreground">Operator checklist</p>
+        <ul className="mt-4 grid gap-3 sm:grid-cols-2">
+          {section.checklist.map((item) => (
+            <li key={item} className="flex items-start gap-3 text-sm text-muted-foreground">
+              <span className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-primary/10">
+                <Check className="h-3 w-3 text-primary" />
+              </span>
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    )}
+
+    {section.scorecard && (
+      <div className="mt-6 rounded-lg border border-border bg-background p-5 shadow-sm">
+        <p className="font-display text-lg font-semibold text-foreground">
+          {section.scorecard.title}
+        </p>
+        <div className="mt-4 grid gap-3">
+          {section.scorecard.items.map((item) => (
+            <div
+              key={item.label}
+              className="grid gap-3 rounded-lg border border-border bg-muted/20 p-4 sm:grid-cols-[10rem_4rem_1fr] sm:items-center"
+            >
+              <p className="font-semibold text-foreground">{item.label}</p>
+              <p className="text-sm font-semibold text-primary">{item.score}</p>
+              <p className="text-sm text-muted-foreground">{item.guidance}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    )}
+
+    {section.steps && (
+      <ol className="mt-6 grid gap-4">
+        {section.steps.map((step, index) => (
+          <li key={step.title} className="flex gap-4 rounded-lg border border-border bg-background p-4">
+            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-bold text-primary">
+              {index + 1}
+            </span>
+            <div>
+              <p className="font-semibold text-foreground">{step.title}</p>
+              <p className="mt-1 text-sm leading-relaxed text-muted-foreground">{step.body}</p>
+            </div>
+          </li>
+        ))}
+      </ol>
+    )}
+
+    {section.script && (
+      <div className="mt-6 rounded-lg border border-border bg-charcoal p-5 text-background">
+        <p className="font-display text-lg font-semibold">{section.script.title}</p>
+        <div className="mt-4 space-y-3 text-sm leading-relaxed text-background/80">
+          {section.script.lines.map((line) => (
+            <p key={line}>{line}</p>
+          ))}
+        </div>
+      </div>
+    )}
+
+    {renderTable(section)}
+  </>
+);
+
+const ArticleBody = ({ article }: { article: BusinessPlaybookArticle }) => (
+  <div className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_20rem]">
+    <article className="min-w-0">
+      <div className="rounded-2xl border border-border bg-background p-5 shadow-elevated sm:p-8">
+        <h2 className="font-display text-2xl font-bold text-foreground">
+          What you will take away
+        </h2>
+        <ul className="mt-5 grid gap-3">
+          {article.keyTakeaways.map((takeaway) => (
+            <li key={takeaway} className="flex items-start gap-3 text-muted-foreground">
+              <span className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-sage-light">
+                <Check className="h-3 w-3 text-sage" />
+              </span>
+              <span>{takeaway}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className="mt-10 space-y-10">
+        {article.sections.map((section) => (
+          <section key={section.heading} className="scroll-mt-24">
+            <h2 className="font-display text-2xl font-bold text-foreground">
+              {section.heading}
+            </h2>
+            <div className="mt-4 space-y-4 text-base leading-8 text-muted-foreground">
+              {section.body.map((paragraph) => (
+                <p key={paragraph}>{paragraph}</p>
+              ))}
+            </div>
+            {renderSectionVisuals(section)}
+          </section>
+        ))}
+      </div>
+    </article>
+
+    <aside className="space-y-5 lg:sticky lg:top-24 lg:self-start">
+      <div className="rounded-xl border border-border bg-background p-5 shadow-sm">
+        <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+          Visual summary
+        </p>
+        <h2 className="mt-2 font-display text-xl font-bold text-foreground">
+          {article.visualSummary.title}
+        </h2>
+        <div className="mt-4 grid gap-3">
+          {article.visualSummary.items.map((item) => (
+            <div key={item.label} className="rounded-lg border border-border bg-muted/20 p-4">
+              <div className="flex items-center gap-3">
+                <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-bold text-primary">
+                  {item.label}
+                </span>
+                <p className="font-semibold text-foreground">{item.value}</p>
+              </div>
+              <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                {item.description}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-border bg-muted/20 p-5">
+        <p className="font-display text-lg font-semibold text-foreground">
+          Ready for machine fit help?
+        </p>
+        <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+          Use what you learned here, then bring your venue, budget, and timeline into
+          the quote conversation.
+        </p>
+        <div className="mt-4 grid gap-2">
+          <Button asChild>
+            <Link to={article.primaryCta.href}>
+              {article.primaryCta.label}
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Link>
+          </Button>
+          {article.secondaryCta && (
+            <Button asChild variant="outline">
+              <Link to={article.secondaryCta.href}>{article.secondaryCta.label}</Link>
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {article.citations.length > 0 && (
+        <div className="rounded-xl border border-border bg-background p-5">
+          <p className="font-display text-lg font-semibold text-foreground">
+            Sources and further reading
+          </p>
+          <ul className="mt-4 space-y-3">
+            {article.citations.map((citation) => (
+              <li key={citation.url}>
+                <a
+                  href={citation.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="group inline-flex items-start gap-2 text-sm font-medium text-primary hover:underline"
+                >
+                  <span>
+                    {citation.source}: {citation.label}
+                  </span>
+                  <ExternalLink className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </aside>
+  </div>
+);
+
+export default function BusinessPlaybookArticlePage() {
+  const { slug } = useParams();
+  const article = getBusinessPlaybookArticle(slug);
+
+  useEffect(() => {
+    if (!article) return;
+    trackEvent("view_business_playbook_article", {
+      slug: article.slug,
+      category: article.category,
+    });
+  }, [article]);
+
+  if (!article) {
+    return (
+      <Layout>
+        <section className="py-16">
+          <div className="container-page">
+            <div className="mx-auto max-w-2xl rounded-xl border border-border bg-background p-8 text-center">
+              <h1 className="font-display text-3xl font-bold text-foreground">
+                Article not found
+              </h1>
+              <p className="mt-3 text-muted-foreground">
+                The Business Playbook article you are looking for may have moved.
+              </p>
+              <Button asChild className="mt-6">
+                <Link to="/resources/business-playbook">Open the Business Playbook</Link>
+              </Button>
+            </div>
+          </div>
+        </section>
+      </Layout>
+    );
+  }
+
+  const category = getPlaybookCategory(article.category);
+  const relatedArticles = getRelatedBusinessPlaybookArticles(article);
+
+  return (
+    <Layout>
+      <section className="border-b border-border bg-gradient-to-b from-cream to-background py-8 sm:py-10">
+        <div className="container-page">
+          <Link
+            to="/resources/business-playbook"
+            className="inline-flex items-center gap-2 text-sm font-semibold text-primary hover:underline"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Business Playbook
+          </Link>
+
+          <div className="mt-6 grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(22rem,0.8fr)] lg:items-center">
+            <div>
+              <div className="flex flex-wrap items-center gap-2 text-xs font-semibold">
+                {category && (
+                  <span className={`rounded-full px-2.5 py-1 ${category.colorClass}`}>
+                    {category.title}
+                  </span>
+                )}
+                <span className="rounded-full bg-background px-2.5 py-1 text-muted-foreground">
+                  {article.readingTime}
+                </span>
+                <span className="rounded-full bg-background px-2.5 py-1 text-muted-foreground">
+                  Updated {article.updatedAt}
+                </span>
+              </div>
+              <h1 className="mt-4 max-w-4xl font-display text-4xl font-bold leading-tight text-foreground sm:text-5xl">
+                {article.title}
+              </h1>
+              <p className="mt-5 max-w-3xl text-lg leading-relaxed text-muted-foreground">
+                {article.description}
+              </p>
+              <div className="mt-6 grid gap-3 text-sm text-muted-foreground sm:grid-cols-2">
+                <div className="rounded-lg border border-border bg-background/70 p-4">
+                  <p className="font-semibold text-foreground">Audience</p>
+                  <p className="mt-1">{article.audience}</p>
+                </div>
+                <div className="rounded-lg border border-border bg-background/70 p-4">
+                  <p className="font-semibold text-foreground">Machine fit</p>
+                  <p className="mt-1">{article.machineFit}</p>
+                </div>
+              </div>
+            </div>
+
+            <figure className="overflow-hidden rounded-2xl border border-border bg-background shadow-elevated">
+              <img
+                src={article.heroImage}
+                alt={article.heroImageAlt}
+                width={720}
+                height={520}
+                loading="eager"
+                decoding="async"
+                className="aspect-[4/3] w-full object-cover"
+              />
+              <figcaption className="flex items-center gap-2 border-t border-border px-4 py-3 text-sm text-muted-foreground">
+                <BookOpen className="h-4 w-4 text-primary" />
+                {article.visualLabel}
+              </figcaption>
+            </figure>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-10 sm:py-12 lg:py-16">
+        <div className="container-page">
+          <ArticleBody article={article} />
+        </div>
+      </section>
+
+      {relatedArticles.length > 0 && (
+        <section className="border-t border-border bg-muted/20 py-10 sm:py-12 lg:py-16">
+          <div className="container-page">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <h2 className="font-display text-2xl font-bold text-foreground">
+                  Read next
+                </h2>
+                <p className="mt-2 text-muted-foreground">
+                  Keep the plan moving with the next most useful playbook guides.
+                </p>
+              </div>
+              <Button asChild variant="outline">
+                <Link to="/resources/business-playbook">View all guides</Link>
+              </Button>
+            </div>
+
+            <div className="mt-6 grid gap-5 md:grid-cols-3">
+              {relatedArticles.map((related) => (
+                <Link
+                  key={related.slug}
+                  to={`/resources/business-playbook/${related.slug}`}
+                  className="group overflow-hidden rounded-xl border border-border bg-background transition-[box-shadow,transform,border-color] duration-200 hover:-translate-y-1 hover:border-primary/50 hover:shadow-elevated"
+                >
+                  <div className="aspect-[16/10] overflow-hidden bg-muted">
+                    <img
+                      src={related.heroImage}
+                      alt={related.heroImageAlt}
+                      loading="lazy"
+                      decoding="async"
+                      className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+                    />
+                  </div>
+                  <div className="p-5">
+                    <p className="text-xs font-semibold uppercase tracking-[0.12em] text-primary">
+                      {related.visualLabel}
+                    </p>
+                    <h3 className="mt-2 font-display text-lg font-bold leading-tight text-foreground group-hover:text-primary">
+                      {related.shortTitle}
+                    </h3>
+                    <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                      {related.description}
+                    </p>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+    </Layout>
+  );
+}

--- a/src/pages/resources/BusinessPlaybookIndex.tsx
+++ b/src/pages/resources/BusinessPlaybookIndex.tsx
@@ -1,0 +1,205 @@
+import { Link } from "react-router-dom";
+import { ArrowRight, BookOpen, ClipboardCheck, MapPinned, Sparkles } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Layout } from "@/components/layout/Layout";
+import {
+  businessPlaybookArticles,
+  featuredBusinessPlaybookArticles,
+  getPlaybookCategory,
+  playbookCategories,
+} from "@/data/businessPlaybook";
+
+const categoryIcons = {
+  start: BookOpen,
+  locations: MapPinned,
+  budget: ClipboardCheck,
+  events: Sparkles,
+  setup: ClipboardCheck,
+};
+
+export default function BusinessPlaybookIndexPage() {
+  return (
+    <Layout>
+      <section className="border-b border-border bg-gradient-to-b from-cream to-background py-10 sm:py-12">
+        <div className="container-page">
+          <div className="grid gap-8 lg:grid-cols-[minmax(0,1.05fr)_minmax(22rem,0.95fr)] lg:items-start">
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-[0.14em] text-primary">
+                Bloomjoy Business Playbook
+              </p>
+              <h1 className="mt-4 max-w-3xl font-display text-4xl font-bold leading-tight text-foreground sm:text-5xl">
+                Practical startup guides for cotton candy operators
+              </h1>
+              <p className="mt-5 max-w-2xl text-lg leading-relaxed text-muted-foreground">
+                Useful, visual, operator-minded articles for planning a vending placement,
+                pitching locations, budgeting launch costs, and deciding whether commercial
+                vending or event service is the better path.
+              </p>
+              <div className="mt-7 flex flex-wrap gap-3">
+                <Button asChild size="lg">
+                  <Link to="/resources/business-playbook/how-to-start-cotton-candy-vending-business">
+                    Start with the launch guide
+                    <ArrowRight className="ml-2 h-4 w-4" />
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" size="lg">
+                  <Link to="/machines">Compare machines</Link>
+                </Button>
+              </div>
+            </div>
+
+            <div className="overflow-hidden rounded-2xl border border-border bg-background shadow-elevated">
+              <div className="grid grid-cols-2 gap-0">
+                {featuredBusinessPlaybookArticles.map((article, index) => (
+                  <Link
+                    key={article.slug}
+                    to={`/resources/business-playbook/${article.slug}`}
+                    className={
+                      index === 0
+                        ? "group col-span-2 grid min-h-[16rem] overflow-hidden sm:grid-cols-[1fr_0.9fr]"
+                        : "group min-h-[10rem] border-t border-border odd:border-r"
+                    }
+                  >
+                    <div className="relative h-full min-h-[11rem] overflow-hidden bg-muted">
+                      <img
+                        src={article.heroImage}
+                        alt={article.heroImageAlt}
+                        loading={index === 0 ? "eager" : "lazy"}
+                        decoding="async"
+                        className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+                      />
+                    </div>
+                    <div className="flex h-full flex-col justify-between p-5">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-[0.12em] text-primary">
+                          {article.visualLabel}
+                        </p>
+                        <h2 className="mt-2 font-display text-xl font-bold leading-tight text-foreground group-hover:text-primary">
+                          {article.shortTitle}
+                        </h2>
+                      </div>
+                      <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
+                        {article.description}
+                      </p>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-b border-border bg-background py-10 sm:py-12 lg:py-16">
+        <div className="container-page">
+          <div className="grid gap-4 md:grid-cols-5">
+            {playbookCategories.map((category) => {
+              const Icon = categoryIcons[category.id];
+              return (
+                <a
+                  key={category.id}
+                  href={`#${category.id}`}
+                  className="rounded-lg border border-border bg-muted/10 p-4 transition-colors hover:border-primary/60"
+                >
+                  <div
+                    className={`flex h-10 w-10 items-center justify-center rounded-lg ${category.colorClass}`}
+                  >
+                    <Icon className="h-5 w-5" />
+                  </div>
+                  <h2 className="mt-4 font-display text-lg font-semibold text-foreground">
+                    {category.title}
+                  </h2>
+                  <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                    {category.description}
+                  </p>
+                </a>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-10 sm:py-12 lg:py-16">
+        <div className="container-page">
+          <div className="grid gap-10">
+            {playbookCategories.map((category) => {
+              const articles = businessPlaybookArticles.filter(
+                (article) => article.category === category.id
+              );
+              const Icon = categoryIcons[category.id];
+
+              return (
+                <section key={category.id} id={category.id} className="scroll-mt-24">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+                    <div>
+                      <div className="flex items-center gap-3">
+                        <span
+                          className={`flex h-9 w-9 items-center justify-center rounded-lg ${category.colorClass}`}
+                        >
+                          <Icon className="h-4 w-4" />
+                        </span>
+                        <h2 className="font-display text-2xl font-bold text-foreground">
+                          {category.title}
+                        </h2>
+                      </div>
+                      <p className="mt-2 max-w-2xl text-muted-foreground">
+                        {category.description}
+                      </p>
+                    </div>
+                  </div>
+
+                  <div className="mt-6 grid gap-5 md:grid-cols-2 lg:grid-cols-3">
+                    {articles.map((article) => {
+                      const articleCategory = getPlaybookCategory(article.category);
+                      return (
+                        <Link
+                          key={article.slug}
+                          to={`/resources/business-playbook/${article.slug}`}
+                          className="group overflow-hidden rounded-xl border border-border bg-background transition-[box-shadow,transform,border-color] duration-200 hover:-translate-y-1 hover:border-primary/50 hover:shadow-elevated"
+                        >
+                          <div className="aspect-[16/10] overflow-hidden bg-muted">
+                            <img
+                              src={article.heroImage}
+                              alt={article.heroImageAlt}
+                              width={640}
+                              height={400}
+                              loading="lazy"
+                              decoding="async"
+                              className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+                            />
+                          </div>
+                          <div className="p-5">
+                            <div className="flex flex-wrap items-center gap-2 text-xs font-semibold">
+                              {articleCategory && (
+                                <span
+                                  className={`rounded-full px-2.5 py-1 ${articleCategory.colorClass}`}
+                                >
+                                  {articleCategory.title}
+                                </span>
+                              )}
+                              <span className="text-muted-foreground">{article.readingTime}</span>
+                            </div>
+                            <h3 className="mt-3 font-display text-xl font-bold leading-tight text-foreground group-hover:text-primary">
+                              {article.title}
+                            </h3>
+                            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                              {article.description}
+                            </p>
+                            <div className="mt-4 flex items-center text-sm font-semibold text-primary">
+                              Read guide
+                              <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover:translate-x-1" />
+                            </div>
+                          </div>
+                        </Link>
+                      );
+                    })}
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+    </Layout>
+  );
+}

--- a/vercel.json
+++ b/vercel.json
@@ -53,7 +53,7 @@
       "status": 308
     },
     {
-      "src": "/(machines(?:/.*)?|products(?:/.*)?|supplies|plus|resources|about|contact|privacy|terms|billing-cancellation|cart)",
+      "src": "/(machines(?:/.*)?|products(?:/.*)?|supplies|plus|resources(?:/.*)?|about|contact|privacy|terms|billing-cancellation|cart)",
       "has": [
         {
           "type": "host",
@@ -98,6 +98,14 @@
     {
       "src": "/machines/(commercial-robotic-machine|mini|micro)/?",
       "dest": "/machines/$1.html"
+    },
+    {
+      "src": "/resources/business-playbook/?",
+      "dest": "/resources/business-playbook.html"
+    },
+    {
+      "src": "/resources/business-playbook/([^/]+)/?",
+      "dest": "/resources/business-playbook/$1.html"
     },
     {
       "src": "/(machines|supplies|plus|resources|about|contact|privacy|terms|billing-cancellation)/?",


### PR DESCRIPTION
## Summary
- Adds the public Bloomjoy Business Playbook under `/resources/business-playbook` with seven operator-led starter guides.
- Redesigns `/resources` into a playbook-first hub with category discovery, visual cards, FAQs, support boundaries, and CTAs.
- Extends SEO/prerender/sitemap coverage and adds contextual playbook CTAs across buyer flows.

## Files changed
- `src/data/businessPlaybook.ts`: static v1 article model, citations, visuals, CTAs, and seven launch articles.
- `src/pages/resources/*`, `src/pages/Resources.tsx`: playbook index, article renderer, and Resources hub redesign.
- `src/lib/seoRoutes.ts`, `scripts/seo-regression-check.mjs`, `public/sitemap.xml`, `vercel.json`: metadata, JSON-LD, prerender, sitemap, and routing checks.
- `src/pages/Contact.tsx`, `src/pages/Products.tsx`, `src/pages/products/*`, `src/pages/Plus.tsx`: contextual buyer-flow links into the playbook.
- `Docs/BUSINESS_PLAYBOOK_CONTENT_BRIEF.md`, `Docs/QA_SMOKE_TEST_CHECKLIST.md`: editorial standard and smoke coverage.

## Verification commands + results
- `npm ci` - passed, 0 vulnerabilities.
- `npm run build` - passed; prerendered 21 public routes and SEO head tags for 19 private routes.
- `npm test --if-present` - passed; no test script output.
- `npm run lint --if-present` - passed with existing Fast Refresh warnings in existing UI/Auth files.
- `npm run seo:check` - passed; 21 public routes and 19 private routes validated.
- Browser QA - passed desktop/mobile checks for `/resources`, `/resources/business-playbook`, article pages, machine-page CTAs, `/plus`, metadata, console errors, and horizontal overflow.

## How to test
1. `npm ci`
2. In PowerShell, run: `$env:VITE_SUPABASE_URL=https://example.supabase.co; $env:VITE_SUPABASE_ANON_KEY=local-anon-key; npm run dev -- --host 127.0.0.1 --port 8083`
3. Visit `http://127.0.0.1:8083/resources`
4. Visit `http://127.0.0.1:8083/resources/business-playbook`
5. Visit `http://127.0.0.1:8083/resources/business-playbook/how-to-start-cotton-candy-vending-business`
6. Check contextual links on `/machines`, `/machines/commercial-robotic-machine`, `/machines/mini`, `/machines/micro`, `/plus`, and the contact success state.
7. Run `npm run seo:check` and verify article canonical, OpenGraph, JSON-LD, and sitemap coverage.

## Notes / risks
- V1 is intentionally static repo-managed content, not a CMS.
- Public content ships first; downloadable Plus tools and calculators remain follow-up work in #340 and #341.
- CMS evaluation remains a later owner decision in #342.
- PR #155 remains parked; this work does not depend on its attribution, lead scoring, or automation changes.

Closes #334
Closes #335
Closes #336
Closes #337
Closes #338
Closes #339