### PR TITLE
Add Business Playbook Plus tool previews

### DIFF
--- a/Docs/BUSINESS_PLAYBOOK_CONTENT_BRIEF.md
+++ b/Docs/BUSINESS_PLAYBOOK_CONTENT_BRIEF.md
@@ -9,6 +9,8 @@ Internal sales/support enablement for these articles lives in `Docs/BUSINESS_PLA
 
 Launch and distribution planning lives in `Docs/BUSINESS_PLAYBOOK_LAUNCH_CAMPAIGN.md`.
 
+Plus-ready tool and template planning lives in `Docs/BUSINESS_PLAYBOOK_PLUS_TOOLS.md`.
+
 ## Editorial Standard
 - Be useful first. Every article needs specific examples, checklists, tables, scripts, scorecards, or decision frameworks.
 - Keep the voice practical, confident, clear, and lightly playful where natural.

--- a/Docs/BUSINESS_PLAYBOOK_PLUS_TOOLS.md
+++ b/Docs/BUSINESS_PLAYBOOK_PLUS_TOOLS.md
@@ -1,0 +1,106 @@
+# Bloomjoy Business Playbook Plus Tools
+
+## Purpose
+This is the repo-managed source brief for Plus-ready Business Playbook tools and templates.
+
+Public Business Playbook articles stay indexable and useful on their own. These tools are the deeper operator layer for people who want reusable worksheets, scripts, checklists, and job aids after they move from research into launch planning or live operation.
+
+Owner: Marketing/CMO owns content quality and positioning. Sales and Operations should review tools before member-facing download files are generated.
+
+## Access Decision
+V1 does not add public file downloads and does not add email capture gates.
+
+The site may show public previews of the tools on `/resources` and `/plus`, but the actual downloadable files should live behind Plus/member access when download plumbing is implemented. This keeps public articles indexable, avoids lead-form friction on educational content, and prevents static public files from becoming the source of truth for operator-only materials.
+
+## Tool Catalog
+### Startup Budget Worksheet
+Purpose: help a buyer estimate the full launch picture before a quote call.
+
+Recommended format: PDF plus editable spreadsheet.
+
+Sections:
+- Machine path: Commercial, Mini, Micro, or hybrid.
+- Machine and delivery assumptions.
+- Opening supplies: sugar, sticks, branded sticks, and event kit needs.
+- Local setup checks: entity, banking, insurance, permits, venue requirements, and professional advice reminders.
+- Operating buffer: first replenishment, cleaning supplies, spare parts, travel, storage, and contingency.
+- Quote-call notes: unknowns to confirm with Bloomjoy.
+
+Support boundary:
+- Do not promise profit, ROI, payback period, or location performance.
+- Keep legal, tax, insurance, and permit rows as local verification prompts.
+
+### Location Pitch Script
+Purpose: help Commercial prospects speak to venue owners clearly.
+
+Recommended format: PDF plus copy/paste message snippets.
+
+Sections:
+- Owner opener: short intro, venue fit, and guest experience.
+- Venue benefit prompts: novelty, visual draw, family appeal, low staff burden, and cleanliness/support plan.
+- Site-walk questions: power, placement, visibility, traffic, access, refill rhythm, and manager contact.
+- Objection notes: space, mess, support, revenue share, downtime, and customer experience.
+- Follow-up note: thank-you, machine specs, next step, and quote/setup context.
+
+Support boundary:
+- Avoid guaranteeing venue results or revenue-share outcomes.
+- Make the next action practical: site walk, spec confirmation, or quote conversation.
+
+### Launch Checklist
+Purpose: give new operators a single first-30-days path.
+
+Recommended format: PDF checklist plus portal task list later.
+
+Sections:
+- Before quote: target use case, venue/event path, city/state, opening timeline, and machine fit.
+- Before delivery: power/space check, supplies, payment setup, support contacts, storage, and cleaning plan.
+- First week: refill rhythm, visual inspection, first venue check-in, sales/reporting review where available, and issue log.
+- First 30 days: supply reorder point, owner feedback, customer flow notes, and operator routine.
+
+Support boundary:
+- Treat this as a launch readiness aid, not a compliance checklist.
+- Keep local requirements buyer-owned.
+
+### Daily Operating Checklist
+Purpose: help live operators keep a repeatable routine.
+
+Recommended format: one-page PDF job aid plus portal checklist later.
+
+Sections:
+- Open check: machine condition, product/supply status, payment screen, surrounding area, and signage.
+- Mid-day or visit check: refill, wipe-down, waste, customer flow, and visible issues.
+- Close/check-in: sales/reporting review where available, notes, venue communication, and next restock.
+- Escalation: when to use manufacturer support, Bloomjoy concierge, or internal notes.
+
+Support boundary:
+- Do not turn this into a warranty promise or 24/7 Bloomjoy support promise.
+- Keep reporting language conditional on account setup and connected machines.
+
+### Venue Evaluation Worksheet
+Purpose: help Commercial prospects score locations before overcommitting.
+
+Recommended format: PDF worksheet plus editable scorecard.
+
+Sections:
+- Dwell time and guest fit.
+- Visibility and impulse potential.
+- Footprint, power, and physical access.
+- Staff/refill/maintenance rhythm.
+- Owner readiness and commercial terms.
+- Risk notes and next action.
+
+Scoring guidance:
+- Strong location: visible, high dwell time, easy service access, owner interest, and clear operating rhythm.
+- Caution location: weak visibility, awkward power/access, unclear ownership, or no obvious restock/check-in path.
+
+## Public Preview Rules
+- Show enough detail that buyers understand the value.
+- Do not expose actual gated file URLs from public pages.
+- Link to the most relevant public article for context.
+- Use `Explore Bloomjoy Plus` and `Operator Login` as the main public next steps.
+- Avoid legal/tax/ROI claims in worksheet previews.
+
+## Maintenance
+- Update this doc when template titles, fields, or Plus positioning changes.
+- Keep `src/data/businessPlaybookPlusTools.ts` aligned with this doc.
+- Review with `Docs/BUSINESS_PLAYBOOK_ANALYTICS.md` monthly after launch.

--- a/Docs/DECISIONS.md
+++ b/Docs/DECISIONS.md
@@ -1,5 +1,20 @@
 # Decisions
 
+## 2026-04-29 - Business Playbook Plus tools access model
+Business Playbook public articles stay indexable. Plus-ready worksheets and operator templates may be previewed publicly, but downloadable files should live behind Plus/member access when download plumbing is implemented.
+
+**Canonical choices**
+- Do not add public static file downloads for Plus tools in this slice.
+- Do not add email capture gates to public Business Playbook articles or tool previews.
+- Public pages may show tool previews and link to related public articles, `/plus`, and operator login.
+- The repo-managed source brief for these tools is `Docs/BUSINESS_PLAYBOOK_PLUS_TOOLS.md`.
+- The UI source of truth for public preview metadata is `src/data/businessPlaybookPlusTools.ts`.
+
+**Why this choice**
+- Public articles remain useful and indexable without lead-form friction.
+- Operator-only tools can stay aligned with Plus, training, reporting, and support boundaries.
+- Avoiding public file URLs prevents static assets from becoming stale or bypassing member access later.
+
 ## 2026-04-28 - Preset-first Corporate Partner access model
 Access management will use admin-facing presets backed by source-aware capabilities and scopes, not a visible raw permission matrix.
 

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -63,7 +63,8 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Cart remains sugar-only and has no horizontal overflow on mobile viewports (`360x800`, `390x844`, `414x896`)
 - [ ] Cart line-item title, quantity controls, price, and remove action stack cleanly on mobile
 - [ ] Plus page: pricing and boundaries are visible and clear
-- [ ] Resources page shows Bloomjoy Plus teaser content for locked downloads (procedure docs, daily checklists, frequent updates)
+- [ ] Resources page shows Bloomjoy Plus teaser content for locked downloads, including Plus-ready worksheet/tool previews and reporting access where available
+- [ ] Plus page shows the Business Playbook worksheet/tool preview library and keeps actual downloads positioned as Plus/operator assets rather than public static files
 - [ ] Resources page leads with the Bloomjoy Business Playbook, shows visual article cards, and still exposes FAQ and Support Boundaries anchors
 - [ ] `/resources/business-playbook` direct-loads and shows category navigation plus all public playbook guides
 - [ ] Business Playbook article routes direct-load, show a real Bloomjoy image, useful visual blocks (tables/checklists/scorecards/scripts), source links, related articles, and quote/machine CTAs

--- a/src/components/resources/PlusToolsPreview.tsx
+++ b/src/components/resources/PlusToolsPreview.tsx
@@ -4,10 +4,10 @@ import {
   BarChart3,
   CalendarCheck2,
   ClipboardCheck,
-  Download,
   FileCheck2,
   FileText,
   Lock,
+  LogIn,
   MapPinned,
   MessageSquareText,
   Wrench,
@@ -47,8 +47,8 @@ const extraIcons: Record<PlusOperatorExtra["icon"], typeof ClipboardCheck> = {
 export function PlusToolsPreview({
   surface,
   introLabel = "Bloomjoy Plus Preview",
-  heading = "Plus-ready worksheets for serious operators",
-  description = "Public playbooks help you plan. Plus adds the operator layer: downloadable worksheets, daily job aids, maintenance references, eligible reporting access, and the Operator Essentials path.",
+  heading = "Plus-ready worksheet previews for serious operators",
+  description = "Public playbooks help you plan. Plus adds the operator layer: worksheet previews, daily job aids, maintenance references, connected reporting where enabled, and the Operator Essentials path.",
   showCtas = true,
   operatorLoginUrl,
 }: PlusToolsPreviewProps) {
@@ -188,7 +188,7 @@ export function PlusToolsPreview({
                   })
                 }
               >
-                <Download className="mr-2 h-4 w-4" />
+                <LogIn className="mr-2 h-4 w-4" />
                 Operator Login
               </a>
             </Button>

--- a/src/components/resources/PlusToolsPreview.tsx
+++ b/src/components/resources/PlusToolsPreview.tsx
@@ -1,0 +1,200 @@
+import { Link } from "react-router-dom";
+import {
+  ArrowRight,
+  BarChart3,
+  CalendarCheck2,
+  ClipboardCheck,
+  Download,
+  FileCheck2,
+  FileText,
+  Lock,
+  MapPinned,
+  MessageSquareText,
+  Wrench,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  businessPlaybookPlusTools,
+  plusOperatorExtras,
+  type BusinessPlaybookPlusTool,
+  type PlusOperatorExtra,
+} from "@/data/businessPlaybookPlusTools";
+import { trackPlusPreviewResourceClick } from "@/lib/businessPlaybookAnalytics";
+
+type PlusToolsPreviewProps = {
+  surface: "resources_plus_preview" | "plus_page";
+  introLabel?: string;
+  heading?: string;
+  description?: string;
+  showCtas?: boolean;
+  operatorLoginUrl?: string;
+};
+
+const toolIcons: Record<BusinessPlaybookPlusTool["icon"], typeof ClipboardCheck> = {
+  budget: ClipboardCheck,
+  pitch: MessageSquareText,
+  launch: CalendarCheck2,
+  dailyOps: FileCheck2,
+  venue: MapPinned,
+};
+
+const extraIcons: Record<PlusOperatorExtra["icon"], typeof ClipboardCheck> = {
+  reporting: BarChart3,
+  maintenance: Wrench,
+  certificate: FileText,
+};
+
+export function PlusToolsPreview({
+  surface,
+  introLabel = "Bloomjoy Plus Preview",
+  heading = "Plus-ready worksheets for serious operators",
+  description = "Public playbooks help you plan. Plus adds the operator layer: downloadable worksheets, daily job aids, maintenance references, eligible reporting access, and the Operator Essentials path.",
+  showCtas = true,
+  operatorLoginUrl,
+}: PlusToolsPreviewProps) {
+  return (
+    <div className="mx-auto max-w-6xl">
+      <div className="flex flex-col gap-3 text-center">
+        <p className="text-xs font-semibold uppercase tracking-[0.14em] text-primary">
+          {introLabel}
+        </p>
+        <h2 className="font-display text-2xl font-bold text-foreground sm:text-3xl">
+          {heading}
+        </h2>
+        <p className="mx-auto max-w-3xl text-muted-foreground">{description}</p>
+      </div>
+
+      <div className="mt-8 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {businessPlaybookPlusTools.map((tool) => {
+          const Icon = toolIcons[tool.icon];
+
+          return (
+            <article
+              key={tool.id}
+              className="flex h-full flex-col rounded-xl border border-border bg-background p-5 shadow-sm"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <span
+                  className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg ${tool.accentClass}`}
+                >
+                  <Icon className="h-5 w-5" />
+                </span>
+                <span className="inline-flex items-center gap-1.5 rounded-full border border-border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                  <Lock className="h-3 w-3" />
+                  {tool.formatLabel}
+                </span>
+              </div>
+
+              <div className="mt-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.12em] text-primary">
+                  {tool.categoryLabel}
+                </p>
+                <h3 className="mt-2 font-display text-lg font-bold leading-tight text-foreground">
+                  {tool.title}
+                </h3>
+                <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                  {tool.description}
+                </p>
+              </div>
+
+              <div className="mt-4 rounded-lg bg-muted/25 p-3">
+                <p className="text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+                  Preview includes
+                </p>
+                <ul className="mt-2 space-y-2 text-sm text-muted-foreground">
+                  {tool.previewItems.map((item) => (
+                    <li key={item} className="flex gap-2">
+                      <ClipboardCheck className="mt-0.5 h-4 w-4 shrink-0 text-sage" />
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <p className="mt-4 text-xs leading-relaxed text-muted-foreground">
+                <span className="font-semibold text-foreground">Best for:</span> {tool.bestFor}
+              </p>
+
+              <Link
+                to={tool.articleHref}
+                onClick={() =>
+                  trackPlusPreviewResourceClick({
+                    surface,
+                    cta: `${tool.id}_related_guide`,
+                    href: tool.articleHref,
+                  })
+                }
+                className="mt-auto inline-flex items-center gap-2 pt-5 text-sm font-semibold text-primary hover:underline"
+              >
+                {tool.articleLabel}
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            </article>
+          );
+        })}
+      </div>
+
+      <div className="mt-6 grid gap-3 md:grid-cols-3">
+        {plusOperatorExtras.map((extra) => {
+          const Icon = extraIcons[extra.icon];
+
+          return (
+            <div
+              key={extra.title}
+              className="flex gap-3 rounded-lg border border-border bg-background/70 p-4"
+            >
+              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                <Icon className="h-4 w-4" />
+              </span>
+              <div>
+                <h3 className="font-display text-base font-semibold text-foreground">
+                  {extra.title}
+                </h3>
+                <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                  {extra.description}
+                </p>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {showCtas && (
+        <div className="mt-8 flex flex-wrap justify-center gap-3">
+          <Button asChild>
+            <Link
+              to="/plus"
+              onClick={() =>
+                trackPlusPreviewResourceClick({
+                  surface,
+                  cta: "explore_bloomjoy_plus",
+                  href: "/plus",
+                })
+              }
+            >
+              Explore Bloomjoy Plus
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Link>
+          </Button>
+          {operatorLoginUrl && (
+            <Button asChild variant="outline">
+              <a
+                href={operatorLoginUrl}
+                onClick={() =>
+                  trackPlusPreviewResourceClick({
+                    surface,
+                    cta: "operator_login",
+                    href: operatorLoginUrl,
+                  })
+                }
+              >
+                <Download className="mr-2 h-4 w-4" />
+                Operator Login
+              </a>
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/data/businessPlaybookPlusTools.ts
+++ b/src/data/businessPlaybookPlusTools.ts
@@ -1,0 +1,143 @@
+export type PlusToolIcon =
+  | "budget"
+  | "pitch"
+  | "launch"
+  | "dailyOps"
+  | "venue";
+
+export type BusinessPlaybookPlusTool = {
+  id: string;
+  title: string;
+  categoryLabel: string;
+  formatLabel: string;
+  description: string;
+  bestFor: string;
+  icon: PlusToolIcon;
+  accentClass: string;
+  previewItems: string[];
+  articleLabel: string;
+  articleHref: string;
+};
+
+export type PlusOperatorExtra = {
+  title: string;
+  description: string;
+  icon: "reporting" | "maintenance" | "certificate";
+};
+
+export const businessPlaybookPlusTools: BusinessPlaybookPlusTool[] = [
+  {
+    id: "startup-budget-worksheet",
+    title: "Startup Budget Worksheet",
+    categoryLabel: "Budget and Plan",
+    formatLabel: "Plus worksheet",
+    description:
+      "A launch-budget builder for machine, delivery, opening supplies, local setup checks, and operating buffer assumptions.",
+    bestFor: "Buyers comparing Commercial, Mini, or Micro paths before a quote call.",
+    icon: "budget",
+    accentClass: "bg-amber/10 text-amber",
+    previewItems: [
+      "Machine and delivery assumptions",
+      "Opening sugar, sticks, and event kit lines",
+      "Local setup and operating-buffer prompts",
+    ],
+    articleLabel: "Read budget guide",
+    articleHref:
+      "/resources/business-playbook/startup-budget-checklist-cotton-candy-machine-business",
+  },
+  {
+    id: "location-pitch-script",
+    title: "Location Pitch Script",
+    categoryLabel: "Find Locations",
+    formatLabel: "Plus script",
+    description:
+      "A practical owner-facing pitch framework with opener, venue-benefit notes, objection prompts, and follow-up language.",
+    bestFor: "Commercial placement prospects preparing for a venue conversation.",
+    icon: "pitch",
+    accentClass: "bg-sage-light text-sage",
+    previewItems: [
+      "Owner opener and venue-fit proof points",
+      "Questions for footprint, power, and support",
+      "Follow-up note after a site walk",
+    ],
+    articleLabel: "Read pitch guide",
+    articleHref: "/resources/business-playbook/how-to-pitch-location-owners",
+  },
+  {
+    id: "launch-checklist",
+    title: "Launch Checklist",
+    categoryLabel: "Start the Business",
+    formatLabel: "Plus checklist",
+    description:
+      "A first-30-days checklist for quote prep, delivery readiness, supplies, venue communication, and operating rhythm.",
+    bestFor: "New operators who want one launch plan instead of scattered notes.",
+    icon: "launch",
+    accentClass: "bg-primary/10 text-primary",
+    previewItems: [
+      "Before quote, before delivery, and first-week tasks",
+      "Venue and support contact checkpoints",
+      "Supply, payment, cleaning, and escalation reminders",
+    ],
+    articleLabel: "Read launch guide",
+    articleHref:
+      "/resources/business-playbook/how-to-start-cotton-candy-vending-business",
+  },
+  {
+    id: "daily-operating-checklist",
+    title: "Daily Operating Checklist",
+    categoryLabel: "Operator Routine",
+    formatLabel: "Plus job aid",
+    description:
+      "A daily task card for restock, visual inspection, wipe-downs, payment checks, issue notes, and venue follow-up.",
+    bestFor: "Operators who want a repeatable routine after the machine is live.",
+    icon: "dailyOps",
+    accentClass: "bg-rose/10 text-rose",
+    previewItems: [
+      "Open, mid-day, and close checks",
+      "Cleaning, refill, and payment review prompts",
+      "Issue log and owner check-in reminders",
+    ],
+    articleLabel: "Compare operating paths",
+    articleHref: "/resources/business-playbook/commercial-vending-vs-event-catering",
+  },
+  {
+    id: "venue-evaluation-worksheet",
+    title: "Venue Evaluation Worksheet",
+    categoryLabel: "Find Locations",
+    formatLabel: "Plus scorecard",
+    description:
+      "A site-walk worksheet for scoring dwell time, visibility, power, access, service rhythm, and owner readiness.",
+    bestFor: "Commercial operators choosing which locations deserve serious follow-up.",
+    icon: "venue",
+    accentClass: "bg-charcoal/10 text-charcoal",
+    previewItems: [
+      "Dwell time, traffic, and guest-fit scoring",
+      "Placement, power, and maintenance access notes",
+      "Owner readiness and next-action prompt",
+    ],
+    articleLabel: "Read location guide",
+    articleHref:
+      "/resources/business-playbook/best-locations-for-cotton-candy-vending-machines",
+  },
+];
+
+export const plusOperatorExtras: PlusOperatorExtra[] = [
+  {
+    title: "Reporting Dashboard",
+    description:
+      "Assigned-machine sales, trends, and exports when reporting access is connected to the account.",
+    icon: "reporting",
+  },
+  {
+    title: "Maintenance References",
+    description:
+      "Cleaning, hygiene, troubleshooting, and function-check references for live operators.",
+    icon: "maintenance",
+  },
+  {
+    title: "Operator Certificate",
+    description:
+      "Operator Essentials completion path for members who finish the required training flow.",
+    icon: "certificate",
+  },
+];

--- a/src/data/businessPlaybookPlusTools.ts
+++ b/src/data/businessPlaybookPlusTools.ts
@@ -123,9 +123,9 @@ export const businessPlaybookPlusTools: BusinessPlaybookPlusTool[] = [
 
 export const plusOperatorExtras: PlusOperatorExtra[] = [
   {
-    title: "Reporting Dashboard",
+    title: "Connected Reporting Views",
     description:
-      "Assigned-machine sales, trends, and exports when reporting access is connected to the account.",
+      "Assigned-machine sales, trends, and exports when reporting has been enabled for the account.",
     icon: "reporting",
   },
   {

--- a/src/pages/Plus.tsx
+++ b/src/pages/Plus.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { Check, ArrowRight, BookOpen } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Layout } from '@/components/layout/Layout';
+import { PlusToolsPreview } from '@/components/resources/PlusToolsPreview';
 import { trackEvent } from '@/lib/analytics';
 import { trackBusinessPlaybookCtaClick } from '@/lib/businessPlaybookAnalytics';
 import { startPlusCheckout } from '@/lib/stripeCheckout';
@@ -168,6 +169,18 @@ export default function PlusPage() {
               </div>
             </div>
           </div>
+        </div>
+      </section>
+
+      <section className="border-y border-border bg-muted/20 py-10 sm:py-12 lg:py-16">
+        <div className="container-page">
+          <PlusToolsPreview
+            surface="plus_page"
+            introLabel="Operator tool library"
+            heading="Downloadable worksheets for the operator layer"
+            description="Plus is where the public Playbook turns into reusable operating tools: budget worksheets, pitch scripts, launch checklists, daily job aids, venue scorecards, reporting access where available, and training references."
+            showCtas={false}
+          />
         </div>
       </section>
 

--- a/src/pages/Plus.tsx
+++ b/src/pages/Plus.tsx
@@ -24,8 +24,8 @@ const benefits = [
     description: 'Complete the Operator Essentials path and unlock a lightweight Bloomjoy completion certificate.',
   },
   {
-    title: 'Reporting Access',
-    description: 'Review assigned-machine sales, trends, and exports when reporting is connected to your account.',
+    title: 'Connected Reporting',
+    description: 'Review assigned-machine sales, trends, and exports when reporting has been enabled for your account.',
   },
   {
     title: 'Concierge Support',
@@ -177,8 +177,8 @@ export default function PlusPage() {
           <PlusToolsPreview
             surface="plus_page"
             introLabel="Operator tool library"
-            heading="Downloadable worksheets for the operator layer"
-            description="Plus is where the public Playbook turns into reusable operating tools: budget worksheets, pitch scripts, launch checklists, daily job aids, venue scorecards, reporting access where available, and training references."
+            heading="Plus-ready worksheets for the operator layer"
+            description="Plus is where the public Playbook turns into member-access operating tools: budget worksheets, pitch scripts, launch checklists, daily job aids, venue scorecards, connected reporting where enabled, and training references."
             showCtas={false}
           />
         </div>

--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -254,7 +254,7 @@ export default function ResourcesPage() {
             </p>
             <Accordion
               type="multiple"
-              defaultValue={resourcesFaqs.map((_, index) => `faq-${index}`)}
+              defaultValue={["faq-0"]}
               className="mt-6"
             >
               {resourcesFaqs.map((faq, i) => (

--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -2,15 +2,13 @@ import { useEffect } from "react";
 import { Link, useLocation } from "react-router-dom";
 import {
   ArrowRight,
-  BarChart3,
   BookOpen,
   ClipboardCheck,
-  Download,
-  Lock,
   MapPinned,
   Sparkles,
 } from "lucide-react";
 import { Layout } from "@/components/layout/Layout";
+import { PlusToolsPreview } from "@/components/resources/PlusToolsPreview";
 import {
   Accordion,
   AccordionContent,
@@ -18,10 +16,7 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
-import {
-  trackPlusPreviewResourceClick,
-  trackResourcesPlaybookCardClick,
-} from "@/lib/businessPlaybookAnalytics";
+import { trackResourcesPlaybookCardClick } from "@/lib/businessPlaybookAnalytics";
 import { getCanonicalUrlForSurface } from "@/lib/appSurface";
 import { resourcesFaqs } from "@/lib/seoRoutes";
 import {
@@ -31,37 +26,6 @@ import {
   playbookCategories,
 } from "@/data/businessPlaybook";
 import landingHeroImage from "@/assets/real/landing-hero.jpg";
-
-const plusTeasers = [
-  {
-    title: "Operator Guides",
-    description:
-      "Task-first setup, pricing, timer, and payment guides so operators can find answers fast.",
-    metaLabel: "Plus download",
-    MetaIcon: Download,
-  },
-  {
-    title: "Maintenance Checklists",
-    description:
-      "Cleaning, hygiene, and function-check references pulled from Bloomjoy training materials.",
-    metaLabel: "Plus download",
-    MetaIcon: Download,
-  },
-  {
-    title: "Reporting Dashboard",
-    description:
-      "Assigned-machine sales, trends, and exports for accounts with reporting access.",
-    metaLabel: "Portal feature",
-    MetaIcon: BarChart3,
-  },
-  {
-    title: "Operator Certificate",
-    description:
-      "Plus members can complete the Operator Essentials path and unlock a lightweight completion certificate.",
-    metaLabel: "Plus download",
-    MetaIcon: Download,
-  },
-];
 
 const categoryIcons = {
   start: BookOpen,
@@ -317,77 +281,10 @@ export default function ResourcesPage() {
 
       <section className="border-y border-border bg-muted/20 py-10 sm:py-12 lg:py-16">
         <div className="container-page">
-          <div className="mx-auto max-w-6xl">
-            <div className="flex flex-col gap-3 text-center">
-              <p className="text-xs font-semibold uppercase tracking-[0.14em] text-primary">
-                Bloomjoy Plus Preview
-              </p>
-              <h2 className="font-display text-2xl font-bold text-foreground">
-                Premium resources unlocked with Plus
-              </h2>
-              <p className="text-muted-foreground">
-                Public playbooks help you plan. Plus adds the operator layer: task-based
-                guides, maintenance checklists, eligible reporting access, troubleshooting
-                references, and the Bloomjoy Operator Essentials certificate path.
-              </p>
-            </div>
-
-            <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-              {plusTeasers.map((item) => {
-                const MetaIcon = item.MetaIcon;
-
-                return (
-                  <div key={item.title} className="rounded-xl border border-border bg-background p-5">
-                    <div className="flex items-center justify-between">
-                      <h3 className="font-display text-lg font-semibold text-foreground">
-                        {item.title}
-                      </h3>
-                      <Lock className="h-4 w-4 text-muted-foreground" />
-                    </div>
-                    <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-                      {item.description}
-                    </p>
-                    <div className="mt-4 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.12em] text-muted-foreground">
-                      <MetaIcon className="h-3.5 w-3.5" />
-                      {item.metaLabel}
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-
-            <div className="mt-8 flex flex-wrap justify-center gap-3">
-              <Button asChild>
-                <Link
-                  to="/plus"
-                  onClick={() =>
-                    trackPlusPreviewResourceClick({
-                      surface: "resources_plus_preview",
-                      cta: "explore_bloomjoy_plus",
-                      href: "/plus",
-                    })
-                  }
-                >
-                  Explore Bloomjoy Plus
-                  <ArrowRight className="ml-2 h-4 w-4" />
-                </Link>
-              </Button>
-              <Button asChild variant="outline">
-                <a
-                  href={operatorLoginUrl}
-                  onClick={() =>
-                    trackPlusPreviewResourceClick({
-                      surface: "resources_plus_preview",
-                      cta: "operator_login",
-                      href: operatorLoginUrl,
-                    })
-                  }
-                >
-                  Operator Login
-                </a>
-              </Button>
-            </div>
-          </div>
+          <PlusToolsPreview
+            surface="resources_plus_preview"
+            operatorLoginUrl={operatorLoginUrl}
+          />
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- Adds a shared Business Playbook Plus tool preview system for public Resources and Plus pages.
- Documents the Plus-ready worksheet/template catalog, ownership, support boundaries, and access model.
- Keeps public pages useful and indexable while positioning actual files as future Plus/operator member assets.

## Files changed
- `src/components/resources/PlusToolsPreview.tsx` and `src/data/businessPlaybookPlusTools.ts` add the reusable preview component and metadata.
- `src/pages/Resources.tsx` and `src/pages/Plus.tsx` surface the tool previews and connected reporting language.
- `Docs/BUSINESS_PLAYBOOK_PLUS_TOOLS.md`, `Docs/DECISIONS.md`, `Docs/BUSINESS_PLAYBOOK_CONTENT_BRIEF.md`, and `Docs/QA_SMOKE_TEST_CHECKLIST.md` capture the content, access, and QA plan.

## Verification commands + results
- `npm ci` - passed.
- `npm run build` - passed; prerendered 21 public routes and validated private route SEO head tags during build output.
- `npm test --if-present` - passed.
- `npm run lint --if-present` - passed with existing fast-refresh warnings in shared UI/Auth files.
- `npm run seo:check` - passed; 21 public routes and 19 private routes validated.
- `git diff --check` / `git diff --cached --check` - passed.
- Browser QA fallback via Playwright Chromium against `http://127.0.0.1:8090/` - checked `/resources` and `/plus` on desktop and mobile, verified all five tool previews plus Connected Reporting Views, no public download-like links, no horizontal overflow, no console/page errors.
- Sub-agent QA - code/functional review found no issues; content/brand review findings were addressed in the follow-up commit.

## How to test
1. `npm ci`
2. Set local public env values if your `.env` is not already configured:
   - `VITE_SUPABASE_URL=https://example.supabase.co`
   - `VITE_SUPABASE_ANON_KEY=local-anon-key`
3. `npm run dev -- --host 127.0.0.1 --port 8090`
4. Visit `http://127.0.0.1:8090/resources` and confirm the Plus preview shows the five worksheet/tool cards and the Connected Reporting Views operator extra.
5. Visit `http://127.0.0.1:8090/plus` and confirm the operator tool library appears below the pricing section without public download links.
6. Resize to mobile widths around `390x844` and confirm cards stack cleanly without horizontal overflow.

Closes #340