### PR TITLE
Reduce authenticated RPC execute surface

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "commerce:preflight": "node scripts/commerce-preflight.mjs",
     "edge-url-allowlists:check": "node scripts/validate-edge-url-allowlists.mjs",
     "db:validate-migrations": "node scripts/validate-supabase-migrations.mjs",
+    "db:validate-rpc-surface": "node scripts/validate-rpc-execute-surface.mjs",
     "orders:backfill": "node scripts/backfill-stripe-orders.mjs",
     "reporting:import-sales": "node scripts/import-sales-reporting-csv.mjs",
     "reporting:import-refunds": "node scripts/import-refund-adjustments-csv.mjs",

--- a/scripts/validate-rpc-execute-surface.mjs
+++ b/scripts/validate-rpc-execute-surface.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const migrationsDir = path.join(repoRoot, 'supabase', 'migrations');
+const hardeningMigrationName = '202605060004_reduce_authenticated_rpc_advisor_surface.sql';
+const hardeningMigrationPath = path.join(migrationsDir, hardeningMigrationName);
+
+const serviceRoleOnlyFunctions = [
+  {
+    signature: 'public.can_access_partner_dashboard(uuid, uuid, date, date)',
+    name: 'can_access_partner_dashboard',
+  },
+  {
+    signature: 'public.admin_grant_machine_report_access(text, uuid, uuid, uuid, text, text)',
+    name: 'admin_grant_machine_report_access',
+  },
+  {
+    signature: 'public.create_report_export(uuid, jsonb)',
+    name: 'create_report_export',
+  },
+  {
+    signature: 'public.admin_list_reporting_sync_runs(integer)',
+    name: 'admin_list_reporting_sync_runs',
+  },
+  {
+    signature: 'public.admin_reconcile_technician_entitlements(text)',
+    name: 'admin_reconcile_technician_entitlements',
+  },
+];
+
+const protectedAuthenticatedFunctions = [
+  'public.is_super_admin(uuid)',
+  'public.has_reporting_machine_access(uuid, uuid)',
+  'public.is_reporting_account_member(uuid, uuid)',
+  'public.can_access_technician_grant(uuid, uuid)',
+  'public.can_access_members_only_training()',
+  'public.has_my_active_customer_account_membership(uuid)',
+  'public.is_my_partner_on_customer_account(uuid)',
+  'public.get_my_admin_access_context()',
+  'public.get_my_portal_access_context()',
+  'public.get_my_reporting_access_context()',
+  'public.get_sales_report(date, date, text, uuid[], uuid[], text[])',
+];
+
+const fail = (message) => {
+  throw new Error(message);
+};
+
+const readText = (filePath) => fs.readFileSync(filePath, 'utf8');
+
+const compactSql = (value) =>
+  value
+    .replace(/--.*$/gm, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const statementMentionsAuthenticated = (sql, verb, signature) => {
+  const pattern = new RegExp(
+    `${verb} execute on function ${escapeRegExp(signature.toLowerCase())} (?:from|to) [^;]*\\bauthenticated\\b`
+  );
+  return pattern.test(compactSql(sql));
+};
+
+const expectMigrationStatement = (sql, snippet) => {
+  if (!compactSql(sql).includes(compactSql(snippet))) {
+    fail(`${hardeningMigrationName}: missing statement: ${snippet}`);
+  }
+};
+
+const getMigrationFiles = () =>
+  fs
+    .readdirSync(migrationsDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.sql'))
+    .map((entry) => entry.name)
+    .sort();
+
+const walkFiles = (dir, predicate, results = []) => {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const filePath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!['node_modules', '.git', 'dist'].includes(entry.name)) {
+        walkFiles(filePath, predicate, results);
+      }
+      continue;
+    }
+
+    if (predicate(filePath)) {
+      results.push(filePath);
+    }
+  }
+
+  return results;
+};
+
+const assertBrowserDoesNotCallServiceOnlyFunctions = () => {
+  const srcDir = path.join(repoRoot, 'src');
+  const sourceFiles = fs.existsSync(srcDir)
+    ? walkFiles(srcDir, (filePath) => /\.(ts|tsx|js|jsx)$/.test(filePath))
+    : [];
+
+  for (const filePath of sourceFiles) {
+    const content = readText(filePath);
+    for (const fn of serviceRoleOnlyFunctions) {
+      const rpcCall = new RegExp(`\\.rpc(?:<[^>]+>)?\\(\\s*['"\`]${escapeRegExp(fn.name)}['"\`]`);
+      if (rpcCall.test(content)) {
+        fail(
+          `${path.relative(repoRoot, filePath)} still calls service-role-only RPC ${fn.name} from browser code.`
+        );
+      }
+    }
+  }
+};
+
+const assertIssueMigration = () => {
+  if (!fs.existsSync(hardeningMigrationPath)) {
+    fail(`Missing migration ${hardeningMigrationName}.`);
+  }
+
+  const sql = readText(hardeningMigrationPath);
+
+  for (const fn of serviceRoleOnlyFunctions) {
+    expectMigrationStatement(
+      sql,
+      `revoke execute on function ${fn.signature} from public, anon, authenticated`
+    );
+    expectMigrationStatement(sql, `grant execute on function ${fn.signature} to service_role`);
+    expectMigrationStatement(sql, `comment on function ${fn.signature} is`);
+  }
+
+  for (const signature of protectedAuthenticatedFunctions) {
+    if (statementMentionsAuthenticated(sql, 'revoke', signature)) {
+      fail(`${hardeningMigrationName} revokes authenticated execute from protected ${signature}.`);
+    }
+  }
+};
+
+const assertNoLaterAuthenticatedRegrant = () => {
+  const migrations = getMigrationFiles();
+  const hardeningIndex = migrations.indexOf(hardeningMigrationName);
+  if (hardeningIndex === -1) {
+    fail(`Unable to locate ${hardeningMigrationName} in migration order.`);
+  }
+
+  for (const migrationName of migrations.slice(hardeningIndex + 1)) {
+    const sql = readText(path.join(migrationsDir, migrationName));
+    for (const fn of serviceRoleOnlyFunctions) {
+      if (statementMentionsAuthenticated(sql, 'grant', fn.signature)) {
+        fail(`${migrationName} re-grants authenticated execute on service-role-only ${fn.signature}.`);
+      }
+    }
+  }
+};
+
+const main = () => {
+  assertIssueMigration();
+  assertNoLaterAuthenticatedRegrant();
+  assertBrowserDoesNotCallServiceOnlyFunctions();
+
+  console.log(
+    `RPC execute surface static checks passed: ${serviceRoleOnlyFunctions.length} service-role-only helper RPCs remain blocked from browser use.`
+  );
+};
+
+main();

--- a/supabase/migrations/202605060004_reduce_authenticated_rpc_advisor_surface.sql
+++ b/supabase/migrations/202605060004_reduce_authenticated_rpc_advisor_surface.sql
@@ -1,0 +1,50 @@
+-- Issue #347: reduce the authenticated SECURITY DEFINER RPC advisor surface.
+--
+-- Categories:
+-- - Browser-facing wrappers and RLS helpers stay authenticated. That includes
+--   auth.uid()-bound route context RPCs, admin wrappers with internal checks,
+--   and helpers directly called by active RLS policies.
+-- - The functions below are service-role/internal or legacy helper surfaces.
+--   They are not current browser RPC entrypoints and should not remain
+--   PostgREST probes for signed-in users.
+--
+-- Function-to-function calls from SECURITY DEFINER wrappers continue to work
+-- through the function owner. Edge Functions and controlled operations keep
+-- service_role execute where needed.
+
+revoke execute on function public.can_access_partner_dashboard(uuid, uuid, date, date)
+  from public, anon, authenticated;
+grant execute on function public.can_access_partner_dashboard(uuid, uuid, date, date)
+  to service_role;
+comment on function public.can_access_partner_dashboard(uuid, uuid, date, date) is
+  'Internal partner-dashboard access predicate. Browser callers must use get_partner_dashboard_partnerships() or admin_preview_partner_period_report().';
+
+revoke execute on function public.admin_grant_machine_report_access(text, uuid, uuid, uuid, text, text)
+  from public, anon, authenticated;
+grant execute on function public.admin_grant_machine_report_access(text, uuid, uuid, uuid, text, text)
+  to service_role;
+comment on function public.admin_grant_machine_report_access(text, uuid, uuid, uuid, text, text) is
+  'Internal reporting-access grant helper. Browser callers must use admin_grant_reporting_access() or admin_set_user_machine_reporting_access().';
+
+revoke execute on function public.create_report_export(uuid, jsonb)
+  from public, anon, authenticated;
+grant execute on function public.create_report_export(uuid, jsonb)
+  to service_role;
+comment on function public.create_report_export(uuid, jsonb) is
+  'Legacy reporting snapshot helper superseded by the sales-report-export Edge Function.';
+
+revoke execute on function public.admin_list_reporting_sync_runs(integer)
+  from public, anon, authenticated;
+grant execute on function public.admin_list_reporting_sync_runs(integer)
+  to service_role;
+comment on function public.admin_list_reporting_sync_runs(integer) is
+  'Legacy reporting sync-run helper kept for service-role/internal operations, not direct browser RPC access.';
+
+revoke execute on function public.admin_reconcile_technician_entitlements(text)
+  from public, anon, authenticated;
+grant execute on function public.admin_reconcile_technician_entitlements(text)
+  to service_role;
+comment on function public.admin_reconcile_technician_entitlements(text) is
+  'Technician entitlement reconciliation helper kept for service-role/internal operations, not direct browser RPC access.';
+
+select pg_notify('pgrst', 'reload schema');


### PR DESCRIPTION
## Summary
- Closes #347.
- Revokes direct `authenticated`/`anon` execute access from five avoidable SECURITY DEFINER helper RPCs while preserving `service_role` access.
- Adds a static RPC execute-surface validator so future migrations do not re-open these helper RPCs to browser callers.

## Files changed
- `supabase/migrations/202605060004_reduce_authenticated_rpc_advisor_surface.sql`: forward-only grant hardening migration.
- `scripts/validate-rpc-execute-surface.mjs`: static checks for protected browser/RLS helpers and service-role-only helpers.
- `package.json`: adds `npm run db:validate-rpc-surface`.

## Verification commands + results
- `npm ci` - passed in worker run.
- `npm run build` - passed; existing Vite large chunk warning remains.
- `npm run seo:check` - passed.
- `npm test --if-present` - passed; no test script configured.
- `npm run lint --if-present` - passed with existing 8 Fast Refresh warnings.
- `npm run db:validate-rpc-surface` - passed.
- `npm run db:validate-migrations` - passed with Docker.
- `supabase db push --dry-run` - not run; fresh worktree is not linked to a Supabase project.

## How to test
No localhost UI route is changed by this DB-only PR; local verification is command-only. Key URLs: linked issue, this PR, and the Vercel preview for deploy health only.
1. From a fresh worktree on this branch, run `npm ci`.
2. Run `npm run build`, `npm run seo:check`, `npm test --if-present`, and `npm run lint --if-present`.
3. Run `npm run db:validate-rpc-surface`.
4. With Docker running, run `npm run db:validate-migrations`.
5. In a linked staging Supabase project, run `supabase db push --dry-run` and verify direct authenticated REST calls to the five service-role-only RPCs fail, while admin/reporting/training/Technician flows still work through their wrapper RPCs.

## Rollback plan
- Revert this PR to restore the prior execute grants if a staging/production flow depends on one of these helper RPCs directly.