### PR TITLE
[agent] Harden supply order notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,8 +28,9 @@ SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
 RESEND_API_KEY=
 INTERNAL_NOTIFICATION_FROM_EMAIL=
-# Comma-separated internal recipients for quote/order notifications.
-INTERNAL_NOTIFICATION_RECIPIENTS=ops@bloomjoyusa.com,support@bloomjoyusa.com
+# Comma-separated additional internal recipients for quote/procurement/order notifications.
+# Ethan and Ian are always included by the Edge Function email helper.
+INTERNAL_NOTIFICATION_RECIPIENTS=etrifari@bloomjoysweets.com,ian@bloomjoysweets.com
 VIMEO_ACCESS_TOKEN=
 
 # Sales reporting automation (server-only)

--- a/Docs/BACKLOG.md
+++ b/Docs/BACKLOG.md
@@ -139,5 +139,5 @@ Guidelines:
 ## P2 - Ops hardening follow-ups
 36. **Operationalize WeCom alerts + WeChat onboarding concierge** (`#110`)
    - Define referral-buddy onboarding runbook and response-time SLA.
-   - Validate 1-week WeCom delivery reliability for quote/order/support alerts.
+   - Validate 1-week WeCom delivery reliability for quote/procurement/order/support alerts.
    - Capture sign-off evidence for onboarding intake + non-blocking alert failure behavior.

--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -6,6 +6,13 @@
 - First priority is to **stabilize the POC** and align it to the MVP routing + docs workflow.
 - Write updates in plain language so non-technical readers can follow.
 
+## Supply order notification hardening (2026-05-06)
+- Paid sugar and 5+ box branded-stick checkouts continue to persist in `orders`, send customer confirmations, and alert internal fulfillment through email plus WeCom when WeCom delivery is allowed.
+- Under-5 branded-stick requests and custom-stick requests now send internal procurement notifications from `lead-submission-intake`; those requests already persist as `lead_submissions`, and notification failures are recorded without losing the submission.
+- Internal email notifications always include Ethan (`etrifari@bloomjoysweets.com`) and Ian (`ian@bloomjoysweets.com`), while `INTERNAL_NOTIFICATION_RECIPIENTS` can add more recipients.
+- `/admin/orders` now opens each paid order with a fulfillment packet that summarizes what to ship, where to ship it, contact details, current fulfillment status, and notification health.
+- WeCom/WeChat Work remains the secondary alert channel. The code path is active for quote, procurement, order, and support events, but production delivery still depends on resolving the known WeCom app/network policy blocker.
+
 ## P0 docs/workflow closeout (2026-05-04)
 - Issue `#380` is no longer a code blocker for the Corporate Partner release. The owner added the Supabase preview redirect wildcard, non-secret OAuth initiation checks preserved preview hosts, and owner local login UAT passed.
 - Vercel Deployment Protection can still block ordinary unauthenticated preview access. Treat that as preview-access configuration, not the old Supabase redirect-to-production bug.
@@ -236,7 +243,7 @@
   - `npm run lint` (passes with existing fast-refresh warnings only)
 
 ## Session closeout snapshot (2026-03-10)
-- PR `#108` merged: WeCom internal-alert POC is now wired server-side for quote/order/support events with non-blocking failure handling.
+- PR `#108` merged: WeCom internal-alert POC is now wired server-side for quote/order/support events with non-blocking failure handling; procurement alerts were added later in the supply order hardening slice.
 - PR `#109` merged: portal + admin support now include WeChat onboarding concierge intake (`request_type=wechat_onboarding` + structured `intake_meta`) and queue filtering/metrics.
 - New follow-up issue opened and added to project board: `#110` (operationalize WeCom alert reliability + WeChat onboarding concierge runbook/SLA).
 
@@ -401,16 +408,16 @@ Execution order is based on launch risk and dependency overlap.
 - SEO structured-data hardening (`2026-03-09`): public-route HTML now includes JSON-LD (`Organization`, `WebSite`, `WebPage`) in both prerendered output and client-side route SEO updates so crawlers receive machine-readable page context.
 - SEO redirect/guard hardening (`2026-03-09`): added permanent host canonicalization redirect (`bloomjoyusa.com` -> `www.bloomjoyusa.com`) and permanent legacy path redirects (`/products*` -> `/machines*`) in `vercel.json`.
 - SEO CI hardening (`2026-03-09`): added `npm run seo:check` plus CI workflow coverage to validate robots/sitemap, canonical/noindex route outputs, JSON-LD presence on public routes, and redirect guard rules.
-- Submission notifications hardening: quote requests now flow through server-side `lead-submission-intake` and send internal summary emails; Stripe sugar order webhooks now send internal summary emails with duplicate-dispatch protection.
+- Submission notifications hardening: quote and procurement requests now flow through server-side `lead-submission-intake` and send internal summary emails; Stripe paid-order webhooks now send internal summary emails with duplicate-dispatch protection.
 - Submission notification recovery (`PR #103`, `2026-03-09`): resolved the internal-notification migration version collision by applying `202603090001_internal_notifications_backfill.sql`, aligned `INTERNAL_NOTIFICATION_FROM_EMAIL` to a verified Resend sender on `bloomjoyusa.com`, and revalidated quote-notification dispatch end-to-end (`lead-submission-intake` returns `200`, `internal_notification_sent_at` and dispatch `sent_at` are populated).
 - Session closeout smoke snapshot (`2026-03-09`): production-config API checks passed for quote notification dispatch, magic-link trigger, and password-reset trigger; remaining launch evidence is now limited to manual inbox/browser screenshots in `Docs/AUTH_PRODUCTION_SIGNOFF.md`.
-- WeCom alerting POC merged (`#107` via PR `#108`, `2026-03-10`): quote/order/support flows now attempt WeCom dispatch using server-only `WECOM_*` secrets with token cache + non-blocking failure logging.
+- WeCom alerting POC merged (`#107` via PR `#108`, `2026-03-10`): quote/procurement/order/support flows now attempt WeCom dispatch using server-only `WECOM_*` secrets with token cache + non-blocking failure logging.
 - WeChat onboarding concierge merged (PR `#109`, `2026-03-10`): support flow now includes structured onboarding intake (`phone/device/blocked step/referral`) persisted in `support_requests.intake_meta` and surfaced in `/admin/support` triage filters/cards.
 
 ## Known risks / blockers
 - Clear support boundary copy must be reviewed early (to prevent support overload)
 - Production credential execution remains owner-controlled (Google/Supabase/SMTP/DNS changes must be completed in dashboard tools before launch sign-off).
-- Internal notification pipeline is restored for quote submissions, but ongoing reliability still depends on keeping Resend/Supabase function secrets valid (`RESEND_API_KEY`, verified sender, recipient list).
+- Internal notification pipeline is restored for quote/procurement submissions and paid supply orders, but ongoing reliability still depends on keeping Resend/Supabase function secrets valid (`RESEND_API_KEY`, verified sender).
 - WeCom alert dispatch reliability now depends on owner-managed app policy as well as valid secrets/recipient scope; current live failure is `60020: not allow to access from your ip`.
 - WeChat onboarding concierge UX is live, but operational effectiveness still depends on documented referral-buddy process/SLA ownership (tracked in issue `#110`).
 - `#78` currently blocked on Supabase side: Custom Domain add-on is not enabled yet for project `ygbzkgxktzqsiygjlqyg`, so domain create/activate commands cannot run.

--- a/Docs/DECISIONS.md
+++ b/Docs/DECISIONS.md
@@ -1,5 +1,19 @@
 # Decisions
 
+## 2026-05-06 - Supply procurement notifications join the internal alert pipeline
+Supply procurement requests should use the same internal alert pattern as quote and paid order events.
+
+**Canonical rule**
+- Under-5 branded-stick requests and custom-stick requests remain `lead_submissions` because they need manual confirmation/proofing before payment or fulfillment.
+- `lead-submission-intake` sends internal notifications for `quote` and `procurement` submissions.
+- Internal notification email always includes Ethan (`etrifari@bloomjoysweets.com`) and Ian (`ian@bloomjoysweets.com`); `INTERNAL_NOTIFICATION_RECIPIENTS` may add more recipients.
+- WeCom/WeChat Work remains a secondary, non-blocking alert channel for quote, procurement, order, and support events.
+
+**Why this choice**
+- Small stick orders and custom sticks are operational supply requests even when they do not go through Stripe checkout yet.
+- Keeping procurement in the existing lead table avoids inventing a second order system while still giving fulfillment the same email/WeCom visibility.
+- Email must not depend on a single mutable recipient secret being perfect before orders start increasing.
+
 ## 2026-05-04 - Vercel preview auth redirect support
 Vercel preview login should return to the same preview host when Supabase Auth is used for preview UAT.
 
@@ -417,6 +431,7 @@ We will use **Resend** from Supabase Edge Functions for internal operations noti
 
 **Scope**
 - Quote request notifications from `lead-submission-intake`.
+- Supply procurement notifications from `lead-submission-intake`.
 - Sugar order notifications from `stripe-webhook` (`checkout.session.completed` payment mode).
 
 **Why this choice**
@@ -460,13 +475,14 @@ For current operations-event alerting, we will use **WeCom app messaging** from 
 
 **Scope**
 - Quote submission alerts (`lead-submission-intake`)
+- Supply procurement alerts (`lead-submission-intake`)
 - Sugar order alerts (`stripe-webhook`)
 - Support request alerts (`support-request-intake`)
 
 **Why this choice**
 - Keeps WeCom credentials server-side only (`WECOM_*` function secrets).
 - Aligns to actual ops communication channel without changing customer-facing auth flows.
-- Adds non-blocking behavior so core quote/order/support flows continue if WeCom is unavailable.
+- Adds non-blocking behavior so core quote/procurement/order/support flows continue if WeCom is unavailable.
 
 **Implementation notes**
 - Token lifecycle handled server-side with cached `access_token` fetch/refresh.

--- a/Docs/LOCAL_DEV.md
+++ b/Docs/LOCAL_DEV.md
@@ -276,7 +276,7 @@ Use this after a PR is merged or intentionally closed. Do not remove a worktree 
 - If an asset is needed in the app, add a small optimized version in `public/` and document it.
 
 ## Stripe and submission server-side functions (current)
-Stripe checkout/webhook flows and lead submission notifications currently run on Supabase Edge Functions.
+Stripe checkout/webhook flows and quote/procurement lead submission notifications currently run on Supabase Edge Functions.
 For production deployment order and rollback, use `Docs/PRODUCTION_RUNBOOK.md`.
 
 ### Supabase Edge Functions (Stripe + submissions)
@@ -294,7 +294,7 @@ For production deployment order and rollback, use `Docs/PRODUCTION_RUNBOOK.md`.
    - `supabase secrets set STRIPE_WEBHOOK_SECRET=...`
    - `supabase secrets set RESEND_API_KEY=...`
    - `supabase secrets set INTERNAL_NOTIFICATION_FROM_EMAIL=...`
-   - `supabase secrets set INTERNAL_NOTIFICATION_RECIPIENTS=ops@bloomjoyusa.com,support@bloomjoyusa.com`
+   - `supabase secrets set INTERNAL_NOTIFICATION_RECIPIENTS=etrifari@bloomjoysweets.com,ian@bloomjoysweets.com`
    - `supabase secrets set WECOM_CORP_ID=...`
    - `supabase secrets set WECOM_AGENT_ID=...`
    - `supabase secrets set WECOM_AGENT_SECRET=...`

--- a/Docs/PRODUCTION_RUNBOOK.md
+++ b/Docs/PRODUCTION_RUNBOOK.md
@@ -28,7 +28,7 @@ Set the following values before launch.
 | `STRIPE_WEBHOOK_SECRET` | Server-only | `stripe-webhook` | Stripe webhook endpoint signing secret | Billing owner |
 | `RESEND_API_KEY` | Server-only | `stripe-webhook`, `lead-submission-intake`, `access-invite` | Resend API key | Technical owner |
 | `INTERNAL_NOTIFICATION_FROM_EMAIL` | Server-only | `stripe-webhook`, `lead-submission-intake`, `access-invite` | Verified sender in Resend | Technical owner |
-| `INTERNAL_NOTIFICATION_RECIPIENTS` | Server-only | `stripe-webhook`, `lead-submission-intake` | Internal recipient list (comma-separated) | Release owner |
+| `INTERNAL_NOTIFICATION_RECIPIENTS` | Server-only | `stripe-webhook`, `lead-submission-intake` | Additional internal recipient list; Ethan/Ian are always included by the email helper | Release owner |
 | `WECOM_CORP_ID` | Server-only | `lead-submission-intake`, `stripe-webhook`, `support-request-intake` | WeCom app settings | Technical owner |
 | `WECOM_AGENT_ID` | Server-only | `lead-submission-intake`, `stripe-webhook`, `support-request-intake` | WeCom app settings | Technical owner |
 | `WECOM_AGENT_SECRET` | Server-only | `lead-submission-intake`, `stripe-webhook`, `support-request-intake` | WeCom app settings | Technical owner |
@@ -113,7 +113,7 @@ supabase secrets set STRIPE_PLUS_PRICE_ID=...
 supabase secrets set STRIPE_WEBHOOK_SECRET=...
 supabase secrets set RESEND_API_KEY=...
 supabase secrets set INTERNAL_NOTIFICATION_FROM_EMAIL=...
-supabase secrets set INTERNAL_NOTIFICATION_RECIPIENTS=ops@bloomjoyusa.com,support@bloomjoyusa.com
+supabase secrets set INTERNAL_NOTIFICATION_RECIPIENTS=etrifari@bloomjoysweets.com,ian@bloomjoysweets.com
 supabase secrets set WECOM_CORP_ID=...
 supabase secrets set WECOM_AGENT_ID=...
 supabase secrets set WECOM_AGENT_SECRET=...
@@ -205,18 +205,20 @@ Run immediately after deploy:
 - [ ] Anonymous/non-member sugar checkout charges `$10/kg` and creates `orders` record in Supabase.
 - [ ] Bloomjoy Plus sugar checkout charges `$8/kg` and creates `orders` record in Supabase.
 - [ ] Sugar checkout test order stores customer contact, billing/shipping address, pricing tier, receipt URL, and color breakdown in `orders`.
-- [ ] Sugar checkout test order sends internal summary email to configured operations recipients.
+- [ ] Sugar checkout test order sends internal summary email to Ethan/Ian plus any configured additional recipients.
 - [ ] Sugar checkout test order sends customer confirmation email with the branded HTML confirmation layout, order summary, and receipt link.
 - [ ] Sugar checkout test order sends WeCom alert when `WECOM_*` secrets are configured and the WeCom app/network policy allows traffic from the live function egress IPs.
 - [ ] Bloomjoy branded sticks checkout test order (5+ boxes) creates `orders` record in Supabase with size/address/shipping metadata.
-- [ ] Bloomjoy branded sticks checkout test order sends internal summary email to configured operations recipients.
+- [ ] Bloomjoy branded sticks checkout test order sends internal summary email to Ethan/Ian plus any configured additional recipients.
 - [ ] Bloomjoy branded sticks checkout test order sends customer confirmation email with the branded HTML confirmation layout.
+- [ ] Under-5 branded-stick procurement request creates a `lead_submissions` record and sends internal procurement email to Ethan/Ian plus any configured additional recipients.
+- [ ] Custom-stick procurement request creates a `lead_submissions` record with private artwork metadata and sends internal procurement email to Ethan/Ian plus any configured additional recipients.
 - [ ] Plus checkout test subscription creates/updates `subscriptions` record in Supabase.
 - [ ] Refund Adjustment Sync manual `dry_run=true` run returns aggregate counts only, with no private customer/payment/free-text values in logs.
 - [ ] Refund Adjustment Sync manual `dry_run=false` run creates a completed import run in `/admin/reporting`, applies only approved closed matched refunds, and leaves open/denied/unmatched/ambiguous/invalid rows in review.
-- [ ] Quote request on `/contact` sends internal summary email to configured operations recipients.
-- [ ] Quote/order/support events send WeCom alerts to configured internal recipients (or log non-blocking warning on dispatch failure).
-- [ ] `/admin/orders` shows address, pricing tier, receipt URL, order breakdown, and notification status for the test orders.
+- [ ] Quote request on `/contact` sends internal summary email to Ethan/Ian plus any configured additional recipients.
+- [ ] Quote/procurement/order/support events send WeCom alerts to configured internal recipients (or log non-blocking warning on dispatch failure).
+- [ ] `/admin/orders` shows the fulfillment packet, address, pricing tier, receipt URL, order breakdown, and notification status for the test orders.
 - [ ] `/admin/access?tab=users` loads account summaries without a red error state.
 - [ ] `/admin/access?tab=reporting-access` can save machine reporting grants with a required reason.
 - [ ] `/admin/partnerships` loads setup tabs without missing-RPC errors.

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -55,9 +55,9 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Sticks ordering on `/supplies?order=sticks` allows direct typed quantity input (not only +/- controls)
 - [ ] Sticks ordering clearly supports Bloomjoy branded paper sticks and custom paper sticks at `$130/box` with `2000 pieces/box`
 - [ ] Bloomjoy branded sticks flow requires machine size selection and delivery location type selection before request/checkout
-- [ ] Bloomjoy branded sticks orders under 5 boxes submit a procurement lead with box count, size, address type, and estimated shipping summary
+- [ ] Bloomjoy branded sticks orders under 5 boxes submit a procurement lead with box count, size, address type, and estimated shipping summary, then send internal email + WeCom procurement alerts when configured
 - [ ] Bloomjoy branded sticks orders of 5+ boxes launch direct Stripe checkout with free shipping and do not use the shared cart
-- [ ] Custom sticks flow on `/supplies?order=custom` accepts logo/image upload through a signed upload token and submits a procurement lead with private artwork storage metadata/path, requested box count, selected size, and `$750` first-order plate-fee note; no public artwork URL is stored in the lead message
+- [ ] Custom sticks flow on `/supplies?order=custom` accepts logo/image upload through a signed upload token and submits a procurement lead with private artwork storage metadata/path, requested box count, selected size, and `$750` first-order plate-fee note, then sends internal email + WeCom procurement alerts when configured; no public artwork URL is stored in the lead message
 - [ ] Super-admin artwork access can generate a signed URL for a submitted `custom-sticks-artwork` object and the link expires after the configured short window
 - [ ] Shared cart remains sugar-only and legacy stick items do not block checkout
 - [ ] Cart remains sugar-only and has no horizontal overflow on mobile viewports (`360x800`, `390x844`, `414x896`)
@@ -85,9 +85,10 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Mobile icon-only cart/menu controls have accessible names
 - [ ] Product-gallery thumbnail buttons are keyboard operable and announce selected image state
 - [ ] Contact/Quote submission creates a `lead_submissions` row in Supabase with expected type/email
-- [ ] Quote submissions send internal notification email with full request summary (name/email/source/type/message)
+- [ ] Quote submissions send internal notification email to Ethan/Ian and any configured additional recipients with full request summary (name/email/source/type/message)
 - [ ] Quote submissions send a WeCom internal alert to configured `WECOM_ALERT_TO_USERIDS` recipients
-- [ ] Public intake anti-abuse: repeated direct POSTs with the same IP/email are throttled, repeated identical payloads dedupe server-side, and quote notifications stop after the configured quota while normal Contact and procurement requests still return success
+- [ ] Procurement submissions send internal notification email to Ethan/Ian and any configured additional recipients with fulfillment next steps
+- [ ] Public intake anti-abuse: repeated direct POSTs with the same IP/email are throttled, repeated identical payloads dedupe server-side, and quote/procurement notifications stop after the configured quota while normal Contact and procurement requests still return success
 - [ ] `/machines/mini` SEO/meta copy no longer references waitlist or upcoming launch language
 
 ## Auth / portal
@@ -246,12 +247,12 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Sugar checkout completes with test card for high-quantity equal split (e.g., 500KG total)
 - [ ] Sugar checkout completes with test card for unequal split mix (custom per-color quantities)
 - [ ] Sugar checkout writes an `orders` row with customer email/name/phone, billing address, shipping address, pricing tier, unit price, shipping total, receipt URL, and sugar color mix
-- [ ] Sugar checkout completed webhook sends internal order summary email (customer, totals, pricing tier, sugar mix, line items)
+- [ ] Sugar checkout completed webhook sends internal order summary email to Ethan/Ian and any configured additional recipients (customer, totals, pricing tier, sugar mix, line items, fulfillment next steps)
 - [ ] Sugar checkout sends customer confirmation email with branded HTML layout, clear totals, shipping address, color quantities, and receipt link
 - [ ] Sugar checkout completed webhook sends a WeCom internal alert with order ID, customer, and sugar breakdown
 - [ ] Bloomjoy branded sticks checkout completes with test card for 5+ boxes and shows free shipping in Stripe Checkout
 - [ ] Bloomjoy branded sticks checkout writes an `orders` row with billing/shipping address, shipping total, receipt URL, and order detail metadata
-- [ ] Bloomjoy branded sticks checkout completed webhook sends internal order summary email with box count, machine size, address type, and shipping total
+- [ ] Bloomjoy branded sticks checkout completed webhook sends internal order summary email to Ethan/Ian and any configured additional recipients with box count, machine size, address type, shipping total, and fulfillment next steps
 - [ ] Bloomjoy branded sticks checkout sends customer confirmation email with branded HTML layout, shipping address, and receipt link
 - [ ] Bloomjoy branded sticks checkout completed webhook sends a WeCom internal alert with order ID, customer, and stick-order summary
 - [ ] Plus subscription checkout shows flat `$100/month` account pricing and completes with test card
@@ -295,7 +296,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Non-admin user cannot access `/admin/orders`
 - [ ] Super-admin user can access `/admin/orders`
 - [ ] Admin orders supports search by customer email/order ID and date range filtering
-- [ ] Admin orders detail panel shows billing/shipping address snapshots, pricing tier, unit price, receipt link, and notification statuses
+- [ ] Admin orders detail panel shows a fulfillment packet plus billing/shipping address snapshots, pricing tier, unit price, receipt link, and notification statuses
 - [ ] Admin orders detail panel shows sugar color quantities for sugar orders and box/size/address metadata for Bloomjoy branded stick orders
 - [ ] Admin fulfillment updates create `admin_audit_log` entries with `action=order.fulfillment_updated`
 - [ ] Non-admin user cannot access `/admin/access`

--- a/scripts/commerce-preflight.mjs
+++ b/scripts/commerce-preflight.mjs
@@ -186,7 +186,6 @@ function run() {
     'SUPABASE_SERVICE_ROLE_KEY',
     'RESEND_API_KEY',
     'INTERNAL_NOTIFICATION_FROM_EMAIL',
-    'INTERNAL_NOTIFICATION_RECIPIENTS',
     'STRIPE_SUGAR_NON_MEMBER_PRICE_ID',
     'STRIPE_STICKS_MEMBER_PRICE_ID',
     'WECOM_CORP_ID',
@@ -254,7 +253,7 @@ function run() {
   printList('Required commerce checks', [
     'Webhook secret present',
     'Member and non-member sugar price IDs configured',
-    'Internal email sender and recipients configured',
+    'Internal email sender configured; Ethan/Ian are default admin recipients',
     'WeCom alert secrets configured',
     'Supabase service-role and anon keys configured',
   ]);

--- a/scripts/validate-public-intake-anti-abuse.mjs
+++ b/scripts/validate-public-intake-anti-abuse.mjs
@@ -66,10 +66,14 @@ assert(
   'Repeated quote notification simulation did not trip the non-caller-controlled global notification quota.'
 );
 
-const insertIndex = intakeFunction.indexOf('.from("lead_submissions")');
-const submissionLimitIndex = intakeFunction.indexOf('rules: PUBLIC_INTAKE_SUBMISSION_LIMITS');
-const notificationLimitIndex = intakeFunction.indexOf('rules: PUBLIC_INTAKE_NOTIFICATION_LIMITS');
-const sendInternalEmailIndex = intakeFunction.indexOf('sendInternalEmail({');
+const handlerStartIndex = intakeFunction.indexOf('serve(async (req) => {');
+assert(handlerStartIndex > -1, 'Could not find lead intake request handler.');
+
+const requestHandler = intakeFunction.slice(handlerStartIndex);
+const insertIndex = requestHandler.search(/\.from\("lead_submissions"\)\s*\.insert\(\{/);
+const submissionLimitIndex = requestHandler.indexOf('rules: PUBLIC_INTAKE_SUBMISSION_LIMITS');
+const notificationLimitIndex = requestHandler.indexOf('rules: PUBLIC_INTAKE_NOTIFICATION_LIMITS');
+const sendInternalEmailIndex = requestHandler.indexOf('sendInternalEmail({');
 
 assert(insertIndex > -1, 'Could not find lead_submissions insert path.');
 assert(submissionLimitIndex > -1, 'Missing submission throttle wiring.');
@@ -88,7 +92,7 @@ assert(
   'Body size enforcement must stream the request body instead of trusting Content-Length alone.'
 );
 assert(
-  intakeFunction.includes('leadSubmission.submission_type !== "quote"'),
+  intakeFunction.includes('internallyNotifiedSubmissionTypes.has(leadSubmission.submission_type)'),
   'Notification eligibility must use the persisted lead type, not the current request type.'
 );
 assert(

--- a/src/pages/admin/Orders.tsx
+++ b/src/pages/admin/Orders.tsx
@@ -89,6 +89,23 @@ const formatPricingTier = (pricingTier: OrderRecord['pricing_tier']) => {
   }
 };
 
+const formatOrderType = (orderType: OrderRecord['order_type']) => {
+  switch (orderType) {
+    case 'sugar':
+      return 'Sugar';
+    case 'blank_sticks':
+      return 'Bloomjoy branded sticks';
+    default:
+      return 'Unknown';
+  }
+};
+
+const formatFulfillmentStatus = (status: OrderFulfillmentStatus) =>
+  status
+    .split('_')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+
 const formatNotificationStatus = (sentAt: string | null, error: string | null) => {
   if (sentAt) {
     return `Sent ${formatDate(sentAt)}`;
@@ -99,6 +116,24 @@ const formatNotificationStatus = (sentAt: string | null, error: string | null) =
   }
 
   return 'Pending';
+};
+
+const getNotificationHealth = (order: OrderRecord) => {
+  const failures = [
+    order.internal_notification_error ? 'internal email' : null,
+    order.customer_confirmation_error ? 'customer confirmation' : null,
+    order.wecom_alert_error ? 'WeCom alert' : null,
+  ].filter(Boolean);
+
+  if (failures.length) {
+    return `Needs review: ${failures.join(', ')}`;
+  }
+
+  if (order.internal_notification_sent_at && order.customer_confirmation_sent_at) {
+    return 'Email notifications sent';
+  }
+
+  return 'Notifications pending';
 };
 
 const formatAddressSnapshot = (address: OrderRecord['shipping_address']) => {
@@ -116,6 +151,28 @@ const formatAddressSnapshot = (address: OrderRecord['shipping_address']) => {
   ]
     .filter(Boolean)
     .join(', ') || 'n/a';
+};
+
+const formatStickSize = (stickSize: string) => {
+  switch (stickSize) {
+    case 'commercial_10x300':
+      return 'Commercial / Full Machine (10mm x 300mm)';
+    case 'mini_10x220':
+      return 'Mini Machine (10mm x 220mm)';
+    default:
+      return stickSize || 'n/a';
+  }
+};
+
+const formatAddressType = (addressType: string) => {
+  switch (addressType) {
+    case 'business':
+      return 'Business address';
+    case 'residential':
+      return 'Residential address';
+    default:
+      return addressType || 'n/a';
+  }
 };
 
 const getOrderReference = (order: OrderRecord) =>
@@ -204,6 +261,22 @@ const getDisplayLineItems = (order: OrderRecord): DisplayLineItem[] =>
       currency: typeof item.currency === 'string' ? item.currency : order.currency,
     }));
 
+const getFulfillmentSummary = (
+  order: OrderRecord,
+  sugarMix: SugarMixSummary | null,
+  blankSticks: BlankSticksSummary | null
+) => {
+  if (sugarMix) {
+    return `Ship ${sugarMix.total} KG sugar: ${sugarMix.white} KG white, ${sugarMix.blue} KG blue, ${sugarMix.orange} KG orange, ${sugarMix.red} KG red.`;
+  }
+
+  if (blankSticks) {
+    return `Ship ${blankSticks.boxCount} boxes of ${formatStickSize(blankSticks.stickSize)} sticks (${blankSticks.piecesPerBox} pieces/box) to a ${formatAddressType(blankSticks.addressType).toLowerCase()}.`;
+  }
+
+  return `Review ${formatOrderType(order.order_type).toLowerCase()} line items before fulfillment.`;
+};
+
 const InfoCard = ({
   label,
   value,
@@ -272,6 +345,9 @@ export default function AdminOrdersPage() {
   const selectedSugarMix = selectedOrder ? getSugarMixSummary(selectedOrder) : null;
   const selectedBlankSticks = selectedOrder ? getBlankSticksSummary(selectedOrder) : null;
   const selectedLineItems = selectedOrder ? getDisplayLineItems(selectedOrder) : [];
+  const selectedFulfillmentSummary = selectedOrder
+    ? getFulfillmentSummary(selectedOrder, selectedSugarMix, selectedBlankSticks)
+    : '';
 
   const selectOrder = (order: OrderRecord) => {
     setSelectedId(order.id);
@@ -357,7 +433,7 @@ export default function AdminOrdersPage() {
               <option value="all">All fulfillment statuses</option>
               {fulfillmentOptions.map((status) => (
                 <option key={status} value={status}>
-                  {status}
+                  {formatFulfillmentStatus(status)}
                 </option>
               ))}
             </select>
@@ -425,10 +501,12 @@ export default function AdminOrdersPage() {
                         <td className="px-4 py-3 text-sm text-foreground">
                           <div className="font-medium">{formatCurrency(order.amount_total, order.currency)}</div>
                           <div className="text-muted-foreground">{order.status}</div>
-                          <div className="text-xs text-muted-foreground">{order.order_type}</div>
+                          <div className="text-xs text-muted-foreground">
+                            {formatOrderType(order.order_type)}
+                          </div>
                         </td>
                         <td className="px-4 py-3 text-sm text-foreground">
-                          {order.fulfillment_status}
+                          {formatFulfillmentStatus(order.fulfillment_status)}
                         </td>
                         <td className="px-4 py-3 text-sm text-muted-foreground">
                           {formatDate(order.created_at)}
@@ -460,8 +538,55 @@ export default function AdminOrdersPage() {
                     </p>
                   </div>
 
+                  <div className="rounded-md bg-muted/35 p-4">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      Fulfillment Packet
+                    </p>
+                    <p className="mt-2 text-sm font-medium text-foreground">
+                      {selectedFulfillmentSummary}
+                    </p>
+                    <div className="mt-3 grid gap-3 text-sm sm:grid-cols-2">
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                          Ship To
+                        </p>
+                        <p className="mt-1 text-foreground">
+                          {selectedOrder.shipping_name ?? selectedOrder.customer_name ?? 'n/a'}
+                        </p>
+                        <p className="text-muted-foreground">
+                          {formatAddressSnapshot(selectedOrder.shipping_address)}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                          Contact
+                        </p>
+                        <p className="mt-1 text-foreground">
+                          {selectedOrder.customer_email ?? 'n/a'}
+                        </p>
+                        <p className="text-muted-foreground">
+                          {selectedOrder.customer_phone ?? selectedOrder.shipping_phone ?? 'No phone'}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                          Current Status
+                        </p>
+                        <p className="mt-1 text-foreground">
+                          {formatFulfillmentStatus(selectedOrder.fulfillment_status)}
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                          Notification Health
+                        </p>
+                        <p className="mt-1 text-foreground">{getNotificationHealth(selectedOrder)}</p>
+                      </div>
+                    </div>
+                  </div>
+
                   <div className="grid gap-3 sm:grid-cols-2">
-                    <InfoCard label="Order Type" value={selectedOrder.order_type} />
+                    <InfoCard label="Order Type" value={formatOrderType(selectedOrder.order_type)} />
                     <InfoCard label="Pricing Tier" value={formatPricingTier(selectedOrder.pricing_tier)} />
                     <InfoCard label="Unit Price" value={formatUnitPrice(selectedOrder.unit_price_cents)} />
                     <InfoCard
@@ -555,8 +680,10 @@ export default function AdminOrdersPage() {
                       <div className="rounded-lg border border-border/70 bg-background/60 p-3 text-sm text-foreground">
                         <p>Boxes: {selectedBlankSticks.boxCount}</p>
                         <p className="mt-1">Pieces per box: {selectedBlankSticks.piecesPerBox}</p>
-                        <p className="mt-1">Stick size: {selectedBlankSticks.stickSize}</p>
-                        <p className="mt-1">Address type: {selectedBlankSticks.addressType}</p>
+                        <p className="mt-1">Stick size: {formatStickSize(selectedBlankSticks.stickSize)}</p>
+                        <p className="mt-1">
+                          Address type: {formatAddressType(selectedBlankSticks.addressType)}
+                        </p>
                         <p className="mt-1">
                           Shipping rate per box: ${selectedBlankSticks.shippingRatePerBoxUsd.toFixed(2)}
                         </p>
@@ -645,7 +772,7 @@ export default function AdminOrdersPage() {
                     >
                       {fulfillmentOptions.map((status) => (
                         <option key={status} value={status}>
-                          {status}
+                          {formatFulfillmentStatus(status)}
                         </option>
                       ))}
                     </select>

--- a/supabase/functions/_shared/internal-email.ts
+++ b/supabase/functions/_shared/internal-email.ts
@@ -16,10 +16,7 @@ const getRecipients = (): string[] => {
   const configuredRecipients = parseRecipients(
     Deno.env.get("INTERNAL_NOTIFICATION_RECIPIENTS")
   );
-  if (configuredRecipients.length > 0) {
-    return configuredRecipients;
-  }
-  return DEFAULT_RECIPIENTS;
+  return Array.from(new Set([...DEFAULT_RECIPIENTS, ...configuredRecipients]));
 };
 
 export type InternalEmailInput = {

--- a/supabase/functions/lead-submission-intake/index.ts
+++ b/supabase/functions/lead-submission-intake/index.ts
@@ -15,7 +15,7 @@ import {
   type PublicIntakeAbuseSupabaseClient,
   sanitizePublicIntakeSourcePage,
 } from "../_shared/public-intake-abuse-controls.ts";
-import { sendWeComAlertSafe } from "../_shared/wecom-alert.ts";
+import { sendWeComAlertResult } from "../_shared/wecom-alert.ts";
 
 export const config = {
   verify_jwt: false,
@@ -29,6 +29,7 @@ const validSubmissionTypes = new Set([
   "procurement",
   "general",
 ]);
+const internallyNotifiedSubmissionTypes = new Set(["quote", "procurement"]);
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/i;
 const uuidPattern =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -357,6 +358,120 @@ const markDispatchSkipped = async (
     .eq("event_key", eventKey);
 };
 
+const updateLeadNotificationState = async (
+  leadSubmissionId: string,
+  patch: Record<string, unknown>,
+) => {
+  if (!supabase) return;
+
+  const { error } = await supabase
+    .from("lead_submissions")
+    .update(patch)
+    .eq("id", leadSubmissionId);
+
+  if (error) {
+    console.error("Failed to update lead notification state.", {
+      leadSubmissionId,
+      error,
+      patch,
+    });
+  }
+};
+
+const formatSubmissionLabel = (submissionType: string) => {
+  switch (submissionType) {
+    case "quote":
+      return "quote request";
+    case "procurement":
+      return "procurement request";
+    case "demo":
+      return "demo request";
+    default:
+      return "contact request";
+  }
+};
+
+const formatArtworkMetadataLines = (metadata: Record<string, unknown>): string[] => {
+  const artwork = isRecord(metadata.customSticksArtwork)
+    ? metadata.customSticksArtwork
+    : null;
+
+  if (!artwork) {
+    return [];
+  }
+
+  return [
+    "",
+    "Private Custom-Sticks Artwork:",
+    `- Bucket: ${sanitizeText(artwork.bucket) || "n/a"}`,
+    `- Storage path: ${sanitizeText(artwork.storagePath) || "n/a"}`,
+    `- File name: ${sanitizeText(artwork.fileName) || "n/a"}`,
+    `- Content type: ${sanitizeText(artwork.contentType) || "n/a"}`,
+    `- Size: ${Number(artwork.sizeBytes) || "n/a"} bytes`,
+  ];
+};
+
+const buildLeadNotification = (
+  leadSubmission: {
+    id: string;
+    submission_type: string;
+    name: string;
+    email: string;
+    source_page: string;
+    message: string;
+    metadata?: Record<string, unknown> | null;
+    created_at: string;
+  },
+) => {
+  const submissionLabel = formatSubmissionLabel(leadSubmission.submission_type);
+  const metadata = isRecord(leadSubmission.metadata) ? leadSubmission.metadata : {};
+  const isProcurement = leadSubmission.submission_type === "procurement";
+  const subject = `New ${submissionLabel}: ${leadSubmission.name}`;
+  const intro = isProcurement
+    ? "A new supply procurement request was submitted."
+    : "A new quote request was submitted.";
+  const nextSteps = isProcurement
+    ? [
+      "",
+      "Fulfillment Next Steps:",
+      "- Reply to the customer to confirm availability, payment/shipping details, and timing.",
+      "- If this is a custom sticks request, generate a short-lived private artwork link before vendor review.",
+      "- Track the request until it is converted to a paid order or closed.",
+    ]
+    : [
+      "",
+      "Next Steps:",
+      "- Review the request context and reply to the customer.",
+      "- Record follow-up outside the public intake form.",
+    ];
+
+  const commonLines = [
+    `Submission ID: ${leadSubmission.id}`,
+    `Submitted At (UTC): ${leadSubmission.created_at}`,
+    `Inquiry Type: ${leadSubmission.submission_type}`,
+    `Name: ${leadSubmission.name}`,
+    `Email: ${leadSubmission.email}`,
+    `Source Page: ${leadSubmission.source_page}`,
+    ...formatArtworkMetadataLines(metadata),
+    "",
+    "Message:",
+    leadSubmission.message,
+  ];
+
+  return {
+    subject,
+    text: [
+      intro,
+      "",
+      ...commonLines,
+      ...nextSteps,
+    ].join("\n"),
+    weComTag: isProcurement ? "Bloomjoy Procurement" : "Bloomjoy Quote",
+    weComTitle: subject,
+    weComLines: commonLines,
+  };
+};
+
 serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });
@@ -551,7 +666,7 @@ serve(async (req) => {
 
     if (
       !leadSubmission ||
-      leadSubmission.submission_type !== "quote" ||
+      !internallyNotifiedSubmissionTypes.has(leadSubmission.submission_type) ||
       leadSubmission.internal_notification_sent_at
     ) {
       return new Response(JSON.stringify({ ok: true }), {
@@ -595,54 +710,49 @@ serve(async (req) => {
       });
     }
 
-    const quoteSubject = `New quote request: ${leadSubmission.name}`;
-    const quoteText = [
-      "A new quote request was submitted.",
-      "",
-      `Submission ID: ${leadSubmission.id}`,
-      `Submitted At (UTC): ${leadSubmission.created_at}`,
-      `Inquiry Type: ${leadSubmission.submission_type}`,
-      `Name: ${leadSubmission.name}`,
-      `Email: ${leadSubmission.email}`,
-      `Source Page: ${leadSubmission.source_page}`,
-      "",
-      "Message:",
-      leadSubmission.message,
-    ].join("\n");
+    const notification = buildLeadNotification(leadSubmission);
 
     try {
       await sendInternalEmail({
-        subject: quoteSubject,
-        text: quoteText,
+        subject: notification.subject,
+        text: notification.text,
       });
     } catch (error) {
+      const message = error instanceof Error
+        ? error.message
+        : "Unknown internal email failure.";
+      await updateLeadNotificationState(leadSubmission.id, {
+        internal_notification_error: message,
+      });
       await releaseDispatch(eventKey);
-      throw error;
+      return new Response(JSON.stringify({ ok: true }), {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
     }
 
-    await sendWeComAlertSafe({
-      tag: "Bloomjoy Quote",
-      title: `New quote request: ${leadSubmission.name}`,
-      lines: [
-        `Submission ID: ${leadSubmission.id}`,
-        `Submitted At (UTC): ${leadSubmission.created_at}`,
-        `Inquiry Type: ${leadSubmission.submission_type}`,
-        `Name: ${leadSubmission.name}`,
-        `Email: ${leadSubmission.email}`,
-        `Source Page: ${leadSubmission.source_page}`,
-        "Message:",
-        leadSubmission.message,
-      ],
+    const weComResult = await sendWeComAlertResult({
+      tag: notification.weComTag,
+      title: notification.weComTitle,
+      lines: notification.weComLines,
     });
 
     await Promise.all([
-      supabase
-        .from("lead_submissions")
-        .update({ internal_notification_sent_at: new Date().toISOString() })
-        .eq("id", leadSubmission.id),
+      updateLeadNotificationState(leadSubmission.id, {
+        internal_notification_sent_at: new Date().toISOString(),
+        internal_notification_error: null,
+        ...(weComResult.ok
+          ? {
+            wecom_alert_sent_at: new Date().toISOString(),
+            wecom_alert_error: null,
+          }
+          : {
+            wecom_alert_error: weComResult.message,
+          }),
+      }),
       markDispatchSent(eventKey, {
         submission_type: leadSubmission.submission_type,
         source_page: leadSubmission.source_page,
+        wecom_alert_sent: weComResult.ok,
       }),
     ]);
 

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -17,6 +17,7 @@ const stripeSecretKey = Deno.env.get("STRIPE_SECRET_KEY");
 const webhookSecret = Deno.env.get("STRIPE_WEBHOOK_SECRET");
 const supabaseUrl = Deno.env.get("SUPABASE_URL");
 const supabaseServiceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+const adminOrdersUrl = "https://app.bloomjoyusa.com/admin/orders";
 
 if (!stripeSecretKey) {
   console.error("Missing STRIPE_SECRET_KEY");
@@ -479,6 +480,12 @@ const buildInternalOrderEmail = (context: OrderContext) => {
       `Receipt URL: ${context.receiptUrl ?? "n/a"}`,
       ...detailSection,
       "",
+      "Fulfillment Next Steps:",
+      `- Open Admin Orders: ${adminOrdersUrl}`,
+      `- Search for checkout session ${context.session.id}.`,
+      "- Assign an owner, add fulfillment notes, and update status/tracking as the order moves.",
+      "- Fulfill from the product details and shipping address above.",
+      "",
       "Line Items:",
       lineItemSummary,
     ].join("\n"),
@@ -494,6 +501,7 @@ const buildWeComAlertLines = (context: OrderContext): string[] => [
   `Customer Email: ${context.customerEmail ?? "n/a"}`,
   `Customer Name: ${context.customerName ?? "n/a"}`,
   `Shipping Name: ${context.shippingName ?? "n/a"}`,
+  `Admin Orders: ${adminOrdersUrl}`,
   context.orderType === "blank_sticks"
     ? `Boxes / Pieces per box: ${context.blankSticks?.box_count ?? "n/a"} / ${context.blankSticks?.pieces_per_box ?? "n/a"}`
     : `Sugar KG (W/B/O/R/T): ${context.sugarMix.white_kg}/${context.sugarMix.blue_kg}/${context.sugarMix.orange_kg}/${context.sugarMix.red_kg}/${context.sugarMix.total_kg}`,

--- a/supabase/migrations/202605060003_supply_procurement_notifications.sql
+++ b/supabase/migrations/202605060003_supply_procurement_notifications.sql
@@ -1,0 +1,18 @@
+-- Track notification status for supply procurement requests.
+
+alter table public.lead_submissions
+  add column if not exists internal_notification_error text,
+  add column if not exists wecom_alert_sent_at timestamptz,
+  add column if not exists wecom_alert_error text;
+
+create index if not exists lead_submissions_submission_type_created_at_idx
+  on public.lead_submissions (submission_type, created_at desc);
+
+comment on column public.lead_submissions.internal_notification_error is
+  'Latest internal email notification failure for quote/procurement intake, if any.';
+
+comment on column public.lead_submissions.wecom_alert_sent_at is
+  'Timestamp when a WeCom internal alert was sent for quote/procurement intake.';
+
+comment on column public.lead_submissions.wecom_alert_error is
+  'Latest non-blocking WeCom alert failure for quote/procurement intake, if any.';


### PR DESCRIPTION
﻿## Summary
- Sends internal procurement notifications for under-5 branded-stick requests and custom-stick requests, using the existing `lead_submission` pipeline plus notification status columns.
- Guarantees Ethan and Ian are included on internal notification emails while still allowing additional configured recipients.
- Adds fulfillment next steps to paid order alerts and a fulfillment packet to `/admin/orders` for faster order handling.

## Files changed
- Supabase Edge Functions: `lead-submission-intake`, `stripe-webhook`, and shared internal email recipient handling.
- Database migration: lead submission notification status fields for procurement/quote alert tracking.
- Admin UI: `/admin/orders` fulfillment packet and friendlier order/stick/status labels.
- Operations docs/checklists: current status, decisions, local/prod runbooks, backlog, smoke checklist, and env example.
- Validation scripts: commerce preflight recipient expectation and public-intake validator scoping.

## Verification commands + results
- `npm ci` - passed; 409 packages installed, 0 vulnerabilities.
- `npm run build` - passed; Vite build/prerender succeeded with the existing large `Reports` chunk warning.
- `npm test --if-present` - passed; no test script is present, so npm exited cleanly.
- `npm run lint --if-present` - passed with the existing 8 fast-refresh warnings in shadcn/Auth files.

Additional checks:
- `git diff --check` - passed.
- `npm run security:validate-public-intake` - passed.
- `npm run edge-url-allowlists:check` - passed.
- `npm run commerce:preflight` - blocked locally because this worktree has no Stripe/Supabase/Resend/WeCom secrets configured.
- `npm run db:validate-migrations` - blocked locally because Docker Desktop is not available (`docker API ... pipe ... not found`).

## How to test
1. From this branch/worktree, run `npm ci` and `npm run dev -- --host 127.0.0.1 --port 8081`.
2. Open `http://127.0.0.1:8081/supplies?order=sticks`, submit a 1-4 box branded-stick request, and verify a `lead_submissions` row plus an internal procurement email to Ethan/Ian.
3. Open `http://127.0.0.1:8081/supplies?order=custom`, upload PNG/JPG/WEBP artwork, submit the request, and verify private artwork metadata is stored without a public URL and the procurement email includes fulfillment next steps.
4. Complete sugar and 5+ branded-stick Stripe test checkouts with Edge Function secrets configured, replay/receive the webhook, and verify `orders` rows, customer confirmations, internal emails, and notification status fields.
5. Log in as a super-admin and open `http://127.0.0.1:8081/admin/orders`; select a test order and verify the fulfillment packet shows what to ship, ship-to/contact details, status, and notification health.

Test credentials: use an existing local super-admin account; no shared test credentials are committed.

## Overlap / risk notes
- Open PR #392 also edits `Docs/CURRENT_STATUS.md` and `Docs/QA_SMOKE_TEST_CHECKLIST.md` and already uses migrations `202605060001`/`202605060002`; this branch uses `202605060003` to avoid timestamp collision.
- Open PR #391 also edits `Docs/CURRENT_STATUS.md`, `Docs/LOCAL_DEV.md`, and `Docs/QA_SMOKE_TEST_CHECKLIST.md`.
- Rebase from `main` and rerun verification if either PR merges first.
- WeCom remains secondary/non-blocking; production delivery still depends on the known WeCom app/network policy fix.
