### PR TITLE
Harden access invite evidence and preview allowlist

### DIFF
--- a/Docs/LOCAL_DEV.md
+++ b/Docs/LOCAL_DEV.md
@@ -290,6 +290,7 @@ For production deployment order and rollback, use `Docs/PRODUCTION_RUNBOOK.md`.
    - `supabase secrets set STRIPE_STICKS_MEMBER_PRICE_ID=...`
    - `supabase secrets set STRIPE_PLUS_PRICE_ID=...`
    - Optional local/dev only: `supabase secrets set BLOOMJOY_ALLOW_LOCAL_REDIRECT_URLS=true` when serving commerce/invite functions locally against a non-local `SUPABASE_URL`
+   - Optional preview/UAT only: `supabase secrets set BLOOMJOY_ALLOWED_VERCEL_PREVIEW_ORIGINS=https://<exact-preview>.vercel.app` when invite emails must link back to a Vercel preview. Use exact origins only; do not set this for production launch.
    - `supabase secrets set STRIPE_WEBHOOK_SECRET=...`
    - `supabase secrets set RESEND_API_KEY=...`
    - `supabase secrets set INTERNAL_NOTIFICATION_FROM_EMAIL=...`
@@ -319,6 +320,7 @@ For production deployment order and rollback, use `Docs/PRODUCTION_RUNBOOK.md`.
    - `supabase functions serve custom-sticks-artwork-upload --no-verify-jwt`
    - `supabase functions serve custom-sticks-artwork-link --no-verify-jwt`
    - `supabase functions serve support-request-intake --no-verify-jwt`
+   - `supabase functions serve access-invite --no-verify-jwt`
    - `supabase functions serve sales-report-export --no-verify-jwt`
    - `supabase functions serve sales-report-scheduler --no-verify-jwt`
    - `supabase functions serve sunze-sales-sync --no-verify-jwt`

--- a/Docs/PRODUCTION_RUNBOOK.md
+++ b/Docs/PRODUCTION_RUNBOOK.md
@@ -26,8 +26,8 @@ Set the following values before launch.
 | `STRIPE_STICKS_MEMBER_PRICE_ID` | Server-only | `stripe-sticks-checkout` | Stripe member sticks price config | Billing owner |
 | `STRIPE_PLUS_PRICE_ID` | Server-only | `stripe-plus-checkout` | Stripe product/price config | Billing owner |
 | `STRIPE_WEBHOOK_SECRET` | Server-only | `stripe-webhook` | Stripe webhook endpoint signing secret | Billing owner |
-| `RESEND_API_KEY` | Server-only | `stripe-webhook`, `lead-submission-intake` | Resend API key | Technical owner |
-| `INTERNAL_NOTIFICATION_FROM_EMAIL` | Server-only | `stripe-webhook`, `lead-submission-intake` | Verified sender in Resend | Technical owner |
+| `RESEND_API_KEY` | Server-only | `stripe-webhook`, `lead-submission-intake`, `access-invite` | Resend API key | Technical owner |
+| `INTERNAL_NOTIFICATION_FROM_EMAIL` | Server-only | `stripe-webhook`, `lead-submission-intake`, `access-invite` | Verified sender in Resend | Technical owner |
 | `INTERNAL_NOTIFICATION_RECIPIENTS` | Server-only | `stripe-webhook`, `lead-submission-intake` | Internal recipient list (comma-separated) | Release owner |
 | `WECOM_CORP_ID` | Server-only | `lead-submission-intake`, `stripe-webhook`, `support-request-intake` | WeCom app settings | Technical owner |
 | `WECOM_AGENT_ID` | Server-only | `lead-submission-intake`, `stripe-webhook`, `support-request-intake` | WeCom app settings | Technical owner |
@@ -35,7 +35,7 @@ Set the following values before launch.
 | `WECOM_ALERT_TO_USERIDS` | Server-only | `lead-submission-intake`, `stripe-webhook`, `support-request-intake` | WeCom recipient user IDs (comma-separated) | Release owner |
 | `SUPABASE_URL` | Server-only | Stripe/order/support Edge Functions, `refund-adjustment-sync` | Supabase project URL | Technical owner |
 | `SUPABASE_ANON_KEY` | Server-only | `stripe-sugar-checkout`, `stripe-plus-checkout`, `stripe-customer-portal` | Supabase project anon key | Technical owner |
-| `SUPABASE_SERVICE_ROLE_KEY` | Server-only | `stripe-webhook`, `stripe-sugar-checkout`, `lead-submission-intake`, `support-request-intake`, `refund-adjustment-sync` | Supabase service role key | Technical owner |
+| `SUPABASE_SERVICE_ROLE_KEY` | Server-only | `stripe-webhook`, `stripe-sugar-checkout`, `lead-submission-intake`, `support-request-intake`, `access-invite`, `refund-adjustment-sync` | Supabase service role key | Technical owner |
 | `REPORT_SCHEDULER_SECRET` | Server-only | `sales-report-scheduler`, `refund-adjustment-sync` | Generated secret stored in function secrets | Technical owner |
 | `REPORTING_INGEST_TOKEN` | Server-only + GitHub Actions secret | `sunze-sales-ingest`, Sunze sync workflow | Generated ingest token | Technical owner |
 | `REPORTING_ROW_HASH_SALT` | Server-only | `sunze-sales-ingest` | Generated secret stored in function secrets | Technical owner |
@@ -53,6 +53,7 @@ Set the following values before launch.
 
 Security rule:
 - Never place secrets in `VITE_` variables.
+- Leave `BLOOMJOY_ALLOWED_VERCEL_PREVIEW_ORIGINS` unset in production. For temporary preview/UAT invite testing only, set it to comma-separated exact `https://<preview>.vercel.app` origins that should be allowed in invite login links.
 
 ## 3) Pre-launch checklist (T-24h)
 - [ ] Launch freeze announced (no unrelated merges to `main` during launch window).
@@ -142,7 +143,7 @@ Refund source note:
 - Add GitHub secrets `REFUND_ADJUSTMENT_SYNC_URL` and `REFUND_ADJUSTMENT_SYNC_TOKEN`. The token should match `REPORT_SCHEDULER_SECRET`; do not use the Supabase service-role key. Manual runs fail fast if they are missing. Scheduled runs skip until the repository variable `REFUND_ADJUSTMENT_SYNC_ENABLED=true`.
 
 ### Step C: Deploy Supabase Edge Functions
-Deploy all current checkout, submission, and reporting functions:
+Deploy all current checkout, submission, invite, and reporting functions:
 
 Before deploying reporting functions, confirm Step A has completed and `supabase db push --dry-run` reports the remote database is up to date. Reporting exports may depend on newly added snapshot columns or indexes.
 
@@ -156,6 +157,7 @@ supabase functions deploy lead-submission-intake --no-verify-jwt
 supabase functions deploy custom-sticks-artwork-upload --no-verify-jwt
 supabase functions deploy custom-sticks-artwork-link --no-verify-jwt
 supabase functions deploy support-request-intake --no-verify-jwt
+supabase functions deploy access-invite --no-verify-jwt
 supabase functions deploy sales-report-export --no-verify-jwt
 supabase functions deploy partner-report-export --no-verify-jwt
 supabase functions deploy sales-report-scheduler --no-verify-jwt
@@ -258,6 +260,7 @@ Rollback order:
      - `stripe-customer-portal`
      - `stripe-webhook`
      - `support-request-intake`
+     - `access-invite`
 3) Secrets:
    - Restore prior secrets only if rotation caused failure.
 4) Database:

--- a/scripts/validate-edge-url-allowlists.mjs
+++ b/scripts/validate-edge-url-allowlists.mjs
@@ -11,6 +11,11 @@ const allowedProductionUrls = [
   "https://app.bloomjoyusa.com/login",
 ];
 
+const allowedPreviewOrigin = "https://bloomjoy-hub-git-cp-uat-challenge-bloomjoy.vercel.app";
+const allowedPreviewUrls = [
+  `${allowedPreviewOrigin}/login?intent=technician&email=qa%40example.com`,
+];
+
 const rejectedUrls = [
   "https://example.com/cart?checkout=success",
   "https://bloomjoyusa.com/login",
@@ -18,6 +23,7 @@ const rejectedUrls = [
   "javascript:alert(1)",
   "https://www.bloomjoyusa.com.evil.test/cart",
   "https://user:pass@app.bloomjoyusa.com/login",
+  "https://bloomjoy-hub-git-unconfigured-bloomjoy.vercel.app/login",
 ];
 
 for (const url of allowedProductionUrls) {
@@ -38,6 +44,32 @@ for (const url of allowedLocalUrls) {
   assert.equal(result.ok, false, `${url} should be rejected by default`);
   assert.match(result.error, /Bloomjoy production origin/);
 }
+
+for (const url of allowedPreviewUrls) {
+  process.env.BLOOMJOY_ALLOWED_VERCEL_PREVIEW_ORIGINS = allowedPreviewOrigin;
+  const result = validateBrowserUrl(url, {
+    label: "test URL",
+    allowConfiguredPreviewOrigins: true,
+  });
+  assert.equal(result.ok, true, `${url} should be allowed for opted-in access-invite preview origin`);
+  assert.equal(result.isPreviewOrigin, true, `${url} should be marked as preview origin`);
+}
+
+for (const url of allowedPreviewUrls) {
+  const result = validateBrowserUrl(url, { label: "test URL" });
+  assert.equal(result.ok, false, `${url} should be rejected by default checkout-style validation`);
+  assert.match(result.error, /Bloomjoy production origin/);
+}
+
+const rejectedPreviewBypass = validateBrowserUrl("https://example.com/login", {
+  label: "test URL",
+  allowedPreviewOrigins: ["https://example.com"],
+});
+assert.equal(
+  rejectedPreviewBypass.ok,
+  false,
+  "configured preview origins must be exact Vercel preview origins",
+);
 
 for (const url of rejectedUrls) {
   const result = validateBrowserUrl(url, { label: "test URL" });

--- a/supabase/functions/_shared/browser-url-allowlist.mjs
+++ b/supabase/functions/_shared/browser-url-allowlist.mjs
@@ -5,19 +5,25 @@ const allowedProductionOrigins = new Set([
 
 const allowedLocalHosts = new Set(["localhost", "127.0.0.1"]);
 const allowedLocalProtocols = new Set(["http:", "https:"]);
+const allowedPreviewProtocol = "https:";
+const vercelPreviewHostnameSuffix = ".vercel.app";
 const enabledEnvValues = new Set(["1", "true", "yes", "on"]);
+const previewOriginsEnvKey = "BLOOMJOY_ALLOWED_VERCEL_PREVIEW_ORIGINS";
 
 /**
  * @typedef {Object} BrowserUrlValidationOptions
  * @property {string} [label]
  * @property {string | null} [fallbackUrl]
  * @property {boolean} [allowLocalUrls]
+ * @property {boolean} [allowConfiguredPreviewOrigins]
+ * @property {string[]} [allowedPreviewOrigins]
  *
  * @typedef {Object} BrowserUrlValidationSuccess
  * @property {true} ok
  * @property {string} url
  * @property {boolean} isProductionOrigin
  * @property {boolean} isLocalOrigin
+ * @property {boolean} isPreviewOrigin
  *
  * @typedef {Object} BrowserUrlValidationFailure
  * @property {false} ok
@@ -32,23 +38,62 @@ export const allowedBrowserUrlOrigins = Object.freeze([
   "https://localhost:<port>",
   "http://127.0.0.1:<port>",
   "https://127.0.0.1:<port>",
+  "configured https://<exact-vercel-preview>.vercel.app origins",
 ]);
 
-const getDenoEnv = (key) => {
-  if (typeof Deno === "undefined") return null;
-
+const getRuntimeEnv = (key) => {
   try {
-    return Deno.env.get(key) ?? null;
+    if (typeof Deno !== "undefined") {
+      return Deno.env.get(key) ?? null;
+    }
   } catch {
-    return null;
+    // Fall through to process.env for Node-based validation scripts.
   }
+
+  if (typeof process !== "undefined" && process?.env) {
+    return process.env[key] ?? null;
+  }
+
+  return null;
 };
 
 const isEnabledEnvValue = (value) =>
   enabledEnvValues.has(String(value ?? "").trim().toLowerCase());
 
+const parseCommaSeparatedValues = (value) =>
+  String(value ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+
+const normalizePreviewOrigin = (value) => {
+  try {
+    const url = new URL(value);
+    const hostname = url.hostname.toLowerCase();
+    if (
+      url.protocol !== allowedPreviewProtocol ||
+      url.username ||
+      url.password ||
+      !hostname.endsWith(vercelPreviewHostnameSuffix)
+    ) {
+      return null;
+    }
+
+    return url.origin;
+  } catch {
+    return null;
+  }
+};
+
+export const getAllowedPreviewOrigins = (configuredOrigins) =>
+  new Set(
+    (configuredOrigins ?? parseCommaSeparatedValues(getRuntimeEnv(previewOriginsEnvKey)))
+      .map(normalizePreviewOrigin)
+      .filter(Boolean),
+  );
+
 const isLocalSupabaseRuntime = () => {
-  const supabaseUrl = getDenoEnv("SUPABASE_URL");
+  const supabaseUrl = getRuntimeEnv("SUPABASE_URL");
   if (!supabaseUrl) return false;
 
   try {
@@ -60,7 +105,7 @@ const isLocalSupabaseRuntime = () => {
 };
 
 export const areLocalBrowserUrlsAllowed = () =>
-  isEnabledEnvValue(getDenoEnv("BLOOMJOY_ALLOW_LOCAL_REDIRECT_URLS")) ||
+  isEnabledEnvValue(getRuntimeEnv("BLOOMJOY_ALLOW_LOCAL_REDIRECT_URLS")) ||
   isLocalSupabaseRuntime();
 
 /**
@@ -70,15 +115,29 @@ export const areLocalBrowserUrlsAllowed = () =>
  */
 export const validateBrowserUrl = (
   value,
-  { label = "URL", fallbackUrl = null, allowLocalUrls } = {},
+  {
+    label = "URL",
+    fallbackUrl = null,
+    allowLocalUrls,
+    allowConfiguredPreviewOrigins = false,
+    allowedPreviewOrigins,
+  } = {},
 ) => {
   const raw = typeof value === "string" ? value.trim() : "";
   const candidate = raw || fallbackUrl;
   const localUrlsAreAllowed =
     typeof allowLocalUrls === "boolean" ? allowLocalUrls : areLocalBrowserUrlsAllowed();
+  const previewOrigins = allowedPreviewOrigins || allowConfiguredPreviewOrigins
+    ? getAllowedPreviewOrigins(allowedPreviewOrigins)
+    : new Set();
+  const previewUrlsAreAllowed = previewOrigins.size > 0;
   const allowedOriginDescription = localUrlsAreAllowed
-    ? "a Bloomjoy production or localhost/127.0.0.1 origin"
-    : "a Bloomjoy production origin";
+    ? previewUrlsAreAllowed
+      ? "a Bloomjoy production, localhost/127.0.0.1, or configured Vercel preview origin"
+      : "a Bloomjoy production or localhost/127.0.0.1 origin"
+    : previewUrlsAreAllowed
+      ? "a Bloomjoy production or configured Vercel preview origin"
+      : "a Bloomjoy production origin";
 
   if (!candidate) {
     return {
@@ -109,8 +168,9 @@ export const validateBrowserUrl = (
     localUrlsAreAllowed &&
     allowedLocalHosts.has(url.hostname) &&
     allowedLocalProtocols.has(url.protocol);
+  const isPreviewOrigin = previewOrigins.has(url.origin);
 
-  if (!isProductionOrigin && !isLocalOrigin) {
+  if (!isProductionOrigin && !isLocalOrigin && !isPreviewOrigin) {
     return {
       ok: false,
       error: `${label} must use ${allowedOriginDescription}.`,
@@ -122,5 +182,6 @@ export const validateBrowserUrl = (
     url: url.toString(),
     isProductionOrigin,
     isLocalOrigin,
+    isPreviewOrigin,
   };
 };

--- a/supabase/functions/access-invite/index.ts
+++ b/supabase/functions/access-invite/index.ts
@@ -40,9 +40,87 @@ type InviteSource = {
   accessSummary: string;
 };
 
+type InviteAttempt = {
+  inviteType: InviteType;
+  sourceType: SourceType;
+  sourceId: string;
+  targetEmail: string;
+  targetUserId?: string | null;
+};
+
+type DeliveryStatus = "sent" | "failed";
+type AuditAction = "access_invite.sent" | "access_invite.failed";
+type InviteEvidenceMeta = Record<string, unknown>;
+type EvidenceTarget = "access_invite_deliveries" | "admin_audit_log";
+type EvidenceWriteFailure = {
+  target: EvidenceTarget;
+  message: string;
+};
+
+const sourceTypeByInviteType: Record<InviteType, SourceType> = {
+  corporate_partner: "corporate_partner_membership",
+  technician: "technician_grant",
+};
+const maxEvidenceMessageLength = 500;
+const sentEvidenceFailureMessage =
+  "Invite email may have been sent, but Bloomjoy could not record delivery evidence. Please verify delivery and audit logs before retrying.";
+
 const sanitizeText = (value: unknown) => (typeof value === "string" ? value.trim() : "");
 
 const normalizeEmail = (value: unknown) => sanitizeText(value).toLowerCase();
+
+class InviteEvidenceError extends Error {
+  failedTargets: EvidenceTarget[];
+
+  constructor(status: DeliveryStatus, failures: EvidenceWriteFailure[]) {
+    const failedTargets = [...new Set(failures.map((failure) => failure.target))];
+    super(`Unable to record access invite ${status} evidence in ${failedTargets.join(" and ")}.`);
+    this.name = "InviteEvidenceError";
+    this.failedTargets = failedTargets;
+  }
+}
+
+const sanitizeErrorEvidence = (value: unknown, fallback = "Unable to send access invite.") => {
+  const raw = value instanceof Error
+    ? value.message
+    : typeof value === "string"
+      ? value
+      : fallback;
+  const message = (raw || fallback)
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[email]")
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [redacted]")
+    .replace(/(api[_-]?key["':=\s]+)[A-Za-z0-9._~+/=-]+/gi, "$1[redacted]")
+    .slice(0, maxEvidenceMessageLength);
+
+  return message || fallback;
+};
+
+const getLoginOriginMeta = (loginUrlResult: {
+  url: string;
+  isProductionOrigin?: boolean;
+  isLocalOrigin?: boolean;
+  isPreviewOrigin?: boolean;
+}): InviteEvidenceMeta => {
+  let loginOrigin = "unknown";
+  try {
+    loginOrigin = new URL(loginUrlResult.url).origin;
+  } catch {
+    loginOrigin = "unparseable";
+  }
+
+  const loginOriginType = loginUrlResult.isProductionOrigin
+    ? "production"
+    : loginUrlResult.isLocalOrigin
+      ? "local"
+      : loginUrlResult.isPreviewOrigin
+        ? "preview"
+        : "unknown";
+
+  return {
+    login_origin: loginOrigin,
+    login_origin_type: loginOriginType,
+  };
+};
 
 const escapeHtml = (value: string): string =>
   value
@@ -216,38 +294,108 @@ async function getTechnicianSource(sourceId: string, targetEmail: string): Promi
   };
 }
 
-async function insertDelivery(source: InviteSource, actorUserId: string, status: "sent" | "failed", errorMessage?: string) {
-  if (!supabase) return;
+async function recordInviteEvidence(
+  attempt: InviteAttempt,
+  actorUserId: string,
+  status: DeliveryStatus,
+  meta: InviteEvidenceMeta = {},
+  errorMessage?: string
+) {
+  if (!supabase) {
+    throw new InviteEvidenceError(status, [
+      { target: "access_invite_deliveries", message: "Supabase is not configured." },
+      { target: "admin_audit_log", message: "Supabase is not configured." },
+    ]);
+  }
 
-  await supabase.from("access_invite_deliveries").insert({
-    invite_type: source.inviteType,
-    source_type: source.sourceType,
-    source_id: source.sourceId,
-    target_email: source.targetEmail,
-    sent_by: actorUserId,
+  const safeErrorMessage = errorMessage ? sanitizeErrorEvidence(errorMessage) : undefined;
+  const action: AuditAction = status === "sent" ? "access_invite.sent" : "access_invite.failed";
+  const auditMeta = {
+    invite_type: attempt.inviteType,
+    source_type: attempt.sourceType,
+    source_id: attempt.sourceId,
+    target_email: attempt.targetEmail,
     delivery_status: status,
-    error_message: errorMessage ?? null,
-  });
+    ...meta,
+    ...(safeErrorMessage ? { error_message: safeErrorMessage } : {}),
+  };
+
+  const evidenceWrites: Array<{ target: EvidenceTarget; write: PromiseLike<void> }> = [
+    {
+      target: "access_invite_deliveries",
+      write: supabase.from("access_invite_deliveries").insert({
+        invite_type: attempt.inviteType,
+        source_type: attempt.sourceType,
+        source_id: attempt.sourceId,
+        target_email: attempt.targetEmail,
+        sent_by: actorUserId,
+        delivery_status: status,
+        error_message: safeErrorMessage ?? null,
+      }).then(({ error }) => {
+        if (error) throw error;
+      }),
+    },
+    {
+      target: "admin_audit_log",
+      write: supabase.from("admin_audit_log").insert({
+        actor_user_id: actorUserId,
+        action,
+        entity_type: attempt.sourceType,
+        entity_id: attempt.sourceId,
+        target_user_id: attempt.targetUserId ?? null,
+        before: {},
+        after: {},
+        meta: auditMeta,
+      }).then(({ error }) => {
+        if (error) throw error;
+      }),
+    },
+  ];
+
+  const writes = await Promise.allSettled(evidenceWrites.map(({ write }) => write));
+  const failedWrites = writes.flatMap((result, index): EvidenceWriteFailure[] =>
+    result.status === "rejected"
+      ? [{
+          target: evidenceWrites[index].target,
+          message: sanitizeErrorEvidence(result.reason, "Unable to record invite evidence."),
+        }]
+      : []
+  );
+
+  if (failedWrites.length > 0) {
+    console.warn("access-invite evidence write failed", {
+      failed_targets: failedWrites.map((failure) => failure.target),
+      failures: failedWrites,
+      source_type: attempt.sourceType,
+      source_id: attempt.sourceId,
+      delivery_status: status,
+    });
+    throw new InviteEvidenceError(status, failedWrites);
+  }
 }
 
-async function insertAudit(
-  source: InviteSource,
+async function recordFailureEvidence(
+  attempt: InviteAttempt,
   actorUserId: string,
-  action: "access_invite.sent" | "access_invite.failed",
-  meta: Record<string, unknown>
+  meta: InviteEvidenceMeta,
+  failure: unknown,
+  fallback: string,
 ) {
-  if (!supabase) return;
+  const message = sanitizeErrorEvidence(failure, fallback);
 
-  await supabase.from("admin_audit_log").insert({
-    actor_user_id: actorUserId,
-    action,
-    entity_type: source.sourceType,
-    entity_id: source.sourceId,
-    target_user_id: source.targetUserId,
-    before: {},
-    after: {},
-    meta,
-  });
+  try {
+    await recordInviteEvidence(attempt, actorUserId, "failed", meta, message);
+  } catch (evidenceError) {
+    console.error("access-invite failure evidence unavailable", {
+      original_error_message: message,
+      evidence_error_message: sanitizeErrorEvidence(
+        evidenceError,
+        "Unable to record invite failure evidence.",
+      ),
+    });
+  }
+
+  return message;
 }
 
 serve(async (req) => {
@@ -302,6 +450,7 @@ serve(async (req) => {
     const loginUrlResult = validateBrowserUrl(body?.loginUrl, {
       label: "login URL",
       fallbackUrl: fallbackLoginUrl,
+      allowConfiguredPreviewOrigins: true,
     });
 
     if (!["corporate_partner", "technician"].includes(inviteType)) {
@@ -325,16 +474,45 @@ serve(async (req) => {
       });
     }
 
+    const inviteAttempt: InviteAttempt = {
+      inviteType,
+      sourceType: sourceTypeByInviteType[inviteType],
+      sourceId,
+      targetEmail,
+    };
+
     if (!loginUrlResult.ok) {
+      await recordFailureEvidence(
+        inviteAttempt,
+        user.id,
+        { login_origin_type: "invalid" },
+        loginUrlResult.error,
+        "Login URL is invalid.",
+      );
+
       return new Response(JSON.stringify({ error: loginUrlResult.error }), {
         status: 400,
         headers: { ...corsHeaders, "Content-Type": "application/json" },
       });
     }
 
-    const source = inviteType === "corporate_partner"
-      ? await getCorporatePartnerSource(sourceId, targetEmail)
-      : await getTechnicianSource(sourceId, targetEmail);
+    const loginOriginMeta = getLoginOriginMeta(loginUrlResult);
+    let source: InviteSource;
+    try {
+      source = inviteType === "corporate_partner"
+        ? await getCorporatePartnerSource(sourceId, targetEmail)
+        : await getTechnicianSource(sourceId, targetEmail);
+    } catch (sourceError) {
+      await recordFailureEvidence(
+        inviteAttempt,
+        user.id,
+        loginOriginMeta,
+        sourceError,
+        "Unable to load invite source.",
+      );
+      throw sourceError;
+    }
+
     const email = buildInviteEmail(source, loginUrlResult.url, normalizeEmail(user.email));
 
     try {
@@ -345,37 +523,40 @@ serve(async (req) => {
         html: email.html,
       });
     } catch (sendError) {
-      const message = sendError instanceof Error ? sendError.message : "Unable to send invite email.";
-      await insertDelivery(source, user.id, "failed", message);
-      await insertAudit(source, user.id, "access_invite.failed", {
-        invite_type: source.inviteType,
-        source_type: source.sourceType,
-        source_id: source.sourceId,
-        target_email: source.targetEmail,
-        delivery_status: "failed",
-        error_message: message,
-      });
-      throw sendError;
+      const message = await recordFailureEvidence(
+        source,
+        user.id,
+        loginOriginMeta,
+        sendError,
+        "Unable to send invite email.",
+      );
+      throw new Error(message);
     }
 
-    await insertDelivery(source, user.id, "sent");
-    await insertAudit(source, user.id, "access_invite.sent", {
-      invite_type: source.inviteType,
-      source_type: source.sourceType,
-      source_id: source.sourceId,
-      target_email: source.targetEmail,
-      delivery_status: "sent",
-    });
+    try {
+      await recordInviteEvidence(source, user.id, "sent", loginOriginMeta);
+    } catch (evidenceError) {
+      console.error("access-invite sent evidence unavailable", {
+        evidence_error_message: sanitizeErrorEvidence(
+          evidenceError,
+          "Unable to record invite sent evidence.",
+        ),
+        source_type: source.sourceType,
+        source_id: source.sourceId,
+      });
+
+      return new Response(JSON.stringify({ error: sentEvidenceFailureMessage }), {
+        status: 500,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
 
     return new Response(JSON.stringify({ ok: true }), {
       headers: { ...corsHeaders, "Content-Type": "application/json" },
     });
   } catch (error) {
-    console.error("access-invite error", error);
-    const message =
-      error instanceof Error && error.message
-        ? error.message
-        : "Unable to send access invite.";
+    const message = sanitizeErrorEvidence(error, "Unable to send access invite.");
+    console.error("access-invite error", message);
 
     return new Response(JSON.stringify({ error: message }), {
       status: 500,


### PR DESCRIPTION
## Summary
- Makes `access-invite` fail closed when invite delivery or audit evidence cannot be recorded.
- Keeps Vercel preview origins opt-in for the invite function instead of widening all browser-return URL allowlists.
- Updates local/prod docs for invite runtime checks and preview environment setup.

Refs #375

## Files changed
- `supabase/functions/access-invite/index.ts`: invite delivery/audit evidence handling.
- `supabase/functions/_shared/browser-url-allowlist.mjs`: opt-in configured preview origins.
- `scripts/validate-edge-url-allowlists.mjs`: allowlist regression checks.
- `Docs/LOCAL_DEV.md`, `Docs/PRODUCTION_RUNBOOK.md`: operator guidance.

## Verification
- `npm ci`: not run in this Codex environment because `npm` is not available on PATH.
- `npm run build`: PASS via direct equivalent `.\node_modules\.bin\vite.cmd build`.
- `npm test --if-present`: not run; package has no `test` script and `npm` is not available on PATH.
- `npm run lint --if-present`: PASS via direct equivalent `.\node_modules\.bin\eslint.cmd .` with 0 errors and 8 existing fast-refresh warnings.
- `npm run db:validate-migrations`: PASS via direct equivalent `node scripts\validate-supabase-migrations.mjs`.
- `node scripts\validate-edge-url-allowlists.mjs`: PASS.
- `deno check supabase/functions/access-invite/index.ts`: PASS.

## How to test
1. Check out this branch and run the app locally from the worktree.
2. Serve/deploy `access-invite` with valid Supabase and Resend secrets.
3. Send a Corporate Partner invite from `/admin/access`.
4. Confirm the function returns success only when both email delivery and evidence rows are recorded.
5. Verify `access_invite_deliveries` has the invite attempt and `admin_audit_log` has the matching admin action.
6. Verify configured preview origins are accepted only for `access-invite`, while checkout/billing return URLs continue to reject arbitrary preview origins.

## Rollback plan
- Revert this PR and redeploy the previous `access-invite` function.

## Release gate
- This PR should merge and deploy before the Corporate Partner admin grant-flow PR, because that UI depends on durable invite evidence before treating portal access as launch-ready.