### PR TITLE
Document preview auth redirect allowlist

### DIFF
--- a/Docs/AUTH_OAUTH_BRANDING_RUNBOOK.md
+++ b/Docs/AUTH_OAUTH_BRANDING_RUNBOOK.md
@@ -2,7 +2,7 @@
 
 Purpose: make Google sign-in show Bloomjoy branding and move OAuth callbacks off `<project-ref>.supabase.co` to a Bloomjoy-owned auth subdomain.
 
-Last updated: 2026-03-22
+Last updated: 2026-05-03
 
 ## 1) Prerequisites
 - Domain access for Bloomjoy DNS (to create CNAME/TXT records).
@@ -11,6 +11,7 @@ Last updated: 2026-03-22
 - Supabase custom domain add-on enabled (required by Supabase to use custom auth hostname).
 - App URLs decided in advance:
   - Local app URL: `http://localhost:8080` (or your active Vite port)
+  - Vercel preview URL pattern: `https://*-snapcase.vercel.app/**`
   - Production operator app URL (canonical): `https://app.bloomjoyusa.com`
   - Production marketing URL: `https://www.bloomjoyusa.com`
   - Auth hostname target (recommended): `auth.bloomjoyusa.com`
@@ -33,6 +34,7 @@ Record status as `Not started`, `In progress`, `Done`, or `Blocked`.
 - Redirect URLs used by app flows:
   - `http://localhost:8080/portal`
   - `http://localhost:8080/reset-password`
+  - `https://*-snapcase.vercel.app/**` for Vercel preview UAT
   - `https://app.bloomjoyusa.com/portal`
   - `https://app.bloomjoyusa.com/reset-password`
 
@@ -57,6 +59,7 @@ Use these exact values when configuring Google OAuth + Supabase auth settings:
     - `http://localhost:8080/login`
     - `http://localhost:8080/portal`
     - `http://localhost:8080/reset-password`
+    - `https://*-snapcase.vercel.app/**`
     - `https://app.bloomjoyusa.com`
     - `https://app.bloomjoyusa.com/login`
     - `https://app.bloomjoyusa.com/portal`
@@ -144,6 +147,7 @@ Supabase Dashboard -> Authentication:
   - `http://localhost:8080/login`
   - `http://localhost:8080/portal`
   - `http://localhost:8080/reset-password`
+  - `https://*-snapcase.vercel.app/**`
   - `https://app.bloomjoyusa.com`
   - `https://app.bloomjoyusa.com/login`
   - `https://app.bloomjoyusa.com/portal`
@@ -160,8 +164,9 @@ Supabase Dashboard -> Authentication:
 - Do not commit production secrets or local `.env` files.
 
 Repo auth redirect behavior:
-- Login and Google auth redirects use the canonical app surface and route to `https://app.bloomjoyusa.com/portal`.
-- Password recovery redirects use the canonical app surface and route to `https://app.bloomjoyusa.com/reset-password`.
+- On production hosts, login and Google auth redirects use the canonical app surface and route to `https://app.bloomjoyusa.com/portal`.
+- On production hosts, password recovery redirects use the canonical app surface and route to `https://app.bloomjoyusa.com/reset-password`.
+- Vercel preview hosts ending in `.vercel.app` intentionally preserve the active preview origin, so preview OAuth/magic-link flows require the Supabase Additional Redirect URL pattern `https://*-snapcase.vercel.app/**`.
 - If Google sign-in lands on bare `http://localhost:3000/#access_token=...`, the fallback is coming from Supabase project settings, not this repo's redirect helper.
 
 ## 8) Verification checklist
@@ -171,6 +176,7 @@ Repo auth redirect behavior:
   - [ ] OAuth callback returns to `/portal` and session is created.
 - Deployed environment:
   - [ ] Repeat verification on `https://app.bloomjoyusa.com/login`.
+  - [ ] For Vercel preview UAT, repeat verification from the PR preview `/login` URL and confirm the final browser URL stays on the same preview host at `/portal` instead of `https://app.bloomjoyusa.com/portal`.
   - [ ] Browser network trace shows callback host `auth.bloomjoyusa.com` (not `<PROJECT_REF>.supabase.co`).
   - [ ] Final post-auth browser URL is `https://app.bloomjoyusa.com/portal` (not `http://localhost:3000`).
   - [ ] No auth-console errors during sign-in.
@@ -203,6 +209,14 @@ Repo auth redirect behavior:
   - Set Supabase Site URL to `https://app.bloomjoyusa.com`.
   - Add `https://app.bloomjoyusa.com`, `/login`, `/portal`, and `/reset-password` to Supabase redirect URLs.
   - Retry from `https://app.bloomjoyusa.com/login` and confirm the final browser URL is `https://app.bloomjoyusa.com/portal`.
+
+### Preview login returns to production
+- Cause: the active Vercel preview origin is not present in the Supabase redirect allowlist, so Supabase falls back to the configured Site URL after auth.
+- Fix:
+  - Keep Supabase Site URL set to `https://app.bloomjoyusa.com`.
+  - Add `https://*-snapcase.vercel.app/**` to Supabase Additional Redirect URLs.
+  - Retry from the PR preview `/login` URL and confirm the final browser URL stays on the same preview host at `/portal`.
+  - Track owner-controlled execution in issue `#380`.
 
 ## 10) Launch hardening follow-up
 Anything still pending for production approval/review stays tracked in issue `#77`:

--- a/Docs/AUTH_PRODUCTION_SIGNOFF.md
+++ b/Docs/AUTH_PRODUCTION_SIGNOFF.md
@@ -2,7 +2,7 @@
 
 Purpose: convert deferred auth launch hardening into an execution checklist with clear ownership and evidence capture.
 
-Last updated: 2026-03-19
+Last updated: 2026-05-03
 
 ## 1) Owners and launch window
 - Launch date/time:
@@ -34,8 +34,8 @@ Status values: `Not started`, `In progress`, `Done`, `Blocked`.
 | Google OAuth callback host resolves to `auth.bloomjoyusa.com` in live flow |  |  |  |
 | Google OAuth client secret rotated after setup-sharing activity |  |  |  |
 | Supabase Google provider updated with current client credentials |  |  |  |
-| Supabase Site URL set to `https://www.bloomjoyusa.com` |  |  |  |
-| Supabase redirect URL allowlist includes `https://www.bloomjoyusa.com` routes plus apex `https://bloomjoyusa.com` cutover aliases |  |  |  |
+| Supabase Site URL set to `https://app.bloomjoyusa.com` |  |  |  |
+| Supabase redirect URL allowlist includes `https://app.bloomjoyusa.com` app routes plus `https://*-snapcase.vercel.app/**` for Vercel preview UAT |  |  |  |
 
 ## 4) Security and reliability checks
 ### Email OTP and rate limits
@@ -62,6 +62,7 @@ Capture evidence links for each required flow.
 | Password login (`/login` -> `/portal`) |  |  |
 | Magic link login (`/login` -> email -> `/portal`) |  |  |
 | Google login (`/login` -> consent -> `/portal`) |  |  |
+| Vercel preview login returns to the same preview host at `/portal` |  |  |
 | Google callback host is `auth.bloomjoyusa.com` |  |  |
 | Logged-out redirect guard (`/portal` -> `/login`) |  |  |
 | Branded auth email (signup confirmation) |  |  |
@@ -103,9 +104,14 @@ Manual evidence still required before go/no-go:
 
 ### Redirect lands on `http://localhost:3000/#access_token=...`
 - Treat this as a stale Supabase URL Configuration issue first.
-- Confirm Supabase Site URL is `https://www.bloomjoyusa.com`.
-- Confirm redirect allowlist includes `https://www.bloomjoyusa.com`, `/login`, `/portal`, and `/reset-password`.
-- Keep apex `https://bloomjoyusa.com` entries allowlisted during cutover if traffic can still start there.
+- Confirm Supabase Site URL is `https://app.bloomjoyusa.com`.
+- Confirm redirect allowlist includes `https://app.bloomjoyusa.com`, `/login`, `/portal`, and `/reset-password`.
+
+### Vercel preview login returns to production
+- Treat this as a missing Supabase preview redirect allowlist entry first.
+- Confirm Supabase Site URL remains `https://app.bloomjoyusa.com`.
+- Confirm Additional Redirect URLs include `https://*-snapcase.vercel.app/**`.
+- Retry from the PR preview `/login` URL and confirm the final URL stays on the same preview host at `/portal`.
 
 ## 7) Go/No-Go sign-off
 - [ ] All checklist items in sections 3-5 are complete.

--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -163,6 +163,7 @@
   - a live `$0` Stripe checkout smoke order after the webhook email redesign deployment
 
 ## Next P0 milestones
+- Clear executive preview-auth UAT blocker `#380`: Supabase Auth URL Configuration must keep Site URL on `https://app.bloomjoyusa.com` and add `https://*-snapcase.vercel.app/**` to Additional Redirect URLs so login-gated Vercel previews return to the same preview host instead of production.
 - Complete trusted corporate partner settlement before building operator performance dashboards:
   - complete issue `#244` by deploying the refund service-account secrets, sharing the source sheet with the service account, and confirming the first dry-run/live sync in production
   - keep issue `#169` open until production UAT evidence confirms reviewed refund handling and partner-ready settlement expectations across current partner agreements
@@ -274,10 +275,10 @@ Execution order is based on launch risk and dependency overlap.
 - UAT signal: Google callback had been landing on `localhost:3000` (`ERR_CONNECTION_REFUSED`) instead of the live domain flow.
 - Recovery evidence (2026-03-19):
   - User-captured live Google login initially returned to `http://localhost:3000/#access_token=...` with no `/portal` path.
-  - Repo audit confirmed the app requests `${window.location.origin}/portal` for Google OAuth redirect, pointing to stale Supabase Site URL and/or missing allowlist entries for `https://www.bloomjoyusa.com`.
+  - Repo audit confirmed the app passes a Supabase `redirectTo`/`emailRedirectTo` URL for the active app surface, so wrong-host returns point first to stale Supabase Site URL and/or missing redirect allowlist entries.
   - After owner dashboard updates, live Google login now completes successfully back to the site.
 - Remaining follow-up:
-  - Merge the auth-host guidance PR and keep `npm run auth:preflight` aligned to canonical `https://www.bloomjoyusa.com` plus apex alias redirects.
+  - Keep `npm run auth:preflight` aligned to canonical `https://app.bloomjoyusa.com` app routes plus the `https://*-snapcase.vercel.app/**` preview UAT redirect pattern.
   - Capture final callback-host and consent-screen evidence in launch sign-off docs.
   - Keep the Supabase project-ref domain on the chooser as an expected temporary state until `auth.bloomjoyusa.com` is enabled and cut over.
 - Owner dependency: Google Cloud + Supabase dashboard branding/custom-domain execution remain owner-controlled.

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -103,6 +103,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Forgot-password flow sends reset email and `/reset-password` successfully updates password
 - [ ] Google sign-in works when Supabase Google provider is enabled
 - [ ] Google sign-in returns to the app host `/portal` route (for production: `https://app.bloomjoyusa.com/portal`, not `http://localhost:3000`)
+- [ ] On Vercel preview UAT, Google or magic-link sign-in returns to the same preview host at `/portal` (not `https://app.bloomjoyusa.com/portal`); if it falls back to production, confirm Supabase Additional Redirect URLs include `https://*-snapcase.vercel.app/**`
 - [ ] Google sign-in button follows official GIS rendering when `VITE_GOOGLE_CLIENT_ID` is configured locally
 - [ ] For auth launch hardening, Google consent screen shows Bloomjoy branding (name/logo/support email)
 - [ ] For auth launch hardening, Google callback host uses `auth.bloomjoyusa.com` (not `<project-ref>.supabase.co`)

--- a/scripts/auth-preflight.mjs
+++ b/scripts/auth-preflight.mjs
@@ -8,6 +8,7 @@ const DEFAULTS = {
   appOrigin: 'http://localhost:8080',
   prodAppOrigin: 'https://app.bloomjoyusa.com',
   prodMarketingOrigin: 'https://www.bloomjoyusa.com',
+  previewRedirectPattern: 'https://*-snapcase.vercel.app/**',
   projectRef: 'ygbzkgxktzqsiygjlqyg',
   customAuthHost: 'auth.bloomjoyusa.com',
   requireCustomAuthDomain: false,
@@ -44,6 +45,12 @@ function parseArgs(argv) {
 
     if (arg === '--prod-marketing-origin' && next) {
       parsed.prodMarketingOrigin = next;
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--preview-redirect-pattern' && next) {
+      parsed.previewRedirectPattern = next;
       i += 1;
       continue;
     }
@@ -264,6 +271,7 @@ function run() {
       `${origin}/portal`,
       `${origin}/reset-password`,
     ]),
+    args.previewRedirectPattern,
   ];
 
   printList('Google OAuth Authorized JavaScript origins (copy/paste)', [


### PR DESCRIPTION
## Summary
- Documented the root cause for preview login returning to production: Supabase Auth URL Configuration is missing the Vercel preview redirect allowlist, so Supabase falls back to the Site URL.
- Added the Bloomjoy Vercel preview wildcard `https://*-snapcase.vercel.app/**` to the auth runbook, sign-off checklist, current status, and `auth:preflight` copy/paste output.
- Created external owner-action issue #380 for the Supabase dashboard change; this PR does not change runtime auth behavior or secrets.

## Files changed
- `scripts/auth-preflight.mjs`: includes the Vercel preview redirect pattern in Supabase URL Configuration output.
- `Docs/AUTH_OAUTH_BRANDING_RUNBOOK.md`: adds preview redirect setup, verification, and troubleshooting.
- `Docs/AUTH_PRODUCTION_SIGNOFF.md`: corrects Site URL guidance to `https://app.bloomjoyusa.com` and adds preview evidence row.
- `Docs/CURRENT_STATUS.md`: records P0 preview-auth UAT blocker #380.
- `Docs/QA_SMOKE_TEST_CHECKLIST.md`: adds preview login return smoke check.

## Root cause
Repo-side redirect construction already preserves preview hosts: `.vercel.app` is treated as local-like in `src/lib/appSurface.ts`, and `src/contexts/AuthContext.tsx` passes the current app-surface `/portal` URL to Supabase as `redirectTo` / `emailRedirectTo`. Supabase only honors that target when it matches Authentication -> URL Configuration -> Redirect URLs. Without the preview wildcard, the auth service falls back to the configured Site URL (`https://app.bloomjoyusa.com`).

## Verification commands + results
- `git fetch origin`: passed.
- `git status -sb`: clean before edits; final branch contains only this commit.
- `npm run auth:preflight`: blocked before edits because `npm` is not on PATH in this shell.
- `node --check scripts/auth-preflight.mjs`: passed.
- `node scripts/auth-preflight.mjs` with dummy non-secret `VITE_SUPABASE_URL` and fake anon-key-shaped value: passed and printed `Additional redirect URL: https://*-snapcase.vercel.app/**`.
- `git diff --check`: passed; Git reported expected LF-to-CRLF warnings only.
- `npm ci`: blocked, `npm` not recognized.
- `npm run build`: blocked, `npm` not recognized.
- `npm test --if-present`: blocked, `npm` not recognized.
- `npm run lint --if-present`: blocked, `npm` not recognized.

## How to test
1. In Supabase Dashboard -> Authentication -> URL Configuration, keep Site URL as `https://app.bloomjoyusa.com`.
2. Add Additional Redirect URL `https://*-snapcase.vercel.app/**`.
3. From this PR's Vercel preview `/login` URL, start Google or magic-link login.
4. Confirm the final browser URL stays on the same preview host at `/portal`, not `https://app.bloomjoyusa.com/portal`.
5. Also confirm production login still returns to `https://app.bloomjoyusa.com/portal`.

## Overlap / risk notes
- This overlaps open PR #379 only in `Docs/QA_SMOKE_TEST_CHECKLIST.md`.
- Auth/OAuth risk is external configuration risk, not runtime app-code risk in this PR.
- No secrets were added or requested.