### PR TITLE
Guard refund settlement calculation fields

### DIFF
--- a/scripts/refunds/refund-adjustment-utils.mjs
+++ b/scripts/refunds/refund-adjustment-utils.mjs
@@ -503,6 +503,12 @@ export const refundReviewRowAppliesToPartnerScope = ({
   const matchedMachineId = row.matched_machine_id ?? row.matchedMachineId ?? null;
   if (matchedMachineId && isAssignedForRefundDate(matchedMachineId)) return true;
 
+  const sourceReportingMachineId =
+    row.source_reporting_machine_id ?? row.sourceReportingMachineId ?? null;
+  if (sourceReportingMachineId && isAssignedForRefundDate(sourceReportingMachineId)) {
+    return true;
+  }
+
   const candidateMachineIds = parseCandidateMachineIds(
     row.candidate_machine_ids ?? row.candidateMachineIds
   );
@@ -543,7 +549,7 @@ export const countPartnerScopedRefundReviewRows = ({
 export const matchRefundToMachine = (input, machineProfiles) => {
   const hasCanonicalMachineId = Boolean(input.hasSourceReportingMachineId);
 
-  if (!input.refundDate || input.amountCents <= 0 || (!input.normalizedLocation && !hasCanonicalMachineId)) {
+  if (!input.refundDate || input.amountCents <= 0 || !input.normalizedLocation) {
     return {
       matchStatus: 'invalid',
       matchConfidence: 0,

--- a/scripts/validate-refund-adjustments.mjs
+++ b/scripts/validate-refund-adjustments.mjs
@@ -127,6 +127,29 @@ assert.equal(canonicalMachineMatch.matchReason, 'canonical_reporting_machine_id_
 assert.equal(canonicalMachineMatch.matchedMachine?.id, machines[1].id);
 assert.deepEqual(canonicalMachineMatch.candidateMachineIds, [machines[1].id]);
 
+const canonicalMachineMissingLocationInput = extractRefundInput(
+  {
+    source_reporting_machine_id: machines[1].id,
+    location_of_purchase: '',
+    refund_date: '2026-04-06',
+    refund_amount_usd: '12.50',
+    status: 'Closed',
+    decision: 'Approve',
+    request_id: 'SANITIZED-CANONICAL-MISSING-LOCATION',
+  },
+  'canonical-machine-missing-location-fixture'
+);
+const canonicalMachineMissingLocationMatch = matchRefundToMachine(
+  canonicalMachineMissingLocationInput,
+  profiles
+);
+assert.equal(canonicalMachineMissingLocationMatch.matchStatus, 'invalid');
+assert.equal(
+  canonicalMachineMissingLocationMatch.matchReason,
+  'missing_required_refund_fields'
+);
+assert.equal(canonicalMachineMissingLocationMatch.matchedMachine, null);
+
 const invalidCanonicalMachineInput = extractRefundInput(
   {
     source_reporting_machine_id: 'not-a-reporting-machine-id',
@@ -463,6 +486,18 @@ const exactUniqueAliasReviewWarns = refundReviewRowAppliesToPartnerScope({
 });
 assert.equal(exactUniqueAliasReviewWarns, true);
 
+const sourceMachineInvalidReviewWarns = refundReviewRowAppliesToPartnerScope({
+  ...scopeArgs,
+  row: {
+    refund_date: '2026-04-12',
+    resolution_status: 'unresolved',
+    match_status: 'invalid',
+    source_reporting_machine_id: machines[1].id,
+    source_location: '',
+  },
+});
+assert.equal(sourceMachineInvalidReviewWarns, true);
+
 const otherPartnerMachineDoesNotWarn = refundReviewRowAppliesToPartnerScope({
   ...scopeArgs,
   row: {
@@ -568,6 +603,7 @@ console.log(
     fixtures: {
       exactLocationMatch: exactMatch.matchStatus,
       canonicalMachineIdPreferred: canonicalMachineMatch.matchStatus,
+      canonicalMachineMissingLocationHeldForReview: canonicalMachineMissingLocationMatch.matchStatus,
       invalidCanonicalMachineIdHeldForReview: invalidCanonicalMachineMatch.matchStatus,
       unknownCanonicalMachineIdHeldForReview: unknownCanonicalMachineMatch.matchStatus,
       fuzzyAliasMatch: fuzzyMatch.matchStatus,
@@ -587,6 +623,7 @@ console.log(
       partnerScopedMatchedMachineReview: matchedMachineReviewWarns,
       partnerScopedSingleCandidateReview: singleCandidateReviewWarns,
       partnerScopedExactAliasReview: exactUniqueAliasReviewWarns,
+      partnerScopedSourceMachineInvalidReview: sourceMachineInvalidReviewWarns,
       partnerScopedOtherPartnerSuppressed: !otherPartnerMachineDoesNotWarn,
       partnerScopedOutOfScopeSuppressed: !outOfScopePhoneCaseDoesNotWarn,
       partnerScopedAmbiguousLabelSuppressed: !ambiguousLabelDoesNotWarn,

--- a/supabase/functions/refund-adjustment-sync/index.ts
+++ b/supabase/functions/refund-adjustment-sync/index.ts
@@ -564,7 +564,7 @@ const uniqueIds = (machines: MachineProfile[]) => [...new Set(machines.map((mach
 const matchRefund = (input: RefundInput, machines: MachineProfile[]) => {
   const hasCanonicalMachineId = Boolean(input.hasSourceReportingMachineId);
 
-  if (!input.refundDate || input.amountCents <= 0 || (!input.normalizedLocation && !hasCanonicalMachineId)) {
+  if (!input.refundDate || input.amountCents <= 0 || !input.normalizedLocation) {
     return {
       status: "invalid",
       confidence: 0,

--- a/supabase/migrations/202605020001_refund_settlement_guardrails.sql
+++ b/supabase/migrations/202605020001_refund_settlement_guardrails.sql
@@ -1,0 +1,677 @@
+-- Keep refund settlement math behind the reviewed adjustment path and restore
+-- applied-refund deductions in the current partner preview RPC.
+
+create or replace function public.assert_sales_adjustment_refund_calculation_fields()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  payload jsonb := coalesce(new.raw_payload, '{}'::jsonb);
+  normalized_status text := public.normalize_reporting_match_text(payload ->> 'source_status');
+  normalized_decision text := public.normalize_reporting_match_text(payload ->> 'source_decision');
+begin
+  if new.source = 'google_sheets'
+    and new.adjustment_type in ('refund', 'complaint_refund') then
+    if coalesce(new.amount_cents, 0) <= 0 then
+      raise exception 'Approved refund adjustments require a positive amount before settlement'
+        using errcode = '23514';
+    end if;
+
+    if nullif(trim(coalesce(new.source_reference, '')), '') is null
+      or nullif(trim(coalesce(new.source_row_reference, '')), '') is null then
+      raise exception 'Approved refund adjustments require source references before settlement'
+        using errcode = '23514';
+    end if;
+
+    if new.refund_review_row_id is null then
+      raise exception 'Approved refund adjustments require a linked review row before settlement'
+        using errcode = '23514';
+    end if;
+
+    if coalesce(new.match_status, '') <> 'applied' then
+      raise exception 'Approved refund adjustments require applied match status before settlement'
+        using errcode = '23514';
+    end if;
+
+    if coalesce(new.match_confidence, 0) <= 0 then
+      raise exception 'Approved refund adjustments require positive match confidence before settlement'
+        using errcode = '23514';
+    end if;
+
+    if nullif(trim(coalesce(payload ->> 'source_location', '')), '') is null then
+      raise exception 'Approved refund adjustments require source location before settlement'
+        using errcode = '23514';
+    end if;
+
+    if nullif(trim(coalesce(payload ->> 'refund_date', '')), '') is null then
+      raise exception 'Approved refund adjustments require refund date before settlement'
+        using errcode = '23514';
+    end if;
+
+    if nullif(trim(coalesce(payload ->> 'amount_source', '')), '') is null then
+      raise exception 'Approved refund adjustments require an amount source before settlement'
+        using errcode = '23514';
+    end if;
+
+    if normalized_status <> 'closed' then
+      raise exception 'Approved refund adjustments require closed source status before settlement'
+        using errcode = '23514';
+    end if;
+
+    if normalized_decision not in ('approve', 'approved', 'refund approved', 'refund approve') then
+      raise exception 'Approved refund adjustments require approve source decision before settlement'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists sales_adjustment_facts_refund_guardrails
+  on public.sales_adjustment_facts;
+
+create trigger sales_adjustment_facts_refund_guardrails
+before insert or update on public.sales_adjustment_facts
+for each row execute function public.assert_sales_adjustment_refund_calculation_fields();
+
+create or replace function public.admin_preview_partner_period_report_internal(
+  p_partnership_id uuid,
+  p_date_from date,
+  p_date_to date,
+  p_period_grain text
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  normalized_grain text;
+  result jsonb;
+  partnership_row public.reporting_partnerships;
+  actor_user_id uuid;
+  actor_is_super_admin boolean;
+  actor_machine_ids uuid[];
+begin
+  actor_user_id := auth.uid();
+  actor_is_super_admin := public.is_super_admin(actor_user_id);
+  actor_machine_ids := public.scoped_admin_machine_ids(actor_user_id);
+  normalized_grain := lower(coalesce(nullif(trim(p_period_grain), ''), 'reporting_week'));
+
+  if p_partnership_id is null then
+    raise exception 'Partnership is required';
+  end if;
+
+  if p_date_from is null or p_date_to is null then
+    raise exception 'Date range is required';
+  end if;
+
+  if p_date_from > p_date_to then
+    raise exception 'Date range is invalid';
+  end if;
+
+  if normalized_grain not in ('reporting_week', 'calendar_month') then
+    raise exception 'Invalid period grain: %', p_period_grain;
+  end if;
+
+  select *
+  into partnership_row
+  from public.reporting_partnerships partnership
+  where partnership.id = p_partnership_id;
+
+  if partnership_row.id is null then
+    raise exception 'Partnership not found';
+  end if;
+
+  if not public.can_access_partner_dashboard(
+    actor_user_id,
+    p_partnership_id,
+    p_date_from,
+    p_date_to
+  ) then
+    raise exception 'Partner dashboard access required';
+  end if;
+
+  with weekly_bounds as (
+    select
+      (
+        p_date_from
+        + ((partnership_row.reporting_week_end_day - extract(dow from p_date_from)::integer + 7) % 7)
+      )::date as first_week_end,
+      (
+        p_date_to
+        - ((extract(dow from p_date_to)::integer - partnership_row.reporting_week_end_day + 7) % 7)
+      )::date as last_week_end
+  ),
+  period_windows as (
+    select
+      (week_end::date - 6) as period_start,
+      week_end::date as period_end
+    from weekly_bounds bounds
+    cross join lateral generate_series(
+      bounds.first_week_end,
+      bounds.last_week_end,
+      interval '7 days'
+    ) as week_end
+    where normalized_grain = 'reporting_week'
+      and bounds.first_week_end <= bounds.last_week_end
+
+    union all
+
+    select
+      month_start::date as period_start,
+      (month_start + interval '1 month' - interval '1 day')::date as period_end
+    from generate_series(
+      date_trunc('month', p_date_from::timestamp)::date,
+      date_trunc('month', p_date_to::timestamp)::date,
+      interval '1 month'
+    ) as month_start
+    where normalized_grain = 'calendar_month'
+  ),
+  assigned_machine_periods as (
+    select distinct
+      period.period_start,
+      period.period_end,
+      machine.id as reporting_machine_id,
+      machine.machine_label,
+      location.name as location_name
+    from period_windows period
+    join public.reporting_machine_partnership_assignments assignment
+      on assignment.partnership_id = p_partnership_id
+      and assignment.assignment_role = 'primary_reporting'
+      and assignment.status = 'active'
+      and assignment.effective_start_date <= period.period_end
+      and (assignment.effective_end_date is null or assignment.effective_end_date >= period.period_start)
+    join public.reporting_machines machine on machine.id = assignment.machine_id
+    left join public.reporting_locations location on location.id = machine.location_id
+    where actor_is_super_admin
+      or machine.id = any(actor_machine_ids)
+  ),
+  scoped_facts as (
+    select
+      period.period_start,
+      period.period_end,
+      fact.id,
+      fact.reporting_machine_id,
+      machine.machine_label,
+      location.name as location_name,
+      fact.sale_date,
+      fact.payment_method,
+      fact.net_sales_cents as source_order_amount_cents,
+      fact.transaction_count,
+      fact.item_quantity,
+      fact.tax_cents as imported_tax_cents,
+      tax.tax_rate_percent,
+      rule.calculation_model,
+      rule.split_base,
+      rule.fee_amount_cents,
+      rule.fee_basis,
+      rule.cost_amount_cents,
+      rule.cost_basis,
+      rule.deduction_timing,
+      rule.gross_to_net_method,
+      rule.fever_share_basis_points,
+      rule.partner_share_basis_points,
+      rule.bloomjoy_share_basis_points
+    from public.machine_sales_facts fact
+    join period_windows period on fact.sale_date between period.period_start and period.period_end
+    join public.reporting_machines machine on machine.id = fact.reporting_machine_id
+    left join public.reporting_locations location on location.id = machine.location_id
+    join public.reporting_machine_partnership_assignments assignment
+      on assignment.machine_id = fact.reporting_machine_id
+      and assignment.partnership_id = p_partnership_id
+      and assignment.assignment_role = 'primary_reporting'
+      and assignment.status = 'active'
+      and assignment.effective_start_date <= fact.sale_date
+      and (assignment.effective_end_date is null or assignment.effective_end_date >= fact.sale_date)
+    left join lateral (
+      select tax_rate.tax_rate_percent
+      from public.reporting_machine_tax_rates tax_rate
+      where tax_rate.machine_id = fact.reporting_machine_id
+        and tax_rate.status = 'active'
+        and tax_rate.effective_start_date <= fact.sale_date
+        and (tax_rate.effective_end_date is null or tax_rate.effective_end_date >= fact.sale_date)
+      order by tax_rate.effective_start_date desc
+      limit 1
+    ) tax on true
+    left join lateral (
+      select financial_rule.*
+      from public.reporting_partnership_financial_rules financial_rule
+      where financial_rule.partnership_id = p_partnership_id
+        and financial_rule.status = 'active'
+        and financial_rule.effective_start_date <= fact.sale_date
+        and (financial_rule.effective_end_date is null or financial_rule.effective_end_date >= fact.sale_date)
+      order by financial_rule.effective_start_date desc
+      limit 1
+    ) rule on true
+    where fact.sale_date between p_date_from and p_date_to
+      and (
+        actor_is_super_admin
+        or fact.reporting_machine_id = any(actor_machine_ids)
+      )
+  ),
+  sales_totals as (
+    select
+      period_start,
+      period_end,
+      reporting_machine_id,
+      coalesce(sum(source_order_amount_cents), 0)::bigint as total_source_order_amount_cents
+    from scoped_facts
+    group by period_start, period_end, reporting_machine_id
+  ),
+  refund_totals as (
+    select
+      period.period_start,
+      period.period_end,
+      adjustment.reporting_machine_id,
+      coalesce(sum(adjustment.amount_cents), 0)::bigint as refund_amount_cents
+    from period_windows period
+    join public.sales_adjustment_facts adjustment
+      on adjustment.adjustment_date between period.period_start and period.period_end
+    join public.reporting_machine_partnership_assignments assignment
+      on assignment.machine_id = adjustment.reporting_machine_id
+      and assignment.partnership_id = p_partnership_id
+      and assignment.assignment_role = 'primary_reporting'
+      and assignment.status = 'active'
+      and assignment.effective_start_date <= adjustment.adjustment_date
+      and (assignment.effective_end_date is null or assignment.effective_end_date >= adjustment.adjustment_date)
+    where adjustment.adjustment_date between p_date_from and p_date_to
+      and adjustment.adjustment_type in ('refund', 'complaint_refund')
+      and adjustment.amount_cents > 0
+      and (
+        actor_is_super_admin
+        or adjustment.reporting_machine_id = any(actor_machine_ids)
+      )
+    group by period.period_start, period.period_end, adjustment.reporting_machine_id
+  ),
+  period_refund_amounts as (
+    select
+      period_start,
+      period_end,
+      coalesce(sum(refund_amount_cents), 0)::bigint as refund_amount_cents
+    from refund_totals
+    group by period_start, period_end
+  ),
+  calculated as (
+    select
+      fact.*,
+      case
+        when coalesce(total.total_source_order_amount_cents, 0) <= 0 then 0
+        else round(
+          coalesce(refund.refund_amount_cents, 0)
+          * greatest(fact.source_order_amount_cents, 0)
+          / greatest(total.total_source_order_amount_cents, 1)::numeric
+        )::integer
+      end as refund_amount_cents,
+      case
+        when fact.source_order_amount_cents <= 0 then 0
+        when fact.gross_to_net_method = 'imported_tax_plus_configured_fees' then fact.imported_tax_cents
+        when fact.gross_to_net_method = 'configured_fees_only' then 0
+        else round(fact.source_order_amount_cents * coalesce(fact.tax_rate_percent, 0) / 100.0)::integer
+      end as calculated_tax_cents,
+      case
+        when fact.source_order_amount_cents <= 0 then 0
+        when fact.fee_basis in ('per_order', 'per_transaction') then coalesce(fact.fee_amount_cents, 0) * coalesce(fact.transaction_count, 1)
+        when fact.fee_basis = 'per_stick' then coalesce(fact.fee_amount_cents, 0) * coalesce(fact.item_quantity, 1)
+        else 0
+      end as fee_cents,
+      case
+        when fact.source_order_amount_cents <= 0 then 0
+        when fact.cost_basis = 'per_order' then coalesce(fact.cost_amount_cents, 0) * coalesce(fact.transaction_count, 1)
+        when fact.cost_basis = 'per_stick' then coalesce(fact.cost_amount_cents, 0) * coalesce(fact.item_quantity, 1)
+        when fact.cost_basis = 'percentage_of_sales' then round(fact.source_order_amount_cents * coalesce(fact.cost_amount_cents, 0) / 10000.0)::integer
+        else 0
+      end as cost_cents
+    from scoped_facts fact
+    left join sales_totals total
+      on total.period_start = fact.period_start
+      and total.period_end = fact.period_end
+      and total.reporting_machine_id = fact.reporting_machine_id
+    left join refund_totals refund
+      on refund.period_start = fact.period_start
+      and refund.period_end = fact.period_end
+      and refund.reporting_machine_id = fact.reporting_machine_id
+  ),
+  row_amounts as (
+    select
+      calculated.*,
+      calculated.source_order_amount_cents as gross_sales_cents,
+      greatest(
+        calculated.source_order_amount_cents
+        - calculated.calculated_tax_cents
+        - calculated.fee_cents
+        - calculated.refund_amount_cents,
+        0
+      ) as net_sales_cents,
+      case
+        when calculated.deduction_timing = 'before_split' then calculated.cost_cents
+        else 0
+      end as split_deductible_cost_cents
+    from calculated
+  ),
+  split_rows as (
+    select
+      row_amounts.*,
+      case
+        when row_amounts.split_base = 'gross_sales' then greatest(row_amounts.gross_sales_cents - row_amounts.refund_amount_cents, 0)
+        when row_amounts.split_base = 'contribution_after_costs' then greatest(row_amounts.net_sales_cents - row_amounts.split_deductible_cost_cents, 0)
+        else row_amounts.net_sales_cents
+      end as split_base_cents
+    from row_amounts
+  ),
+  split_amounts as (
+    select
+      split_rows.*,
+      round(
+        split_rows.split_base_cents
+        * (
+          coalesce(split_rows.fever_share_basis_points, 0)
+          + coalesce(split_rows.partner_share_basis_points, 0)
+        )
+        / 10000.0
+      )::bigint as amount_owed_cents,
+      round(split_rows.split_base_cents * coalesce(split_rows.bloomjoy_share_basis_points, 0) / 10000.0)::bigint as bloomjoy_retained_cents
+    from split_rows
+  ),
+  period_amounts as (
+    select
+      period_start,
+      period_end,
+      coalesce(sum(transaction_count), 0)::integer as order_count,
+      coalesce(sum(item_quantity), 0)::integer as item_quantity,
+      coalesce(sum(gross_sales_cents), 0)::bigint as gross_sales_cents,
+      coalesce(sum(refund_amount_cents), 0)::bigint as allocated_refund_amount_cents,
+      coalesce(sum(calculated_tax_cents), 0)::bigint as tax_cents,
+      coalesce(sum(fee_cents), 0)::bigint as fee_cents,
+      coalesce(sum(cost_cents), 0)::bigint as cost_cents,
+      coalesce(sum(net_sales_cents), 0)::bigint as net_sales_cents,
+      coalesce(sum(split_base_cents), 0)::bigint as split_base_cents,
+      coalesce(sum(amount_owed_cents), 0)::bigint as amount_owed_cents,
+      coalesce(sum(bloomjoy_retained_cents), 0)::bigint as bloomjoy_retained_cents
+    from split_amounts
+    group by period_start, period_end
+  ),
+  machine_amounts as (
+    select
+      period_start,
+      period_end,
+      reporting_machine_id,
+      machine_label,
+      location_name,
+      coalesce(sum(transaction_count), 0)::integer as order_count,
+      coalesce(sum(item_quantity), 0)::integer as item_quantity,
+      coalesce(sum(gross_sales_cents), 0)::bigint as gross_sales_cents,
+      coalesce(sum(refund_amount_cents), 0)::bigint as allocated_refund_amount_cents,
+      coalesce(sum(calculated_tax_cents), 0)::bigint as tax_cents,
+      coalesce(sum(fee_cents), 0)::bigint as fee_cents,
+      coalesce(sum(cost_cents), 0)::bigint as cost_cents,
+      coalesce(sum(net_sales_cents), 0)::bigint as net_sales_cents,
+      coalesce(sum(split_base_cents), 0)::bigint as split_base_cents,
+      coalesce(sum(amount_owed_cents), 0)::bigint as amount_owed_cents,
+      coalesce(sum(bloomjoy_retained_cents), 0)::bigint as bloomjoy_retained_cents
+    from split_amounts
+    group by period_start, period_end, reporting_machine_id, machine_label, location_name
+  ),
+  periods as (
+    select
+      period.period_start,
+      period.period_end,
+      coalesce(amount.order_count, 0)::integer as order_count,
+      coalesce(amount.item_quantity, 0)::integer as item_quantity,
+      coalesce(amount.gross_sales_cents, 0)::bigint as gross_sales_cents,
+      coalesce(refund.refund_amount_cents, amount.allocated_refund_amount_cents, 0)::bigint as refund_amount_cents,
+      coalesce(amount.tax_cents, 0)::bigint as tax_cents,
+      coalesce(amount.fee_cents, 0)::bigint as fee_cents,
+      coalesce(amount.cost_cents, 0)::bigint as cost_cents,
+      coalesce(amount.net_sales_cents, 0)::bigint as net_sales_cents,
+      coalesce(amount.split_base_cents, 0)::bigint as split_base_cents,
+      coalesce(amount.amount_owed_cents, 0)::bigint as amount_owed_cents,
+      coalesce(amount.bloomjoy_retained_cents, 0)::bigint as bloomjoy_retained_cents
+    from period_windows period
+    left join period_amounts amount
+      on amount.period_start = period.period_start
+      and amount.period_end = period.period_end
+    left join period_refund_amounts refund
+      on refund.period_start = period.period_start
+      and refund.period_end = period.period_end
+  ),
+  machine_periods as (
+    select
+      assigned.period_start,
+      assigned.period_end,
+      assigned.reporting_machine_id,
+      assigned.machine_label,
+      assigned.location_name,
+      coalesce(amount.order_count, 0)::integer as order_count,
+      coalesce(amount.item_quantity, 0)::integer as item_quantity,
+      coalesce(amount.gross_sales_cents, 0)::bigint as gross_sales_cents,
+      coalesce(refund.refund_amount_cents, amount.allocated_refund_amount_cents, 0)::bigint as refund_amount_cents,
+      coalesce(amount.tax_cents, 0)::bigint as tax_cents,
+      coalesce(amount.fee_cents, 0)::bigint as fee_cents,
+      coalesce(amount.cost_cents, 0)::bigint as cost_cents,
+      coalesce(amount.net_sales_cents, 0)::bigint as net_sales_cents,
+      coalesce(amount.split_base_cents, 0)::bigint as split_base_cents,
+      coalesce(amount.amount_owed_cents, 0)::bigint as amount_owed_cents,
+      coalesce(amount.bloomjoy_retained_cents, 0)::bigint as bloomjoy_retained_cents
+    from assigned_machine_periods assigned
+    left join machine_amounts amount
+      on amount.period_start = assigned.period_start
+      and amount.period_end = assigned.period_end
+      and amount.reporting_machine_id = assigned.reporting_machine_id
+    left join refund_totals refund
+      on refund.period_start = assigned.period_start
+      and refund.period_end = assigned.period_end
+      and refund.reporting_machine_id = assigned.reporting_machine_id
+  ),
+  summary as (
+    select
+      coalesce(sum(order_count), 0)::integer as order_count,
+      coalesce(sum(item_quantity), 0)::integer as item_quantity,
+      coalesce(sum(gross_sales_cents), 0)::bigint as gross_sales_cents,
+      coalesce(sum(refund_amount_cents), 0)::bigint as refund_amount_cents,
+      coalesce(sum(tax_cents), 0)::bigint as tax_cents,
+      coalesce(sum(fee_cents), 0)::bigint as fee_cents,
+      coalesce(sum(cost_cents), 0)::bigint as cost_cents,
+      coalesce(sum(net_sales_cents), 0)::bigint as net_sales_cents,
+      coalesce(sum(split_base_cents), 0)::bigint as split_base_cents,
+      coalesce(sum(amount_owed_cents), 0)::bigint as amount_owed_cents,
+      coalesce(sum(bloomjoy_retained_cents), 0)::bigint as bloomjoy_retained_cents
+    from periods
+  ),
+  global_unique_refund_scope_labels as (
+    select
+      label.normalized_label,
+      (array_agg(distinct label.reporting_machine_id))[1] as reporting_machine_id
+    from (
+      select
+        public.normalize_reporting_match_text(machine.machine_label) as normalized_label,
+        machine.id as reporting_machine_id
+      from public.reporting_machines machine
+      where machine.status = 'active'
+
+      union all
+
+      select
+        public.normalize_reporting_match_text(location.name) as normalized_label,
+        machine.id as reporting_machine_id
+      from public.reporting_machines machine
+      join public.reporting_locations location on location.id = machine.location_id
+      where machine.status = 'active'
+        and location.status = 'active'
+
+      union all
+
+      select
+        alias.normalized_alias as normalized_label,
+        alias.reporting_machine_id
+      from public.reporting_machine_aliases alias
+      join public.reporting_machines machine on machine.id = alias.reporting_machine_id
+      where alias.status = 'active'
+        and machine.status = 'active'
+    ) label
+    where coalesce(label.normalized_label, '') <> ''
+    group by label.normalized_label
+    having count(distinct label.reporting_machine_id) = 1
+  ),
+  unresolved_refund_review as (
+    select count(distinct review.id)::integer as row_count
+    from public.refund_adjustment_review_rows review
+    where review.refund_date between p_date_from and p_date_to
+      and review.resolution_status = 'unresolved'
+      and review.match_status in ('needs_review', 'matched', 'ambiguous', 'unmatched', 'invalid', 'duplicate')
+      and (
+        exists (
+          select 1
+          from public.reporting_machine_partnership_assignments assignment
+          where assignment.machine_id = review.matched_machine_id
+            and assignment.partnership_id = p_partnership_id
+            and assignment.assignment_role = 'primary_reporting'
+            and assignment.status = 'active'
+            and assignment.effective_start_date <= review.refund_date
+            and (assignment.effective_end_date is null or assignment.effective_end_date >= review.refund_date)
+            and (
+              actor_is_super_admin
+              or assignment.machine_id = any(actor_machine_ids)
+            )
+        )
+        or exists (
+          select 1
+          from public.reporting_machine_partnership_assignments assignment
+          where assignment.machine_id = review.source_reporting_machine_id
+            and assignment.partnership_id = p_partnership_id
+            and assignment.assignment_role = 'primary_reporting'
+            and assignment.status = 'active'
+            and assignment.effective_start_date <= review.refund_date
+            and (assignment.effective_end_date is null or assignment.effective_end_date >= review.refund_date)
+            and (
+              actor_is_super_admin
+              or assignment.machine_id = any(actor_machine_ids)
+            )
+        )
+        or (
+          cardinality(coalesce(review.candidate_machine_ids, '{}'::uuid[])) = 1
+          and exists (
+            select 1
+            from public.reporting_machine_partnership_assignments assignment
+            where assignment.machine_id = review.candidate_machine_ids[1]
+              and assignment.partnership_id = p_partnership_id
+              and assignment.assignment_role = 'primary_reporting'
+              and assignment.status = 'active'
+              and assignment.effective_start_date <= review.refund_date
+              and (assignment.effective_end_date is null or assignment.effective_end_date >= review.refund_date)
+              and (
+                actor_is_super_admin
+                or assignment.machine_id = any(actor_machine_ids)
+              )
+          )
+        )
+        or exists (
+          select 1
+          from global_unique_refund_scope_labels label
+          join public.reporting_machine_partnership_assignments assignment
+            on assignment.machine_id = label.reporting_machine_id
+            and assignment.partnership_id = p_partnership_id
+            and assignment.assignment_role = 'primary_reporting'
+            and assignment.status = 'active'
+            and assignment.effective_start_date <= review.refund_date
+            and (assignment.effective_end_date is null or assignment.effective_end_date >= review.refund_date)
+          where label.normalized_label = review.normalized_source_location
+            and (
+              actor_is_super_admin
+              or assignment.machine_id = any(actor_machine_ids)
+            )
+        )
+      )
+  ),
+  warnings as (
+    select jsonb_build_object(
+      'warning_type', 'missing_machine_tax_rate',
+      'severity', 'blocking',
+      'machine_id', fact.reporting_machine_id,
+      'machine_label', fact.machine_label,
+      'message', fact.machine_label || ' has sales in this period without an active machine tax rate.'
+    ) as warning
+    from scoped_facts fact
+    where fact.tax_rate_percent is null
+      and coalesce(fact.gross_to_net_method, 'machine_tax_plus_configured_fees') <> 'configured_fees_only'
+    group by fact.reporting_machine_id, fact.machine_label
+    union all
+    select jsonb_build_object(
+      'warning_type', 'missing_financial_rule',
+      'severity', 'blocking',
+      'message', 'This report includes sales without an active partnership financial rule.'
+    ) as warning
+    where exists (select 1 from scoped_facts fact where fact.calculation_model is null)
+    union all
+    select jsonb_build_object(
+      'warning_type', 'no_assigned_machines',
+      'severity', 'blocking',
+      'message', 'This partnership has no active reporting machines for the selected period.'
+    ) as warning
+    where not exists (select 1 from assigned_machine_periods)
+    union all
+    select jsonb_build_object(
+      'warning_type', 'no_sales_for_machine',
+      'severity', 'non_blocking',
+      'machine_id', assigned.reporting_machine_id,
+      'machine_label', assigned.machine_label,
+      'message', assigned.machine_label || ' has no sales in the selected period.'
+    ) as warning
+    from (
+      select reporting_machine_id, machine_label, sum(order_count) as total_orders
+      from machine_periods
+      group by reporting_machine_id, machine_label
+    ) assigned
+    where coalesce(assigned.total_orders, 0) = 0
+    union all
+    select jsonb_build_object(
+      'warning_type', 'refund_adjustment_review_needed',
+      'severity', 'non_blocking',
+      'message', 'Refund adjustment rows for this report''s machines need admin review before they affect partner settlement.'
+    ) as warning
+    from unresolved_refund_review review
+    where review.row_count > 0
+    union all
+    select jsonb_build_object(
+      'warning_type', 'refund_adjustment_without_sales',
+      'severity', 'non_blocking',
+      'machine_id', refund.reporting_machine_id,
+      'machine_label', assigned.machine_label,
+      'message', assigned.machine_label || ' has refund adjustments in this period without sales to allocate.'
+    ) as warning
+    from refund_totals refund
+    join assigned_machine_periods assigned
+      on assigned.period_start = refund.period_start
+      and assigned.period_end = refund.period_end
+      and assigned.reporting_machine_id = refund.reporting_machine_id
+    left join sales_totals sales
+      on sales.period_start = refund.period_start
+      and sales.period_end = refund.period_end
+      and sales.reporting_machine_id = refund.reporting_machine_id
+    where coalesce(sales.total_source_order_amount_cents, 0) <= 0
+  )
+  select jsonb_build_object(
+    'partnership_id', p_partnership_id,
+    'partnership_name', partnership_row.name,
+    'period_grain', normalized_grain,
+    'date_from', p_date_from,
+    'date_to', p_date_to,
+    'summary', coalesce((select to_jsonb(summary) from summary), '{}'::jsonb),
+    'periods', coalesce((select jsonb_agg(to_jsonb(periods) order by periods.period_start) from periods), '[]'::jsonb),
+    'machine_periods', coalesce((select jsonb_agg(to_jsonb(machine_periods) order by machine_periods.period_start, machine_periods.machine_label) from machine_periods), '[]'::jsonb),
+    'warnings', coalesce((select jsonb_agg(warnings.warning) from warnings), '[]'::jsonb)
+  )
+  into result;
+
+  return result;
+end;
+$$;
+
+revoke execute on function public.admin_preview_partner_period_report_internal(uuid, date, date, text)
+  from public, anon, authenticated;
+
+select pg_notify('pgrst', 'reload schema');


### PR DESCRIPTION
Refs #264

## Summary
- Require source location before an approved refund can auto-match, even when a canonical reporting machine ID is present.
- Add a DB-side guardrail so Google Sheets refund adjustment facts need reviewed/applied calculation fields before they can affect settlement.
- Restore applied-refund deductions and partner-scoped refund review warnings in the current partner period preview internal RPC.

## Files changed
- `scripts/refunds/refund-adjustment-utils.mjs`: refund matching and partner-scoped review warning logic.
- `scripts/validate-refund-adjustments.mjs`: sanitized fixtures for missing-location canonical rows and source-machine-scoped invalid review warnings.
- `supabase/functions/refund-adjustment-sync/index.ts`: Edge Function matching guardrail parity with the script utility.
- `supabase/migrations/202605020001_refund_settlement_guardrails.sql`: forward-only trigger/RPC guardrail migration.

## Verification commands + results
- `npm ci`: passed; 0 vulnerabilities.
- `npm run reporting:validate-refund-adjustments`: passed; sanitized aggregate fixture output only.
- `npm run build`: passed.
- `npm test --if-present`: passed; no test script is present.
- `npm run lint --if-present`: passed with 8 existing Fast Refresh warnings in shared UI/Auth files.
- `npm run db:validate-migrations`: passed after starting Docker Desktop; 69 migrations applied in a disposable local Supabase project.
- `npm run reporting:import-refunds -- --file scripts/sample-refund-adjustments.csv --dry-run`: blocked locally because `SUPABASE_URL`/`VITE_SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are not configured in this worktree.
- Focused sanitized parser/matcher dry-run: passed with aggregate result `matched=1`, `invalid=1`, proving a canonical-ID row with blank source location stays out of apply.

## How to test
1. From this branch, run `npm ci`.
2. Run `npm run reporting:validate-refund-adjustments` and confirm the sanitized fixture output includes `canonicalMachineMissingLocationHeldForReview: "invalid"` and `refundReducesPartnerSettlement: true`.
3. Run `npm run db:validate-migrations` with Docker Desktop running.
4. Start local app with `npm run dev` and open `http://localhost:8080/admin/reporting` to review refund adjustment rows.
5. With local admin access configured, open `http://localhost:8080/admin/partnerships` and `http://localhost:8080/portal/reports` to preview/export partner reporting views. No test credentials are included here; use the repo's local admin override guidance if needed.

## Rollback plan
- Revert this commit for script and Edge Function changes, then redeploy `refund-adjustment-sync`.
- Because Supabase migrations are forward-only, ship a follow-up migration that drops `sales_adjustment_facts_refund_guardrails`/`assert_sales_adjustment_refund_calculation_fields()` and redefines `admin_preview_partner_period_report_internal` to the prior implementation if rollback is required.

## Privacy note
- This PR uses only aggregate counts and sanitized fixture rows. It does not include raw customer rows, payment details, card data, source locations tied to people, or free-text incident content.

## Remaining external blockers
- Issue #264 remains open with `P0` and `blocked-external` labels. Aggregate-only issue evidence still shows remaining source data quality work: latest recorded live sync saw 1,057 rows, 103 duplicate/already-applied rows, 0 newly applied rows, 341 invalid review rows, 612 unmatched review rows, and 0 ambiguous rows.
- Remaining invalid/unmatched rows need source-process cleanup or explicit out-of-scope resolution before they can safely affect settlement.

## Multi-agent overlap
- Checked open PRs before publishing. Only PR #377 is open and it touches `Docs/SPRINT_RETROS.md`; no overlap with this branch's files.

## Merge sequencing
- This PR owns migration `202605020001_refund_settlement_guardrails.sql`.
- PR #379 has been renumbered to `202605020002_corporate_partner_technician_scope_repair.sql` to avoid a Supabase migration version collision.
- Preferred merge order: merge this PR before #379, then rebase/verify #379 if main changes before merge.
