### PR TITLE
Make access invite email copy generic

### DIFF
--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -267,6 +267,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Access Launcher opens from `/admin/access` and deep links from `/admin/access?action=add-access`, with preset links for `corporate_partner`, `technician`, `scoped_admin`, `super_admin`, and `plus_customer`.
 - [ ] Access Launcher Corporate Partner preset can grant email-based access for a never-authenticated email, send the invite email, and write both `access_invite_deliveries` and `admin_audit_log` evidence.
 - [ ] Access Launcher Technician preset can grant training-only access or exactly one machine, send the invite email, and preserve the one-machine Technician reporting boundary.
+- [ ] Access invite email copy stays generic: it may mention the relevant partner/account context, but it must not promise specific roles, grants, discounts, Technician management, or reporting permissions.
 - [ ] Login invite URLs `/login?intent=corporate_partner&email=...` and `/login?intent=technician&email=...` prefill the email, show the contextual invite banner, and keep password, Google, and email-link sign-in available.
 - [ ] Scoped Admin, Super Admin, and Plus Customer presets require an existing auth user and route to the selected person workspace instead of creating pending admin/customer invites.
 - [ ] Non-admin and Scoped Admin sessions cannot call the `access-invite` Edge Function; invalid source IDs, mismatched target emails, revoked grants, and expired Technician grants are rejected.

--- a/supabase/functions/access-invite/index.ts
+++ b/supabase/functions/access-invite/index.ts
@@ -134,9 +134,7 @@ const getStringValue = (record: Record<string, unknown>, key: string) =>
   typeof record[key] === "string" ? record[key] as string : "";
 
 const buildInviteEmail = (source: InviteSource, loginUrl: string, actorEmail: string) => {
-  const subject = source.inviteType === "corporate_partner"
-    ? "Bloomjoy Corporate Partner access"
-    : "Bloomjoy Technician access";
+  const subject = "Bloomjoy portal invitation";
   const inviter = actorEmail || "A Bloomjoy administrator";
 
   const text = [
@@ -233,10 +231,10 @@ async function getCorporatePartnerSource(sourceId: string, targetEmail: string):
     sourceId,
     targetEmail,
     targetUserId: getStringValue(membershipRecord, "user_id") || null,
-    title: "Corporate Partner access is ready",
-    body: `You have been added as a Corporate Partner for ${partnerName}.`,
+    title: "Your Bloomjoy portal invitation",
+    body: `You have been invited to access Bloomjoy Hub for ${partnerName}.`,
     accessSummary:
-      "Corporate Partner access can include partner reporting, training, support, member supply pricing, and Technician management for eligible portal-enabled partnership machines.",
+      "After you sign in, Bloomjoy Hub will show the tools and information available to your account.",
   };
 }
 
@@ -287,10 +285,10 @@ async function getTechnicianSource(sourceId: string, targetEmail: string): Promi
     sourceId,
     targetEmail,
     targetUserId: getStringValue(grantRecord, "technician_user_id") || null,
-    title: "Technician access is ready",
-    body: `You have been added as a Technician for ${accountName}.`,
+    title: "Your Bloomjoy portal invitation",
+    body: `You have been invited to access Bloomjoy Hub for ${accountName}.`,
     accessSummary:
-      "Technician access includes Bloomjoy training and, when assigned, reporting for the specific machine selected by the account owner or Bloomjoy admin.",
+      "After you sign in, Bloomjoy Hub will show the tools and information available to your account.",
   };
 }
 


### PR DESCRIPTION
## Summary
- Makes access invite email subject/body generic so invite emails do not promise specific roles, grants, discounts, Technician management, or reporting permissions.
- Keeps useful partner/account context in the email so recipients know which Bloomjoy relationship the invite is for.
- Adds a smoke-checklist guardrail for future invite-email copy regressions.

## Files changed
- `supabase/functions/access-invite/index.ts`: generic invite subject, title, body, and summary copy for Corporate Partner and Technician invite emails.
- `Docs/QA_SMOKE_TEST_CHECKLIST.md`: new smoke coverage requiring generic invite copy.

## Verification
- `npm ci` equivalent via local npm CLI: passed, 0 vulnerabilities.
- `npm run build`: passed.
- `npm test --if-present`: passed; no test script present.
- `npm run lint --if-present`: passed with 0 errors and 8 existing Fast Refresh warnings.
- `npm run auth:preflight` equivalent with process-local env: passed.
- `npm run edge-url-allowlists:check` equivalent: passed.
- Independent AI review: no blocking issues; residual risk is that this copy change has not yet been exercised through a fresh end-to-end email after deployment.

## How to test
1. Start the app locally from this branch: `npm run dev`.
2. Open `http://localhost:8080/admin/access` as a Super Admin.
3. Use **Add or invite access** for either Corporate Partner or Technician.
4. Send an invite to a safe test email.
5. Confirm the received email uses generic copy:
   - Subject: `Bloomjoy portal invitation`
   - Body may mention the partner/account context.
   - Body must not promise specific roles, grants, discounts, Technician management, or reporting permissions.
6. Confirm the invite still opens the login link and the app decides permissions after sign-in.

## Rollback plan
- Revert this PR to restore the previous invite email copy.
- No database rollback is required.
- If merged, redeploy the `access-invite` Edge Function after rollback.

## Labels
- `P1`
- `risky-auth-payment`
- `ui-change`
- `ready-for-uat`