### PR TITLE
Close out P0 docs housekeeping

### DIFF
--- a/Docs/AUTH_OAUTH_BRANDING_RUNBOOK.md
+++ b/Docs/AUTH_OAUTH_BRANDING_RUNBOOK.md
@@ -2,7 +2,7 @@
 
 Purpose: make Google sign-in show Bloomjoy branding and move OAuth callbacks off `<project-ref>.supabase.co` to a Bloomjoy-owned auth subdomain.
 
-Last updated: 2026-03-22
+Last updated: 2026-05-04
 
 ## 1) Prerequisites
 - Domain access for Bloomjoy DNS (to create CNAME/TXT records).
@@ -11,6 +11,7 @@ Last updated: 2026-03-22
 - Supabase custom domain add-on enabled (required by Supabase to use custom auth hostname).
 - App URLs decided in advance:
   - Local app URL: `http://localhost:8080` (or your active Vite port)
+  - Vercel preview URL pattern: `https://*-snapcase.vercel.app/**`
   - Production operator app URL (canonical): `https://app.bloomjoyusa.com`
   - Production marketing URL: `https://www.bloomjoyusa.com`
   - Auth hostname target (recommended): `auth.bloomjoyusa.com`
@@ -33,6 +34,7 @@ Record status as `Not started`, `In progress`, `Done`, or `Blocked`.
 - Redirect URLs used by app flows:
   - `http://localhost:8080/portal`
   - `http://localhost:8080/reset-password`
+  - `https://*-snapcase.vercel.app/**` for Vercel preview UAT
   - `https://app.bloomjoyusa.com/portal`
   - `https://app.bloomjoyusa.com/reset-password`
 
@@ -57,6 +59,7 @@ Use these exact values when configuring Google OAuth + Supabase auth settings:
     - `http://localhost:8080/login`
     - `http://localhost:8080/portal`
     - `http://localhost:8080/reset-password`
+    - `https://*-snapcase.vercel.app/**`
     - `https://app.bloomjoyusa.com`
     - `https://app.bloomjoyusa.com/login`
     - `https://app.bloomjoyusa.com/portal`
@@ -144,6 +147,7 @@ Supabase Dashboard -> Authentication:
   - `http://localhost:8080/login`
   - `http://localhost:8080/portal`
   - `http://localhost:8080/reset-password`
+  - `https://*-snapcase.vercel.app/**`
   - `https://app.bloomjoyusa.com`
   - `https://app.bloomjoyusa.com/login`
   - `https://app.bloomjoyusa.com/portal`
@@ -160,8 +164,9 @@ Supabase Dashboard -> Authentication:
 - Do not commit production secrets or local `.env` files.
 
 Repo auth redirect behavior:
-- Login and Google auth redirects use the canonical app surface and route to `https://app.bloomjoyusa.com/portal`.
-- Password recovery redirects use the canonical app surface and route to `https://app.bloomjoyusa.com/reset-password`.
+- On production hosts, login and Google auth redirects use the canonical app surface and route to `https://app.bloomjoyusa.com/portal`.
+- On production hosts, password recovery redirects use the canonical app surface and route to `https://app.bloomjoyusa.com/reset-password`.
+- Vercel preview hosts ending in `.vercel.app` intentionally keep the active preview origin, so preview OAuth and magic-link flows require the Supabase Additional Redirect URL pattern `https://*-snapcase.vercel.app/**`.
 - If Google sign-in lands on bare `http://localhost:3000/#access_token=...`, the fallback is coming from Supabase project settings, not this repo's redirect helper.
 
 ## 8) Verification checklist
@@ -171,6 +176,7 @@ Repo auth redirect behavior:
   - [ ] OAuth callback returns to `/portal` and session is created.
 - Deployed environment:
   - [ ] Repeat verification on `https://app.bloomjoyusa.com/login`.
+  - [ ] For Vercel preview UAT, repeat verification from the PR preview `/login` URL and confirm the final browser URL stays on the same preview host at `/portal` instead of `https://app.bloomjoyusa.com/portal`.
   - [ ] Browser network trace shows callback host `auth.bloomjoyusa.com` (not `<PROJECT_REF>.supabase.co`).
   - [ ] Final post-auth browser URL is `https://app.bloomjoyusa.com/portal` (not `http://localhost:3000`).
   - [ ] No auth-console errors during sign-in.
@@ -203,6 +209,14 @@ Repo auth redirect behavior:
   - Set Supabase Site URL to `https://app.bloomjoyusa.com`.
   - Add `https://app.bloomjoyusa.com`, `/login`, `/portal`, and `/reset-password` to Supabase redirect URLs.
   - Retry from `https://app.bloomjoyusa.com/login` and confirm the final browser URL is `https://app.bloomjoyusa.com/portal`.
+
+### Preview login returns to production
+- Cause: the active Vercel preview origin is not present in the Supabase redirect allowlist, so Supabase falls back to the configured Site URL after auth.
+- Fix:
+  - Keep Supabase Site URL set to `https://app.bloomjoyusa.com`.
+  - Add `https://*-snapcase.vercel.app/**` to Supabase Additional Redirect URLs.
+  - Retry from the PR preview `/login` URL and confirm the final browser URL stays on the same preview host at `/portal`.
+  - If the preview is protected by Vercel Deployment Protection, treat that as a separate preview-access setting, not a Supabase redirect bug.
 
 ## 10) Launch hardening follow-up
 Anything still pending for production approval/review stays tracked in issue `#77`:

--- a/Docs/AUTH_PRODUCTION_SIGNOFF.md
+++ b/Docs/AUTH_PRODUCTION_SIGNOFF.md
@@ -2,7 +2,7 @@
 
 Purpose: convert deferred auth launch hardening into an execution checklist with clear ownership and evidence capture.
 
-Last updated: 2026-03-19
+Last updated: 2026-05-04
 
 ## 1) Owners and launch window
 - Launch date/time:
@@ -34,8 +34,8 @@ Status values: `Not started`, `In progress`, `Done`, `Blocked`.
 | Google OAuth callback host resolves to `auth.bloomjoyusa.com` in live flow |  |  |  |
 | Google OAuth client secret rotated after setup-sharing activity |  |  |  |
 | Supabase Google provider updated with current client credentials |  |  |  |
-| Supabase Site URL set to `https://www.bloomjoyusa.com` |  |  |  |
-| Supabase redirect URL allowlist includes `https://www.bloomjoyusa.com` routes plus apex `https://bloomjoyusa.com` cutover aliases |  |  |  |
+| Supabase Site URL set to `https://app.bloomjoyusa.com` |  |  |  |
+| Supabase redirect URL allowlist includes `https://app.bloomjoyusa.com` app routes plus `https://*-snapcase.vercel.app/**` for Vercel preview UAT |  |  |  |
 
 ## 4) Security and reliability checks
 ### Email OTP and rate limits
@@ -62,6 +62,7 @@ Capture evidence links for each required flow.
 | Password login (`/login` -> `/portal`) |  |  |
 | Magic link login (`/login` -> email -> `/portal`) |  |  |
 | Google login (`/login` -> consent -> `/portal`) |  |  |
+| Vercel preview login returns to the same preview host at `/portal` |  |  |
 | Google callback host is `auth.bloomjoyusa.com` |  |  |
 | Logged-out redirect guard (`/portal` -> `/login`) |  |  |
 | Branded auth email (signup confirmation) |  |  |
@@ -103,9 +104,14 @@ Manual evidence still required before go/no-go:
 
 ### Redirect lands on `http://localhost:3000/#access_token=...`
 - Treat this as a stale Supabase URL Configuration issue first.
-- Confirm Supabase Site URL is `https://www.bloomjoyusa.com`.
-- Confirm redirect allowlist includes `https://www.bloomjoyusa.com`, `/login`, `/portal`, and `/reset-password`.
-- Keep apex `https://bloomjoyusa.com` entries allowlisted during cutover if traffic can still start there.
+- Confirm Supabase Site URL is `https://app.bloomjoyusa.com`.
+- Confirm redirect allowlist includes `https://app.bloomjoyusa.com`, `/login`, `/portal`, and `/reset-password`.
+
+### Vercel preview login returns to production
+- Treat this as a missing Supabase preview redirect allowlist entry first.
+- Confirm Supabase Site URL remains `https://app.bloomjoyusa.com`.
+- Confirm Additional Redirect URLs include `https://*-snapcase.vercel.app/**`.
+- Retry from the PR preview `/login` URL and confirm the final URL stays on the same preview host at `/portal`.
 
 ## 7) Go/No-Go sign-off
 - [ ] All checklist items in sections 3-5 are complete.

--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -6,6 +6,13 @@
 - First priority is to **stabilize the POC** and align it to the MVP routing + docs workflow.
 - Write updates in plain language so non-technical readers can follow.
 
+## P0 docs/workflow closeout (2026-05-04)
+- Issue `#380` is no longer a code blocker for the Corporate Partner release. The owner added the Supabase preview redirect wildcard, non-secret OAuth initiation checks preserved preview hosts, and owner local login UAT passed.
+- Vercel Deployment Protection can still block ordinary unauthenticated preview access. Treat that as preview-access configuration, not the old Supabase redirect-to-production bug.
+- PR `#381` is superseded by the current closeout docs: the still-useful preview redirect guidance was carried into the auth runbook, auth sign-off checklist, smoke checklist, and `auth:preflight` output.
+- PR `#377` is superseded by the merged Corporate Partner release and this closeout. The durable admin-boundary and refund fallback decisions were moved into `Docs/DECISIONS.md`; its pre-release retro wording should not be merged as-is.
+- Recommended GitHub cleanup: close `#380` as resolved, close draft PRs `#381` and `#377` as superseded, and use the current closeout PR as the small documentation record.
+
 ## P0 admin permission-boundary QA (2026-05-04)
 - PR `#379` live security QA applied the pending Supabase migrations for refund guardrails and admin/Corporate Partner permission-boundary repair, then restored the missing `admin_revoke_super_admin` RPC with a forward-only migration.
 - Controlled live validation used disposable QA-only personas and sacrificial reporting/partner/Technician rows. The validator passed all static checks and all live negative RPC checks for Scoped Admin, Corporate Partner, Technician, Reporting User, and Baseline users.

--- a/Docs/DECISIONS.md
+++ b/Docs/DECISIONS.md
@@ -1,5 +1,41 @@
 # Decisions
 
+## 2026-05-04 - Vercel preview auth redirect support
+Vercel preview login should return to the same preview host when Supabase Auth is used for preview UAT.
+
+**Canonical rule**
+- Keep the Supabase Site URL on the production app host: `https://app.bloomjoyusa.com`.
+- Keep `https://*-snapcase.vercel.app/**` in Supabase Additional Redirect URLs so PR previews can complete login without falling back to production.
+- Treat Vercel Deployment Protection as a separate preview-access setting. It can block ordinary executive preview access even when Supabase redirects are configured correctly.
+
+**Why this choice**
+- Preview UAT needs to test the PR deployment, not the production app.
+- The app already asks Supabase to return to the active app surface; Supabase must allow that destination before it will honor the request.
+
+## 2026-05-02 - Admin access boundary rule
+Scoped admins and partner-facing admins may manage only their current active machine/account scope.
+
+**Canonical rule**
+- Current active scope is the only manageable scope for partner/scoped admin workflows.
+- Historical, expired, inactive, removed, or otherwise out-of-scope machine/account access must not remain manageable through partner/scoped admin tools.
+- Any later expansion to historical or inactive access management needs an explicit new decision and implementation guardrails.
+
+**Why this choice**
+- Access management must reflect current authority, not old operational relationships.
+- This prevents partner/scoped admins from changing users or machines they no longer actively own.
+
+## 2026-05-02 - Refund fallback settlement rule
+Refund settlement may use Request Amount as a narrow fallback only after the rest of the required settlement context is present.
+
+**Canonical rule**
+- When refund status is `Closed`, the decision is approve-style, and the approved/refund amount is blank, Request Amount may be used as the settlement amount.
+- This fallback applies only when required settlement fields are otherwise present.
+- Rows missing date, location, status, or decision remain review-only and must not become settlement-ready through the fallback.
+
+**Why this choice**
+- Closed approved refunds often carry the business amount in Request Amount, but incomplete rows still need human review.
+- The fallback improves settlement completeness without weakening data-quality gates.
+
 ## 2026-04-29 - Business Playbook Plus tools access model
 Business Playbook public articles stay indexable. Plus-ready worksheets and operator templates may be previewed publicly, but downloadable files should live behind Plus/member access when download plumbing is implemented.
 

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -103,6 +103,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Forgot-password flow sends reset email and `/reset-password` successfully updates password
 - [ ] Google sign-in works when Supabase Google provider is enabled
 - [ ] Google sign-in returns to the app host `/portal` route (for production: `https://app.bloomjoyusa.com/portal`, not `http://localhost:3000`)
+- [ ] On Vercel preview UAT, Google or magic-link sign-in returns to the same preview host at `/portal` instead of `https://app.bloomjoyusa.com/portal`; if it falls back to production, confirm Supabase Additional Redirect URLs include `https://*-snapcase.vercel.app/**`
 - [ ] Google sign-in button follows official GIS rendering when `VITE_GOOGLE_CLIENT_ID` is configured locally
 - [ ] For auth launch hardening, Google consent screen shows Bloomjoy branding (name/logo/support email)
 - [ ] For auth launch hardening, Google callback host uses `auth.bloomjoyusa.com` (not `<project-ref>.supabase.co`)

--- a/scripts/auth-preflight.mjs
+++ b/scripts/auth-preflight.mjs
@@ -8,6 +8,7 @@ const DEFAULTS = {
   appOrigin: 'http://localhost:8080',
   prodAppOrigin: 'https://app.bloomjoyusa.com',
   prodMarketingOrigin: 'https://www.bloomjoyusa.com',
+  previewRedirectPattern: 'https://*-snapcase.vercel.app/**',
   projectRef: 'ygbzkgxktzqsiygjlqyg',
   customAuthHost: 'auth.bloomjoyusa.com',
   requireCustomAuthDomain: false,
@@ -44,6 +45,12 @@ function parseArgs(argv) {
 
     if (arg === '--prod-marketing-origin' && next) {
       parsed.prodMarketingOrigin = next;
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--preview-redirect-pattern' && next) {
+      parsed.previewRedirectPattern = next;
       i += 1;
       continue;
     }
@@ -264,6 +271,7 @@ function run() {
       `${origin}/portal`,
       `${origin}/reset-password`,
     ]),
+    args.previewRedirectPattern,
   ];
 
   printList('Google OAuth Authorized JavaScript origins (copy/paste)', [


### PR DESCRIPTION
## Summary
- Records the post-release recommendation for #380, #381, and #377 in `Docs/CURRENT_STATUS.md`.
- Carries forward the still-current Supabase preview redirect guidance from #381 into the auth docs, smoke checklist, and `auth:preflight` output.
- Preserves the durable admin-boundary and refund fallback decisions from #377 in `Docs/DECISIONS.md`, without merging stale pre-release retro wording.

## Files changed
- `Docs/CURRENT_STATUS.md`: plain-English closeout status and cleanup recommendation for #380/#381/#377.
- `Docs/DECISIONS.md`: Vercel preview auth redirect, admin active-scope boundary, and refund fallback settlement decisions.
- `Docs/AUTH_OAUTH_BRANDING_RUNBOOK.md`, `Docs/AUTH_PRODUCTION_SIGNOFF.md`, `Docs/QA_SMOKE_TEST_CHECKLIST.md`: preview auth redirect setup and smoke-test guidance.
- `scripts/auth-preflight.mjs`: prints `https://*-snapcase.vercel.app/**` in Supabase redirect copy/paste output.

## Recommendation
- #380: close as resolved after this closeout is accepted. Supabase preview redirects are no longer the Corporate Partner release blocker; Vercel Deployment Protection is a separate preview-access setting.
- #381: close as superseded by this PR. Its useful auth guidance is incorporated here on top of current `main`.
- #377: close as superseded by this PR and the merged release. Its durable decisions are incorporated here; its pre-release sprint retro should not merge as-is.

## Verification commands + results
- `git fetch origin`: passed during worktree preflight.
- `git status -sb`: clean before edits on `agent/p0-closeout-docs`; final branch contains one commit.
- `git diff --check`: passed; Git printed expected Windows LF-to-CRLF warnings only.
- `node --check scripts/auth-preflight.mjs`: passed.
- `node --run auth:preflight` with dummy non-secret local env values: passed and printed `Additional redirect URL: https://*-snapcase.vercel.app/**`.
- `npm ci`: blocked because `npm` is not installed/on PATH in this Codex shell.
- `npm run build`: blocked because `npm` is not installed/on PATH in this Codex shell.
- `npm test --if-present`: blocked because `npm` is not installed/on PATH in this Codex shell.
- `npm run lint --if-present`: blocked because `npm` is not installed/on PATH in this Codex shell.

## How to test
1. From a local checkout of this PR branch, run `npm ci` and `npm run dev` in `C:\Repos\wt-p0-closeout-docs` or another worktree.
2. Open `http://localhost:8080/login` and confirm the existing login page still renders.
3. Run `npm run auth:preflight` and confirm the Supabase URL Configuration output includes `Additional redirect URL: https://*-snapcase.vercel.app/**`.
4. Review `Docs/CURRENT_STATUS.md` and confirm the #380/#381/#377 recommendation is understandable to a nontechnical reader.

No secrets were added.