### PR TITLE
Add Business Playbook launch campaign plan

### DIFF
--- a/Docs/BUSINESS_PLAYBOOK_CONTENT_BRIEF.md
+++ b/Docs/BUSINESS_PLAYBOOK_CONTENT_BRIEF.md
@@ -7,6 +7,8 @@ The content should help a serious buyer make a better business decision before t
 
 Internal sales/support enablement for these articles lives in `Docs/BUSINESS_PLAYBOOK_SALES_ENABLEMENT.md`.
 
+Launch and distribution planning lives in `Docs/BUSINESS_PLAYBOOK_LAUNCH_CAMPAIGN.md`.
+
 ## Editorial Standard
 - Be useful first. Every article needs specific examples, checklists, tables, scripts, scorecards, or decision frameworks.
 - Keep the voice practical, confident, clear, and lightly playful where natural.

--- a/Docs/BUSINESS_PLAYBOOK_LAUNCH_CAMPAIGN.md
+++ b/Docs/BUSINESS_PLAYBOOK_LAUNCH_CAMPAIGN.md
@@ -78,7 +78,7 @@ Copy approval note: the site, email, and social copy in this document is the lau
 ### Homepage Or Sitewide Strip
 Headline: `New: Bloomjoy Business Playbook`
 
-Body: `Practical startup, budget, location, and event-planning guides for people exploring cotton candy vending or catering. Built from Bloomjoy's operator experience, not generic business fluff.`
+Body: `Practical startup, budget, location, and event-planning guides for people exploring cotton candy vending or catering, built from Bloomjoy's operator experience.`
 
 CTA: `Read the Playbook`
 
@@ -120,7 +120,7 @@ What should I budget for?
 How do I pitch a location owner?
 Should I choose Commercial, Mini, or Micro?
 
-We built the Bloomjoy Business Playbook to answer those questions in a practical way. It is not a pile of generic startup advice. It is a set of operator-led guides with checklists, examples, pitch notes, budget prompts, and machine-fit guidance based on what Bloomjoy has learned from selling, operating, and supporting machines.
+We built the Bloomjoy Business Playbook to answer those questions in a practical way. It is a set of operator-led guides with checklists, examples, pitch notes, budget prompts, and machine-fit guidance based on what Bloomjoy has learned from selling, operating, and supporting machines.
 
 Start here:
 https://www.bloomjoyusa.com/resources/business-playbook
@@ -130,12 +130,12 @@ If you are already comparing machines or have a location/event in mind, reply wi
 - The Bloomjoy team
 ```
 
-Follow-up email for clickers who do not request a quote, if email tooling supports it:
+Optional follow-up email for warm leads who still need a planning path, if email tooling and consent posture support it:
 
 ```
 Hi [first name],
 
-Saw you were checking out the Bloomjoy Business Playbook. If you are still in planning mode, the most useful next step is usually to pick one path:
+If you are still in planning mode, the most useful next step is usually to pick one path:
 
 Commercial placement: start with location fit and owner pitch.
 Events or catering: start with Mini/Micro event planning.

--- a/Docs/BUSINESS_PLAYBOOK_LAUNCH_CAMPAIGN.md
+++ b/Docs/BUSINESS_PLAYBOOK_LAUNCH_CAMPAIGN.md
@@ -1,0 +1,252 @@
+# Bloomjoy Business Playbook Launch Campaign
+
+## Purpose
+Turn the Bloomjoy Business Playbook into an active marketing and sales asset, not just a resources page.
+
+The launch should feel like Bloomjoy opening the operator notebook: useful, friendly, visual, practical, and generous with what we have learned from running machines ourselves. The campaign should help buyers feel more prepared before they ask for a quote, while giving Sales a clean way to answer common questions without sounding scripted.
+
+Owner: Marketing/CMO owns launch execution and measurement. Sales owns day-to-day use in lead follow-up. Operations should review any operator guidance before broad distribution.
+
+Assumed launch window: May 2026 after production deployment of the Business Playbook and sales enablement library.
+
+## Core Message
+Bloomjoy does not just sell cotton candy machines. We operate them, support partners, and help new operators think through the business before they buy.
+
+Use this message across channels:
+
+> We built the Bloomjoy Business Playbook for people who are seriously exploring cotton candy vending, events, or catering. It pulls together practical startup guidance, location strategy, budget planning, pitch scripts, and machine-fit notes from the way Bloomjoy actually operates and supports machines.
+
+Short version:
+
+> Starting a cotton candy vending or event business? The Bloomjoy Business Playbook gives you the practical planning notes we wish every new operator had before buying a machine.
+
+## Primary Launch Goals
+- Help serious buyers answer their first business questions before they request a quote.
+- Give Sales one useful article and one clear next step for common questions.
+- Increase quote intent from educated prospects without pushing every reader into a hard sell.
+- Learn which buyer paths drive the most useful downstream conversations: Commercial placement, Mini/Micro events, budget planning, business setup, or location pitching.
+
+## Audience Map
+| Audience | Likely question | Best article | Primary next step |
+| --- | --- | --- | --- |
+| New vending-curious leads | "How do I even start?" | [How to Start a Cotton Candy Vending Business](https://www.bloomjoyusa.com/resources/business-playbook/how-to-start-cotton-candy-vending-business) | Ask target venue type, city/state, timeline, and machine preference. |
+| Commercial placement prospects | "Where would this machine work?" | [How to Find Good Locations](https://www.bloomjoyusa.com/resources/business-playbook/best-locations-for-cotton-candy-vending-machines) | Invite a quote conversation once they have a likely venue or owner interest. |
+| Venue pitch prospects | "How do I convince a location owner?" | [How to Pitch a Location Owner](https://www.bloomjoyusa.com/resources/business-playbook/how-to-pitch-location-owners) | Ask what the owner cares about: footprint, experience, support, cleanliness, or commercial terms. |
+| Budget-conscious buyers | "What will this really cost to launch?" | [Startup Budget Checklist](https://www.bloomjoyusa.com/resources/business-playbook/startup-budget-checklist-cotton-candy-machine-business) | Help define quote assumptions and opening supply needs. |
+| Mini/Micro event operators | "Can I build an event or catering business?" | [Mini/Micro Event Business Guide](https://www.bloomjoyusa.com/resources/business-playbook/mini-micro-event-catering-business-guide) | Ask event type, serving expectations, staffing, and portability needs. |
+| Machine-fit shoppers | "Commercial, Mini, or Micro?" | [Commercial Vending vs. Event Catering](https://www.bloomjoyusa.com/resources/business-playbook/commercial-vending-vs-event-catering) | Route to a machine-fit quote conversation when the use case is clear. |
+| Setup researchers | "Do I need an LLC, EIN, insurance, or permits?" | [Business Setup Basics](https://www.bloomjoyusa.com/resources/business-playbook/business-setup-basics-llc-ein-insurance-permits) | Remind them to verify legal, tax, insurance, permit, and venue requirements locally. |
+
+## Launch Sequence
+### Pre-Launch: 1-2 Business Days Before Announcement
+- Confirm production URLs load for `/resources`, `/resources/business-playbook`, and all 7 article routes.
+- Confirm Sales has `Docs/BUSINESS_PLAYBOOK_SALES_ENABLEMENT.md` and knows to send one best article per reply.
+- Confirm email audience list: existing leads, warm quote prospects, Mini/Micro inquiries, Commercial placement inquiries, and operators asking about Plus/reporting.
+- Pick visuals for launch assets: real machine photos, article screenshots, table/checklist snippets, location scorecard, and budget worksheet preview.
+- Verify analytics events are visible in local or production analytics: article views, CTA clicks, buyer flow clicks, and contact submissions from Playbook sources.
+
+### Launch Day
+- Add the Playbook announcement to owned channels:
+  - Resources page feature already exists; use homepage or sitewide placement only if there is room without distracting from quote conversion.
+  - Send one email to warm leads and prior inquiries.
+  - Publish the founder/operator launch post.
+  - Tell Sales to use the enablement matrix for inbound replies starting the same day.
+- Check all linked URLs in email/social drafts before sending.
+- Monitor contact submissions and buyer questions for confusing copy, missing article coverage, or broken expectations.
+
+### Week 1
+- Publish 3-4 social/founder posts, each anchored to one practical article.
+- Use Playbook links in quote follow-up and "how do I start?" replies.
+- Review the first 7 days by article views, CTA clicks, and Sales feedback.
+
+### Week 2
+- Publish 3-4 more posts focused on location pitching, budget planning, and events.
+- Send a short follow-up to leads who clicked but did not request a quote if the CRM/email tool supports compliant segmentation.
+- Identify one content gap from repeated buyer questions.
+
+### 30-Day Review
+- Owner: Marketing/CMO.
+- Target review date if launched May 1, 2026: June 1, 2026.
+- Inputs: analytics events, quote-source notes, Sales feedback, article-level engagement, and top objections.
+- Decisions: update CTAs, create a missing article/FAQ, prioritize Plus downloads (#340), or prioritize interactive tools (#341).
+
+## Site Placement Copy
+Use only if the page has room without hurting the main buyer flow.
+
+Copy approval note: the site, email, and social copy in this document is the launch-ready owner review set. PR approval is the final copy approval checkpoint before public send; sender, audience, and visual choices still need the operational checks listed at the end of this document.
+
+### Homepage Or Sitewide Strip
+Headline: `New: Bloomjoy Business Playbook`
+
+Body: `Practical startup, budget, location, and event-planning guides for people exploring cotton candy vending or catering. Built from Bloomjoy's operator experience, not generic business fluff.`
+
+CTA: `Read the Playbook`
+
+URL: `https://www.bloomjoyusa.com/resources/business-playbook`
+
+### Resources Page Feature
+Headline: `Start smarter with the Bloomjoy Business Playbook`
+
+Body: `Use practical guides, budget examples, location scorecards, pitch scripts, and machine-fit notes before you request a quote.`
+
+CTA: `Open the Business Playbook`
+
+URL: `https://www.bloomjoyusa.com/resources/business-playbook`
+
+### Quote Follow-Up Line
+`Before our quote conversation, this guide can help you organize the business side: machine fit, location plan, opening supplies, basic setup questions, and the first operating rhythm.`
+
+## Email Launch Copy
+Audience: existing leads, warm quote prospects, and people who have asked how to start a vending or event business.
+
+Subject options:
+- `New from Bloomjoy: the Business Playbook`
+- `Thinking about cotton candy vending? Start here.`
+- `The operator notes behind a smarter Bloomjoy launch`
+
+Preheader:
+`Practical guides for startup planning, location pitching, budget questions, events, and machine fit.`
+
+Email body:
+
+```
+Hi [first name],
+
+A lot of people come to Bloomjoy with the same good questions:
+
+How do I start a vending business?
+Where should I place a machine?
+What should I budget for?
+How do I pitch a location owner?
+Should I choose Commercial, Mini, or Micro?
+
+We built the Bloomjoy Business Playbook to answer those questions in a practical way. It is not a pile of generic startup advice. It is a set of operator-led guides with checklists, examples, pitch notes, budget prompts, and machine-fit guidance based on what Bloomjoy has learned from selling, operating, and supporting machines.
+
+Start here:
+https://www.bloomjoyusa.com/resources/business-playbook
+
+If you are already comparing machines or have a location/event in mind, reply with the setup you are considering and we can point you to the best next step.
+
+- The Bloomjoy team
+```
+
+Follow-up email for clickers who do not request a quote, if email tooling supports it:
+
+```
+Hi [first name],
+
+Saw you were checking out the Bloomjoy Business Playbook. If you are still in planning mode, the most useful next step is usually to pick one path:
+
+Commercial placement: start with location fit and owner pitch.
+Events or catering: start with Mini/Micro event planning.
+Budget planning: start with opening supplies, delivery assumptions, and operating buffer.
+
+Reply with the path you are considering and we can point you to the right guide or quote conversation.
+
+- The Bloomjoy team
+```
+
+## Social And Founder Post Calendar
+Use real Bloomjoy machine photos, article screenshots, scorecards, checklists, or simple branded visuals. Avoid generic stock photos. Keep posts useful even if someone never clicks.
+
+| Post | Channel | Visual | Copy |
+| --- | --- | --- | --- |
+| 1. Launch announcement | Founder LinkedIn, Instagram, Facebook | Playbook index screenshot plus real machine photo | `People ask us all the time: "How do I start a cotton candy vending business?" So we built the Bloomjoy Business Playbook. It covers startup planning, location fit, budget questions, pitch scripts, Mini/Micro event paths, and the boring-but-important setup research. We sell machines, yes, but we also want operators to make better decisions before they buy. Start here: https://www.bloomjoyusa.com/resources/business-playbook` |
+| 2. Startup path | Founder LinkedIn | First-launch checklist visual | `The first question is not "which machine is coolest?" It is: where will this machine live, who will operate it, what does launch actually require, and what needs local verification? Our startup guide breaks that down in plain English. https://www.bloomjoyusa.com/resources/business-playbook/how-to-start-cotton-candy-vending-business` |
+| 3. Location scoring | LinkedIn, Facebook | Location scorecard or venue checklist | `A great commercial cotton candy machine location usually has dwell time, visibility, easy access, and a venue owner who sees the machine as an experience. We put our location-fit notes into a practical guide for new operators. https://www.bloomjoyusa.com/resources/business-playbook/best-locations-for-cotton-candy-vending-machines` |
+| 4. Budget planning | LinkedIn, email snippet | Budget table preview | `Machine price is only one part of launch planning. Opening supplies, delivery, payment/setup needs, local requirements, and a small operating buffer all matter. This budget checklist helps new operators think beyond the sticker price. https://www.bloomjoyusa.com/resources/business-playbook/startup-budget-checklist-cotton-candy-machine-business` |
+| 5. Venue pitch | LinkedIn, Facebook | Pitch script card | `If you are pitching a location owner, make their decision easier. Lead with guest experience, placement, support, cleanliness, and what the next test would look like. We drafted a practical pitch guide with scripts. https://www.bloomjoyusa.com/resources/business-playbook/how-to-pitch-location-owners` |
+| 6. Mini/Micro events | Instagram, Facebook | Mini/Micro event setup photo or event-day kit visual | `A Mini or Micro path is different from a commercial vending path. You are thinking about staffing, setup time, servings per event, travel radius, and how simple or detailed the cotton candy designs need to be. Here is the event business guide. https://www.bloomjoyusa.com/resources/business-playbook/mini-micro-event-catering-business-guide` |
+| 7. Machine fit | LinkedIn, Facebook | Commercial vs. Mini vs. Micro comparison visual | `Commercial, Mini, or Micro? The best answer depends on the business model: fixed high-traffic placement, staffed events, lower-volume validation, or a mix. This comparison helps buyers narrow the path before a quote call. https://www.bloomjoyusa.com/resources/business-playbook/commercial-vending-vs-event-catering` |
+| 8. Business setup boundary | LinkedIn | Setup research checklist visual | `We can help with machine fit, supplies, operating guidance, training, and support. Business setup still needs local verification: entity, EIN, banking, insurance, permits, and venue rules can vary. We wrote a guide that keeps those boundaries clear. https://www.bloomjoyusa.com/resources/business-playbook/business-setup-basics-llc-ein-insurance-permits` |
+| 9. Helpful operator story | Founder LinkedIn | Real machine/detail photo | `The best buyer conversations usually start with a real plan: "I have a venue," "I want to test events," or "I need to understand my launch budget." The Playbook is designed to help people get to that kind of conversation faster, with less guesswork. https://www.bloomjoyusa.com/resources/business-playbook` |
+| 10. Sales/usefulness reminder | LinkedIn, Facebook | Collage of article visuals | `If you know someone exploring vending, events, or catering with cotton candy machines, send them the Playbook. It is built to answer the early questions honestly before anyone has to sit through a sales pitch. https://www.bloomjoyusa.com/resources/business-playbook` |
+
+## Sales Coordination
+Sales should use `Docs/BUSINESS_PLAYBOOK_SALES_ENABLEMENT.md` as the source of truth.
+
+Rules for lead follow-up:
+- Send one best article, not every article.
+- Add one next step: quote call, machine comparison, supplies planning, Plus after launch, reporting discussion, or local verification.
+- Ask one useful follow-up question.
+- Avoid legal, tax, insurance, permit, ROI, income, or payback promises.
+- Add a simple CRM note such as `sent_playbook_startup`, `sent_playbook_budget`, `sent_playbook_location`, or `sent_playbook_events`.
+
+Suggested lead follow-up mapping:
+- New lead asks "how do I start?" -> send startup guide and ask target venue/timeline.
+- Commercial inquiry -> send location guide or pitch guide depending on whether they have a venue.
+- Mini/Micro inquiry -> send event guide and ask expected event types/servings.
+- Budget inquiry -> send budget checklist and ask machine path/opening inventory needs.
+- Setup/compliance inquiry -> send business setup basics and remind them to verify locally.
+- Existing or near-purchase operator asks about training/reporting -> explain Plus and reporting availability only where connected to account setup.
+
+## Retargeting And Follow-Up Audiences
+Use only if tracking and consent posture support it. Do not send names, emails, phone numbers, free-form messages, or raw lead notes to analytics.
+
+Audience ideas:
+- Playbook visitors: viewed `/resources/business-playbook` or any article.
+- Machine-fit readers: viewed Commercial vs. Event Catering.
+- Commercial placement readers: viewed location guide or pitch guide.
+- Event path readers: viewed Mini/Micro event guide.
+- Budget planners: viewed startup budget checklist.
+- Business setup researchers: viewed setup basics.
+- High-intent clickers: clicked article CTA to contact, machines, Plus, or operator login.
+- Playbook-originated leads: successful contact submissions with normalized `source_page`.
+
+Follow-up use:
+- Send one article-specific follow-up, not a generic sales blast.
+- Suppress recent purchasers from prospecting sends unless the message is about Plus, supplies, training, or reporting.
+- Review audiences weekly for the first 30 days after launch, then monthly.
+
+## Launch QA Checklist
+Before sending public traffic, verify these URLs:
+- `https://www.bloomjoyusa.com/resources`
+- `https://www.bloomjoyusa.com/resources/business-playbook`
+- `https://www.bloomjoyusa.com/resources/business-playbook/how-to-start-cotton-candy-vending-business`
+- `https://www.bloomjoyusa.com/resources/business-playbook/best-locations-for-cotton-candy-vending-machines`
+- `https://www.bloomjoyusa.com/resources/business-playbook/mini-micro-event-catering-business-guide`
+- `https://www.bloomjoyusa.com/resources/business-playbook/startup-budget-checklist-cotton-candy-machine-business`
+- `https://www.bloomjoyusa.com/resources/business-playbook/how-to-pitch-location-owners`
+- `https://www.bloomjoyusa.com/resources/business-playbook/commercial-vending-vs-event-catering`
+- `https://www.bloomjoyusa.com/resources/business-playbook/business-setup-basics-llc-ein-insurance-permits`
+- `https://www.bloomjoyusa.com/contact?type=quote&source=%2Fresources%2Fbusiness-playbook`
+
+QA steps:
+- Load each URL on desktop and mobile.
+- Confirm article cards, visuals, tables, and CTAs are readable.
+- Confirm contact links preserve a normalized Playbook source without query leakage.
+- Confirm social/email links use full production URLs.
+- Confirm no public copy promises income, ROI, specific permits, or legal/tax outcomes.
+- Confirm analytics events are visible for article views, CTA clicks, buyer-flow links, and Playbook-originated contact submissions.
+
+## Measurement Plan
+Owner: Marketing/CMO.
+
+Review schedule:
+- First weekly review: 7 calendar days after launch. If launched May 1, 2026, review May 8, 2026.
+- First 30-day review: June 1, 2026 if launched May 1, 2026.
+- Ongoing cadence: monthly with Sales and Operations feedback.
+
+Core metrics:
+- Playbook index views.
+- Article views by slug.
+- CTA clicks by article and surface.
+- Contact submissions from normalized Playbook source pages.
+- Machine-page Playbook clicks.
+- Plus preview clicks.
+- Sales usage notes by article sent.
+- Qualitative buyer questions Sales keeps answering manually.
+
+Decision rules:
+- High views, low CTA: strengthen the article CTA, add a more practical example, or move a relevant CTA earlier.
+- Low views, high Sales usefulness: add stronger internal links from buyer pages or quote follow-up.
+- High setup questions: improve support boundary copy and link to official/local verification sources.
+- High budget engagement: prioritize Plus/downloadable worksheets from #340.
+- High machine-fit engagement: prioritize interactive fit/budget tools from #341.
+
+## Open Owner Checks Before Send
+- Confirm final sender name and reply-to inbox.
+- Confirm the launch audience list and suppression rules.
+- Confirm whether homepage/sitewide placement should be added now or saved for a later UI PR.
+- Confirm final visuals for social/email from real Bloomjoy assets or approved article screenshots.
+- Confirm whether any paid retargeting is in scope or whether this launch stays owned-channel only.

--- a/Docs/BUSINESS_PLAYBOOK_SALES_ENABLEMENT.md
+++ b/Docs/BUSINESS_PLAYBOOK_SALES_ENABLEMENT.md
@@ -10,7 +10,7 @@ Owner: Marketing/CMO maintains this library with Sales and Operations input.
 Maintenance:
 - Review monthly with the Business Playbook analytics review.
 - Update snippets when article URLs, pricing, Plus benefits, reporting availability, or support boundaries change.
-- Keep snippets short enough for email, SMS, chat, or CRM notes.
+- Keep full snippets email-ready. For SMS, chat, or CRM notes, trim to one helpful point, one article link, and one follow-up question.
 - Keep legal, tax, insurance, permit, and ROI language cautious. Point buyers to official/local sources instead of making promises.
 
 ## How to Use
@@ -64,6 +64,8 @@ Avoid:
 
 ## Reusable Reply Snippets
 Replace bracketed fields before sending. Keep the article link and one follow-up question.
+
+Channel trimming rule: for SMS or chat, use the first useful sentence, the article link, and the final question. Do not paste the full email-style snippet into a short channel.
 
 ### SNIP-01: Starting A Vending Business
 Great question. The cleanest way to start is to think in pieces: machine fit, location strategy, launch budget, basic business setup, supplies, and the weekly operating rhythm.


### PR DESCRIPTION
## Summary
- Adds the Business Playbook launch/distribution campaign plan for owned-channel activation.
- Includes site placement copy, launch email copy, 10 social/founder posts, sales coordination, retargeting audience ideas, launch QA, and measurement cadence.
- Incorporates QA feedback by softening follow-up language, removing negative contrast copy, and clarifying SMS/chat trimming for sales snippets.

## Files changed
- `Docs/BUSINESS_PLAYBOOK_LAUNCH_CAMPAIGN.md`: new CMO/content launch plan and ready-to-review copy set.
- `Docs/BUSINESS_PLAYBOOK_SALES_ENABLEMENT.md`: adds channel-trimming guidance for email vs. SMS/chat use.
- `Docs/BUSINESS_PLAYBOOK_CONTENT_BRIEF.md`: adds pointer to the launch/distribution plan.

## Verification commands + results
- `npm ci` - passed; 409 packages installed, 0 vulnerabilities. Note: npm emitted the existing `glob@10.5.0` deprecation warning.
- `npm run build` - passed; prerendered 21 public routes and SEO head tags for 19 private routes.
- `npm test --if-present` - passed; no test script configured.
- `npm run lint --if-present` - passed with existing fast-refresh warnings in shared UI/context files.
- `npm run seo:check` - passed; 21 public routes and 19 private routes validated.
- Local URL consistency check - passed; Bloomjoy URLs in launch/sales docs match known routes or the allowed contact path.

## How to test
1. Check out `agent/playbook-launch-campaign`.
2. Run `npm ci`.
3. Run `npm run dev` and open the local URL printed by Vite.
4. Spot-check these local routes:
   - `/resources`
   - `/resources/business-playbook`
   - `/resources/business-playbook/how-to-start-cotton-candy-vending-business`
   - `/resources/business-playbook/best-locations-for-cotton-candy-vending-machines`
   - `/resources/business-playbook/mini-micro-event-catering-business-guide`
   - `/resources/business-playbook/startup-budget-checklist-cotton-candy-machine-business`
   - `/resources/business-playbook/how-to-pitch-location-owners`
   - `/resources/business-playbook/commercial-vending-vs-event-catering`
   - `/resources/business-playbook/business-setup-basics-llc-ein-insurance-permits`
   - `/contact?type=quote&source=%2Fresources%2Fbusiness-playbook`
5. Run `npm run build` and `npm run seo:check` to confirm no site regressions.
6. Open `Docs/BUSINESS_PLAYBOOK_LAUNCH_CAMPAIGN.md` and review the launch copy, article links, QA checklist, and measurement plan.
7. Open `Docs/BUSINESS_PLAYBOOK_SALES_ENABLEMENT.md` and confirm the channel-trimming guidance matches Sales usage.
8. Before public send, verify the production URLs listed in the launch QA checklist on desktop and mobile.

Closes #349