### PR TITLE
Harden Vite env exposure

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -5,8 +5,13 @@ const requiredClientEnvKeys = [
 
 type RequiredClientEnvKey = (typeof requiredClientEnvKeys)[number];
 
+const requiredClientEnv: Record<RequiredClientEnvKey, string | undefined> = {
+  VITE_SUPABASE_URL: import.meta.env.VITE_SUPABASE_URL,
+  VITE_SUPABASE_ANON_KEY: import.meta.env.VITE_SUPABASE_ANON_KEY,
+};
+
 const readRequiredClientEnv = (key: RequiredClientEnvKey): string => {
-  const value = import.meta.env[key];
+  const value = requiredClientEnv[key];
 
   if (typeof value !== 'string' || value.trim().length === 0) {
     throw new Error(


### PR DESCRIPTION
## Summary
- Harden Vite client config so required public env reads are explicit instead of using dynamic `import.meta.env[key]` access.
- Verified fake Stripe/Vimeo server sentinels and unused fake `VITE_STRIPE_*` values do not appear in the production bundle after the change.
- Confirmed commerce secrets are present in the Supabase project where the Edge Functions read them; Vercel cleanup recommendations are listed below.

## Files changed
- `src/lib/config.ts`: replaces dynamic Vite env lookup with explicit `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` reads.

## Security audit notes
- Current architecture keeps Stripe checkout/webhook code in Supabase Edge Functions, with server-only values read through `Deno.env` in `supabase/functions/*`.
- The Vercel screenshot includes Stripe and Vimeo values that this Vite app does not need at build/runtime. Those should either be removed from Vercel or re-added as Sensitive variables for Preview/Production if there is a separate Vercel-only reason to keep them.
- `VITE_STRIPE_PUBLISHABLE_KEY_TEST` and `VITE_STRIPE_PUBLISHABLE_KEY_LIVE` are public by definition, but they are unused by this repo today.
- `VITE_GOOGLE_CLIENT_ID` is public; protect it through Google OAuth origin and redirect restrictions rather than treating it as a secret.

## Verification commands + results
- `npm ci`: pass; 0 vulnerabilities. One upstream `glob` deprecation warning.
- `npm run build`: pass with dummy public Supabase env values and fake sentinel env values for Stripe/Vimeo exposure testing.
- `rg` over `dist`: pass; no fake Stripe secret, Stripe webhook, Vimeo token/app-secret, or unused `VITE_STRIPE_*` sentinels found after the patch. Expected public Supabase anon and Google client ID sentinels were present.
- `npm test --if-present`: pass; no test script configured.
- `npm run lint --if-present`: pass with existing fast-refresh warnings only.
- `npm run edge-url-allowlists:check`: pass.
- `npm run commerce:preflight -- --project-ref ygbzkgxktzqsiygjlqyg`: pass for remote Supabase secret presence. Warning: remote inspection validates presence only.
- `npm run commerce:preflight`: expected local failure in this fresh worktree because no local `.env` secrets are present.
- `npm run auth:preflight`: expected local failure in this fresh worktree because `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` are not locally configured.

## How to test
1. From `C:\Repos\wt-security-secrets-check`, run `npm ci`.
2. Set local public values for `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` in `.env.local` or in the shell.
3. Run `npm run build`.
4. Optional exposure check: set fake `VITE_STRIPE_PUBLISHABLE_KEY_TEST`, `STRIPE_SECRET_KEY_TEST`, `STRIPE_WEBHOOK_SECRET_TEST`, `VIMEO_ACCESS_TOKEN`, and `VIMEO_APP_SECRET` values, rebuild, then confirm the Stripe/Vimeo sentinels do not appear in `dist`.
5. Run `npm run dev` and open `http://localhost:8080`, `http://localhost:8080/login`, `http://localhost:8080/cart`, and `http://localhost:8080/plus`.

Test credentials: none required for this env-exposure check.