### PR TITLE
Add Business Playbook sales enablement library

### DIFF
--- a/Docs/BUSINESS_PLAYBOOK_CONTENT_BRIEF.md
+++ b/Docs/BUSINESS_PLAYBOOK_CONTENT_BRIEF.md
@@ -5,6 +5,8 @@ The Bloomjoy Business Playbook is the public resource hub for people exploring c
 
 The content should help a serious buyer make a better business decision before they request a quote. It should feel practical, visual, operator-led, and enjoyable to read.
 
+Internal sales/support enablement for these articles lives in `Docs/BUSINESS_PLAYBOOK_SALES_ENABLEMENT.md`.
+
 ## Editorial Standard
 - Be useful first. Every article needs specific examples, checklists, tables, scripts, scorecards, or decision frameworks.
 - Keep the voice practical, confident, clear, and lightly playful where natural.

--- a/Docs/BUSINESS_PLAYBOOK_SALES_ENABLEMENT.md
+++ b/Docs/BUSINESS_PLAYBOOK_SALES_ENABLEMENT.md
@@ -1,0 +1,154 @@
+# Bloomjoy Business Playbook Sales Enablement
+
+## Purpose
+This is the internal sales and support companion to the public Bloomjoy Business Playbook.
+
+Use it when a buyer asks how to start, budget, choose a machine, find a location, pitch a venue, plan events, or handle basic business setup. The goal is to answer helpfully first, then guide the buyer to the right next step without turning every reply into a hard sell.
+
+Owner: Marketing/CMO maintains this library with Sales and Operations input.
+
+Maintenance:
+- Review monthly with the Business Playbook analytics review.
+- Update snippets when article URLs, pricing, Plus benefits, reporting availability, or support boundaries change.
+- Keep snippets short enough for email, SMS, chat, or CRM notes.
+- Keep legal, tax, insurance, permit, and ROI language cautious. Point buyers to official/local sources instead of making promises.
+
+## How to Use
+1. Identify the buyer's main question and where they are in the journey.
+2. Send one primary article, not a pile of links.
+3. Add one practical next step: quote call, machine comparison, supplies planning, Plus after launch, or local verification.
+4. Ask one useful follow-up question if needed.
+5. Keep the tone operator-first: "Here is how we would think about it" beats "Buy now."
+
+## Response Matrix
+| Buyer question | Primary article | Best next step | When to recommend quote, Plus, supplies, or reporting |
+| --- | --- | --- | --- |
+| How do I start a vending business? | [How to Start a Cotton Candy Vending Business](https://www.bloomjoyusa.com/resources/business-playbook/how-to-start-cotton-candy-vending-business) | Ask about target venue type, city/state, timeline, and whether they already have a location lead. | Recommend a quote call once they have a likely venue type, target launch window, or machine preference. Mention Plus later as the operator layer after machine purchase. |
+| What should I budget for? | [Startup Budget Checklist](https://www.bloomjoyusa.com/resources/business-playbook/startup-budget-checklist-cotton-candy-machine-business) | Ask which machine they are considering and whether they are planning vending, events, or both. | Recommend quote when they need machine, shipping, opening supplies, or configuration assumptions. Mention supplies because opening inventory affects the real launch budget. |
+| Where should I place a commercial machine? | [How to Find Good Locations](https://www.bloomjoyusa.com/resources/business-playbook/best-locations-for-cotton-candy-vending-machines) | Ask for the venue category, expected foot traffic, audience, and operating constraints. | Recommend Commercial quote when the location has steady dwell time, visibility, power, staff/maintenance access, and owner interest. |
+| How do I pitch a location owner? | [How to Pitch a Location Owner](https://www.bloomjoyusa.com/resources/business-playbook/how-to-pitch-location-owners) | Help them frame the venue benefit, then ask whether they need a simple intro script or machine spec context. | Recommend quote once the venue asks about footprint, power, wrap, support, setup, or commercial terms. |
+| Should I choose Commercial, Mini, or Micro? | [Commercial Vending vs. Event Catering](https://www.bloomjoyusa.com/resources/business-playbook/commercial-vending-vs-event-catering) | Ask whether their revenue path is unattended placement, staffed events, low-volume validation, or a mix. | Recommend quote when they need final machine fit. Mention Commercial for high-traffic placement, Mini for portable/event use, and Micro for basic-shape low-volume validation. |
+| Can I use Mini or Micro for events or catering? | [Mini/Micro Event Business Guide](https://www.bloomjoyusa.com/resources/business-playbook/mini-micro-event-catering-business-guide) | Ask what event types they want, expected servings per event, staffing, travel radius, and setup constraints. | Recommend Mini quote when portability and pattern capability matter. Recommend Micro only when basic shapes and lower-volume service are acceptable. |
+| What business setup steps should I research? | [Business Setup Basics](https://www.bloomjoyusa.com/resources/business-playbook/business-setup-basics-llc-ein-insurance-permits) | Tell them to verify entity, EIN, banking, insurance, permits, and venue requirements locally. | Do not provide legal/tax advice. Recommend quote only for machine fit; recommend local professional/government sources for setup requirements. |
+| What does Bloomjoy help with vs. what should I verify locally? | [Business Setup Basics](https://www.bloomjoyusa.com/resources/business-playbook/business-setup-basics-llc-ein-insurance-permits) | Explain Bloomjoy helps with machine fit, operating guidance, supplies, training/Plus, and support boundaries. | Recommend Plus for onboarding/training/concierge after launch. Recommend reporting only when assigned-machine reporting is connected to the account. Local legal, tax, insurance, and permits remain buyer-owned. |
+| I have a venue interested. What do I send them? | [How to Pitch a Location Owner](https://www.bloomjoyusa.com/resources/business-playbook/how-to-pitch-location-owners) | Ask for the venue type and what the owner asked for: revenue share, footprint, support, cleanliness, or customer experience. | Recommend quote call if the owner needs machine specs, availability, configuration, custom wrap, support boundaries, or purchase timing. |
+| I am ready to buy supplies or plan opening inventory. | [Startup Budget Checklist](https://www.bloomjoyusa.com/resources/business-playbook/startup-budget-checklist-cotton-candy-machine-business) | Ask expected opening volume, machine model, and whether they need sugar, sticks, or custom/branded sticks. | Send supplies path when they are planning launch inventory. Mention Plus only if they ask about operator training, checklists, or ongoing support. |
+
+## When to Recommend Each Next Step
+- Quote call: The buyer has a venue, event plan, timeline, machine preference, budget question, shipping question, or spec/configuration question.
+- Plus: The buyer is asking about onboarding, training, daily operation, maintenance checklists, troubleshooting, reporting access, or post-purchase confidence.
+- Supplies: The buyer is budgeting launch inventory, replenishment, sugar/stick setup, or custom/branded sticks.
+- Reporting: The buyer already owns or is planning assigned machines and asks about sales visibility. Keep it conditional: reporting access depends on account setup and connected machines.
+- Local verification: The buyer asks about LLCs, EINs, tax, insurance, licenses, permits, food handling rules, contracts, or venue-specific compliance.
+
+## Support Boundary Language
+Use this framing when a buyer asks what Bloomjoy will handle:
+
+Bloomjoy can help with:
+- Choosing the right machine for the use case.
+- Quote assumptions, shipping context, opening supplies, and configuration questions.
+- Practical operator guidance based on Bloomjoy's machine experience.
+- Plus onboarding, task guides, maintenance checklists, troubleshooting references, and reporting access where available.
+
+The buyer should verify:
+- Business entity, EIN, tax, banking, and insurance decisions.
+- State, county, city, event, venue, and food-service requirements.
+- Local permits, inspections, health department expectations, and contract terms.
+- Financial projections, profit assumptions, and legal obligations.
+
+Avoid:
+- Promising income, ROI, payback periods, or location performance.
+- Saying an LLC, EIN, permit, insurance policy, or license is definitely required or not required.
+- Presenting Bloomjoy as legal, tax, insurance, or local compliance counsel.
+- Sending every article at once.
+
+## Reusable Reply Snippets
+Replace bracketed fields before sending. Keep the article link and one follow-up question.
+
+### SNIP-01: Starting A Vending Business
+Great question. The cleanest way to start is to think in pieces: machine fit, location strategy, launch budget, basic business setup, supplies, and the weekly operating rhythm.
+
+I would start here: [How to Start a Cotton Candy Vending Business](https://www.bloomjoyusa.com/resources/business-playbook/how-to-start-cotton-candy-vending-business). It is practical and walks through the first launch without assuming you already know the vending world.
+
+What kind of location are you imagining first: mall/retail, entertainment venue, tourist spot, school/community venue, or something else?
+
+### SNIP-02: Budget Planning
+You are right to ask about budget before choosing only by machine price. The machine is one line item; launch planning should also include opening supplies, payment/setup needs, delivery, maintenance rhythm, insurance/permits to research locally, and a small operating buffer.
+
+This guide is the best starting point: [Startup Budget Checklist](https://www.bloomjoyusa.com/resources/business-playbook/startup-budget-checklist-cotton-candy-machine-business).
+
+If you tell me which model you are considering and whether this is for vending, events, or both, I can help you think through the right quote assumptions.
+
+### SNIP-03: Commercial Location Fit
+For a commercial placement, we usually look for three things before getting excited: enough dwell time, a visible and easy-to-access machine location, and an owner/operator who sees the machine as an experience, not just a snack sale.
+
+This article gives a useful scoring framework: [How to Find Good Locations](https://www.bloomjoyusa.com/resources/business-playbook/best-locations-for-cotton-candy-vending-machines).
+
+What venue type are you evaluating, and do you already know where the machine would physically sit?
+
+### SNIP-04: Location Owner Pitch
+A good venue pitch should make the owner's life easier. Lead with why it fits their guests, where it would sit, how operation/support works, and what the next test would look like.
+
+Here is a practical pitch guide with sample scripts: [How to Pitch a Location Owner](https://www.bloomjoyusa.com/resources/business-playbook/how-to-pitch-location-owners).
+
+If you want, send me the venue type and the owner's main concern, and I can point you to the strongest angle to lead with.
+
+### SNIP-05: Choosing Commercial, Mini, Or Micro
+The best model depends less on "which machine is best" and more on the business model.
+
+Commercial is usually the first fit for high-traffic placements and unattended-style vending. Mini is more natural for portable/event use where you have an operator present. Micro is the compact entry point when basic shapes and lower volume are acceptable.
+
+This comparison is the best starting point: [Commercial Vending vs. Event Catering](https://www.bloomjoyusa.com/resources/business-playbook/commercial-vending-vs-event-catering).
+
+Are you picturing a fixed location, staffed events, or a first test before committing to a bigger setup?
+
+### SNIP-06: Mini/Micro Events Or Catering
+Yes, Mini and Micro can fit event-style businesses, but the operating model matters. You will want to think about event type, setup time, staffing, expected servings, travel radius, and how simple or detailed the cotton candy designs need to be.
+
+Start here: [Mini/Micro Event Business Guide](https://www.bloomjoyusa.com/resources/business-playbook/mini-micro-event-catering-business-guide).
+
+What kind of events are you targeting first: birthdays, school/community events, corporate events, fairs, festivals, or pop-ups?
+
+### SNIP-07: Business Setup Basics
+We can help with machine fit and operator planning, but business setup details need local verification. Entity structure, EIN, banking, insurance, permits, food-service requirements, and venue rules can vary by state, city, county, and event.
+
+This guide gives a good research sequence without pretending to be legal or tax advice: [Business Setup Basics](https://www.bloomjoyusa.com/resources/business-playbook/business-setup-basics-llc-ein-insurance-permits).
+
+Once you know your target location or event type, it is usually easier to ask the right local questions.
+
+### SNIP-08: Bloomjoy Help Vs. Buyer-Owned Work
+The simple version: Bloomjoy helps with machine fit, quote assumptions, operating guidance, supplies, and the operator layer after purchase. You should locally verify business formation, tax, insurance, permits, venue requirements, and financial projections.
+
+This is a helpful overview of the setup side: [Business Setup Basics](https://www.bloomjoyusa.com/resources/business-playbook/business-setup-basics-llc-ein-insurance-permits).
+
+If your next question is about machine fit, send me your target use case and I can help narrow Commercial vs. Mini vs. Micro.
+
+### SNIP-09: Ready For A Quote Conversation
+It sounds like you are close to a quote conversation. The most useful details to bring are: target machine, intended use case, city/state for delivery assumptions, target launch date, opening supply needs, and any venue/event constraints.
+
+Before the call, this guide can help organize the plan: [How to Start a Cotton Candy Vending Business](https://www.bloomjoyusa.com/resources/business-playbook/how-to-start-cotton-candy-vending-business).
+
+If you send over your target machine and timeline, we can help confirm the right quote path.
+
+### SNIP-10: Plus, Training, And Reporting
+The public Playbook is designed to help you plan before you buy. Bloomjoy Plus is the operator layer after launch: onboarding, task-based guides, maintenance checklists, troubleshooting references, certificate path, concierge support, and reporting access where connected to your account.
+
+If you are still planning the business model, start here: [Commercial Vending vs. Event Catering](https://www.bloomjoyusa.com/resources/business-playbook/commercial-vending-vs-event-catering).
+
+If you are already thinking about operating rhythm, support, or reporting, we can talk through whether Plus makes sense for your setup.
+
+## Brand Voice Checklist
+Before sending a reply, check:
+- Does this answer the buyer's actual question first?
+- Did we send one best article instead of overwhelming them?
+- Does the reply sound like a helpful operator, not a generic sales script?
+- Did we avoid ROI, income, legal, tax, insurance, and permit overclaims?
+- Is the next step clear and low-friction?
+- Did we ask one useful follow-up question?
+
+## Internal Maintenance Notes
+- Source of truth: `Docs/BUSINESS_PLAYBOOK_SALES_ENABLEMENT.md`.
+- Related public content standard: `Docs/BUSINESS_PLAYBOOK_CONTENT_BRIEF.md`.
+- Related analytics review: `Docs/BUSINESS_PLAYBOOK_ANALYTICS.md`.
+- If an article is renamed or moved, update the matrix and snippets in the same PR.
+- If Sales keeps answering the same question manually, add a snippet here and consider whether the public Playbook needs a new article or FAQ.


### PR DESCRIPTION
## Summary
- Adds an internal Business Playbook sales enablement library for common buyer questions, article routing, next steps, support boundaries, and brand voice.
- Drafts 10 reusable reply snippets for startup, budgeting, location placement, machine fit, events/catering, business setup, quote readiness, Plus, and reporting conversations.
- Links the public Business Playbook content brief to the internal enablement source of truth.

## Files changed
- `Docs/BUSINESS_PLAYBOOK_SALES_ENABLEMENT.md`: new sales/support matrix, snippets, support boundaries, maintenance rules, and brand voice checklist.
- `Docs/BUSINESS_PLAYBOOK_CONTENT_BRIEF.md`: adds pointer to the internal enablement library.

## Verification commands + results
- `npm ci` - passed; 409 packages installed, 0 vulnerabilities.
- `npm run build` - passed; prerendered 21 public routes and validated SEO head tags for 19 private routes.
- `npm test --if-present` - passed; no test script configured.
- `npm run lint --if-present` - passed with existing fast-refresh warnings in shared UI/context files.
- `npm run seo:check` - passed; 21 public routes and 19 private routes validated.

## How to test
1. Check out `agent/playbook-sales-enablement`.
2. Run `npm ci`.
3. Run `npm run build` and `npm run seo:check` to confirm no site regressions.
4. Open `Docs/BUSINESS_PLAYBOOK_SALES_ENABLEMENT.md` and verify the response matrix maps each buyer question to one primary article and one next step.
5. Review the snippets for Bloomjoy voice, support boundaries, and practical usefulness before sharing with Sales/Support.

Closes #350