### PR TITLE
Align Technician access copy with Portal Settings

### DIFF
--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -121,9 +121,10 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Non-Plus login can access baseline pages (`/portal`, `/portal/orders`, `/portal/account`)
 - [ ] Non-Plus login is blocked from gated pages (`/portal/training`, `/portal/onboarding`, `/portal/support`) with clear access messaging
 - [ ] Non-Plus login still sees Plus/training gated destinations in portal navigation and dashboard action cards with clear locked/access-tier treatment; Reporting stays hidden unless reporting access is granted
-- [ ] Active Plus member or super-admin can add multiple operator emails from `/portal/account` under Operator Training Access
+- [ ] Active Plus member or super-admin can add multiple operator emails from Settings (`/portal/account`) under Operator Training Access
 - [ ] Adding operator training access sends the operator an invite email with a login link
 - [ ] Operator Training Access shows a simple list of people with training access and a clear setup message when the database rollout is missing
+- [ ] Operator Training Access is treated as transitional UX; new training-only access should be represented as a Technician with no assigned machines in a future Settings IA follow-up
 - [ ] Technician with no assigned machines can access `/portal` and `/portal/training*`
 - [ ] Technician with no assigned machines cannot access `/portal/reports`, Plus/Corporate Partner supply discounts, billing, account-owner tools, partner settlement, or `/admin`
 - [ ] Revoking operator training access removes `/portal/training*` access on the next session refresh/re-login
@@ -132,7 +133,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] `/portal/account` has no horizontal page overflow on mobile viewports (360x800, 390x844, 414x896)
 - [ ] `/portal/account` profile save persists and reloads from `customer_profiles`
 - [ ] `/portal/account` shipping save persists and reloads from `customer_profiles`
-- [ ] Plus Account Owner sees Technician Access on `/portal/account` with seat usage, owned machines, and current Technician grants
+- [ ] Plus Account Owner sees Technician Access in Settings (`/portal/account`) with seat usage, owned machines, and current Technician grants
 - [ ] Plus Account Owner can add a Technician with one or more owned machines, then edit that Technician's machine assignments
 - [ ] Pending Technician invite resolves on first login so the Technician gets training plus assigned-machine reporting without admin repair
 - [ ] Authenticated `/portal` and `/admin` route loads do not show `404` or `PGRST202` for `resolve_my_technician_entitlements` in the browser network log or console
@@ -297,7 +298,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Manual reporting access save does not show missing-function errors for `admin_set_user_machine_reporting_access`
 - [ ] Manual reporting access can revoke one user's machine access without removing other viewers from the same machine
 - [ ] Super-admin users show all-machine reporting access as read-only in Admin Access
-- [ ] Technician source card is read-only in Admin Access and clearly points Technician grant/change/revoke work to `/portal/account`
+- [ ] Technician source card is read-only in Admin Access and clearly points Technician grant/change/revoke work to Portal > Settings > Technician Access (`/portal/account`)
 - [ ] Scoped Admin source card can grant or update `scoped_admin` for an existing user with selected machine scopes, save preview, and required reason
 - [ ] Scoped Admin users with active machine scopes see `/portal/reports` for those machines without requiring separate `report_manager` entitlements
 - [ ] Scoped Admin users can open `/portal/training*` but do not become Plus members or get Plus billing/commerce benefits

--- a/src/pages/admin/accessPersonConsole.tsx
+++ b/src/pages/admin/accessPersonConsole.tsx
@@ -1503,7 +1503,7 @@ function TechnicianAccessCard({ effectiveAccess }: { effectiveAccess: EffectiveA
       icon={Wrench}
       title="Technician"
       status={activeGrants.length > 0 ? 'Active' : 'Inactive'}
-      description="Shows customer-managed Technician access. The customer-facing grant/change/revoke flow stays in Portal Account."
+      description="Shows customer-managed Technician access. The customer-facing grant/change/revoke flow stays in Portal Settings."
     >
       {grants.length === 0 ? (
         <div className="rounded-md border border-border bg-muted/20 p-3 text-sm text-muted-foreground">
@@ -1535,7 +1535,7 @@ function TechnicianAccessCard({ effectiveAccess }: { effectiveAccess: EffectiveA
       <PreviewBox>
         Technician access is source-aware and customer-managed. Admins can review why it exists here,
         but Plus Customers and Corporate Partners manage Technician grant, renewal, scope, and revoke
-        actions from `/portal/account`.
+        actions from Portal &gt; Settings &gt; Technician Access (`/portal/account`).
       </PreviewBox>
     </SourceCard>
   );


### PR DESCRIPTION
## Summary
- Aligns the Admin Access Technician source card with the post-#363 navigation language: Portal > Settings > Technician Access.
- Updates Technician-related smoke steps to reference Settings (`/portal/account`) while keeping the canonical route explicit.
- Documents Operator Training Access as transitional UX and links the consolidation follow-up to #364.

## Files changed
- `src/pages/admin/accessPersonConsole.tsx`: copy-only update for the read-only Technician source card.
- `Docs/QA_SMOKE_TEST_CHECKLIST.md`: smoke wording updates for Settings / Technician Access and transitional Operator Training Access.

## Verification commands + results
- `npm ci`: passed; 409 packages installed/audited, 0 vulnerabilities. Existing `glob@10.5.0` deprecation warning remains.
- `npm run build`: passed; Vite build and prerender completed.
- `npm test --if-present`: passed/no output; repo currently has no test script configured.
- `npm run lint --if-present`: passed with 8 existing Fast Refresh warnings in shared UI/Auth files only.
- `git diff --check`: passed.
- Browser smoke via Playwright on `http://127.0.0.1:8098`: passed for `/admin/access` Technician copy, `/portal/account` Settings route, and mobile `390x844` Technician panel render.

## How to test
1. In `C:\Repos\wt-portal-settings-technician-copy`, create `.env.local` with local `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, and optional `VITE_DEV_ADMIN_EMAILS`.
2. Run `npm ci`.
3. Run `npm run dev`.
4. Sign in as a super-admin and open `/admin/access`.
5. Search/select a person with Technician access and confirm the Technician source card is read-only and points to `Portal > Settings > Technician Access` (`/portal/account`).
6. Open `/portal/account` and confirm the portal nav labels the destination as Settings while the page title remains Account Settings and Technician Access still appears for eligible Plus Account Owners / Corporate Partners.
7. Resize to `390x844` and confirm the Settings navigation and Technician Access panel remain readable.

## Backend/API limitations
- No backend, schema, RPC, entitlement, or authorization changes were made.
- Operator Training Access remains unchanged in this PR; follow-up consolidation is tracked in #364.
