### PR TITLE
Document P0 sprint closeout decisions

### DIFF
--- a/Docs/AI_WORKFLOW.md
+++ b/Docs/AI_WORKFLOW.md
@@ -21,6 +21,7 @@ This repo is operated primarily through AI coding agents. The owner is not expec
 - For UI changes, provide preview/localhost links and desktop/mobile screenshots.
 - For user-facing changes, provide exact UAT steps and expected results.
 - Use `Docs/UAT_PERSONA_PLAYBOOK.md` when preparing owner UAT steps for public, portal, admin, reporting, Technician, or Corporate Partner changes.
+- If login-gated preview UAT redirects to production, do not use it for executive pre-merge testing. Use agent/technical UAT with controlled test sessions or JWTs, and record the evidence.
 - For high-risk changes, include an explicit rollback plan and independent AI review evidence.
 
 Use an independent AI reviewer or delegated subagent for high-risk review when the current agent environment allows it. If not available, perform a separate review pass and record what was checked.
@@ -29,6 +30,8 @@ Use an independent AI reviewer or delegated subagent for high-risk review when t
 - Low risk: no owner involvement unless wording or product direction is unclear.
 - Medium risk: owner UAT is optional; agents still provide a preview checklist.
 - High risk: owner UAT or go/no-go confirmation is required before merge or production rollout.
+
+Until preview auth redirects are fixed, executive testing for login-gated flows is post-release acceptance, not preview sign-off.
 
 The owner should not need to inspect code diffs to make routine decisions. PRs should present enough evidence for a product-level go/no-go.
 

--- a/Docs/DECISIONS.md
+++ b/Docs/DECISIONS.md
@@ -1,5 +1,29 @@
 # Decisions
 
+## 2026-05-02 - Admin access boundary rule
+Scoped admins and partner-facing admins may manage only their current active machine/account scope.
+
+**Canonical rule**
+- Current active scope is the only manageable scope for partner/scoped admin workflows.
+- Historical, expired, inactive, removed, or otherwise out-of-scope machine/account access must not remain manageable through partner/scoped admin tools.
+- Any later expansion to historical or inactive access management needs an explicit new decision and implementation guardrails.
+
+**Why this choice**
+- Access management must reflect current authority, not old operational relationships.
+- This prevents partner/scoped admins from changing users or machines they no longer actively own.
+
+## 2026-05-02 - Refund fallback settlement rule
+Refund settlement may use Request Amount as a narrow fallback only after the rest of the required settlement context is present.
+
+**Canonical rule**
+- When refund status is `Closed`, the decision is approve-style, and the approved/refund amount is blank, Request Amount may be used as the settlement amount.
+- This fallback applies only when required settlement fields are otherwise present.
+- Rows missing date, location, status, or decision remain review-only and must not become settlement-ready through the fallback.
+
+**Why this choice**
+- Closed approved refunds often carry the business amount in Request Amount, but incomplete rows still need human review.
+- The fallback improves settlement completeness without weakening data-quality gates.
+
 ## 2026-04-29 - Business Playbook Plus tools access model
 Business Playbook public articles stay indexable. Plus-ready worksheets and operator templates may be previewed publicly, but downloadable files should live behind Plus/member access when download plumbing is implemented.
 

--- a/Docs/SPRINT_RETROS.md
+++ b/Docs/SPRINT_RETROS.md
@@ -23,26 +23,39 @@ Keep entries plain-language and brief. Link to issues and PRs instead of copying
 ## Entries
 
 ### Sprint: P0 risk burn-down
-- Dates: `2026-05-02` to `TBD`
+- Dates: `2026-05-02`
 - Goal: Reduce launch-blocking risk around admin permission boundaries, refund settlement data quality, and UAT packaging.
 - Lead issues:
   - `#376` - QA Super Admin and Scoped Admin permission boundaries.
   - `#264` - Require calculation fields before approved refunds reach settlement.
 - PRs:
-  - `TBD` - add implementation and UAT PRs as they open or merge.
+  - `#377` - docs-only closeout packet for sprint retro/UAT status; keep narrow.
+  - `#378` - refund settlement calculation guardrails; merged to `main`.
+  - `#379` - admin permission boundary QA; draft with green automated checks, pending credentialed live UAT.
 - Verification:
-  - `TBD` - record final branch verification after implementation lanes report results.
+  - `#378`: CI, Supabase migration validation, and Vercel checks passed before merge.
+  - `#379`: CI, Supabase migration validation, and Vercel checks are green, but this is not release-ready until live persona/RPC UAT is captured.
+  - `#377`: docs-only verification should stay lightweight (`git diff --check` plus PR diff review).
 - UAT evidence:
-  - `TBD` - link final UAT packet, screenshots, and role/persona notes.
+  - `#379` still needs credentialed live checks for Super Admin, Scoped Admin, Corporate Partner, Technician, and non-admin boundaries.
+  - Required evidence: persona used, key URL/RPC exercised, expected allow/deny result, and any cleanup performed.
 - What worked:
-  - `TBD`
+  - Parallel worktrees kept implementation, database, QA, and docs lanes separated.
+  - Keeping UAT-gated work in draft made the automated-check status visible without implying live readiness.
+  - Challenge/fix loops on `#379` improved independent coverage before credentialed UAT.
 - What was confusing:
-  - `TBD`
+  - Migration timestamp collisions remain easy to create during multi-agent work; use later forward-only repair migrations instead of editing already-applied files.
+  - `#264` is not fully closed by settlement guardrails alone because invalid or unmatched source rows may still remain outside settlement-ready data.
+  - Environment setup must use each agent's own local `.env`; do not copy secrets or another agent's env file.
 - Open risks:
-  - `TBD`
+  - `#379` remains draft/UAT-required until credentialed live persona/RPC verification proves the permission boundaries in the target environment.
+  - `#264` still needs external/source-data cleanup for invalid or unmatched rows that guardrails cannot classify automatically.
 - Follow-up issues:
-  - `TBD`
+  - Keep `#264` scoped to source-data cleanup and reconciliation after settlement guardrails.
+  - Use the `#379` UAT packet to decide whether any additional access-boundary repair PR is needed.
 - Owner decisions needed:
-  - `TBD`
+  - Confirm the live UAT credential/persona set and cleanup expectations for `#379`.
+  - Decide who owns invalid/unmatched refund source rows that remain after guardrails block incomplete settlement records.
 - Rollback notes:
-  - `TBD`
+  - `#377` is docs-only and has no app rollback.
+  - `#378` includes database guardrails; rollback should be treated as a controlled production decision, not a docs-lane change.

--- a/Docs/SPRINT_RETROS.md
+++ b/Docs/SPRINT_RETROS.md
@@ -27,16 +27,18 @@ Keep entries plain-language and brief. Link to issues and PRs instead of copying
 - Goal: Reduce launch-blocking risk around admin permission boundaries, refund settlement data quality, and UAT packaging.
 - Lead issues:
   - `#376` - QA Super Admin and Scoped Admin permission boundaries.
-  - `#264` - Require calculation fields before approved refunds reach settlement.
+  - `#264` - Require calculation fields before approved refunds reach settlement; remains open/blocked-external for source-data cleanup.
 - PRs:
   - `#377` - docs-only closeout packet for sprint retro/UAT status; keep narrow.
-  - `#378` - refund settlement calculation guardrails; merged to `main`.
-  - `#379` - admin permission boundary QA; draft with green automated checks, pending credentialed live UAT.
+  - `#378` - refund settlement calculation guardrails; merged to `main`, pending paired DB migration plus `refund-adjustment-sync` function deploy before production rollout.
+  - `#379` - admin permission boundary QA; draft with a code-change blocker under remediation before live UAT/production rollout.
 - Verification:
   - `#378`: CI, Supabase migration validation, and Vercel checks passed before merge.
-  - `#379`: CI, Supabase migration validation, and Vercel checks are green, but this is not release-ready until live persona/RPC UAT is captured.
+  - `#378`: production rollout still needs the paired migration/function deploy and aggregate post-deploy audit.
+  - `#379`: automated checks were green before independent review found a code-change blocker; treat as not release-ready until remediation plus live persona/RPC UAT are captured.
   - `#377`: docs-only verification should stay lightweight (`git diff --check` plus PR diff review).
 - UAT evidence:
+  - Independent review findings are now part of sprint closeout status, not just optional notes.
   - `#379` still needs credentialed live checks for Super Admin, Scoped Admin, Corporate Partner, Technician, and non-admin boundaries.
   - Required evidence: persona used, key URL/RPC exercised, expected allow/deny result, and any cleanup performed.
 - What worked:
@@ -48,10 +50,11 @@ Keep entries plain-language and brief. Link to issues and PRs instead of copying
   - `#264` is not fully closed by settlement guardrails alone because invalid or unmatched source rows may still remain outside settlement-ready data.
   - Environment setup must use each agent's own local `.env`; do not copy secrets or another agent's env file.
 - Open risks:
-  - `#379` remains draft/UAT-required until credentialed live persona/RPC verification proves the permission boundaries in the target environment.
-  - `#264` still needs external/source-data cleanup for invalid or unmatched rows that guardrails cannot classify automatically.
+  - `#379` remains draft/blocker-remediation/UAT-required until the code-change blocker is fixed and credentialed live persona/RPC verification proves the permission boundaries.
+  - `#378` should not roll out to production until the DB migration and `refund-adjustment-sync` function are deployed together and the aggregate post-deploy audit passes.
+  - `#264` remains open/blocked-external for invalid or unmatched rows that guardrails cannot classify automatically.
 - Follow-up issues:
-  - Keep `#264` scoped to source-data cleanup and reconciliation after settlement guardrails.
+  - Keep `#264` scoped to source-data cleanup and reconciliation after settlement guardrails and post-deploy audit evidence.
   - Use the `#379` UAT packet to decide whether any additional access-boundary repair PR is needed.
 - Owner decisions needed:
   - Confirm the live UAT credential/persona set and cleanup expectations for `#379`.

--- a/Docs/SPRINT_RETROS.md
+++ b/Docs/SPRINT_RETROS.md
@@ -40,6 +40,8 @@ Keep entries plain-language and brief. Link to issues and PRs instead of copying
 - UAT evidence:
   - Independent review findings are now part of sprint closeout status, not just optional notes.
   - `#379` still needs credentialed live checks for Super Admin, Scoped Admin, Corporate Partner, Technician, and non-admin boundaries.
+  - Login-gated preview UAT currently redirects to production, so executive testing should be treated as post-release acceptance until preview auth redirects are fixed.
+  - Pre-merge UAT for risky logged-in features should be agent/technical UAT with controlled test sessions or JWTs, not executive preview testing.
   - Required evidence: persona used, key URL/RPC exercised, expected allow/deny result, and any cleanup performed.
 - What worked:
   - Parallel worktrees kept implementation, database, QA, and docs lanes separated.
@@ -53,11 +55,13 @@ Keep entries plain-language and brief. Link to issues and PRs instead of copying
   - `#379` remains draft/blocker-remediation/UAT-required until the code-change blocker is fixed and credentialed live persona/RPC verification proves the permission boundaries.
   - `#378` should not roll out to production until the DB migration and `refund-adjustment-sync` function are deployed together and the aggregate post-deploy audit passes.
   - `#264` remains open/blocked-external for invalid or unmatched rows that guardrails cannot classify automatically.
+  - Preview-login UAT blocker: no issue found yet; create/link one before relying on executive preview UAT for logged-in flows.
 - Follow-up issues:
   - Keep `#264` scoped to source-data cleanup and reconciliation after settlement guardrails and post-deploy audit evidence.
   - Use the `#379` UAT packet to decide whether any additional access-boundary repair PR is needed.
+  - `TBD preview-login UAT blocker` - fix preview auth redirects so login-gated UAT stays on the preview deployment.
 - Owner decisions needed:
-  - Confirm the live UAT credential/persona set and cleanup expectations for `#379`.
+  - Confirm the post-release acceptance window, credential/persona set, and cleanup expectations for `#379`.
   - Decide who owns invalid/unmatched refund source rows that remain after guardrails block incomplete settlement records.
 - Rollback notes:
   - `#377` is docs-only and has no app rollback.

--- a/Docs/SPRINT_RETROS.md
+++ b/Docs/SPRINT_RETROS.md
@@ -1,0 +1,48 @@
+# Sprint Retros
+
+Use this file for short sprint retros that help the next agent or owner understand what changed, what risk remains, and what should happen next.
+
+Keep entries plain-language and brief. Link to issues and PRs instead of copying long implementation notes.
+
+## Reusable Template
+
+### Sprint: `<name>`
+- Dates:
+- Goal:
+- Lead issues:
+- PRs:
+- Verification:
+- UAT evidence:
+- What worked:
+- What was confusing:
+- Open risks:
+- Follow-up issues:
+- Owner decisions needed:
+- Rollback notes:
+
+## Entries
+
+### Sprint: P0 risk burn-down
+- Dates: `2026-05-02` to `TBD`
+- Goal: Reduce launch-blocking risk around admin permission boundaries, refund settlement data quality, and UAT packaging.
+- Lead issues:
+  - `#376` - QA Super Admin and Scoped Admin permission boundaries.
+  - `#264` - Require calculation fields before approved refunds reach settlement.
+- PRs:
+  - `TBD` - add implementation and UAT PRs as they open or merge.
+- Verification:
+  - `TBD` - record final branch verification after implementation lanes report results.
+- UAT evidence:
+  - `TBD` - link final UAT packet, screenshots, and role/persona notes.
+- What worked:
+  - `TBD`
+- What was confusing:
+  - `TBD`
+- Open risks:
+  - `TBD`
+- Follow-up issues:
+  - `TBD`
+- Owner decisions needed:
+  - `TBD`
+- Rollback notes:
+  - `TBD`


### PR DESCRIPTION
## Summary
- Adds May 2 canonical executive decisions for admin access boundaries and refund fallback settlement handling.
- Updates the P0 sprint retro with current rollout/blocker status, including the preview-login UAT blocker and post-release executive acceptance rule.
- Adds durable AI workflow guidance for agent/technical UAT when login-gated previews redirect to production.

## Files changed
- `Docs/DECISIONS.md` - May 2 canonical decisions for access scope and refund fallback rules.
- `Docs/SPRINT_RETROS.md` - P0 closeout status, #378/#379/#264 follow-ups, preview-login UAT blocker placeholder, and post-release acceptance wording.
- `Docs/AI_WORKFLOW.md` - Governance rule for controlled agent/technical UAT when preview auth redirects are blocked.

## Risk level
- Low - docs-only, no runtime behavior change.

## Verification
- `npm ci`: Not run - docs-only change; current agent shell also has no `npm` on PATH.
- `npm run build`: Not run - docs-only change; current agent shell also has no `npm` on PATH.
- `npm test --if-present`: Not run - docs-only change; current agent shell also has no `npm` on PATH.
- `npm run lint --if-present`: Not run - docs-only change; current agent shell also has no `npm` on PATH.
- `npm run auth:preflight`: Attempted for preflight context; blocked because `npm` is not recognized in this shell.
- `git diff --check`: Pass.
- `git diff --cached --check`: Pass before commit.

## How to test
1. Localhost: no dev server required because this PR changes docs only.
2. Review `Docs/DECISIONS.md` on this branch and confirm the May 2 executive decisions are present and concise.
3. Review `Docs/SPRINT_RETROS.md` and confirm the P0 sprint retro says login-gated preview UAT redirects to production, executive testing is post-release acceptance until fixed, and the preview-login blocker has a follow-up placeholder.
4. Review `Docs/AI_WORKFLOW.md` and confirm risky logged-in features require agent/technical UAT with controlled test sessions or JWTs when preview auth redirects are blocked.

## Rollback plan
- Revert this PR to remove the docs-only closeout updates.

## Notes
- No code, migrations, or PR #379 files were edited.
- Owner UAT required: No for this docs-only PR; #379 still requires controlled technical UAT before merge and post-release acceptance while preview login redirects are blocked.