### PR TITLE
Docs: add sprint orchestration workflow

### DIFF
--- a/Docs/AGENT_SPRINT_WORKFLOW.md
+++ b/Docs/AGENT_SPRINT_WORKFLOW.md
@@ -1,0 +1,62 @@
+# Agent Sprint Workflow
+
+Repeatable PM/PO orchestration for Bloomjoy Hub agent sprints.
+
+## 1. Sprint Intake
+- Start from GitHub Issues labeled `P0`-`P3` and the project board: https://github.com/users/ethtri/projects/2.
+- Read repo docs in this order before planning: `Docs/CURRENT_STATUS.md`, `Docs/POC_NOTES.md`, `Docs/MVP_SCOPE.md`, `Docs/DECISIONS.md`, `Docs/BACKLOG.md`, `Docs/QA_SMOKE_TEST_CHECKLIST.md`, `Docs/LOCAL_DEV.md`, `Docs/ARCHITECTURE.md`.
+- If docs conflict, `Docs/DECISIONS.md` wins.
+- Convert vague asks into small PR-sized lanes: one implementation slice, research spike, QA pass, or docs closeout per lane.
+- Classify each lane as low, medium, or high risk using `Docs/AI_WORKFLOW.md`.
+
+## 2. Worktree Setup
+- Never edit `C:\Repos\Bloomjoy_hub` directly.
+- Use one worktree per lane: `C:\Repos\wt-<short-task-slug>`.
+- Use one branch per lane: `agent/<short-task-slug>`.
+- Create worktrees from current `origin/main` unless the lane explicitly depends on another PR branch.
+- Before edits, run the preflight in `Docs/LOCAL_DEV.md`: confirm worktree path, confirm `agent/` branch, `git fetch origin`, and clean `git status -sb`.
+- Do not switch branches inside another agent's worktree. Do not touch implementation PR worktrees unless explicitly assigned.
+
+## 3. Lane Patterns
+- PM/PO planning lane: inventory open P0/P1 items, decide sequencing, split work, identify blockers, and open/refresh issues.
+- Implementation lane: make the smallest code/doc change that satisfies one issue or acceptance slice.
+- Research/QC lane: inspect risky areas, verify assumptions, compare docs/issues/PRs, and produce specific implementation guidance or blocker evidence.
+- QA challenge lane: independently test the implementation against acceptance criteria, smoke checklist, risk model, and privacy/evidence rules.
+- Closeout lane: reconcile docs, PR descriptions, labels, issue status, merge order, and follow-up items.
+
+## 4. Sequencing
+- PM/PO plan first, then implementation and research/QC in parallel only when they do not write the same files.
+- Run QA challenge after implementation verification is available. QA may request a fix lane or approve with residual risks.
+- For high-risk work, require an independent AI review or a clearly separated challenge pass before merge.
+- If a shared foundation PR merges, sync dependent branches from `main` and rerun verification before marking them ready.
+- Merge in dependency order: foundations first, then feature slices, then QA/docs closeout.
+
+## 5. Blockers
+- Treat external-account work, production credentials, owner product decisions, missing secrets, and ambiguous go/no-go calls as blockers.
+- Record blockers in the PR and, when they affect current priorities, in `Docs/CURRENT_STATUS.md`.
+- Park stale or blocked branches as issues instead of leaving broad draft PRs open.
+- Do not invent new platforms, CMS, commerce providers, or workflow infrastructure without a `Docs/DECISIONS.md` entry.
+
+## 6. Evidence and Privacy
+- Keep evidence actionable: exact commands, PR numbers, URLs, screenshots, sanitized logs, and dates.
+- Do not paste secrets, `.env` values, service-role keys, customer PII, raw Sunze workbooks, raw refund exports, payment identifiers, or private artwork links into docs, issues, PRs, or chat.
+- Use environment variables for secrets and remember that `VITE_*` values are browser-exposed.
+- Keep personal scratch notes local and uncommitted.
+
+## 7. PR Requirements
+Every repo change gets a PR into `main`, usually draft until verification is complete.
+
+PR body must include:
+- Summary: 1-3 bullets.
+- Files changed: high-level paths and purpose.
+- Verification commands and exact results: `npm ci`, `npm run build`, `npm test --if-present`, `npm run lint --if-present`; include `npm run seo:check` when relevant or reasonable.
+- How to test: localhost steps, key URLs, and any non-secret test credentials or persona notes.
+- Risk/overlap notes: open PRs, shared files, blockers, rollback if high risk.
+
+## 8. Sprint Closeout
+- Confirm all implementation, QA challenge, and docs closeout PRs are merged or intentionally parked.
+- Update issues and project board status.
+- Close superseded PRs only when the replacement evidence is clear.
+- Update `Docs/CURRENT_STATUS.md` for completed P0 work or newly discovered blockers.
+- Update `Docs/QA_SMOKE_TEST_CHECKLIST.md` when a new user-facing flow exists.
+- Run a short retro with `Docs/SPRINT_RETRO_TEMPLATE.md` and turn follow-ups into issues.

--- a/Docs/AI_WORKFLOW.md
+++ b/Docs/AI_WORKFLOW.md
@@ -8,6 +8,7 @@ This repo is operated primarily through AI coding agents. The owner is not expec
 - Convert vague ideas, parked work, or exploratory branches into issues instead of leaving long-lived draft PRs.
 - Use the GitHub PR template as the source of truth for risk, verification, UAT steps, screenshots, and rollback.
 - Ask the owner only for product judgment, external-account actions, final high-risk UAT, or ambiguous go/no-go decisions.
+- For repeatable PM/PO sprint orchestration with subagent execution and QA challenge lanes, use `Docs/AGENT_SPRINT_WORKFLOW.md`.
 
 ## Risk levels
 - Low risk: docs-only, copy-only, small cleanup, or non-runtime guardrails.

--- a/Docs/SPRINT_RETRO_TEMPLATE.md
+++ b/Docs/SPRINT_RETRO_TEMPLATE.md
@@ -1,0 +1,52 @@
+# Sprint Retro Template
+
+Use this after a Bloomjoy sprint that followed PM/PO planning, subagent execution, QA challenge, iteration, and closeout.
+
+## Sprint Snapshot
+- Dates:
+- Primary P0/P1 goals:
+- PM/PO planning source:
+- Implementation PRs:
+- Research/QC PRs or artifacts:
+- QA challenge PRs or artifacts:
+- Closeout PRs:
+- Final project-board state:
+
+## 1. PM Plan
+- What was the intended sequence?
+- Which assumptions were correct?
+- Which assumptions changed after agents inspected the repo, issues, board, or docs?
+- Were lanes small enough for reviewable PRs?
+
+## 2. Subagents Execute / Research / QC
+- What shipped?
+- What research or QC changed the implementation plan?
+- Which worktrees or PRs overlapped?
+- Did any agent touch shared foundations without enough coordination?
+
+## 3. Subagents QA / Challenge
+- What did QA challenge catch?
+- What acceptance criteria were missing, vague, or stale?
+- Was evidence strong enough for a product-level go/no-go?
+- Did privacy and secret-handling guardrails hold?
+
+## 4. Iterate
+- What fixes were required after QA?
+- Were branches synced from `main` after shared PRs merged?
+- Which verification commands were rerun after fixes or syncs?
+- What residual risks remained?
+
+## 5. Closeout
+- Which PRs merged, parked, or closed as superseded?
+- Which issues moved to Done, Review, Ready, or Backlog?
+- What docs were updated?
+- What smoke checklist items changed?
+- What follow-up issues are now required?
+
+## Retro Actions
+- Keep:
+- Change:
+- Stop:
+- Start:
+- Owner-dependent blockers:
+- Next sprint candidates:


### PR DESCRIPTION
## Summary
- Add a repo-owned PM/PO orchestration runbook for repeatable Bloomjoy sprint planning, subagent execution, QA challenge, merge sequencing, blocker handling, evidence/privacy, PR requirements, and closeout.
- Add a sprint retro template for the PM plan -> subagents execute/research/QC -> QA challenge -> iterate -> closeout workflow.
- Add a minimal discoverability pointer from `Docs/AI_WORKFLOW.md`.

## Files changed
- `Docs/AGENT_SPRINT_WORKFLOW.md` - new agent sprint orchestration runbook.
- `Docs/SPRINT_RETRO_TEMPLATE.md` - new workflow-specific sprint retro template.
- `Docs/AI_WORKFLOW.md` - one-line pointer to the orchestration runbook.

## Verification commands + results
- `npm ci` - passed after rebase; 409 packages installed/audited, 0 vulnerabilities. Deprecation warning for `glob@10.5.0` remains from dependency tree.
- `npm run build` - passed after rebase; Vite build and public-route prerender completed. Existing chunk-size warning remains for `Reports` chunk.
- `npm test --if-present` - passed after rebase; no test script present, command exited 0.
- `npm run lint --if-present` - passed after rebase with 0 errors and 8 existing fast-refresh warnings in shadcn/auth context files.
- `npm run seo:check` - passed after rebase; 22 public routes and 19 private routes validated.
- Local skill validation: `quick_validate.py C:\Users\ethtr\.codex\skills\bloomjoy-sprint-orchestrator` - passed (`Skill is valid!`).

## How to test
1. Checkout this PR branch or use worktree `C:\Repos\wt-sprint-orchestration-workflow`.
2. Run `npm ci`.
3. Run `npm run dev` and open the printed localhost URL, usually http://localhost:8080, to confirm the app still starts.
4. Review `Docs/AI_WORKFLOW.md` and follow its pointer to `Docs/AGENT_SPRINT_WORKFLOW.md`.
5. Review `Docs/SPRINT_RETRO_TEMPLATE.md` for the sprint closeout agenda.

## Risk / overlap notes
- Risk: low, docs-only.
- Rebased onto latest `origin/main` commit `9dadef0` and reran verification after syncing.
- No implementation PR worktrees were touched.
- Local Codex skill files were created outside the repo at `C:\Users\ethtr\.codex\skills\bloomjoy-sprint-orchestrator` and are not included in this PR.
- Blockers: none.