### PR TITLE
Share partner report PDF generation with scheduler

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "reporting:provider-health": "node scripts/sunze/notify-health.mjs",
     "reporting:validate-provider-parser": "node scripts/sunze/validate-sunze-orders-parser.mjs",
     "reporting:validate-refund-adjustments": "node scripts/validate-refund-adjustments.mjs",
+    "reporting:validate-partner-scheduled-export": "node scripts/validate-partner-report-scheduled-export.mjs",
     "training:dedupe-catalog": "node scripts/dedupe-training-catalog.mjs",
     "training:sync-guides": "node scripts/sync-training-guides.mjs",
     "training:upload-docs": "node scripts/upload-training-documents.mjs",

--- a/scripts/validate-partner-report-scheduled-export.mjs
+++ b/scripts/validate-partner-report-scheduled-export.mjs
@@ -1,0 +1,71 @@
+import { readFileSync } from 'node:fs';
+
+const files = {
+  exportFunction: 'supabase/functions/partner-report-export/index.ts',
+  migration: 'supabase/migrations/202605070001_partner_report_scheduler_pdf_export.sql',
+};
+
+const read = (path) => readFileSync(path, 'utf8');
+const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+const exportFunction = read(files.exportFunction);
+const migration = read(files.migration);
+
+assert(
+  exportFunction.includes('buildPartnerReportArtifact') &&
+    exportFunction.includes('buildPartnerReportPdf(context)') &&
+    exportFunction.includes('buildPartnerReportCsv(context)') &&
+    exportFunction.includes('buildPartnerReportXlsx(context)'),
+  'Partner export function must keep one shared artifact builder for PDF/CSV/XLSX.',
+);
+
+assert(
+  exportFunction.includes('REPORT_SCHEDULER_SECRET') &&
+    exportFunction.includes('handleScheduledPdfExport') &&
+    exportFunction.includes('Authorization") !== `Bearer ${schedulerSecret}`'),
+  'Scheduled partner PDF endpoint path must enforce the scheduler secret.',
+);
+
+assert(
+  exportFunction.includes('partner_report_scheduler_preview_partner_period_report') &&
+    exportFunction.includes('actorUserId: null') &&
+    exportFunction.includes('createSignedUrl: false'),
+  'Scheduled partner PDF generation must use the service-role preview path without a browser user token or signed URL creation.',
+);
+
+assert(
+  exportFunction.includes('String(warning.severity ?? "blocking").toLowerCase() !== "non_blocking"'),
+  'Blocking warning semantics must treat anything other than non_blocking as blocking.',
+);
+
+assert(
+  exportFunction.includes('status: "blocked"') &&
+    exportFunction.includes('warning_gate_status: "blocked"') &&
+    exportFunction.includes('snapshot_id: null') &&
+    exportFunction.includes('artifact_storage_path: null') &&
+    exportFunction.includes('artifact_generated_at: null'),
+  'Scheduled blocking runs must record warnings and clear snapshot/artifact fields.',
+);
+
+assert(
+  exportFunction.includes('snapshot_id: artifact.snapshotId') &&
+    exportFunction.includes('artifact_storage_path: artifact.storagePath') &&
+    exportFunction.includes('artifact_format: "pdf"') &&
+    exportFunction.includes('artifact_generated_at: artifact.generatedAt'),
+  'Passing scheduled PDF runs must write snapshot and artifact linkage to the run record.',
+);
+
+assert(
+  migration.includes('partner_report_scheduler_preview_partner_period_report') &&
+    migration.includes("auth.role() is distinct from 'service_role'") &&
+    migration.includes('revoke execute on function public.partner_report_scheduler_preview_partner_period_report') &&
+    migration.includes('from public, anon, authenticated') &&
+    migration.includes('to service_role'),
+  'Scheduler preview RPC must be service-role-only and keep public/anon/authenticated closed.',
+);
+
+console.log('Partner scheduled PDF export validation passed.');

--- a/scripts/validate-rpc-execute-surface.mjs
+++ b/scripts/validate-rpc-execute-surface.mjs
@@ -16,22 +16,32 @@ const serviceRoleOnlyFunctions = [
   {
     signature: 'public.can_access_partner_dashboard(uuid, uuid, date, date)',
     name: 'can_access_partner_dashboard',
+    migrationName: hardeningMigrationName,
   },
   {
     signature: 'public.admin_grant_machine_report_access(text, uuid, uuid, uuid, text, text)',
     name: 'admin_grant_machine_report_access',
+    migrationName: hardeningMigrationName,
   },
   {
     signature: 'public.create_report_export(uuid, jsonb)',
     name: 'create_report_export',
+    migrationName: hardeningMigrationName,
   },
   {
     signature: 'public.admin_list_reporting_sync_runs(integer)',
     name: 'admin_list_reporting_sync_runs',
+    migrationName: hardeningMigrationName,
   },
   {
     signature: 'public.admin_reconcile_technician_entitlements(text)',
     name: 'admin_reconcile_technician_entitlements',
+    migrationName: hardeningMigrationName,
+  },
+  {
+    signature: 'public.partner_report_scheduler_preview_partner_period_report(uuid, date, date, text)',
+    name: 'partner_report_scheduler_preview_partner_period_report',
+    migrationName: '202605070001_partner_report_scheduler_pdf_export.sql',
   },
 ];
 
@@ -71,9 +81,9 @@ const statementMentionsAuthenticated = (sql, verb, signature) => {
   return pattern.test(compactSql(sql));
 };
 
-const expectMigrationStatement = (sql, snippet) => {
+const expectMigrationStatement = (migrationName, sql, snippet) => {
   if (!compactSql(sql).includes(compactSql(snippet))) {
-    fail(`${hardeningMigrationName}: missing statement: ${snippet}`);
+    fail(`${migrationName}: missing statement: ${snippet}`);
   }
 };
 
@@ -121,21 +131,32 @@ const assertBrowserDoesNotCallServiceOnlyFunctions = () => {
   }
 };
 
-const assertIssueMigration = () => {
+const assertServiceOnlyMigrations = () => {
   if (!fs.existsSync(hardeningMigrationPath)) {
     fail(`Missing migration ${hardeningMigrationName}.`);
   }
 
-  const sql = readText(hardeningMigrationPath);
-
   for (const fn of serviceRoleOnlyFunctions) {
+    const migrationPath = path.join(migrationsDir, fn.migrationName);
+    if (!fs.existsSync(migrationPath)) {
+      fail(`Missing migration ${fn.migrationName} for ${fn.signature}.`);
+    }
+
+    const sql = readText(migrationPath);
     expectMigrationStatement(
+      fn.migrationName,
       sql,
       `revoke execute on function ${fn.signature} from public, anon, authenticated`
     );
-    expectMigrationStatement(sql, `grant execute on function ${fn.signature} to service_role`);
-    expectMigrationStatement(sql, `comment on function ${fn.signature} is`);
+    expectMigrationStatement(
+      fn.migrationName,
+      sql,
+      `grant execute on function ${fn.signature} to service_role`
+    );
+    expectMigrationStatement(fn.migrationName, sql, `comment on function ${fn.signature} is`);
   }
+
+  const sql = readText(hardeningMigrationPath);
 
   for (const signature of protectedAuthenticatedFunctions) {
     if (statementMentionsAuthenticated(sql, 'revoke', signature)) {
@@ -146,14 +167,14 @@ const assertIssueMigration = () => {
 
 const assertNoLaterAuthenticatedRegrant = () => {
   const migrations = getMigrationFiles();
-  const hardeningIndex = migrations.indexOf(hardeningMigrationName);
-  if (hardeningIndex === -1) {
-    fail(`Unable to locate ${hardeningMigrationName} in migration order.`);
-  }
+  for (const fn of serviceRoleOnlyFunctions) {
+    const migrationIndex = migrations.indexOf(fn.migrationName);
+    if (migrationIndex === -1) {
+      fail(`Unable to locate ${fn.migrationName} in migration order.`);
+    }
 
-  for (const migrationName of migrations.slice(hardeningIndex + 1)) {
-    const sql = readText(path.join(migrationsDir, migrationName));
-    for (const fn of serviceRoleOnlyFunctions) {
+    for (const migrationName of migrations.slice(migrationIndex + 1)) {
+      const sql = readText(path.join(migrationsDir, migrationName));
       if (statementMentionsAuthenticated(sql, 'grant', fn.signature)) {
         fail(`${migrationName} re-grants authenticated execute on service-role-only ${fn.signature}.`);
       }
@@ -162,7 +183,7 @@ const assertNoLaterAuthenticatedRegrant = () => {
 };
 
 const main = () => {
-  assertIssueMigration();
+  assertServiceOnlyMigrations();
   assertNoLaterAuthenticatedRegrant();
   assertBrowserDoesNotCallServiceOnlyFunctions();
 

--- a/supabase/functions/partner-report-export/index.ts
+++ b/supabase/functions/partner-report-export/index.ts
@@ -10,12 +10,14 @@ import {
   buildPartnerReportPdf,
   buildPartnerReportReference,
   buildPartnerReportXlsx,
+  type PartnerReportExportContext,
   type PartnerReportPreview,
 } from "../_shared/partner-report-export.ts";
 
 const supabaseUrl = Deno.env.get("SUPABASE_URL");
 const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY");
 const supabaseServiceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+const schedulerSecret = Deno.env.get("REPORT_SCHEDULER_SECRET");
 const exportBucket = "sales-report-exports";
 const uuidPattern =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -31,6 +33,7 @@ const validPeriodModes = new Set([
 type PartnerReportPeriodGrain = "reporting_week" | "calendar_month";
 type PartnerReportPeriodMode = "weekly" | "month_to_date" | "completed_month";
 type PartnerReportExportFormat = "pdf" | "csv" | "xlsx";
+type PartnerReportWarning = NonNullable<PartnerReportPreview["warnings"]>[number];
 
 type PartnerPeriodPreviewRpc = {
   partnership_id?: string;
@@ -59,6 +62,35 @@ type ExportRequest = {
 
 type PartnerReportPeriod = NonNullable<PartnerReportPreview["periods"]>[number];
 type PartnerReportMachine = NonNullable<PartnerReportPreview["machines"]>[number];
+
+type PartnerReportScheduleRun = {
+  id: string;
+  schedule_id: string;
+  partnership_id: string;
+  period_grain: PartnerReportPeriodGrain;
+  period_start_date: string;
+  period_end_date: string;
+  period_label: string;
+  trigger_type: string;
+  status: string;
+  warning_gate_status: string;
+};
+
+type PartnerReportArtifact = {
+  snapshotId: string;
+  storagePath: string;
+  signedUrl?: string;
+  format: PartnerReportExportFormat;
+  fileName: string;
+  periodGrain: PartnerReportPeriodGrain;
+  periodMode: PartnerReportPeriodMode;
+  periodStartDate: string;
+  periodEndDate: string;
+  machineScopeLabel?: string;
+  warnings: PartnerReportWarning[];
+  generatedAt: string;
+  reportReference: string;
+};
 
 const serviceSupabase = supabaseUrl && supabaseServiceRoleKey
   ? createClient(supabaseUrl, supabaseServiceRoleKey, {
@@ -485,6 +517,13 @@ const getBlockingWarnings = (preview: PartnerReportPreview) =>
     String(warning.severity ?? "blocking").toLowerCase() !== "non_blocking"
   );
 
+const assertNoBlockingWarnings = (preview: PartnerReportPreview) => {
+  const blockingWarnings = getBlockingWarnings(preview);
+  if (blockingWarnings.length > 0) {
+    throw new BlockingWarningsError(blockingWarnings);
+  }
+};
+
 const getPayoutRecipientLabels = async (
   partnershipId: string,
 ): Promise<string[]> => {
@@ -547,6 +586,35 @@ const getActiveFinancialRule = async (
 class MachineScopeError extends Error {
   status = 400;
 }
+
+class PreviewLoadError extends Error {
+  status = 400;
+}
+
+class BlockingWarningsError extends Error {
+  status = 409;
+  warnings: PartnerReportWarning[];
+
+  constructor(warnings: PartnerReportWarning[]) {
+    super("Resolve blocking report review items before exporting this partner report.");
+    this.warnings = warnings;
+  }
+}
+
+class ScheduleRunValidationError extends Error {
+  status = 400;
+}
+
+const getErrorMessage = (error: unknown, fallback: string) =>
+  error instanceof Error && error.message ? error.message : fallback;
+
+const getErrorStatus = (error: unknown) =>
+  error instanceof MachineScopeError ||
+    error instanceof PreviewLoadError ||
+    error instanceof BlockingWarningsError ||
+    error instanceof ScheduleRunValidationError
+    ? error.status
+    : 500;
 
 const mapReportPeriod = (period: Record<string, unknown>): PartnerReportPeriod => ({
   period_start: String(period.period_start ?? ""),
@@ -791,15 +859,17 @@ const mapPeriodPreviewToPartnerReportPreview = (
 };
 
 const loadTrendPeriods = async ({
-  userSupabase,
+  previewSupabase,
+  periodPreviewRpcName,
   request,
 }: {
-  userSupabase: SupabaseClient;
+  previewSupabase: SupabaseClient;
+  periodPreviewRpcName: string;
   request: ExportRequest;
 }): Promise<PartnerReportPeriod[]> => {
   const { trendStartDate, trendEndDate } = getTrendRange(request);
-  const { data, error } = await userSupabase.rpc(
-    "admin_preview_partner_period_report",
+  const { data, error } = await previewSupabase.rpc(
+    periodPreviewRpcName,
     {
       p_partnership_id: request.partnershipId,
       p_date_from: trendStartDate,
@@ -830,6 +900,54 @@ const loadTrendPeriods = async ({
     .slice(-expectedCount);
 };
 
+const loadPartnerReportPreview = async ({
+  previewSupabase,
+  periodPreviewRpcName,
+  request,
+}: {
+  previewSupabase: SupabaseClient;
+  periodPreviewRpcName: string;
+  request: ExportRequest;
+}): Promise<PartnerReportPreview> => {
+  const { data, error } = request.useLegacyWeeklyPreview
+    ? await previewSupabase.rpc(
+      "admin_preview_partner_weekly_report",
+      {
+        p_partnership_id: request.partnershipId,
+        p_week_ending_date: request.periodEndDate,
+      },
+    )
+    : await previewSupabase.rpc(
+      periodPreviewRpcName,
+      {
+        p_partnership_id: request.partnershipId,
+        p_date_from: request.periodStartDate,
+        p_date_to: request.periodEndDate,
+        p_period_grain: request.periodGrain,
+      },
+    );
+
+  if (error) {
+    throw new PreviewLoadError(
+      error.message || "Unable to preview partner report.",
+    );
+  }
+
+  return request.useLegacyWeeklyPreview
+    ? ({
+      ...((data ?? {}) as PartnerReportPreview),
+      periodGrain: "reporting_week",
+      periodMode: request.periodMode,
+      periodStartDate: request.periodStartDate,
+      periodEndDate: request.periodEndDate,
+      periodLabel: request.periodLabel,
+    } satisfies PartnerReportPreview)
+    : mapPeriodPreviewToPartnerReportPreview(
+      (data ?? {}) as PartnerPeriodPreviewRpc,
+      request,
+    );
+};
+
 const getOrCreateSnapshot = async ({
   partnershipId,
   periodGrain,
@@ -844,7 +962,7 @@ const getOrCreateSnapshot = async ({
   periodStartDate: string;
   periodEndDate: string;
   machineScopeKey: string;
-  userId: string;
+  userId: string | null;
   summaryJson: Record<string, unknown>;
 }) => {
   if (!serviceSupabase) {
@@ -873,7 +991,7 @@ const getOrCreateSnapshot = async ({
       .from("partner_report_snapshots")
       .update({
         generated_at: new Date().toISOString(),
-        generated_by: userId,
+        ...(userId ? { generated_by: userId } : {}),
         week_ending_date: periodEndDate,
         period_grain: periodGrain,
         period_start_date: periodStartDate,
@@ -922,224 +1040,65 @@ const getOrCreateSnapshot = async ({
   return inserted;
 };
 
-serve(async (req) => {
-  if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: corsHeaders });
+const buildPartnerReportArtifact = async ({
+  request,
+  preview,
+  previewSupabase,
+  periodPreviewRpcName,
+  actorUserId,
+  createSignedUrl,
+}: {
+  request: ExportRequest;
+  preview: PartnerReportPreview;
+  previewSupabase: SupabaseClient;
+  periodPreviewRpcName: string;
+  actorUserId: string | null;
+  createSignedUrl: boolean;
+}): Promise<PartnerReportArtifact> => {
+  if (!serviceSupabase) {
+    throw new Error("Partner report export is not configured.");
   }
 
-  try {
-    if (req.method !== "POST") {
-      return jsonResponse({ error: "Method not allowed." }, 405);
-    }
+  assertNoBlockingWarnings(preview);
 
-    if (!supabaseUrl || !supabaseAnonKey || !serviceSupabase) {
-      return jsonResponse(
-        { error: "Partner report export is not configured." },
-        500,
-      );
-    }
-
-    const accessToken = resolveSupabaseAccessToken(req);
-    if (!accessToken) {
-      return jsonResponse({ error: "Unauthorized." }, 401);
-    }
-
-    const { data: authData, error: authError } = await serviceSupabase.auth
-      .getUser(accessToken);
-    const user = authData?.user;
-    if (authError || !user) {
-      return jsonResponse({ error: "Unauthorized." }, 401);
-    }
-
-    const body = await req.json().catch(() => ({}));
-    const raw = body && typeof body === "object"
-      ? (body as Record<string, unknown>)
-      : {};
-    const { request, error: requestError } = resolveExportRequest(raw);
-
-    if (!request) {
-      return jsonResponse(
-        { error: requestError ?? "Invalid export request." },
-        400,
-      );
-    }
-
-    const userSupabase = createClient(supabaseUrl, supabaseAnonKey, {
-      auth: { persistSession: false },
-      global: {
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      },
-    });
-
-    const { data: previewData, error: previewError } = request
-        .useLegacyWeeklyPreview
-      ? await userSupabase.rpc(
-        "admin_preview_partner_weekly_report",
-        {
-          p_partnership_id: request.partnershipId,
-          p_week_ending_date: request.periodEndDate,
-        },
-      )
-      : await userSupabase.rpc(
-        "admin_preview_partner_period_report",
-        {
-          p_partnership_id: request.partnershipId,
-          p_date_from: request.periodStartDate,
-          p_date_to: request.periodEndDate,
-          p_period_grain: request.periodGrain,
-        },
-      );
-
-    if (previewError) {
-      return jsonResponse({
-        error: previewError.message || "Unable to preview partner report.",
-      }, 400);
-    }
-
-    const preview = request.useLegacyWeeklyPreview
-      ? ({
-        ...((previewData ?? {}) as PartnerReportPreview),
-        periodGrain: "reporting_week",
-        periodMode: request.periodMode,
-        periodStartDate: request.periodStartDate,
-        periodEndDate: request.periodEndDate,
-        periodLabel: request.periodLabel,
-      } satisfies PartnerReportPreview)
-      : mapPeriodPreviewToPartnerReportPreview(
-        (previewData ?? {}) as PartnerPeriodPreviewRpc,
-        request,
-      );
-    const blockingWarnings = getBlockingWarnings(preview);
-    if (blockingWarnings.length > 0) {
-      return jsonResponse({
-        error:
-          "Resolve blocking report review items before exporting this partner report.",
-      }, 409);
-    }
-
-    const generatedAt = new Date().toISOString();
-    const [payoutRecipientLabels, financialRule, trendPeriods] = await Promise.all([
-      getPayoutRecipientLabels(request.partnershipId),
-      getActiveFinancialRule(
-        request.partnershipId,
-        request.periodStartDate,
-        request.periodEndDate,
-      ),
-      request.format === "pdf" || request.format === "xlsx" ||
-        request.machineIds.length > 0
-        ? loadTrendPeriods({ userSupabase, request })
-        : Promise.resolve([]),
-    ]);
-    const calculationLabel = formatCalculationLabel(financialRule);
-    const exportPayoutRecipientLabels = request.useLegacyWeeklyPreview
-      ? payoutRecipientLabels
-      : payoutRecipientLabels.length > 1
-      ? [payoutRecipientLabels.join(" + ")]
-      : payoutRecipientLabels;
-    const ruleExportLabels = getRuleExportLabels(financialRule, {
-      combineRecipientShares: !request.useLegacyWeeklyPreview,
-    });
-    const exportPreview = trendPeriods.length > 0
-      ? { ...preview, periods: trendPeriods }
-      : preview;
-    const snapshot = await getOrCreateSnapshot({
-      partnershipId: request.partnershipId,
-      periodGrain: request.periodGrain,
-      periodStartDate: request.periodStartDate,
-      periodEndDate: request.periodEndDate,
-      machineScopeKey: request.machineScopeKey,
-      userId: user.id,
-      summaryJson: {
-        preview: exportPreview,
-        calculationLabel,
-        payoutRecipientLabels: exportPayoutRecipientLabels,
-        ...ruleExportLabels,
-        generatedAt,
-        periodGrain: request.periodGrain,
-        periodStartDate: request.periodStartDate,
-        periodEndDate: request.periodEndDate,
-        periodLabel: request.periodLabel,
-        periodMode: request.periodMode,
-        machineScopeKey: request.machineScopeKey,
-        machineIds: request.machineIds,
-        machineScopeLabel: exportPreview.machineScopeLabel,
-      },
-    });
-    const reportReference = buildPartnerReportReference(snapshot.id, exportPreview);
-    const context = {
+  const generatedAt = new Date().toISOString();
+  const [payoutRecipientLabels, financialRule, trendPeriods] = await Promise.all([
+    getPayoutRecipientLabels(request.partnershipId),
+    getActiveFinancialRule(
+      request.partnershipId,
+      request.periodStartDate,
+      request.periodEndDate,
+    ),
+    request.format === "pdf" || request.format === "xlsx" ||
+      request.machineIds.length > 0
+      ? loadTrendPeriods({ previewSupabase, periodPreviewRpcName, request })
+      : Promise.resolve([]),
+  ]);
+  const calculationLabel = formatCalculationLabel(financialRule);
+  const exportPayoutRecipientLabels = request.useLegacyWeeklyPreview
+    ? payoutRecipientLabels
+    : payoutRecipientLabels.length > 1
+    ? [payoutRecipientLabels.join(" + ")]
+    : payoutRecipientLabels;
+  const ruleExportLabels = getRuleExportLabels(financialRule, {
+    combineRecipientShares: !request.useLegacyWeeklyPreview,
+  });
+  const exportPreview = trendPeriods.length > 0
+    ? { ...preview, periods: trendPeriods }
+    : preview;
+  const snapshot = await getOrCreateSnapshot({
+    partnershipId: request.partnershipId,
+    periodGrain: request.periodGrain,
+    periodStartDate: request.periodStartDate,
+    periodEndDate: request.periodEndDate,
+    machineScopeKey: request.machineScopeKey,
+    userId: actorUserId,
+    summaryJson: {
       preview: exportPreview,
-      payoutRecipientLabels: exportPayoutRecipientLabels,
       calculationLabel,
+      payoutRecipientLabels: exportPayoutRecipientLabels,
+      ...ruleExportLabels,
       generatedAt,
-      snapshotId: snapshot.id,
-      ...ruleExportLabels,
-    };
-    const fileBytes = request.format === "pdf"
-      ? await buildPartnerReportPdf(context)
-      : request.format === "xlsx"
-      ? buildPartnerReportXlsx(context)
-      : encoder.encode(buildPartnerReportCsv(context));
-    const contentType = request.format === "pdf"
-      ? "application/pdf"
-      : request.format === "xlsx"
-      ? "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-      : "text/csv";
-    const periodSlug = request.periodGrain === "calendar_month"
-      ? request.periodMode === "month_to_date"
-        ? `${request.periodStartDate}-to-${request.periodEndDate}`
-        : request.periodStartDate.slice(0, 7)
-      : request.periodEndDate;
-    const modeSlug = request.periodMode === "month_to_date"
-      ? "month-to-date"
-      : request.periodGrain === "calendar_month"
-      ? "monthly"
-      : "weekly";
-    const machineSlug = request.machineIds.length > 0
-      ? `-${slugify(exportPreview.machineScopeLabel ?? "selected-machine")}`
-      : "";
-    const fileName = `${slugify(exportPreview.partnershipName ?? "partner-report")}-${
-      modeSlug
-    }-${periodSlug}${machineSlug}.${request.format}`;
-    const storagePath =
-      `partner-reports/${request.partnershipId}/${request.periodGrain}/${snapshot.id}/${fileName}`;
-
-    const { error: uploadError } = await serviceSupabase.storage
-      .from(exportBucket)
-      .upload(
-        storagePath,
-        new Blob([toBlobPart(fileBytes)], { type: contentType }),
-        {
-          contentType,
-          upsert: true,
-        },
-      );
-
-    if (uploadError) {
-      if (
-        (request.format === "csv" || request.format === "xlsx") &&
-        uploadError.message?.toLowerCase().includes("mime")
-      ) {
-        throw new Error(
-          request.format === "xlsx"
-            ? "XLSX export storage is not configured. Apply the latest reporting export migration and retry."
-            : "CSV export storage is not configured for text/csv. Apply the latest reporting export migration and retry.",
-        );
-      }
-      throw new Error(
-        uploadError.message || "Unable to upload partner report.",
-      );
-    }
-
-    const nextSummaryJson = {
-      ...((snapshot.summary_json as Record<string, unknown> | null) ?? {}),
-      preview: exportPreview,
-      calculationLabel,
-      payoutRecipientLabels: exportPayoutRecipientLabels,
-      snapshotId: snapshot.id,
-      reportReference,
-      ...ruleExportLabels,
       periodGrain: request.periodGrain,
       periodStartDate: request.periodStartDate,
       periodEndDate: request.periodEndDate,
@@ -1148,38 +1107,123 @@ serve(async (req) => {
       machineScopeKey: request.machineScopeKey,
       machineIds: request.machineIds,
       machineScopeLabel: exportPreview.machineScopeLabel,
-      exports: {
-        ...(((snapshot.summary_json as Record<string, unknown> | null)
-          ?.exports as Record<string, unknown> | undefined) ?? {}),
-        [request.format]: {
-          storagePath,
-          generatedAt,
-          fileName,
-        },
+    },
+  });
+  const reportReference = buildPartnerReportReference(snapshot.id, exportPreview);
+  const context: PartnerReportExportContext = {
+    preview: exportPreview,
+    payoutRecipientLabels: exportPayoutRecipientLabels,
+    calculationLabel,
+    generatedAt,
+    snapshotId: snapshot.id,
+    ...ruleExportLabels,
+  };
+  const fileBytes = request.format === "pdf"
+    ? await buildPartnerReportPdf(context)
+    : request.format === "xlsx"
+    ? buildPartnerReportXlsx(context)
+    : encoder.encode(buildPartnerReportCsv(context));
+  const contentType = request.format === "pdf"
+    ? "application/pdf"
+    : request.format === "xlsx"
+    ? "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    : "text/csv";
+  const periodSlug = request.periodGrain === "calendar_month"
+    ? request.periodMode === "month_to_date"
+      ? `${request.periodStartDate}-to-${request.periodEndDate}`
+      : request.periodStartDate.slice(0, 7)
+    : request.periodEndDate;
+  const modeSlug = request.periodMode === "month_to_date"
+    ? "month-to-date"
+    : request.periodGrain === "calendar_month"
+    ? "monthly"
+    : "weekly";
+  const machineSlug = request.machineIds.length > 0
+    ? `-${slugify(exportPreview.machineScopeLabel ?? "selected-machine")}`
+    : "";
+  const fileName = `${slugify(exportPreview.partnershipName ?? "partner-report")}-${
+    modeSlug
+  }-${periodSlug}${machineSlug}.${request.format}`;
+  const storagePath =
+    `partner-reports/${request.partnershipId}/${request.periodGrain}/${snapshot.id}/${fileName}`;
+
+  const { error: uploadError } = await serviceSupabase.storage
+    .from(exportBucket)
+    .upload(
+      storagePath,
+      new Blob([toBlobPart(fileBytes)], { type: contentType }),
+      {
+        contentType,
+        upsert: true,
       },
-    };
+    );
 
-    const { error: snapshotUpdateError } = await serviceSupabase
-      .from("partner_report_snapshots")
-      .update({
-        export_storage_path: storagePath,
-        week_ending_date: request.periodEndDate,
-        period_grain: request.periodGrain,
-        period_start_date: request.periodStartDate,
-        period_end_date: request.periodEndDate,
-        machine_scope_key: request.machineScopeKey,
-        summary_json: nextSummaryJson,
-        generated_at: generatedAt,
-      })
-      .eq("id", snapshot.id);
-
-    if (snapshotUpdateError) {
+  if (uploadError) {
+    if (
+      (request.format === "csv" || request.format === "xlsx") &&
+      uploadError.message?.toLowerCase().includes("mime")
+    ) {
       throw new Error(
-        snapshotUpdateError.message ||
-          "Unable to update partner report snapshot.",
+        request.format === "xlsx"
+          ? "XLSX export storage is not configured. Apply the latest reporting export migration and retry."
+          : "CSV export storage is not configured for text/csv. Apply the latest reporting export migration and retry.",
       );
     }
+    throw new Error(
+      uploadError.message || "Unable to upload partner report.",
+    );
+  }
 
+  const nextSummaryJson = {
+    ...((snapshot.summary_json as Record<string, unknown> | null) ?? {}),
+    preview: exportPreview,
+    calculationLabel,
+    payoutRecipientLabels: exportPayoutRecipientLabels,
+    snapshotId: snapshot.id,
+    reportReference,
+    ...ruleExportLabels,
+    periodGrain: request.periodGrain,
+    periodStartDate: request.periodStartDate,
+    periodEndDate: request.periodEndDate,
+    periodLabel: request.periodLabel,
+    periodMode: request.periodMode,
+    machineScopeKey: request.machineScopeKey,
+    machineIds: request.machineIds,
+    machineScopeLabel: exportPreview.machineScopeLabel,
+    exports: {
+      ...(((snapshot.summary_json as Record<string, unknown> | null)
+        ?.exports as Record<string, unknown> | undefined) ?? {}),
+      [request.format]: {
+        storagePath,
+        generatedAt,
+        fileName,
+      },
+    },
+  };
+
+  const { error: snapshotUpdateError } = await serviceSupabase
+    .from("partner_report_snapshots")
+    .update({
+      export_storage_path: storagePath,
+      week_ending_date: request.periodEndDate,
+      period_grain: request.periodGrain,
+      period_start_date: request.periodStartDate,
+      period_end_date: request.periodEndDate,
+      machine_scope_key: request.machineScopeKey,
+      summary_json: nextSummaryJson,
+      generated_at: generatedAt,
+    })
+    .eq("id", snapshot.id);
+
+  if (snapshotUpdateError) {
+    throw new Error(
+      snapshotUpdateError.message ||
+        "Unable to update partner report snapshot.",
+    );
+  }
+
+  let signedUrl: string | undefined;
+  if (createSignedUrl) {
     const { data: signedUrlData, error: signedUrlError } = await serviceSupabase
       .storage
       .from(exportBucket)
@@ -1191,27 +1235,399 @@ serve(async (req) => {
       );
     }
 
-    return jsonResponse({
-      snapshotId: snapshot.id,
-      storagePath,
-      signedUrl: signedUrlData.signedUrl,
-      format: request.format,
-      fileName,
-      periodGrain: request.periodGrain,
-      periodMode: request.periodMode,
-      periodStartDate: request.periodStartDate,
-      periodEndDate: request.periodEndDate,
-      machineScopeLabel: exportPreview.machineScopeLabel,
+    signedUrl = signedUrlData.signedUrl;
+  }
+
+  return {
+    snapshotId: snapshot.id,
+    storagePath,
+    signedUrl,
+    format: request.format,
+    fileName,
+    periodGrain: request.periodGrain,
+    periodMode: request.periodMode,
+    periodStartDate: request.periodStartDate,
+    periodEndDate: request.periodEndDate,
+    machineScopeLabel: exportPreview.machineScopeLabel,
+    warnings: exportPreview.warnings ?? [],
+    generatedAt,
+    reportReference,
+  };
+};
+
+const scheduleRunToExportRequest = (
+  run: PartnerReportScheduleRun,
+): ExportRequest => {
+  if (run.trigger_type === "dry_run") {
+    throw new ScheduleRunValidationError(
+      "Dry-run schedule records validate warnings only and do not generate PDF artifacts.",
+    );
+  }
+
+  if (!validPeriodGrains.has(run.period_grain)) {
+    throw new ScheduleRunValidationError(
+      "Schedule run period grain is invalid.",
+    );
+  }
+
+  if (
+    !isValidDateInput(run.period_start_date) ||
+    !isValidDateInput(run.period_end_date)
+  ) {
+    throw new ScheduleRunValidationError(
+      "Schedule run date range is invalid.",
+    );
+  }
+
+  const periodMode = getDefaultPeriodMode(run.period_grain);
+  return {
+    partnershipId: run.partnership_id,
+    format: "pdf",
+    periodGrain: run.period_grain,
+    periodMode,
+    periodStartDate: run.period_start_date,
+    periodEndDate: run.period_end_date,
+    periodLabel: run.period_label ||
+      formatPeriodLabel(
+        run.period_grain,
+        run.period_start_date,
+        run.period_end_date,
+        periodMode,
+      ),
+    machineIds: [],
+    machineScopeKey: "all",
+    useLegacyWeeklyPreview: false,
+  };
+};
+
+const updateScheduleRun = async (
+  runId: string,
+  values: Record<string, unknown>,
+) => {
+  if (!serviceSupabase) {
+    throw new Error("Partner report export is not configured.");
+  }
+
+  const { data, error } = await serviceSupabase
+    .from("partner_report_schedule_runs")
+    .update(values)
+    .eq("id", runId)
+    .select("*")
+    .single();
+
+  if (error || !data) {
+    throw new Error(
+      error?.message || "Unable to update partner report schedule run.",
+    );
+  }
+
+  return data as PartnerReportScheduleRun;
+};
+
+const releaseScheduleRun = async (
+  runId: string,
+  workerKey: string,
+  status: string,
+  errorCode: string | null = null,
+  errorMessage: string | null = null,
+) => {
+  if (!serviceSupabase) {
+    throw new Error("Partner report export is not configured.");
+  }
+
+  const { data, error } = await serviceSupabase.rpc(
+    "partner_report_schedule_release_run",
+    {
+      p_run_id: runId,
+      p_worker_key: workerKey,
+      p_status: status,
+      p_error_code: errorCode,
+      p_error_message: errorMessage,
+    },
+  );
+
+  if (error || !data) {
+    throw new Error(
+      error?.message || "Unable to release partner report schedule run.",
+    );
+  }
+
+  return data as PartnerReportScheduleRun;
+};
+
+const getScheduleRunId = (raw: Record<string, unknown>) =>
+  String(raw.scheduleRunId ?? raw.runId ?? "").trim();
+
+const isScheduledPdfRequest = (raw: Record<string, unknown>) => {
+  const mode = String(raw.mode ?? raw.action ?? "").trim().toLowerCase();
+  return Boolean(getScheduleRunId(raw)) ||
+    mode === "scheduled_pdf" ||
+    mode === "generate_scheduled_pdf";
+};
+
+const handleScheduledPdfExport = async (
+  req: Request,
+  raw: Record<string, unknown>,
+) => {
+  if (!schedulerSecret) {
+    return jsonResponse(
+      { error: "REPORT_SCHEDULER_SECRET is not configured." },
+      500,
+    );
+  }
+
+  if (req.headers.get("Authorization") !== `Bearer ${schedulerSecret}`) {
+    return jsonResponse({ error: "Unauthorized." }, 401);
+  }
+
+  if (!serviceSupabase) {
+    return jsonResponse(
+      { error: "Partner report export is not configured." },
+      500,
+    );
+  }
+
+  const scheduleRunId = getScheduleRunId(raw);
+  if (!uuidPattern.test(scheduleRunId)) {
+    return jsonResponse({ error: "Valid scheduleRunId is required." }, 400);
+  }
+
+  const workerKey = String(raw.workerKey ?? "partner-report-export").trim() ||
+    "partner-report-export";
+
+  const { data: claimedRunData, error: claimError } = await serviceSupabase.rpc(
+    "partner_report_schedule_claim_run",
+    {
+      p_run_id: scheduleRunId,
+      p_worker_key: workerKey,
+      p_lease_seconds: 600,
+    },
+  );
+
+  if (claimError || !claimedRunData) {
+    return jsonResponse(
+      {
+        error: claimError?.message ||
+          "Partner report schedule run is not claimable.",
+      },
+      409,
+    );
+  }
+
+  const run = claimedRunData as PartnerReportScheduleRun;
+
+  try {
+    const request = scheduleRunToExportRequest(run);
+
+    await updateScheduleRun(run.id, {
+      status: "checking_warnings",
+      warning_gate_status: "not_checked",
+      warnings_json: [],
+      error_code: null,
+      error_message: null,
     });
+
+    const preview = await loadPartnerReportPreview({
+      previewSupabase: serviceSupabase,
+      periodPreviewRpcName: "partner_report_scheduler_preview_partner_period_report",
+      request,
+    });
+    const warnings = preview.warnings ?? [];
+    const blockingWarnings = getBlockingWarnings(preview);
+
+    if (blockingWarnings.length > 0) {
+      await updateScheduleRun(run.id, {
+        warning_gate_status: "blocked",
+        warnings_json: warnings,
+        snapshot_id: null,
+        artifact_storage_path: null,
+        artifact_format: null,
+        artifact_generated_at: null,
+      });
+      await releaseScheduleRun(
+        run.id,
+        workerKey,
+        "blocked",
+        "blocking_warnings",
+        "Resolve blocking report review items before scheduled PDF generation.",
+      );
+
+      return jsonResponse({
+        runId: run.id,
+        scheduleId: run.schedule_id,
+        status: "blocked",
+        warningGateStatus: "blocked",
+        blockingWarningCount: blockingWarnings.length,
+        warnings,
+      });
+    }
+
+    await updateScheduleRun(run.id, {
+      status: "generating",
+      warning_gate_status: "passed",
+      warnings_json: warnings,
+      error_code: null,
+      error_message: null,
+    });
+
+    const artifact = await buildPartnerReportArtifact({
+      request,
+      preview,
+      previewSupabase: serviceSupabase,
+      periodPreviewRpcName: "partner_report_scheduler_preview_partner_period_report",
+      actorUserId: null,
+      createSignedUrl: false,
+    });
+
+    await updateScheduleRun(run.id, {
+      snapshot_id: artifact.snapshotId,
+      artifact_storage_path: artifact.storagePath,
+      artifact_format: "pdf",
+      artifact_generated_at: artifact.generatedAt,
+      warning_gate_status: "passed",
+      warnings_json: artifact.warnings,
+      error_code: null,
+      error_message: null,
+    });
+    await releaseScheduleRun(run.id, workerKey, "artifact_ready");
+
+    return jsonResponse({
+      runId: run.id,
+      scheduleId: run.schedule_id,
+      status: "artifact_ready",
+      warningGateStatus: "passed",
+      snapshotId: artifact.snapshotId,
+      storagePath: artifact.storagePath,
+      format: artifact.format,
+      fileName: artifact.fileName,
+      periodGrain: artifact.periodGrain,
+      periodMode: artifact.periodMode,
+      periodStartDate: artifact.periodStartDate,
+      periodEndDate: artifact.periodEndDate,
+      machineScopeLabel: artifact.machineScopeLabel,
+      warnings: artifact.warnings,
+    });
+  } catch (error) {
+    const message = getErrorMessage(
+      error,
+      "Unable to generate scheduled partner report PDF.",
+    );
+
+    try {
+      await releaseScheduleRun(
+        run.id,
+        workerKey,
+        "failed",
+        error instanceof ScheduleRunValidationError
+          ? "invalid_schedule_run"
+          : "artifact_generation_failed",
+        message,
+      );
+    } catch (releaseError) {
+      console.error("partner-report-export schedule run release error", releaseError);
+    }
+
+    return jsonResponse(
+      { runId: run.id, status: "failed", error: message },
+      getErrorStatus(error),
+    );
+  }
+};
+
+const handleManualExport = async (
+  req: Request,
+  raw: Record<string, unknown>,
+) => {
+  if (!supabaseUrl || !supabaseAnonKey || !serviceSupabase) {
+    return jsonResponse(
+      { error: "Partner report export is not configured." },
+      500,
+    );
+  }
+
+  const accessToken = resolveSupabaseAccessToken(req);
+  if (!accessToken) {
+    return jsonResponse({ error: "Unauthorized." }, 401);
+  }
+
+  const { data: authData, error: authError } = await serviceSupabase.auth
+    .getUser(accessToken);
+  const user = authData?.user;
+  if (authError || !user) {
+    return jsonResponse({ error: "Unauthorized." }, 401);
+  }
+
+  const { request, error: requestError } = resolveExportRequest(raw);
+
+  if (!request) {
+    return jsonResponse(
+      { error: requestError ?? "Invalid export request." },
+      400,
+    );
+  }
+
+  const userSupabase = createClient(supabaseUrl, supabaseAnonKey, {
+    auth: { persistSession: false },
+    global: {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+  });
+
+  const preview = await loadPartnerReportPreview({
+    previewSupabase: userSupabase,
+    periodPreviewRpcName: "admin_preview_partner_period_report",
+    request,
+  });
+  const artifact = await buildPartnerReportArtifact({
+    request,
+    preview,
+    previewSupabase: userSupabase,
+    periodPreviewRpcName: "admin_preview_partner_period_report",
+    actorUserId: user.id,
+    createSignedUrl: true,
+  });
+
+  return jsonResponse({
+    snapshotId: artifact.snapshotId,
+    storagePath: artifact.storagePath,
+    signedUrl: artifact.signedUrl,
+    format: artifact.format,
+    fileName: artifact.fileName,
+    periodGrain: artifact.periodGrain,
+    periodMode: artifact.periodMode,
+    periodStartDate: artifact.periodStartDate,
+    periodEndDate: artifact.periodEndDate,
+    machineScopeLabel: artifact.machineScopeLabel,
+  });
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    if (req.method !== "POST") {
+      return jsonResponse({ error: "Method not allowed." }, 405);
+    }
+
+    const body = await req.json().catch(() => ({}));
+    const raw = body && typeof body === "object"
+      ? (body as Record<string, unknown>)
+      : {};
+
+    return isScheduledPdfRequest(raw)
+      ? await handleScheduledPdfExport(req, raw)
+      : await handleManualExport(req, raw);
   } catch (error) {
     console.error("partner-report-export error", error);
     return jsonResponse(
       {
-        error: error instanceof Error && error.message
-          ? error.message
-          : "Unable to export partner report.",
+        error: getErrorMessage(error, "Unable to export partner report."),
       },
-      error instanceof MachineScopeError ? error.status : 500,
+      getErrorStatus(error),
     );
   }
 });

--- a/supabase/migrations/202605070001_partner_report_scheduler_pdf_export.sql
+++ b/supabase/migrations/202605070001_partner_report_scheduler_pdf_export.sql
@@ -1,0 +1,152 @@
+-- Scheduler-safe partner report preview path for service-role PDF artifact generation.
+-- This does not enable recurring triggers, email sends, or automated CSV/XLSX.
+
+create or replace function public.is_super_admin(uid uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, auth
+as $$
+  select (
+    current_setting('app.partner_report_scheduler_scope', true) = 'service_role'
+    and auth.role() = 'service_role'
+  )
+  or exists (
+    select 1
+    from public.admin_roles ar
+    where ar.user_id = uid
+      and ar.role = 'super_admin'
+      and ar.active = true
+  );
+$$;
+
+create or replace function public.can_access_partner_dashboard(
+  p_user_id uuid,
+  p_partnership_id uuid,
+  p_date_from date default null,
+  p_date_to date default null
+)
+returns boolean
+language plpgsql
+stable
+security definer
+set search_path = public, auth
+as $$
+declare
+  scoped_machine_ids uuid[];
+  corporate_machine_ids uuid[];
+  actor_machine_ids uuid[];
+  scope_start date;
+  scope_end date;
+begin
+  if current_setting('app.partner_report_scheduler_scope', true) = 'service_role'
+     and auth.role() = 'service_role'
+     and p_partnership_id is not null then
+    return true;
+  end if;
+
+  if p_user_id is null or p_partnership_id is null then
+    return false;
+  end if;
+
+  if public.is_super_admin(p_user_id) then
+    return true;
+  end if;
+
+  if public.is_active_corporate_partner_user(p_user_id) then
+    if not exists (
+      select 1
+      from public.reporting_partnerships partnership
+      join public.reporting_partnership_parties party
+        on party.partnership_id = partnership.id
+      where partnership.id = p_partnership_id
+        and partnership.status = 'active'
+        and party.portal_access_enabled
+        and party.partner_id = any(public.corporate_partner_ids_for_user(p_user_id))
+    ) then
+      return false;
+    end if;
+
+    return true;
+  end if;
+
+  scoped_machine_ids := public.scoped_admin_machine_ids(p_user_id);
+  corporate_machine_ids := public.corporate_partner_machine_ids_for_user(p_user_id);
+  actor_machine_ids := scoped_machine_ids || corporate_machine_ids;
+
+  if coalesce(array_length(actor_machine_ids, 1), 0) = 0 then
+    return false;
+  end if;
+
+  scope_start := coalesce(p_date_from, current_date);
+  scope_end := coalesce(p_date_to, scope_start);
+
+  if scope_start > scope_end then
+    return false;
+  end if;
+
+  return exists (
+    select 1
+    from public.reporting_machine_partnership_assignments assignment
+    where assignment.partnership_id = p_partnership_id
+      and assignment.assignment_role = 'primary_reporting'
+      and assignment.status = 'active'
+      and assignment.effective_start_date <= scope_end
+      and (assignment.effective_end_date is null or assignment.effective_end_date >= scope_start)
+  )
+  and not exists (
+    select 1
+    from public.reporting_machine_partnership_assignments assignment
+    where assignment.partnership_id = p_partnership_id
+      and assignment.assignment_role = 'primary_reporting'
+      and assignment.status = 'active'
+      and assignment.effective_start_date <= scope_end
+      and (assignment.effective_end_date is null or assignment.effective_end_date >= scope_start)
+      and not (assignment.machine_id = any(actor_machine_ids))
+  );
+end;
+$$;
+
+revoke execute on function public.can_access_partner_dashboard(uuid, uuid, date, date)
+  from public, anon, authenticated;
+grant execute on function public.can_access_partner_dashboard(uuid, uuid, date, date)
+  to service_role;
+
+create or replace function public.partner_report_scheduler_preview_partner_period_report(
+  p_partnership_id uuid,
+  p_date_from date,
+  p_date_to date,
+  p_period_grain text
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public, auth
+as $$
+begin
+  if auth.role() is distinct from 'service_role' then
+    raise exception 'Service role access required';
+  end if;
+
+  perform set_config('app.partner_report_scheduler_scope', 'service_role', true);
+
+  return public.admin_preview_partner_period_report_internal(
+    p_partnership_id,
+    p_date_from,
+    p_date_to,
+    p_period_grain
+  );
+end;
+$$;
+
+revoke execute on function public.partner_report_scheduler_preview_partner_period_report(uuid, date, date, text)
+  from public, anon, authenticated;
+grant execute on function public.partner_report_scheduler_preview_partner_period_report(uuid, date, date, text)
+  to service_role;
+
+comment on function public.partner_report_scheduler_preview_partner_period_report(uuid, date, date, text) is
+  'Service-role-only preview wrapper used by scheduled partner PDF artifact generation.';
+
+select pg_notify('pgrst', 'reload schema');


### PR DESCRIPTION
﻿Refs #310

## Summary
- Refactors `partner-report-export` so manual exports and scheduled PDF generation use the same preview, warning gate, snapshot, artifact upload, PDF/CSV/XLSX rendering, and private storage helper path.
- Adds a scheduler-secret/server-side PDF-only branch that claims a `partner_report_schedule_runs` row, records blocked warning state without artifacts, or records PDF artifact metadata when generation passes.
- Adds a service-role-only preview RPC wrapper for scheduler runs plus focused/static validation for scheduled PDF export and RPC execute-surface regressions.

## Files changed
- `supabase/functions/partner-report-export/index.ts`: shared artifact helper, manual export wrapper, scheduler PDF wrapper, run record updates.
- `supabase/migrations/202605070001_partner_report_scheduler_pdf_export.sql`: service-role scheduler preview wrapper and narrow GUC bridge for the existing trusted preview internals.
- `scripts/validate-partner-report-scheduled-export.mjs`: focused static checks for warning gates, scheduler secret, signed URL behavior, and run artifact linkage.
- `scripts/validate-rpc-execute-surface.mjs`: extends service-role-only RPC surface validation to the new scheduler preview helper.
- `package.json`: adds `reporting:validate-partner-scheduled-export`.

## Verification
- `npm ci` - passed; 0 vulnerabilities; existing deprecated `glob@10.5.0` warning from dependency tree.
- `npm run build` - passed; existing Vite chunk-size warning.
- `npm run seo:check` - passed; 22 public routes and 19 private routes validated.
- `npm test --if-present` - passed; no test script is configured.
- `npm run lint --if-present` - passed with 0 errors and 8 existing Fast Refresh warnings in shared UI/Auth files.
- `npm run db:validate-migrations` - passed; 79 migrations applied in a disposable Supabase project.
- `npm run reporting:validate-partner-scheduled-export` - passed.
- `npm run db:validate-rpc-surface` - passed; now validates 6 service-role-only helpers, including `partner_report_scheduler_preview_partner_period_report`.
- `deno check supabase/functions/partner-report-export/index.ts` - passed.
- `git diff --check origin/main...HEAD` - passed.
- `supabase db push --dry-run` - passed after linking to Bloomjoy Hub project `ygbzkgxktzqsiygjlqyg`; remote would apply pending migrations `202605060001` through `202605070001` in order.
- GitHub checks after QA fix - passed: CI `verify`, Supabase Migrations `validate`, Vercel, and Vercel Preview Comments.

## Local scheduled/manual smoke
- Local Supabase + fresh Edge runtime smoke passed on `C:\Repos\wt-partner-report-shared-pdf`.
- Scheduler auth boundary: missing bearer `401`, bad bearer `401`, and the run stayed queued/unclaimed.
- Scheduled blocked run: `status=blocked`, `warning_gate_status=blocked`, `warnings_json` count `2`, `error_code=blocking_warnings`; `snapshot_id`, `artifact_storage_path`, `artifact_format`, and `artifact_generated_at` stayed null; response had no `signedUrl`.
- Scheduled artifact-ready run: `status=artifact_ready`, `warning_gate_status=passed`, `snapshot_id` populated, `artifact_format=pdf`, `artifact_generated_at` populated, private PDF storage path populated, no run error, and response had no `signedUrl`; service-role storage download returned `200`, `application/pdf`, `%PDF`, 11781 bytes.
- Manual regression: same passing partnership/period exported PDF, CSV, and XLSX with `200` responses, private `storagePath`, signed URL present, signed downloads `200`; PDF was `%PDF`, CSV contained the expected partnership label, XLSX was a ZIP workbook.
- Manual warning gate regression: blocked partnership PDF export returned `409`.
- RPC boundary: anon REST call to `partner_report_scheduler_preview_partner_period_report` returned `401`; authenticated super-admin JWT returned `403`; service role returned `200`.

## QA challenge
- Security/RPC QA found one P2 guardrail gap: the new scheduler preview RPC was not covered by the shared RPC execute-surface validator. Fixed in commit `fdbe592`.
- Reporting artifact QA found no behavior blockers.
- Independent QA requested scheduled run, manual export, auth, RPC boundary, and high-risk release evidence before merge; those checks are now recorded above.

## How to test
1. Local app/manual export: `npm ci`, `npm run dev`, open `http://localhost:8080/admin/reporting`, choose an existing partnership/period, and verify manual PDF, CSV, and XLSX export still return signed download URLs.
2. Local scheduled PDF foundation: serve the function with `supabase functions serve partner-report-export --no-verify-jwt`, ensure `REPORT_SCHEDULER_SECRET` is available to the Edge runtime, then POST a queued/claimable run: `curl -X POST http://127.0.0.1:54321/functions/v1/partner-report-export -H "Authorization: Bearer $REPORT_SCHEDULER_SECRET" -H "Content-Type: application/json" --data "{\"scheduleRunId\":\"<partner_report_schedule_runs.id>\"}"`.
3. For a run with blocking warnings, expect `status=blocked`, `warning_gate_status=blocked`, warnings recorded, and no `snapshot_id`, artifact path, or signed URL.
4. For a passing run, expect `status=artifact_ready`, `warning_gate_status=passed`, `snapshot_id`, `artifact_storage_path`, `artifact_format=pdf`, and `artifact_generated_at`; the run stores no signed URL.

## Risk / overlap notes
- No open PRs currently overlap these files.
- The migration reuses the existing trusted preview internals through a service-role-only wrapper instead of adding a second renderer. The temporary scheduler GUC is only set inside that wrapper after `auth.role()` is confirmed as `service_role`.
- `partner-report-export` has `verify_jwt=false`; manual exports still require a Supabase user token, while the new scheduler-facing path requires `REPORT_SCHEDULER_SECRET`.
- High-risk PR: reporting math/artifacts, database migration/RPC, and server-side secret boundary.
- Production rollout gate: confirm `REPORT_SCHEDULER_SECRET` is configured before enabling any scheduler caller, apply migrations/functions in the release window, and keep automated email/trigger work disabled because it is out of scope for #310.
- Rollback/roll-forward: if scheduled PDF generation misbehaves after deploy, disable/unset the scheduler caller secret and stop scheduler invocations; manual exports remain token-gated. Use a forward-only follow-up migration/function patch for database or RPC correction rather than reverting migrations in production.

## Explicit out of scope
- No recurring trigger.
- No real partner email sends.
- No automated CSV/XLSX delivery.
- No storage of signed URLs on schedule run records.
