### PR TITLE
Enforce partner effective windows in previews and exports

### DIFF
--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -231,6 +231,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Corporate Partner sees machine reporting only for machines derived from current partnership assignments
 - [ ] Corporate Partner cannot access `/admin`, tax/rule editing, machine metadata editing, imports, schedules, global reporting, or internal warning ledgers
 - [ ] Inactive partnership status stops Corporate Partner live reporting access
+- [ ] Partner Dashboard preview/export respects the partnership effective window: `effective_end_date = null` is open-ended, fully outside weeks/months generate no settlement amounts, and partial weeks/months show a trimming warning while including only active-window dates
 - [ ] Revoked Corporate Partner membership removes portal reporting access after refresh/re-login
 - [ ] `/portal/reports` export creates a private signed PDF link that matches the selected filters
 - [ ] `npm run reporting:validate-provider-parser` passes with the sanitized provider `.xlsx` fixture
@@ -381,6 +382,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Admin Partnerships warns before leaving the Machines or Payout Rules step with unsaved changes, including on mobile Back/Next navigation
 - [ ] Admin Partnerships > Weekly Preview enforces the partnership week-ending day and uses the previous completed Monday-Sunday week for Bubble Planet-style reporting
 - [ ] Admin Partnerships > Weekly Preview shows actionable in-page readiness messages when the selected week has no active machine assignment coverage, no active payout rule coverage, partial-week coverage, or no imported assigned-machine sales
+- [ ] Admin Partnerships > Weekly Preview and export respect the partnership effective window: inactive/archived partnerships and fully outside weeks produce no settlement amounts; partial weeks are bounded to active partnership dates and show the trimming note
 - [ ] Authenticated Weekly Preview smoke path is run from `Docs/WEEKLY_PREVIEW_SMOKE_TEST.md` with a super-admin on `/admin/partnerships?partnershipId=<qualified_fixture_partnership_id>&step=preview`
 - [ ] Authenticated Weekly Preview happy path for week ending `2026-04-19` shows `2026-04-13 through 2026-04-19`, `Ready`, `Orders` > 0, `Gross sales` > `$0`, and at least one `Sales by Machine` row after the provider import backfill/setup dates are corrected
 - [ ] Authenticated Weekly Preview warning states are checked for `No machines are assigned for this week`, `No active payout rule covers this week`, and `No sales found for this selected week`

--- a/Docs/WEEKLY_PREVIEW_SMOKE_TEST.md
+++ b/Docs/WEEKLY_PREVIEW_SMOKE_TEST.md
@@ -18,6 +18,16 @@ The happy-path fixture should be a test or launch partnership with:
 
 If the happy-path fixture returns no rows, treat the smoke as blocked. Fix the setup dates, payout-rule coverage, machine mapping, or provider import backfill first; do not pass the smoke by changing the expected date.
 
+## Partnership Effective Window Rule
+
+Partner previews and exports are bounded by the partnership agreement window before settlement amounts are calculated:
+
+- `reporting_partnerships.status` must be `active`.
+- `effective_end_date = null` is open-ended and should not require admins to keep extending long-running partnerships.
+- A selected week/month fully before `effective_start_date` or fully after `effective_end_date` must generate no settlement amounts.
+- For partial weeks/months, the selected reporting period label stays the same, but sales facts, refund adjustments, assignment checks, and payout-rule checks are trimmed to the overlapping active partnership dates.
+- The preview should show a non-blocking trimming warning for partial weeks/months so QA/admins can understand why totals are bounded.
+
 ## Optional Fixture Qualification Query
 Run this only in an approved local, preview, or production admin SQL context. It is for finding a qualifying fixture; it is not a migration.
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "reporting:provider-health": "node scripts/sunze/notify-health.mjs",
     "reporting:validate-provider-parser": "node scripts/sunze/validate-sunze-orders-parser.mjs",
     "reporting:validate-refund-adjustments": "node scripts/validate-refund-adjustments.mjs",
+    "reporting:validate-partner-effective-windows": "node scripts/validate-partner-effective-windows.mjs",
     "reporting:validate-partner-scheduled-export": "node scripts/validate-partner-report-scheduled-export.mjs",
     "training:dedupe-catalog": "node scripts/dedupe-training-catalog.mjs",
     "training:sync-guides": "node scripts/sync-training-guides.mjs",

--- a/scripts/validate-partner-effective-windows.mjs
+++ b/scripts/validate-partner-effective-windows.mjs
@@ -1,0 +1,235 @@
+import { readFileSync } from 'node:fs';
+
+const files = {
+  migration: 'supabase/migrations/202605070002_partner_effective_window_reporting.sql',
+  exportFunction: 'supabase/functions/partner-report-export/index.ts',
+  schedulerMigration: 'supabase/migrations/202605070001_partner_report_scheduler_pdf_export.sql',
+  smokeChecklist: 'Docs/QA_SMOKE_TEST_CHECKLIST.md',
+  weeklyPreviewSmoke: 'Docs/WEEKLY_PREVIEW_SMOKE_TEST.md',
+};
+
+const read = (path) => readFileSync(path, 'utf8');
+const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+const maxDate = (left, right) => (left > right ? left : right);
+const minDate = (left, right) => (left < right ? left : right);
+
+const boundPartnershipWindow = ({
+  status,
+  effectiveStart,
+  effectiveEnd,
+  periodStart,
+  periodEnd,
+}) => {
+  const overlaps = status === 'active' &&
+    effectiveStart <= periodEnd &&
+    (effectiveEnd === null || effectiveEnd >= periodStart);
+
+  if (!overlaps) {
+    return {
+      included: false,
+      amountAllowed: false,
+      trimmed: false,
+      includedStart: null,
+      includedEnd: null,
+    };
+  }
+
+  const includedStart = maxDate(periodStart, effectiveStart);
+  const includedEnd = minDate(periodEnd, effectiveEnd ?? periodEnd);
+
+  return {
+    included: includedStart <= includedEnd,
+    amountAllowed: includedStart <= includedEnd,
+    trimmed: includedStart !== periodStart || includedEnd !== periodEnd,
+    includedStart,
+    includedEnd,
+  };
+};
+
+const cases = [
+  {
+    name: 'archived partnership blocks settlement',
+    input: {
+      status: 'archived',
+      effectiveStart: '2026-04-01',
+      effectiveEnd: null,
+      periodStart: '2026-04-06',
+      periodEnd: '2026-04-12',
+    },
+    expected: { included: false, amountAllowed: false, trimmed: false },
+  },
+  {
+    name: 'period fully before partnership start blocks settlement',
+    input: {
+      status: 'active',
+      effectiveStart: '2026-04-01',
+      effectiveEnd: null,
+      periodStart: '2026-03-01',
+      periodEnd: '2026-03-31',
+    },
+    expected: { included: false, amountAllowed: false, trimmed: false },
+  },
+  {
+    name: 'period fully after partnership end blocks settlement',
+    input: {
+      status: 'active',
+      effectiveStart: '2026-04-01',
+      effectiveEnd: '2026-04-30',
+      periodStart: '2026-05-01',
+      periodEnd: '2026-05-31',
+    },
+    expected: { included: false, amountAllowed: false, trimmed: false },
+  },
+  {
+    name: 'partial weekly start trims included dates',
+    input: {
+      status: 'active',
+      effectiveStart: '2026-04-09',
+      effectiveEnd: null,
+      periodStart: '2026-04-06',
+      periodEnd: '2026-04-12',
+    },
+    expected: {
+      included: true,
+      amountAllowed: true,
+      trimmed: true,
+      includedStart: '2026-04-09',
+      includedEnd: '2026-04-12',
+    },
+  },
+  {
+    name: 'partial monthly end trims included dates',
+    input: {
+      status: 'active',
+      effectiveStart: '2026-04-01',
+      effectiveEnd: '2026-04-20',
+      periodStart: '2026-04-01',
+      periodEnd: '2026-04-30',
+    },
+    expected: {
+      included: true,
+      amountAllowed: true,
+      trimmed: true,
+      includedStart: '2026-04-01',
+      includedEnd: '2026-04-20',
+    },
+  },
+  {
+    name: 'open-ended partnership keeps full selected period',
+    input: {
+      status: 'active',
+      effectiveStart: '2026-04-01',
+      effectiveEnd: null,
+      periodStart: '2026-04-06',
+      periodEnd: '2026-04-12',
+    },
+    expected: {
+      included: true,
+      amountAllowed: true,
+      trimmed: false,
+      includedStart: '2026-04-06',
+      includedEnd: '2026-04-12',
+    },
+  },
+  {
+    name: 'wider assignment and rule windows remain bounded by partnership',
+    input: {
+      status: 'active',
+      effectiveStart: '2026-04-10',
+      effectiveEnd: '2026-04-20',
+      periodStart: '2026-04-01',
+      periodEnd: '2026-04-30',
+      assignmentStart: '2026-01-01',
+      assignmentEnd: null,
+      ruleStart: '2026-01-01',
+      ruleEnd: null,
+    },
+    expected: {
+      included: true,
+      amountAllowed: true,
+      trimmed: true,
+      includedStart: '2026-04-10',
+      includedEnd: '2026-04-20',
+    },
+  },
+];
+
+for (const { name, input, expected } of cases) {
+  const result = boundPartnershipWindow(input);
+  for (const [key, value] of Object.entries(expected)) {
+    assert(
+      result[key] === value,
+      `${name}: expected ${key}=${value}, received ${result[key]}`,
+    );
+  }
+
+  if (input.assignmentStart || input.ruleStart) {
+    const assignmentCoversPeriod = input.assignmentStart <= input.periodEnd &&
+      (input.assignmentEnd === null || input.assignmentEnd >= input.periodStart);
+    const ruleCoversPeriod = input.ruleStart <= input.periodEnd &&
+      (input.ruleEnd === null || input.ruleEnd >= input.periodStart);
+
+    assert(assignmentCoversPeriod, `${name}: fixture assignment must cover the unbounded period.`);
+    assert(ruleCoversPeriod, `${name}: fixture rule must cover the unbounded period.`);
+    assert(
+      result.includedStart === input.effectiveStart && result.includedEnd === input.effectiveEnd,
+      `${name}: partnership dates must be the narrowing window even when assignment/rule dates are wider.`,
+    );
+  }
+}
+
+const migration = read(files.migration);
+const exportFunction = read(files.exportFunction);
+const schedulerMigration = read(files.schedulerMigration);
+const smokeChecklist = read(files.smokeChecklist);
+const weeklyPreviewSmoke = read(files.weeklyPreviewSmoke);
+
+assert(
+  migration.includes("partnership_row.status = 'active'") &&
+    migration.includes('active_period_windows') &&
+    migration.includes('active_period_start') &&
+    migration.includes('active_period_end'),
+  'Partner preview SQL must derive active period windows from active partnerships only.',
+);
+
+assert(
+  migration.includes('fact.sale_date between period.active_period_start and period.active_period_end') &&
+    migration.includes('adjustment.adjustment_date between period.active_period_start and period.active_period_end') &&
+    migration.includes('review.refund_date between period.active_period_start and period.active_period_end'),
+  'Partner preview SQL must bound sales facts, refund facts, and refund review warnings to the active partnership window.',
+);
+
+assert(
+  migration.includes("'warning_type', 'inactive_partnership'") &&
+    migration.includes("'warning_type', 'partnership_effective_window_excluded'") &&
+    migration.includes("'warning_type', 'partnership_effective_window_trimmed'") &&
+    migration.includes("'severity', 'non_blocking'"),
+  'Partner preview SQL must surface inactive, fully excluded, and partial trimming states.',
+);
+
+assert(
+  !exportFunction.includes('"admin_preview_partner_weekly_report"') &&
+    exportFunction.includes('periodPreviewRpcName') &&
+    exportFunction.includes('mapPeriodPreviewToPartnerReportPreview'),
+  'Manual partner exports must load previews through the shared period preview RPC path.',
+);
+
+assert(
+  exportFunction.includes('partner_report_scheduler_preview_partner_period_report') &&
+    schedulerMigration.includes('return public.admin_preview_partner_period_report_internal'),
+  'Scheduled partner PDF exports must use the service-role period preview wrapper backed by the hardened internal RPC.',
+);
+
+assert(
+  smokeChecklist.includes('partnership effective window') &&
+    weeklyPreviewSmoke.includes('effective_end_date = null') &&
+    weeklyPreviewSmoke.includes('partial weeks/months'),
+  'Reporting QA docs must document the active-window boundary rule.',
+);
+
+console.log('Partner effective-window validation passed.');

--- a/supabase/functions/partner-report-export/index.ts
+++ b/supabase/functions/partner-report-export/index.ts
@@ -909,23 +909,15 @@ const loadPartnerReportPreview = async ({
   periodPreviewRpcName: string;
   request: ExportRequest;
 }): Promise<PartnerReportPreview> => {
-  const { data, error } = request.useLegacyWeeklyPreview
-    ? await previewSupabase.rpc(
-      "admin_preview_partner_weekly_report",
-      {
-        p_partnership_id: request.partnershipId,
-        p_week_ending_date: request.periodEndDate,
-      },
-    )
-    : await previewSupabase.rpc(
-      periodPreviewRpcName,
-      {
-        p_partnership_id: request.partnershipId,
-        p_date_from: request.periodStartDate,
-        p_date_to: request.periodEndDate,
-        p_period_grain: request.periodGrain,
-      },
-    );
+  const { data, error } = await previewSupabase.rpc(
+    periodPreviewRpcName,
+    {
+      p_partnership_id: request.partnershipId,
+      p_date_from: request.periodStartDate,
+      p_date_to: request.periodEndDate,
+      p_period_grain: request.periodGrain,
+    },
+  );
 
   if (error) {
     throw new PreviewLoadError(
@@ -933,19 +925,10 @@ const loadPartnerReportPreview = async ({
     );
   }
 
-  return request.useLegacyWeeklyPreview
-    ? ({
-      ...((data ?? {}) as PartnerReportPreview),
-      periodGrain: "reporting_week",
-      periodMode: request.periodMode,
-      periodStartDate: request.periodStartDate,
-      periodEndDate: request.periodEndDate,
-      periodLabel: request.periodLabel,
-    } satisfies PartnerReportPreview)
-    : mapPeriodPreviewToPartnerReportPreview(
-      (data ?? {}) as PartnerPeriodPreviewRpc,
-      request,
-    );
+  return mapPeriodPreviewToPartnerReportPreview(
+    (data ?? {}) as PartnerPeriodPreviewRpc,
+    request,
+  );
 };
 
 const getOrCreateSnapshot = async ({

--- a/supabase/migrations/202605070002_partner_effective_window_reporting.sql
+++ b/supabase/migrations/202605070002_partner_effective_window_reporting.sql
@@ -1,0 +1,685 @@
+-- Enforce partnership status and effective-date windows in partner preview/export math.
+-- Null effective_end_date remains open-ended; partial periods keep their selected
+-- period label but include only sales/refunds inside the active partnership dates.
+
+create or replace function public.admin_preview_partner_period_report_internal(
+  p_partnership_id uuid,
+  p_date_from date,
+  p_date_to date,
+  p_period_grain text
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  normalized_grain text;
+  result jsonb;
+  partnership_row public.reporting_partnerships;
+  actor_user_id uuid;
+  actor_is_super_admin boolean;
+  actor_machine_ids uuid[];
+begin
+  actor_user_id := auth.uid();
+  actor_is_super_admin := public.is_super_admin(actor_user_id);
+  actor_machine_ids := public.scoped_admin_machine_ids(actor_user_id);
+  normalized_grain := lower(coalesce(nullif(trim(p_period_grain), ''), 'reporting_week'));
+
+  if p_partnership_id is null then
+    raise exception 'Partnership is required';
+  end if;
+
+  if p_date_from is null or p_date_to is null then
+    raise exception 'Date range is required';
+  end if;
+
+  if p_date_from > p_date_to then
+    raise exception 'Date range is invalid';
+  end if;
+
+  if normalized_grain not in ('reporting_week', 'calendar_month') then
+    raise exception 'Invalid period grain: %', p_period_grain;
+  end if;
+
+  select *
+  into partnership_row
+  from public.reporting_partnerships partnership
+  where partnership.id = p_partnership_id;
+
+  if partnership_row.id is null then
+    raise exception 'Partnership not found';
+  end if;
+
+  if not public.can_access_partner_dashboard(
+    actor_user_id,
+    p_partnership_id,
+    p_date_from,
+    p_date_to
+  ) then
+    raise exception 'Partner dashboard access required';
+  end if;
+
+  with weekly_bounds as (
+    select
+      (
+        p_date_from
+        + ((partnership_row.reporting_week_end_day - extract(dow from p_date_from)::integer + 7) % 7)
+      )::date as first_week_end,
+      (
+        p_date_to
+        - ((extract(dow from p_date_to)::integer - partnership_row.reporting_week_end_day + 7) % 7)
+      )::date as last_week_end
+  ),
+  period_windows as (
+    select
+      (week_end::date - 6) as period_start,
+      week_end::date as period_end
+    from weekly_bounds bounds
+    cross join lateral generate_series(
+      bounds.first_week_end,
+      bounds.last_week_end,
+      interval '7 days'
+    ) as week_end
+    where normalized_grain = 'reporting_week'
+      and bounds.first_week_end <= bounds.last_week_end
+
+    union all
+
+    select
+      month_start::date as period_start,
+      (month_start + interval '1 month' - interval '1 day')::date as period_end
+    from generate_series(
+      date_trunc('month', p_date_from::timestamp)::date,
+      date_trunc('month', p_date_to::timestamp)::date,
+      interval '1 month'
+    ) as month_start
+    where normalized_grain = 'calendar_month'
+  ),
+  active_period_windows as (
+    select
+      period.period_start,
+      period.period_end,
+      greatest(period.period_start, partnership_row.effective_start_date) as active_period_start,
+      least(period.period_end, coalesce(partnership_row.effective_end_date, period.period_end)) as active_period_end,
+      (
+        partnership_row.status = 'active'
+        and partnership_row.effective_start_date <= period.period_end
+        and (
+          partnership_row.effective_end_date is null
+          or partnership_row.effective_end_date >= period.period_start
+        )
+      ) as has_active_partnership_overlap,
+      (
+        partnership_row.status = 'active'
+        and partnership_row.effective_start_date <= period.period_end
+        and (
+          partnership_row.effective_end_date is null
+          or partnership_row.effective_end_date >= period.period_start
+        )
+        and (
+          partnership_row.effective_start_date > period.period_start
+          or (
+            partnership_row.effective_end_date is not null
+            and partnership_row.effective_end_date < period.period_end
+          )
+        )
+      ) as is_trimmed_to_partnership_window
+    from period_windows period
+  ),
+  active_periods as (
+    select *
+    from active_period_windows period
+    where period.has_active_partnership_overlap
+      and period.active_period_start <= period.active_period_end
+  ),
+  assigned_machine_periods as (
+    select distinct
+      period.period_start,
+      period.period_end,
+      machine.id as reporting_machine_id,
+      machine.machine_label,
+      location.name as location_name
+    from active_periods period
+    join public.reporting_machine_partnership_assignments assignment
+      on assignment.partnership_id = p_partnership_id
+      and assignment.assignment_role = 'primary_reporting'
+      and assignment.status = 'active'
+      and assignment.effective_start_date <= period.active_period_end
+      and (assignment.effective_end_date is null or assignment.effective_end_date >= period.active_period_start)
+    join public.reporting_machines machine on machine.id = assignment.machine_id
+    left join public.reporting_locations location on location.id = machine.location_id
+    where actor_is_super_admin
+      or machine.id = any(actor_machine_ids)
+  ),
+  scoped_facts as (
+    select
+      period.period_start,
+      period.period_end,
+      fact.id,
+      fact.reporting_machine_id,
+      machine.machine_label,
+      location.name as location_name,
+      fact.sale_date,
+      fact.payment_method,
+      fact.net_sales_cents as source_order_amount_cents,
+      fact.transaction_count,
+      fact.item_quantity,
+      fact.tax_cents as imported_tax_cents,
+      tax.tax_rate_percent,
+      rule.calculation_model,
+      rule.split_base,
+      rule.fee_amount_cents,
+      rule.fee_basis,
+      rule.cost_amount_cents,
+      rule.cost_basis,
+      rule.deduction_timing,
+      rule.gross_to_net_method,
+      rule.fever_share_basis_points,
+      rule.partner_share_basis_points,
+      rule.bloomjoy_share_basis_points
+    from public.machine_sales_facts fact
+    join active_periods period
+      on fact.sale_date between period.active_period_start and period.active_period_end
+    join public.reporting_machines machine on machine.id = fact.reporting_machine_id
+    left join public.reporting_locations location on location.id = machine.location_id
+    join public.reporting_machine_partnership_assignments assignment
+      on assignment.machine_id = fact.reporting_machine_id
+      and assignment.partnership_id = p_partnership_id
+      and assignment.assignment_role = 'primary_reporting'
+      and assignment.status = 'active'
+      and assignment.effective_start_date <= fact.sale_date
+      and (assignment.effective_end_date is null or assignment.effective_end_date >= fact.sale_date)
+    left join lateral (
+      select tax_rate.tax_rate_percent
+      from public.reporting_machine_tax_rates tax_rate
+      where tax_rate.machine_id = fact.reporting_machine_id
+        and tax_rate.status = 'active'
+        and tax_rate.effective_start_date <= fact.sale_date
+        and (tax_rate.effective_end_date is null or tax_rate.effective_end_date >= fact.sale_date)
+      order by tax_rate.effective_start_date desc
+      limit 1
+    ) tax on true
+    left join lateral (
+      select financial_rule.*
+      from public.reporting_partnership_financial_rules financial_rule
+      where financial_rule.partnership_id = p_partnership_id
+        and financial_rule.status = 'active'
+        and financial_rule.effective_start_date <= fact.sale_date
+        and (financial_rule.effective_end_date is null or financial_rule.effective_end_date >= fact.sale_date)
+      order by financial_rule.effective_start_date desc
+      limit 1
+    ) rule on true
+    where fact.sale_date between p_date_from and p_date_to
+      and (
+        actor_is_super_admin
+        or fact.reporting_machine_id = any(actor_machine_ids)
+      )
+  ),
+  sales_totals as (
+    select
+      period_start,
+      period_end,
+      reporting_machine_id,
+      coalesce(sum(source_order_amount_cents), 0)::bigint as total_source_order_amount_cents
+    from scoped_facts
+    group by period_start, period_end, reporting_machine_id
+  ),
+  refund_totals as (
+    select
+      period.period_start,
+      period.period_end,
+      adjustment.reporting_machine_id,
+      coalesce(sum(adjustment.amount_cents), 0)::bigint as refund_amount_cents
+    from active_periods period
+    join public.sales_adjustment_facts adjustment
+      on adjustment.adjustment_date between period.active_period_start and period.active_period_end
+    join public.reporting_machine_partnership_assignments assignment
+      on assignment.machine_id = adjustment.reporting_machine_id
+      and assignment.partnership_id = p_partnership_id
+      and assignment.assignment_role = 'primary_reporting'
+      and assignment.status = 'active'
+      and assignment.effective_start_date <= adjustment.adjustment_date
+      and (assignment.effective_end_date is null or assignment.effective_end_date >= adjustment.adjustment_date)
+    where adjustment.adjustment_date between p_date_from and p_date_to
+      and adjustment.adjustment_type in ('refund', 'complaint_refund')
+      and adjustment.amount_cents > 0
+      and (
+        actor_is_super_admin
+        or adjustment.reporting_machine_id = any(actor_machine_ids)
+      )
+    group by period.period_start, period.period_end, adjustment.reporting_machine_id
+  ),
+  period_refund_amounts as (
+    select
+      period_start,
+      period_end,
+      coalesce(sum(refund_amount_cents), 0)::bigint as refund_amount_cents
+    from refund_totals
+    group by period_start, period_end
+  ),
+  calculated as (
+    select
+      fact.*,
+      case
+        when coalesce(total.total_source_order_amount_cents, 0) <= 0 then 0
+        else round(
+          coalesce(refund.refund_amount_cents, 0)
+          * greatest(fact.source_order_amount_cents, 0)
+          / greatest(total.total_source_order_amount_cents, 1)::numeric
+        )::integer
+      end as refund_amount_cents,
+      case
+        when fact.source_order_amount_cents <= 0 then 0
+        when fact.gross_to_net_method = 'imported_tax_plus_configured_fees' then fact.imported_tax_cents
+        when fact.gross_to_net_method = 'configured_fees_only' then 0
+        else round(fact.source_order_amount_cents * coalesce(fact.tax_rate_percent, 0) / 100.0)::integer
+      end as calculated_tax_cents,
+      case
+        when fact.source_order_amount_cents <= 0 then 0
+        when fact.fee_basis in ('per_order', 'per_transaction') then coalesce(fact.fee_amount_cents, 0) * coalesce(fact.transaction_count, 1)
+        when fact.fee_basis = 'per_stick' then coalesce(fact.fee_amount_cents, 0) * coalesce(fact.item_quantity, 1)
+        else 0
+      end as fee_cents,
+      case
+        when fact.source_order_amount_cents <= 0 then 0
+        when fact.cost_basis = 'per_order' then coalesce(fact.cost_amount_cents, 0) * coalesce(fact.transaction_count, 1)
+        when fact.cost_basis = 'per_stick' then coalesce(fact.cost_amount_cents, 0) * coalesce(fact.item_quantity, 1)
+        when fact.cost_basis = 'percentage_of_sales' then round(fact.source_order_amount_cents * coalesce(fact.cost_amount_cents, 0) / 10000.0)::integer
+        else 0
+      end as cost_cents
+    from scoped_facts fact
+    left join sales_totals total
+      on total.period_start = fact.period_start
+      and total.period_end = fact.period_end
+      and total.reporting_machine_id = fact.reporting_machine_id
+    left join refund_totals refund
+      on refund.period_start = fact.period_start
+      and refund.period_end = fact.period_end
+      and refund.reporting_machine_id = fact.reporting_machine_id
+  ),
+  row_amounts as (
+    select
+      calculated.*,
+      calculated.source_order_amount_cents as gross_sales_cents,
+      greatest(
+        calculated.source_order_amount_cents
+        - calculated.calculated_tax_cents
+        - calculated.fee_cents
+        - calculated.refund_amount_cents,
+        0
+      ) as net_sales_cents,
+      case
+        when calculated.deduction_timing = 'before_split' then calculated.cost_cents
+        else 0
+      end as split_deductible_cost_cents
+    from calculated
+  ),
+  split_rows as (
+    select
+      row_amounts.*,
+      case
+        when row_amounts.split_base = 'gross_sales' then greatest(row_amounts.gross_sales_cents - row_amounts.refund_amount_cents, 0)
+        when row_amounts.split_base = 'contribution_after_costs' then greatest(row_amounts.net_sales_cents - row_amounts.split_deductible_cost_cents, 0)
+        else row_amounts.net_sales_cents
+      end as split_base_cents
+    from row_amounts
+  ),
+  split_amounts as (
+    select
+      split_rows.*,
+      round(
+        split_rows.split_base_cents
+        * (
+          coalesce(split_rows.fever_share_basis_points, 0)
+          + coalesce(split_rows.partner_share_basis_points, 0)
+        )
+        / 10000.0
+      )::bigint as amount_owed_cents,
+      round(split_rows.split_base_cents * coalesce(split_rows.bloomjoy_share_basis_points, 0) / 10000.0)::bigint as bloomjoy_retained_cents
+    from split_rows
+  ),
+  period_amounts as (
+    select
+      period_start,
+      period_end,
+      coalesce(sum(transaction_count), 0)::integer as order_count,
+      coalesce(sum(item_quantity), 0)::integer as item_quantity,
+      coalesce(sum(gross_sales_cents), 0)::bigint as gross_sales_cents,
+      coalesce(sum(refund_amount_cents), 0)::bigint as allocated_refund_amount_cents,
+      coalesce(sum(calculated_tax_cents), 0)::bigint as tax_cents,
+      coalesce(sum(fee_cents), 0)::bigint as fee_cents,
+      coalesce(sum(cost_cents), 0)::bigint as cost_cents,
+      coalesce(sum(net_sales_cents), 0)::bigint as net_sales_cents,
+      coalesce(sum(split_base_cents), 0)::bigint as split_base_cents,
+      coalesce(sum(amount_owed_cents), 0)::bigint as amount_owed_cents,
+      coalesce(sum(bloomjoy_retained_cents), 0)::bigint as bloomjoy_retained_cents
+    from split_amounts
+    group by period_start, period_end
+  ),
+  machine_amounts as (
+    select
+      period_start,
+      period_end,
+      reporting_machine_id,
+      machine_label,
+      location_name,
+      coalesce(sum(transaction_count), 0)::integer as order_count,
+      coalesce(sum(item_quantity), 0)::integer as item_quantity,
+      coalesce(sum(gross_sales_cents), 0)::bigint as gross_sales_cents,
+      coalesce(sum(refund_amount_cents), 0)::bigint as allocated_refund_amount_cents,
+      coalesce(sum(calculated_tax_cents), 0)::bigint as tax_cents,
+      coalesce(sum(fee_cents), 0)::bigint as fee_cents,
+      coalesce(sum(cost_cents), 0)::bigint as cost_cents,
+      coalesce(sum(net_sales_cents), 0)::bigint as net_sales_cents,
+      coalesce(sum(split_base_cents), 0)::bigint as split_base_cents,
+      coalesce(sum(amount_owed_cents), 0)::bigint as amount_owed_cents,
+      coalesce(sum(bloomjoy_retained_cents), 0)::bigint as bloomjoy_retained_cents
+    from split_amounts
+    group by period_start, period_end, reporting_machine_id, machine_label, location_name
+  ),
+  periods as (
+    select
+      period.period_start,
+      period.period_end,
+      coalesce(amount.order_count, 0)::integer as order_count,
+      coalesce(amount.item_quantity, 0)::integer as item_quantity,
+      coalesce(amount.gross_sales_cents, 0)::bigint as gross_sales_cents,
+      coalesce(refund.refund_amount_cents, amount.allocated_refund_amount_cents, 0)::bigint as refund_amount_cents,
+      coalesce(amount.tax_cents, 0)::bigint as tax_cents,
+      coalesce(amount.fee_cents, 0)::bigint as fee_cents,
+      coalesce(amount.cost_cents, 0)::bigint as cost_cents,
+      coalesce(amount.net_sales_cents, 0)::bigint as net_sales_cents,
+      coalesce(amount.split_base_cents, 0)::bigint as split_base_cents,
+      coalesce(amount.amount_owed_cents, 0)::bigint as amount_owed_cents,
+      coalesce(amount.bloomjoy_retained_cents, 0)::bigint as bloomjoy_retained_cents
+    from period_windows period
+    left join period_amounts amount
+      on amount.period_start = period.period_start
+      and amount.period_end = period.period_end
+    left join period_refund_amounts refund
+      on refund.period_start = period.period_start
+      and refund.period_end = period.period_end
+  ),
+  machine_periods as (
+    select
+      assigned.period_start,
+      assigned.period_end,
+      assigned.reporting_machine_id,
+      assigned.machine_label,
+      assigned.location_name,
+      coalesce(amount.order_count, 0)::integer as order_count,
+      coalesce(amount.item_quantity, 0)::integer as item_quantity,
+      coalesce(amount.gross_sales_cents, 0)::bigint as gross_sales_cents,
+      coalesce(refund.refund_amount_cents, amount.allocated_refund_amount_cents, 0)::bigint as refund_amount_cents,
+      coalesce(amount.tax_cents, 0)::bigint as tax_cents,
+      coalesce(amount.fee_cents, 0)::bigint as fee_cents,
+      coalesce(amount.cost_cents, 0)::bigint as cost_cents,
+      coalesce(amount.net_sales_cents, 0)::bigint as net_sales_cents,
+      coalesce(amount.split_base_cents, 0)::bigint as split_base_cents,
+      coalesce(amount.amount_owed_cents, 0)::bigint as amount_owed_cents,
+      coalesce(amount.bloomjoy_retained_cents, 0)::bigint as bloomjoy_retained_cents
+    from assigned_machine_periods assigned
+    left join machine_amounts amount
+      on amount.period_start = assigned.period_start
+      and amount.period_end = assigned.period_end
+      and amount.reporting_machine_id = assigned.reporting_machine_id
+    left join refund_totals refund
+      on refund.period_start = assigned.period_start
+      and refund.period_end = assigned.period_end
+      and refund.reporting_machine_id = assigned.reporting_machine_id
+  ),
+  summary as (
+    select
+      coalesce(sum(order_count), 0)::integer as order_count,
+      coalesce(sum(item_quantity), 0)::integer as item_quantity,
+      coalesce(sum(gross_sales_cents), 0)::bigint as gross_sales_cents,
+      coalesce(sum(refund_amount_cents), 0)::bigint as refund_amount_cents,
+      coalesce(sum(tax_cents), 0)::bigint as tax_cents,
+      coalesce(sum(fee_cents), 0)::bigint as fee_cents,
+      coalesce(sum(cost_cents), 0)::bigint as cost_cents,
+      coalesce(sum(net_sales_cents), 0)::bigint as net_sales_cents,
+      coalesce(sum(split_base_cents), 0)::bigint as split_base_cents,
+      coalesce(sum(amount_owed_cents), 0)::bigint as amount_owed_cents,
+      coalesce(sum(bloomjoy_retained_cents), 0)::bigint as bloomjoy_retained_cents
+    from periods
+  ),
+  global_unique_refund_scope_labels as (
+    select
+      label.normalized_label,
+      (array_agg(distinct label.reporting_machine_id))[1] as reporting_machine_id
+    from (
+      select
+        public.normalize_reporting_match_text(machine.machine_label) as normalized_label,
+        machine.id as reporting_machine_id
+      from public.reporting_machines machine
+      where machine.status = 'active'
+
+      union all
+
+      select
+        public.normalize_reporting_match_text(location.name) as normalized_label,
+        machine.id as reporting_machine_id
+      from public.reporting_machines machine
+      join public.reporting_locations location on location.id = machine.location_id
+      where machine.status = 'active'
+        and location.status = 'active'
+
+      union all
+
+      select
+        alias.normalized_alias as normalized_label,
+        alias.reporting_machine_id
+      from public.reporting_machine_aliases alias
+      join public.reporting_machines machine on machine.id = alias.reporting_machine_id
+      where alias.status = 'active'
+        and machine.status = 'active'
+    ) label
+    where coalesce(label.normalized_label, '') <> ''
+    group by label.normalized_label
+    having count(distinct label.reporting_machine_id) = 1
+  ),
+  unresolved_refund_review as (
+    select count(distinct review.id)::integer as row_count
+    from public.refund_adjustment_review_rows review
+    where review.refund_date between p_date_from and p_date_to
+      and exists (
+        select 1
+        from active_periods period
+        where review.refund_date between period.active_period_start and period.active_period_end
+      )
+      and review.resolution_status = 'unresolved'
+      and review.match_status in ('needs_review', 'matched', 'ambiguous', 'unmatched', 'invalid', 'duplicate')
+      and (
+        exists (
+          select 1
+          from public.reporting_machine_partnership_assignments assignment
+          where assignment.machine_id = review.matched_machine_id
+            and assignment.partnership_id = p_partnership_id
+            and assignment.assignment_role = 'primary_reporting'
+            and assignment.status = 'active'
+            and assignment.effective_start_date <= review.refund_date
+            and (assignment.effective_end_date is null or assignment.effective_end_date >= review.refund_date)
+            and (
+              actor_is_super_admin
+              or assignment.machine_id = any(actor_machine_ids)
+            )
+        )
+        or exists (
+          select 1
+          from public.reporting_machine_partnership_assignments assignment
+          where assignment.machine_id = review.source_reporting_machine_id
+            and assignment.partnership_id = p_partnership_id
+            and assignment.assignment_role = 'primary_reporting'
+            and assignment.status = 'active'
+            and assignment.effective_start_date <= review.refund_date
+            and (assignment.effective_end_date is null or assignment.effective_end_date >= review.refund_date)
+            and (
+              actor_is_super_admin
+              or assignment.machine_id = any(actor_machine_ids)
+            )
+        )
+        or (
+          cardinality(coalesce(review.candidate_machine_ids, '{}'::uuid[])) = 1
+          and exists (
+            select 1
+            from public.reporting_machine_partnership_assignments assignment
+            where assignment.machine_id = review.candidate_machine_ids[1]
+              and assignment.partnership_id = p_partnership_id
+              and assignment.assignment_role = 'primary_reporting'
+              and assignment.status = 'active'
+              and assignment.effective_start_date <= review.refund_date
+              and (assignment.effective_end_date is null or assignment.effective_end_date >= review.refund_date)
+              and (
+                actor_is_super_admin
+                or assignment.machine_id = any(actor_machine_ids)
+              )
+          )
+        )
+        or exists (
+          select 1
+          from global_unique_refund_scope_labels label
+          join public.reporting_machine_partnership_assignments assignment
+            on assignment.machine_id = label.reporting_machine_id
+            and assignment.partnership_id = p_partnership_id
+            and assignment.assignment_role = 'primary_reporting'
+            and assignment.status = 'active'
+            and assignment.effective_start_date <= review.refund_date
+            and (assignment.effective_end_date is null or assignment.effective_end_date >= review.refund_date)
+          where label.normalized_label = review.normalized_source_location
+            and (
+              actor_is_super_admin
+              or assignment.machine_id = any(actor_machine_ids)
+            )
+        )
+      )
+  ),
+  warnings as (
+    select jsonb_build_object(
+      'warning_type', 'inactive_partnership',
+      'severity', 'blocking',
+      'partnership_status', partnership_row.status,
+      'message', 'This partnership is not active. Partner previews and exports generate settlement amounts only for active partnerships.'
+    ) as warning
+    where partnership_row.status <> 'active'
+    union all
+    select jsonb_build_object(
+      'warning_type', 'partnership_effective_window_excluded',
+      'severity', 'blocking',
+      'effective_start_date', partnership_row.effective_start_date,
+      'effective_end_date', partnership_row.effective_end_date,
+      'message', 'The selected period is outside this partnership''s active date window, so no settlement amounts were generated.'
+    ) as warning
+    where partnership_row.status = 'active'
+      and exists (select 1 from period_windows)
+      and not exists (select 1 from active_periods)
+    union all
+    select jsonb_build_object(
+      'warning_type', 'partnership_effective_window_trimmed',
+      'severity', 'non_blocking',
+      'period_start', period.period_start,
+      'period_end', period.period_end,
+      'included_start_date', period.active_period_start,
+      'included_end_date', period.active_period_end,
+      'effective_start_date', partnership_row.effective_start_date,
+      'effective_end_date', partnership_row.effective_end_date,
+      'message',
+        'This period is bounded to the partnership active date window; only sales and refund adjustments from '
+        || period.active_period_start
+        || ' through '
+        || period.active_period_end
+        || ' are included.'
+    ) as warning
+    from active_period_windows period
+    where period.is_trimmed_to_partnership_window
+      and period.active_period_start <= period.active_period_end
+    union all
+    select jsonb_build_object(
+      'warning_type', 'missing_machine_tax_rate',
+      'severity', 'blocking',
+      'machine_id', fact.reporting_machine_id,
+      'machine_label', fact.machine_label,
+      'message', fact.machine_label || ' has sales in this period without an active machine tax rate.'
+    ) as warning
+    from scoped_facts fact
+    where fact.tax_rate_percent is null
+      and coalesce(fact.gross_to_net_method, 'machine_tax_plus_configured_fees') <> 'configured_fees_only'
+    group by fact.reporting_machine_id, fact.machine_label
+    union all
+    select jsonb_build_object(
+      'warning_type', 'missing_financial_rule',
+      'severity', 'blocking',
+      'message', 'This report includes sales without an active partnership financial rule.'
+    ) as warning
+    where exists (select 1 from scoped_facts fact where fact.calculation_model is null)
+    union all
+    select jsonb_build_object(
+      'warning_type', 'no_assigned_machines',
+      'severity', 'blocking',
+      'message', 'This partnership has no active reporting machines for the selected period.'
+    ) as warning
+    where exists (select 1 from active_periods)
+      and not exists (select 1 from assigned_machine_periods)
+    union all
+    select jsonb_build_object(
+      'warning_type', 'no_sales_for_machine',
+      'severity', 'non_blocking',
+      'machine_id', assigned.reporting_machine_id,
+      'machine_label', assigned.machine_label,
+      'message', assigned.machine_label || ' has no sales in the selected period.'
+    ) as warning
+    from (
+      select reporting_machine_id, machine_label, sum(order_count) as total_orders
+      from machine_periods
+      group by reporting_machine_id, machine_label
+    ) assigned
+    where coalesce(assigned.total_orders, 0) = 0
+    union all
+    select jsonb_build_object(
+      'warning_type', 'refund_adjustment_review_needed',
+      'severity', 'non_blocking',
+      'message', 'Refund adjustment rows for this report''s machines need admin review before they affect partner settlement.'
+    ) as warning
+    from unresolved_refund_review review
+    where review.row_count > 0
+    union all
+    select jsonb_build_object(
+      'warning_type', 'refund_adjustment_without_sales',
+      'severity', 'non_blocking',
+      'machine_id', refund.reporting_machine_id,
+      'machine_label', assigned.machine_label,
+      'message', assigned.machine_label || ' has refund adjustments in this period without sales to allocate.'
+    ) as warning
+    from refund_totals refund
+    join assigned_machine_periods assigned
+      on assigned.period_start = refund.period_start
+      and assigned.period_end = refund.period_end
+      and assigned.reporting_machine_id = refund.reporting_machine_id
+    left join sales_totals sales
+      on sales.period_start = refund.period_start
+      and sales.period_end = refund.period_end
+      and sales.reporting_machine_id = refund.reporting_machine_id
+    where coalesce(sales.total_source_order_amount_cents, 0) <= 0
+  )
+  select jsonb_build_object(
+    'partnership_id', p_partnership_id,
+    'partnership_name', partnership_row.name,
+    'period_grain', normalized_grain,
+    'date_from', p_date_from,
+    'date_to', p_date_to,
+    'summary', coalesce((select to_jsonb(summary) from summary), '{}'::jsonb),
+    'periods', coalesce((select jsonb_agg(to_jsonb(periods) order by periods.period_start) from periods), '[]'::jsonb),
+    'machine_periods', coalesce((select jsonb_agg(to_jsonb(machine_periods) order by machine_periods.period_start, machine_periods.machine_label) from machine_periods), '[]'::jsonb),
+    'warnings', coalesce((select jsonb_agg(warnings.warning) from warnings), '[]'::jsonb)
+  )
+  into result;
+
+  return result;
+end;
+$$;
+
+revoke execute on function public.admin_preview_partner_period_report_internal(uuid, date, date, text)
+  from public, anon, authenticated;
+
+select pg_notify('pgrst', 'reload schema');


### PR DESCRIPTION
﻿## Summary
- Enforces `reporting_partnerships.status = active` plus partnership effective start/end dates in the shared partner period preview calculation.
- Keeps `effective_end_date = null` open-ended and bounds partial weeks/months to the active partnership dates with a non-blocking trimming warning.
- Routes manual partner exports, including legacy weekly export requests, through the same period-preview RPC path used by scheduled PDF exports.

Closes #241

## Files changed
- `supabase/migrations/202605070002_partner_effective_window_reporting.sql`: replaces the internal partner period preview RPC with active-window period bounding for sales facts, refund adjustments, assignment checks, payout-rule checks, and refund review warnings.
- `supabase/functions/partner-report-export/index.ts`: removes the legacy weekly preview RPC branch from export preview loading so manual and scheduled exports share period-preview logic.
- `scripts/validate-partner-effective-windows.mjs` and `package.json`: adds a focused regression validator for archived, fully before/after, partial start/end, open-ended, and wider assignment/rule-window cases.
- `Docs/QA_SMOKE_TEST_CHECKLIST.md` and `Docs/WEEKLY_PREVIEW_SMOKE_TEST.md`: documents the boundary/trimming rule for QA.

## Verification
- `npm ci` - passed; 0 vulnerabilities; existing `glob@10.5.0` deprecation warning.
- `npm run build` - passed; existing Vite warning that `Reports` chunk is larger than 450 kB.
- `npm run seo:check` - passed; 22 public routes and 19 private routes validated.
- `npm test --if-present` - passed; no test script is configured.
- `npm run lint --if-present` - passed with 8 existing fast-refresh warnings in shared UI/Auth files.
- `npm run db:validate-migrations` - passed; 80 migrations applied in disposable Supabase project.
- `supabase db push --dry-run` - blocked locally: `Cannot find project ref. Have you run supabase link?`
- `npm run reporting:validate-partner-effective-windows` - passed.
- `npm run reporting:validate-partner-scheduled-export` - passed.
- `npm run db:validate-rpc-surface` - passed.
- `git diff --check` - passed; only local LF-to-CRLF warnings reported by Git.

## How to test
1. From this branch, run `npm ci` and `npm run dev`.
2. Open `http://localhost:8080/admin/partnerships?partnershipId=<fixture_partnership_id>&step=preview` as a super-admin.
3. Verify a partnership with `effective_end_date = null` includes the full selected weekly/monthly period when the start date already covers it.
4. Verify archived, fully-before-start, and fully-after-end fixture periods show no settlement amounts and blocking warning state.
5. Verify partial start/end fixture periods keep the selected period label but include only active partnership dates and show the trimming warning.
6. Open `http://localhost:8080/portal/reports` for a Corporate Partner/super-admin fixture and confirm dashboard preview and PDF/CSV/XLSX export totals match the same bounded period behavior.

## Risk / overlap notes
- Risk level: high, because this changes reporting math and a frontend-facing Supabase RPC through a forward-only migration.
- Open PR #399 (`agent/refund-source-reconcile`) also edits `Docs/QA_SMOKE_TEST_CHECKLIST.md`; overlap is docs-only and should be resolved by keeping both checklist entries.
- This intentionally avoids admin archive UI work (#326) and refund reconciliation code paths (#256/#399).
- Admin date-editing UX is not expanded here; if UAT finds agreement date editing clunky, that should be a separate admin UX follow-up rather than part of this backend guardrail.

## Rollback
- Revert this PR before applying the new migration, or add a later forward-only migration restoring the previous internal preview RPC definition if this has already been deployed.
