### PR TITLE
P1: Add safe partner record archive flow

### DIFF
--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -356,7 +356,9 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Mobile admin routes show the same super-admin destinations in the operator menu: Admin Home, Orders, Support, Access, Partner Records, Machines, Partnerships, and Reporting
 - [ ] Non-admin user cannot access `/admin/partner-records` or `/admin/machines`
 - [ ] Super-admin user can access `/admin/partner-records` and `/admin/machines`
-- [ ] Admin Partner Records can search, create, and edit reusable partner records with separate display name and legal name fields, without exposing "party" terminology
+- [ ] Admin Partner Records can search, create, edit, and archive reusable partner records with separate display name and legal name fields, without exposing "party" terminology
+- [ ] Issue `#326`: super-admin can archive an unused test partner record from `/admin/partner-records` with required reason copy naming the record, and `admin_audit_log` stores actor, target ID/status, timestamp, and reason without customer/payment/source payloads or signed URLs
+- [ ] Issue `#326`: archiving a partner record is blocked when active memberships, active partnership parties, active assignments, active schedules, report snapshots, schedule runs, sales facts, or applied adjustment history are tied to it
 - [ ] Admin Partnerships setup loads without missing-RPC errors for `admin_get_partnership_reporting_setup`
 - [ ] Admin Partnerships opens as a guided setup flow with Details, Participants, Machines, Payout Rules, and Weekly Preview steps
 - [ ] Admin Partnerships is navigable on mobile with a compact partnership picker, `Step X of 5` header, horizontal step controls, and sticky Back/Next controls
@@ -372,7 +374,11 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Admin Machines can record a reporting tax rate change with only `New reporting tax %` and `Applies from`, and the previous active rate closes without overlap
 - [ ] Admin Machines exposes read-only reporting tax history for a machine without making normal admins manage tax status, end date, or notes
 - [ ] Machine tax warnings appear on Admin Machines, not Admin Partnerships
-- [ ] Admin Partnerships > Details exposes one agreement-level effective date window plus weekly/monthly cadence, report due days, invoice payment due days, payment method, ownership model, pricing authority, contract reference, and a simple active/inactive control
+- [ ] Admin Partnerships > Details exposes one agreement-level effective date window plus weekly/monthly cadence, report due days, invoice payment due days, payment method, ownership model, pricing authority, contract reference, and archive cleanup action
+- [ ] Issue `#326`: super-admin can archive an unused test partnership from `/admin/partnerships` with required reason copy naming the partnership; related active assignments, payout rules, and schedules without run history are archived, and audit metadata stays limited to IDs/status/counts/reason
+- [ ] Issue `#326`: archiving or hard-deleting a partnership is blocked when report snapshots, schedule runs, sales facts, applied adjustments, active memberships, active parties, active assignments, or active schedules make the record unsafe to remove
+- [ ] Issue `#326`: archived partner records and archived partnerships are hidden from `/admin/partnerships` selectors, `/admin/reporting` report/partnership selectors, Portal Reports partner dashboard lists, and partner-report schedule creation options
+- [ ] Issue `#326`: anonymous, non-admin, scoped-admin, `report_manager`, and Corporate Partner sessions cannot call archive RPCs or hard-delete partner/partnership records directly
 - [ ] Admin Partnerships > Payout Rules shows a plain-language sales-to-payout summary, one current payout rule, stable participant-named Payout Allocation rows based on Participants marked `Receives payout`, whole-percent inputs, a 100% allocation check, click/tap help popovers, and no editable payout-rule date/status fields
 - [ ] Admin Partnerships > Payout Rules can save a contract-specific deduction label and additional deduction notes for cashless processing, royalties, or other agreement-specific deductions
 - [ ] Saving Admin Partnerships > Payout Rules repeatedly updates the current payout rule instead of creating duplicate visible rules

--- a/src/lib/partnershipReporting.ts
+++ b/src/lib/partnershipReporting.ts
@@ -395,6 +395,23 @@ export type ExportPartnerWeeklyReportResponse = {
   fileName: string;
 };
 
+export type ArchiveReportingPartnerResult = {
+  targetType: 'reporting_partner';
+  targetId: string;
+  status: 'archived';
+  alreadyArchived: boolean;
+};
+
+export type ArchiveReportingPartnershipResult = {
+  targetType: 'reporting_partnership';
+  targetId: string;
+  status: 'archived';
+  alreadyArchived: boolean;
+  archivedAssignments: number;
+  archivedFinancialRules: number;
+  archivedSchedules: number;
+};
+
 const emptySetup: PartnershipReportingSetup = {
   partners: [],
   partnerships: [],
@@ -465,6 +482,59 @@ export const upsertReportingPartnershipAdmin = async (input: UpsertPartnershipIn
   }
 
   return data as ReportingPartnership;
+};
+
+export const archiveReportingPartnerAdmin = async ({
+  partnerId,
+  reason,
+}: {
+  partnerId: string;
+  reason: string;
+}): Promise<ArchiveReportingPartnerResult> => {
+  const { data, error } = await supabaseClient.rpc('admin_archive_reporting_partner', {
+    p_partner_id: partnerId,
+    p_reason: reason,
+  });
+
+  if (error || !data) {
+    throw new Error(error?.message || 'Unable to archive partner record.');
+  }
+
+  const record = data as Partial<ArchiveReportingPartnerResult>;
+  return {
+    targetType: 'reporting_partner',
+    targetId: String(record.targetId ?? partnerId),
+    status: 'archived',
+    alreadyArchived: Boolean(record.alreadyArchived),
+  };
+};
+
+export const archiveReportingPartnershipAdmin = async ({
+  partnershipId,
+  reason,
+}: {
+  partnershipId: string;
+  reason: string;
+}): Promise<ArchiveReportingPartnershipResult> => {
+  const { data, error } = await supabaseClient.rpc('admin_archive_reporting_partnership', {
+    p_partnership_id: partnershipId,
+    p_reason: reason,
+  });
+
+  if (error || !data) {
+    throw new Error(error?.message || 'Unable to archive partnership.');
+  }
+
+  const record = data as Partial<ArchiveReportingPartnershipResult>;
+  return {
+    targetType: 'reporting_partnership',
+    targetId: String(record.targetId ?? partnershipId),
+    status: 'archived',
+    alreadyArchived: Boolean(record.alreadyArchived),
+    archivedAssignments: Number(record.archivedAssignments ?? 0),
+    archivedFinancialRules: Number(record.archivedFinancialRules ?? 0),
+    archivedSchedules: Number(record.archivedSchedules ?? 0),
+  };
 };
 
 export const upsertReportingMachineAssignmentAdmin = async (

--- a/src/pages/admin/PartnerRecords.tsx
+++ b/src/pages/admin/PartnerRecords.tsx
@@ -1,6 +1,16 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { CheckCircle2, Loader2, Pencil, Plus, RefreshCw, Search, UserPlus } from 'lucide-react';
+import {
+  AlertTriangle,
+  Archive,
+  CheckCircle2,
+  Loader2,
+  Pencil,
+  Plus,
+  RefreshCw,
+  Search,
+  UserPlus,
+} from 'lucide-react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { AppLayout } from '@/components/layout/AppLayout';
@@ -18,6 +28,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import {
+  archiveReportingPartnerAdmin,
   fetchPartnershipReportingSetup,
   upsertReportingPartnerAdmin,
   type PartnershipReportingSetup,
@@ -69,8 +80,9 @@ const getPartnerAccessInvitePath = (partner: ReportingPartner) => {
 export default function AdminPartnerRecordsPage() {
   const queryClient = useQueryClient();
   const [search, setSearch] = useState('');
-  const [statusFilter, setStatusFilter] = useState('all');
+  const [statusFilter, setStatusFilter] = useState('active');
   const [editingPartner, setEditingPartner] = useState<ReportingPartner | null>(null);
+  const [archivingPartner, setArchivingPartner] = useState<ReportingPartner | null>(null);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   const {
@@ -243,16 +255,29 @@ export default function AdminPartnerRecordsPage() {
                         </td>
                         <td className="px-4 py-3">
                           <div className="flex justify-end gap-2">
-                            <Button asChild variant="outline" size="sm">
-                              <Link to={getPartnerAccessInvitePath(partner)}>
-                                <UserPlus className="mr-2 h-4 w-4" />
-                                Invite
-                              </Link>
-                            </Button>
+                            {partner.status === 'active' && (
+                              <Button asChild variant="outline" size="sm">
+                                <Link to={getPartnerAccessInvitePath(partner)}>
+                                  <UserPlus className="mr-2 h-4 w-4" />
+                                  Invite
+                                </Link>
+                              </Button>
+                            )}
                             <Button variant="outline" size="sm" onClick={() => openEdit(partner)}>
                               <Pencil className="mr-2 h-4 w-4" />
                               Edit
                             </Button>
+                            {partner.status !== 'archived' && (
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                className="border-destructive/40 text-destructive hover:border-destructive hover:text-destructive"
+                                onClick={() => setArchivingPartner(partner)}
+                              >
+                                <Archive className="mr-2 h-4 w-4" />
+                                Archive
+                              </Button>
+                            )}
                           </div>
                         </td>
                       </tr>
@@ -271,6 +296,13 @@ export default function AdminPartnerRecordsPage() {
         partner={editingPartner}
         existingPartners={setup.partners}
         onSaved={refresh}
+      />
+      <ArchivePartnerRecordDialog
+        partner={archivingPartner}
+        onOpenChange={(open) => {
+          if (!open) setArchivingPartner(null);
+        }}
+        onArchived={refresh}
       />
     </AppLayout>
   );
@@ -291,6 +323,7 @@ function PartnerRecordDialog({
 }) {
   const [form, setForm] = useState(emptyPartnerForm);
   const [isSaving, setIsSaving] = useState(false);
+  const statusOptions = partner?.status === 'archived' ? statuses : ['active'];
 
   useEffect(() => {
     if (!open) return;
@@ -420,8 +453,13 @@ function PartnerRecordDialog({
               id="partner-record-status-field"
               value={form.status}
               onChange={(status) => setForm({ ...form, status })}
-              options={statuses}
+              options={statusOptions}
             />
+            {partner?.status !== 'archived' && (
+              <p className="mt-1 text-xs text-muted-foreground">
+                Use the archive action when a test record should leave reporting setup.
+              </p>
+            )}
           </div>
           <div>
             <Label htmlFor="partner-record-notes">Notes</Label>
@@ -439,6 +477,103 @@ function PartnerRecordDialog({
           <Button onClick={savePartner} disabled={isSaving}>
             {isSaving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <CheckCircle2 className="mr-2 h-4 w-4" />}
             Save Record
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ArchivePartnerRecordDialog({
+  partner,
+  onOpenChange,
+  onArchived,
+}: {
+  partner: ReportingPartner | null;
+  onOpenChange: (open: boolean) => void;
+  onArchived: () => Promise<unknown>;
+}) {
+  const [reason, setReason] = useState('');
+  const [isArchiving, setIsArchiving] = useState(false);
+
+  useEffect(() => {
+    if (partner) {
+      setReason('');
+    }
+  }, [partner]);
+
+  const archivePartner = async () => {
+    if (!partner) return;
+    const normalizedReason = reason.trim();
+    if (!normalizedReason) {
+      toast.error('Enter a reason before archiving this partner record.');
+      return;
+    }
+
+    setIsArchiving(true);
+    try {
+      const result = await archiveReportingPartnerAdmin({
+        partnerId: partner.id,
+        reason: normalizedReason,
+      });
+      toast.success(
+        result.alreadyArchived
+          ? 'Partner record was already archived.'
+          : 'Partner record archived.'
+      );
+      onOpenChange(false);
+      await onArchived();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Unable to archive partner record.');
+    } finally {
+      setIsArchiving(false);
+    }
+  };
+
+  return (
+    <Dialog open={Boolean(partner)} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Archive Partner Record?</DialogTitle>
+          <DialogDescription>
+            This archives {partner?.name ?? 'this partner record'} and removes it from normal
+            partnership setup selectors. Hard delete stays blocked unless the record is a disposable
+            fixture with no dependent history.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-950">
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+            <div>
+              Archive is blocked when active partnerships, memberships, schedules, report snapshots,
+              sales facts, or applied adjustments are tied to this record.
+            </div>
+          </div>
+        </div>
+        <div>
+          <Label htmlFor="partner-record-archive-reason">Archive reason</Label>
+          <Textarea
+            id="partner-record-archive-reason"
+            value={reason}
+            onChange={(event) => setReason(event.target.value)}
+            placeholder="Example: Test partner record created for QA cleanup"
+          />
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isArchiving}>
+            Cancel
+          </Button>
+          <Button
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            onClick={archivePartner}
+            disabled={isArchiving}
+          >
+            {isArchiving ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Archive className="mr-2 h-4 w-4" />
+            )}
+            Archive Record
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/pages/admin/Partnerships.tsx
+++ b/src/pages/admin/Partnerships.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {
   AlertTriangle,
+  Archive,
   ChevronLeft,
   ChevronRight,
   CheckCircle2,
@@ -44,9 +45,9 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
 import {
+  archiveReportingPartnershipAdmin,
   fetchPartnershipReportingSetup,
   exportPartnerWeeklyReportAdmin,
   type ExportPartnerWeeklyReportFormat,
@@ -491,10 +492,14 @@ export default function AdminPartnershipsPage() {
     staleTime: 1000 * 30,
   });
 
+  const visiblePartnerships = useMemo(
+    () => setup.partnerships.filter((partnership) => partnership.status !== 'archived'),
+    [setup.partnerships]
+  );
   const selectedPartnership = useMemo(
     () =>
-      setup.partnerships.find((partnership) => partnership.id === selectedPartnershipId) ?? null,
-    [selectedPartnershipId, setup.partnerships]
+      visiblePartnerships.find((partnership) => partnership.id === selectedPartnershipId) ?? null,
+    [selectedPartnershipId, visiblePartnerships]
   );
 
   const refresh = () => queryClient.invalidateQueries({ queryKey: setupQueryKey });
@@ -658,6 +663,7 @@ export default function AdminPartnershipsPage() {
                     <PartnershipDetailsSection
                       selectedPartnership={selectedPartnership}
                       onSaved={(partnershipId) => updateRouteState(partnershipId, 'participants')}
+                      onArchived={() => updateRouteState('', 'details')}
                       onRefresh={refresh}
                     />
                   )}
@@ -736,6 +742,10 @@ function PartnershipPicker({
   selectedPartnershipId: string;
   onSelect: (partnershipId: string) => void;
 }) {
+  const visiblePartnerships = setup.partnerships.filter(
+    (partnership) => partnership.status !== 'archived'
+  );
+
   return (
     <div className="rounded-lg border border-border bg-card p-4">
       <div className="flex items-center justify-between gap-3">
@@ -749,10 +759,10 @@ function PartnershipPicker({
       </div>
 
       <div className="mt-4 space-y-2">
-        {setup.partnerships.length === 0 ? (
-          <EmptyState text="No partnerships yet." />
+        {visiblePartnerships.length === 0 ? (
+          <EmptyState text="No active or draft partnerships yet." />
         ) : (
-          setup.partnerships.map((partnership) => {
+          visiblePartnerships.map((partnership) => {
             const isSelected = selectedPartnershipId === partnership.id;
 
             return (
@@ -796,6 +806,9 @@ function MobileSetupControls({
   onSelectPartnership: (partnershipId: string) => void;
   onStepChange: (step: PartnershipStep) => void;
 }) {
+  const visiblePartnerships = setup.partnerships.filter(
+    (partnership) => partnership.status !== 'archived'
+  );
   const countByStep: Partial<Record<PartnershipStep, number>> = {
     participants: stepCounts.participants,
     machines: stepCounts.machines,
@@ -813,7 +826,7 @@ function MobileSetupControls({
           className="mt-1 h-11 w-full rounded-md border border-input bg-background px-3 text-sm"
         >
           <option value="">New partnership</option>
-          {setup.partnerships.map((partnership) => (
+          {visiblePartnerships.map((partnership) => (
             <option key={partnership.id} value={partnership.id}>
               {partnership.name}
             </option>
@@ -993,14 +1006,17 @@ function StepHeader({
 function PartnershipDetailsSection({
   selectedPartnership,
   onSaved,
+  onArchived,
   onRefresh,
 }: {
   selectedPartnership: ReportingPartnership | null;
   onSaved: (partnershipId: string) => void;
+  onArchived: () => void;
   onRefresh: () => Promise<unknown>;
 }) {
   const [form, setForm] = useState(emptyPartnershipForm);
   const [isSaving, setIsSaving] = useState(false);
+  const [isArchiveDialogOpen, setIsArchiveDialogOpen] = useState(false);
 
   useEffect(() => {
     if (!selectedPartnership) {
@@ -1069,6 +1085,7 @@ function PartnershipDetailsSection({
   };
 
   return (
+    <>
     <section className="rounded-lg border border-border bg-card p-5">
       <div className="grid gap-4 lg:grid-cols-2">
         <div>
@@ -1192,18 +1209,28 @@ function PartnershipDetailsSection({
         <div className="rounded-md border border-border bg-muted/20 p-4">
           <div className="flex items-center justify-between gap-3">
             <div>
-              <Label htmlFor="partnership-active">Partnership active</Label>
+              <Label>Archive cleanup</Label>
               <p className="mt-1 text-xs text-muted-foreground">
-                Inactive partnerships stay saved but are removed from normal reporting setup.
+                Archive unused test partnerships to remove them from normal reporting setup.
               </p>
             </div>
-            <Switch
-              id="partnership-active"
-              checked={form.status !== 'archived'}
-              onCheckedChange={(checked) =>
-                setForm({ ...form, status: checked ? 'active' : 'archived' })
-              }
-            />
+            {selectedPartnership ? (
+              selectedPartnership.status === 'archived' ? (
+                <Badge variant="outline">Archived</Badge>
+              ) : (
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="border-destructive/40 text-destructive hover:border-destructive hover:text-destructive"
+                  onClick={() => setIsArchiveDialogOpen(true)}
+                >
+                  <Archive className="mr-2 h-4 w-4" />
+                  Archive
+                </Button>
+              )
+            ) : (
+              <Badge variant="outline">New</Badge>
+            )}
           </div>
         </div>
         <div className="lg:col-span-2">
@@ -1220,6 +1247,119 @@ function PartnershipDetailsSection({
         {form.partnershipId ? 'Save Details' : 'Create Partnership'}
       </Button>
     </section>
+    <ArchivePartnershipDialog
+      partnership={selectedPartnership}
+      open={isArchiveDialogOpen}
+      onOpenChange={setIsArchiveDialogOpen}
+      onArchived={async () => {
+        await onRefresh();
+        onArchived();
+      }}
+    />
+    </>
+  );
+}
+
+function ArchivePartnershipDialog({
+  partnership,
+  open,
+  onOpenChange,
+  onArchived,
+}: {
+  partnership: ReportingPartnership | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onArchived: () => Promise<unknown>;
+}) {
+  const [reason, setReason] = useState('');
+  const [isArchiving, setIsArchiving] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setReason('');
+    }
+  }, [open]);
+
+  const archivePartnership = async () => {
+    if (!partnership) return;
+    const normalizedReason = reason.trim();
+    if (!normalizedReason) {
+      toast.error('Enter a reason before archiving this partnership.');
+      return;
+    }
+
+    setIsArchiving(true);
+    try {
+      const result = await archiveReportingPartnershipAdmin({
+        partnershipId: partnership.id,
+        reason: normalizedReason,
+      });
+      const relatedSummary = [
+        `${result.archivedAssignments} assignment${result.archivedAssignments === 1 ? '' : 's'}`,
+        `${result.archivedFinancialRules} payout rule${result.archivedFinancialRules === 1 ? '' : 's'}`,
+        `${result.archivedSchedules} schedule${result.archivedSchedules === 1 ? '' : 's'}`,
+      ].join(', ');
+      toast.success(
+        result.alreadyArchived
+          ? 'Partnership was already archived.'
+          : `Partnership archived with ${relatedSummary}.`
+      );
+      onOpenChange(false);
+      await onArchived();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Unable to archive partnership.');
+    } finally {
+      setIsArchiving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open && Boolean(partnership)} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Archive Partnership?</DialogTitle>
+          <DialogDescription>
+            This archives {partnership?.name ?? 'this partnership'} and hides it from partnership
+            setup, reporting setup, partner dashboard lists, and scheduled-delivery selectors.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-950">
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+            <div>
+              Archive is blocked when report snapshots, schedule runs, sales facts, applied
+              adjustments, or active Corporate Partner memberships are tied to this partnership.
+            </div>
+          </div>
+        </div>
+        <div>
+          <Label htmlFor="partnership-archive-reason">Archive reason</Label>
+          <Textarea
+            id="partnership-archive-reason"
+            value={reason}
+            onChange={(event) => setReason(event.target.value)}
+            placeholder="Example: Test reporting partnership created for QA cleanup"
+          />
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isArchiving}>
+            Cancel
+          </Button>
+          <Button
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            onClick={archivePartnership}
+            disabled={isArchiving}
+          >
+            {isArchiving ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Archive className="mr-2 h-4 w-4" />
+            )}
+            Archive Partnership
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -1391,7 +1531,7 @@ function ParticipantsSection({
                 )}
               </div>
               <div className="flex items-center gap-2">
-                {partner && (
+                {partner?.status === 'active' && (
                   <Button asChild variant="outline" size="sm">
                     <Link to={getCorporatePartnerInvitePath(partner)}>
                       <UserPlus className="mr-2 h-4 w-4" />
@@ -2961,6 +3101,8 @@ function PartnerSelectWithAdd({
   onChange: (partnerId: string) => void;
   onAddNew: () => void;
 }) {
+  const activePartners = setup.partners.filter((partner) => partner.status === 'active');
+
   return (
     <div>
       <Label htmlFor="participant-partner">Partner record</Label>
@@ -2978,7 +3120,7 @@ function PartnerSelectWithAdd({
       >
         <option value="">Select partner record</option>
         <option value="__add_new__">+ Add new partner record</option>
-        {setup.partners.map((partner) => (
+        {activePartners.map((partner) => (
           <option key={partner.id} value={partner.id}>
             {partner.legal_name ? `${partner.name} / ${partner.legal_name}` : partner.name}
           </option>

--- a/supabase/migrations/202605070003_partner_record_archive_guardrails.sql
+++ b/supabase/migrations/202605070003_partner_record_archive_guardrails.sql
@@ -1,0 +1,1146 @@
+-- Safe archive/delete guardrails for test partner records and reporting partnerships.
+-- The admin UI uses archive-only flows. Direct hard deletes are allowed only for
+-- disposable fixtures with no protected history or active setup.
+
+create or replace function public.reporting_partnership_archive_dependency_counts(
+  p_partnership_id uuid
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  snapshot_count integer := 0;
+  schedule_run_count integer := 0;
+  sales_fact_count integer := 0;
+  adjustment_fact_count integer := 0;
+  active_membership_count integer := 0;
+  active_party_count integer := 0;
+  active_assignment_count integer := 0;
+  active_schedule_count integer := 0;
+begin
+  if p_partnership_id is null then
+    return jsonb_build_object(
+      'snapshotCount', 0,
+      'scheduleRunCount', 0,
+      'salesFactCount', 0,
+      'adjustmentFactCount', 0,
+      'activeMembershipCount', 0,
+      'activePartyCount', 0,
+      'activeAssignmentCount', 0,
+      'activeScheduleCount', 0
+    );
+  end if;
+
+  select count(*)::integer
+  into snapshot_count
+  from public.partner_report_snapshots snapshot
+  where snapshot.partnership_id = p_partnership_id;
+
+  select count(*)::integer
+  into schedule_run_count
+  from public.partner_report_schedule_runs run
+  where run.partnership_id = p_partnership_id;
+
+  select count(distinct fact.id)::integer
+  into sales_fact_count
+  from public.machine_sales_facts fact
+  join public.reporting_machine_partnership_assignments assignment
+    on assignment.machine_id = fact.reporting_machine_id
+  where assignment.partnership_id = p_partnership_id
+    and public.reporting_date_windows_overlap(
+      assignment.effective_start_date,
+      assignment.effective_end_date,
+      fact.sale_date,
+      fact.sale_date
+    );
+
+  select count(distinct adjustment.id)::integer
+  into adjustment_fact_count
+  from public.sales_adjustment_facts adjustment
+  join public.reporting_machine_partnership_assignments assignment
+    on assignment.machine_id = adjustment.reporting_machine_id
+  where assignment.partnership_id = p_partnership_id
+    and public.reporting_date_windows_overlap(
+      assignment.effective_start_date,
+      assignment.effective_end_date,
+      adjustment.adjustment_date,
+      adjustment.adjustment_date
+    );
+
+  select count(distinct membership.id)::integer
+  into active_membership_count
+  from public.reporting_partnership_parties party
+  join public.corporate_partner_memberships membership
+    on membership.partner_id = party.partner_id
+  where party.partnership_id = p_partnership_id
+    and membership.status = 'active'
+    and membership.revoked_at is null
+    and membership.starts_at <= now()
+    and (membership.expires_at is null or membership.expires_at > now());
+
+  select count(*)::integer
+  into active_party_count
+  from public.reporting_partnership_parties party
+  join public.reporting_partnerships partnership
+    on partnership.id = party.partnership_id
+  where party.partnership_id = p_partnership_id
+    and partnership.status in ('draft', 'active');
+
+  select count(*)::integer
+  into active_assignment_count
+  from public.reporting_machine_partnership_assignments assignment
+  where assignment.partnership_id = p_partnership_id
+    and assignment.status = 'active';
+
+  select count(*)::integer
+  into active_schedule_count
+  from public.partner_report_schedules schedule
+  where schedule.partnership_id = p_partnership_id
+    and schedule.status = 'active';
+
+  return jsonb_build_object(
+    'snapshotCount', snapshot_count,
+    'scheduleRunCount', schedule_run_count,
+    'salesFactCount', sales_fact_count,
+    'adjustmentFactCount', adjustment_fact_count,
+    'activeMembershipCount', active_membership_count,
+    'activePartyCount', active_party_count,
+    'activeAssignmentCount', active_assignment_count,
+    'activeScheduleCount', active_schedule_count
+  );
+end;
+$$;
+
+create or replace function public.reporting_partner_archive_dependency_counts(
+  p_partner_id uuid
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  partnership_ids uuid[];
+  snapshot_count integer := 0;
+  schedule_run_count integer := 0;
+  sales_fact_count integer := 0;
+  adjustment_fact_count integer := 0;
+  active_membership_count integer := 0;
+  active_party_count integer := 0;
+  active_assignment_count integer := 0;
+  active_schedule_count integer := 0;
+begin
+  if p_partner_id is null then
+    return jsonb_build_object(
+      'snapshotCount', 0,
+      'scheduleRunCount', 0,
+      'salesFactCount', 0,
+      'adjustmentFactCount', 0,
+      'activeMembershipCount', 0,
+      'activePartyCount', 0,
+      'activeAssignmentCount', 0,
+      'activeScheduleCount', 0
+    );
+  end if;
+
+  select coalesce(array_agg(distinct party.partnership_id), array[]::uuid[])
+  into partnership_ids
+  from public.reporting_partnership_parties party
+  where party.partner_id = p_partner_id;
+
+  select count(distinct snapshot.id)::integer
+  into snapshot_count
+  from public.partner_report_snapshots snapshot
+  where snapshot.partnership_id = any(partnership_ids);
+
+  select count(distinct run.id)::integer
+  into schedule_run_count
+  from public.partner_report_schedule_runs run
+  where run.partnership_id = any(partnership_ids);
+
+  select count(distinct fact.id)::integer
+  into sales_fact_count
+  from public.machine_sales_facts fact
+  join public.reporting_machine_partnership_assignments assignment
+    on assignment.machine_id = fact.reporting_machine_id
+  where assignment.partnership_id = any(partnership_ids)
+    and public.reporting_date_windows_overlap(
+      assignment.effective_start_date,
+      assignment.effective_end_date,
+      fact.sale_date,
+      fact.sale_date
+    );
+
+  select count(distinct adjustment.id)::integer
+  into adjustment_fact_count
+  from public.sales_adjustment_facts adjustment
+  join public.reporting_machine_partnership_assignments assignment
+    on assignment.machine_id = adjustment.reporting_machine_id
+  where assignment.partnership_id = any(partnership_ids)
+    and public.reporting_date_windows_overlap(
+      assignment.effective_start_date,
+      assignment.effective_end_date,
+      adjustment.adjustment_date,
+      adjustment.adjustment_date
+    );
+
+  select count(*)::integer
+  into active_membership_count
+  from public.corporate_partner_memberships membership
+  where membership.partner_id = p_partner_id
+    and membership.status = 'active'
+    and membership.revoked_at is null
+    and membership.starts_at <= now()
+    and (membership.expires_at is null or membership.expires_at > now());
+
+  select count(*)::integer
+  into active_party_count
+  from public.reporting_partnership_parties party
+  join public.reporting_partnerships partnership
+    on partnership.id = party.partnership_id
+  where party.partner_id = p_partner_id
+    and partnership.status in ('draft', 'active');
+
+  select count(distinct assignment.id)::integer
+  into active_assignment_count
+  from public.reporting_machine_partnership_assignments assignment
+  join public.reporting_partnership_parties party
+    on party.partnership_id = assignment.partnership_id
+  join public.reporting_partnerships partnership
+    on partnership.id = assignment.partnership_id
+  where party.partner_id = p_partner_id
+    and assignment.status = 'active'
+    and partnership.status in ('draft', 'active');
+
+  select count(distinct schedule.id)::integer
+  into active_schedule_count
+  from public.partner_report_schedules schedule
+  where schedule.partnership_id = any(partnership_ids)
+    and schedule.status = 'active';
+
+  return jsonb_build_object(
+    'snapshotCount', snapshot_count,
+    'scheduleRunCount', schedule_run_count,
+    'salesFactCount', sales_fact_count,
+    'adjustmentFactCount', adjustment_fact_count,
+    'activeMembershipCount', active_membership_count,
+    'activePartyCount', active_party_count,
+    'activeAssignmentCount', active_assignment_count,
+    'activeScheduleCount', active_schedule_count
+  );
+end;
+$$;
+
+create or replace function public.admin_archive_reporting_partnership(
+  p_partnership_id uuid,
+  p_reason text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  normalized_reason text;
+  before_row public.reporting_partnerships;
+  after_row public.reporting_partnerships;
+  counts jsonb;
+  snapshot_count integer;
+  schedule_run_count integer;
+  sales_fact_count integer;
+  adjustment_fact_count integer;
+  active_membership_count integer;
+  archive_end_date date;
+  archived_assignment_count integer := 0;
+  archived_rule_count integer := 0;
+  archived_schedule_count integer := 0;
+begin
+  if not public.is_super_admin(auth.uid()) then
+    raise exception 'Admin access required';
+  end if;
+
+  normalized_reason := public.reporting_admin_assert_reason(p_reason);
+
+  select *
+  into before_row
+  from public.reporting_partnerships partnership
+  where partnership.id = p_partnership_id
+  for update;
+
+  if before_row.id is null then
+    raise exception 'Partnership not found';
+  end if;
+
+  counts := public.reporting_partnership_archive_dependency_counts(before_row.id);
+  snapshot_count := coalesce((counts ->> 'snapshotCount')::integer, 0);
+  schedule_run_count := coalesce((counts ->> 'scheduleRunCount')::integer, 0);
+  sales_fact_count := coalesce((counts ->> 'salesFactCount')::integer, 0);
+  adjustment_fact_count := coalesce((counts ->> 'adjustmentFactCount')::integer, 0);
+  active_membership_count := coalesce((counts ->> 'activeMembershipCount')::integer, 0);
+
+  if snapshot_count > 0
+     or schedule_run_count > 0
+     or sales_fact_count > 0
+     or adjustment_fact_count > 0
+     or active_membership_count > 0 then
+    raise exception
+      'Archive blocked: protected reporting history or active access exists (snapshots %, schedule runs %, sales facts %, applied adjustments %, active memberships %).',
+      snapshot_count,
+      schedule_run_count,
+      sales_fact_count,
+      adjustment_fact_count,
+      active_membership_count;
+  end if;
+
+  if before_row.status = 'archived' then
+    return jsonb_build_object(
+      'targetType', 'reporting_partnership',
+      'targetId', before_row.id,
+      'status', before_row.status,
+      'alreadyArchived', true,
+      'archivedAssignments', 0,
+      'archivedFinancialRules', 0,
+      'archivedSchedules', 0
+    );
+  end if;
+
+  archive_end_date := greatest(current_date, before_row.effective_start_date);
+
+  update public.reporting_machine_partnership_assignments assignment
+  set
+    status = 'archived',
+    effective_end_date = case
+      when assignment.effective_end_date is null
+        or assignment.effective_end_date > greatest(current_date, assignment.effective_start_date)
+        then greatest(current_date, assignment.effective_start_date)
+      else assignment.effective_end_date
+    end
+  where assignment.partnership_id = before_row.id
+    and assignment.status = 'active';
+  get diagnostics archived_assignment_count = row_count;
+
+  update public.reporting_partnership_financial_rules rule
+  set
+    status = 'archived',
+    effective_end_date = case
+      when rule.effective_end_date is null
+        or rule.effective_end_date > greatest(current_date, rule.effective_start_date)
+        then greatest(current_date, rule.effective_start_date)
+      else rule.effective_end_date
+    end
+  where rule.partnership_id = before_row.id
+    and rule.status in ('draft', 'active');
+  get diagnostics archived_rule_count = row_count;
+
+  update public.partner_report_schedules schedule
+  set
+    status = 'archived',
+    archived_at = coalesce(schedule.archived_at, now()),
+    archived_by = coalesce(schedule.archived_by, auth.uid()),
+    archive_reason = coalesce(schedule.archive_reason, normalized_reason)
+  where schedule.partnership_id = before_row.id
+    and schedule.status in ('paused', 'active');
+  get diagnostics archived_schedule_count = row_count;
+
+  update public.reporting_partnerships
+  set
+    status = 'archived',
+    effective_end_date = case
+      when effective_end_date is null or effective_end_date > archive_end_date
+        then archive_end_date
+      else effective_end_date
+    end
+  where id = before_row.id
+  returning * into after_row;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    auth.uid(),
+    'reporting_partnership.archived',
+    'reporting_partnership',
+    after_row.id::text,
+    jsonb_build_object(
+      'id', before_row.id,
+      'status', before_row.status,
+      'effectiveEndDate', before_row.effective_end_date
+    ),
+    jsonb_build_object(
+      'id', after_row.id,
+      'status', after_row.status,
+      'effectiveEndDate', after_row.effective_end_date
+    ),
+    jsonb_build_object(
+      'reason', normalized_reason,
+      'targetType', 'reporting_partnership',
+      'targetId', after_row.id,
+      'targetStatus', after_row.status,
+      'archivedAssignmentCount', archived_assignment_count,
+      'archivedFinancialRuleCount', archived_rule_count,
+      'archivedScheduleCount', archived_schedule_count,
+      'blockerCounts', counts
+    )
+  );
+
+  return jsonb_build_object(
+    'targetType', 'reporting_partnership',
+    'targetId', after_row.id,
+    'status', after_row.status,
+    'archivedAssignments', archived_assignment_count,
+    'archivedFinancialRules', archived_rule_count,
+    'archivedSchedules', archived_schedule_count
+  );
+end;
+$$;
+
+create or replace function public.admin_archive_reporting_partner(
+  p_partner_id uuid,
+  p_reason text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  normalized_reason text;
+  before_row public.reporting_partners;
+  after_row public.reporting_partners;
+  counts jsonb;
+  snapshot_count integer;
+  schedule_run_count integer;
+  sales_fact_count integer;
+  adjustment_fact_count integer;
+  active_membership_count integer;
+  active_party_count integer;
+  active_assignment_count integer;
+  active_schedule_count integer;
+begin
+  if not public.is_super_admin(auth.uid()) then
+    raise exception 'Admin access required';
+  end if;
+
+  normalized_reason := public.reporting_admin_assert_reason(p_reason);
+
+  select *
+  into before_row
+  from public.reporting_partners partner
+  where partner.id = p_partner_id
+  for update;
+
+  if before_row.id is null then
+    raise exception 'Partner record not found';
+  end if;
+
+  counts := public.reporting_partner_archive_dependency_counts(before_row.id);
+  snapshot_count := coalesce((counts ->> 'snapshotCount')::integer, 0);
+  schedule_run_count := coalesce((counts ->> 'scheduleRunCount')::integer, 0);
+  sales_fact_count := coalesce((counts ->> 'salesFactCount')::integer, 0);
+  adjustment_fact_count := coalesce((counts ->> 'adjustmentFactCount')::integer, 0);
+  active_membership_count := coalesce((counts ->> 'activeMembershipCount')::integer, 0);
+  active_party_count := coalesce((counts ->> 'activePartyCount')::integer, 0);
+  active_assignment_count := coalesce((counts ->> 'activeAssignmentCount')::integer, 0);
+  active_schedule_count := coalesce((counts ->> 'activeScheduleCount')::integer, 0);
+
+  if snapshot_count > 0
+     or schedule_run_count > 0
+     or sales_fact_count > 0
+     or adjustment_fact_count > 0
+     or active_membership_count > 0
+     or active_party_count > 0
+     or active_assignment_count > 0
+     or active_schedule_count > 0 then
+    raise exception
+      'Archive blocked: archive related active partnerships/setup first and keep protected history intact (snapshots %, schedule runs %, sales facts %, applied adjustments %, active memberships %, active parties %, active assignments %, active schedules %).',
+      snapshot_count,
+      schedule_run_count,
+      sales_fact_count,
+      adjustment_fact_count,
+      active_membership_count,
+      active_party_count,
+      active_assignment_count,
+      active_schedule_count;
+  end if;
+
+  if before_row.status = 'archived' then
+    return jsonb_build_object(
+      'targetType', 'reporting_partner',
+      'targetId', before_row.id,
+      'status', before_row.status,
+      'alreadyArchived', true
+    );
+  end if;
+
+  update public.reporting_partners
+  set status = 'archived'
+  where id = before_row.id
+  returning * into after_row;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    auth.uid(),
+    'reporting_partner.archived',
+    'reporting_partner',
+    after_row.id::text,
+    jsonb_build_object('id', before_row.id, 'status', before_row.status),
+    jsonb_build_object('id', after_row.id, 'status', after_row.status),
+    jsonb_build_object(
+      'reason', normalized_reason,
+      'targetType', 'reporting_partner',
+      'targetId', after_row.id,
+      'targetStatus', after_row.status,
+      'blockerCounts', counts
+    )
+  );
+
+  return jsonb_build_object(
+    'targetType', 'reporting_partner',
+    'targetId', after_row.id,
+    'status', after_row.status
+  );
+end;
+$$;
+
+create or replace function public.reporting_partnership_delete_guard()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  counts jsonb;
+begin
+  counts := public.reporting_partnership_archive_dependency_counts(old.id);
+
+  if coalesce((counts ->> 'snapshotCount')::integer, 0) > 0
+     or coalesce((counts ->> 'scheduleRunCount')::integer, 0) > 0
+     or coalesce((counts ->> 'salesFactCount')::integer, 0) > 0
+     or coalesce((counts ->> 'adjustmentFactCount')::integer, 0) > 0
+     or coalesce((counts ->> 'activeMembershipCount')::integer, 0) > 0
+     or coalesce((counts ->> 'activePartyCount')::integer, 0) > 0
+     or coalesce((counts ->> 'activeAssignmentCount')::integer, 0) > 0
+     or coalesce((counts ->> 'activeScheduleCount')::integer, 0) > 0 then
+    raise exception
+      'Hard delete blocked: archive instead or remove active setup first (target %, blockers %).',
+      old.id,
+      counts;
+  end if;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    auth.uid(),
+    'reporting_partnership.deleted',
+    'reporting_partnership',
+    old.id::text,
+    jsonb_build_object(
+      'id', old.id,
+      'status', old.status,
+      'effectiveEndDate', old.effective_end_date
+    ),
+    '{}'::jsonb,
+    jsonb_build_object(
+      'reason', 'Disposable fixture hard delete',
+      'targetType', 'reporting_partnership',
+      'targetId', old.id,
+      'targetStatus', old.status,
+      'blockerCounts', counts
+    )
+  );
+
+  return old;
+end;
+$$;
+
+create or replace function public.reporting_partner_delete_guard()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  counts jsonb;
+begin
+  counts := public.reporting_partner_archive_dependency_counts(old.id);
+
+  if coalesce((counts ->> 'snapshotCount')::integer, 0) > 0
+     or coalesce((counts ->> 'scheduleRunCount')::integer, 0) > 0
+     or coalesce((counts ->> 'salesFactCount')::integer, 0) > 0
+     or coalesce((counts ->> 'adjustmentFactCount')::integer, 0) > 0
+     or coalesce((counts ->> 'activeMembershipCount')::integer, 0) > 0
+     or coalesce((counts ->> 'activePartyCount')::integer, 0) > 0
+     or coalesce((counts ->> 'activeAssignmentCount')::integer, 0) > 0
+     or coalesce((counts ->> 'activeScheduleCount')::integer, 0) > 0 then
+    raise exception
+      'Hard delete blocked: archive instead or remove active setup first (target %, blockers %).',
+      old.id,
+      counts;
+  end if;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    auth.uid(),
+    'reporting_partner.deleted',
+    'reporting_partner',
+    old.id::text,
+    jsonb_build_object('id', old.id, 'status', old.status),
+    '{}'::jsonb,
+    jsonb_build_object(
+      'reason', 'Disposable fixture hard delete',
+      'targetType', 'reporting_partner',
+      'targetId', old.id,
+      'targetStatus', old.status,
+      'blockerCounts', counts
+    )
+  );
+
+  return old;
+end;
+$$;
+
+drop trigger if exists reporting_partnerships_delete_guard
+  on public.reporting_partnerships;
+create trigger reporting_partnerships_delete_guard
+before delete on public.reporting_partnerships
+for each row execute function public.reporting_partnership_delete_guard();
+
+drop trigger if exists reporting_partners_delete_guard
+  on public.reporting_partners;
+create trigger reporting_partners_delete_guard
+before delete on public.reporting_partners
+for each row execute function public.reporting_partner_delete_guard();
+
+create or replace function public.admin_upsert_reporting_partner(
+  p_partner_id uuid,
+  p_name text,
+  p_legal_name text,
+  p_partner_type text,
+  p_primary_contact_name text,
+  p_primary_contact_email text,
+  p_status text,
+  p_notes text,
+  p_reason text
+)
+returns public.reporting_partners
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  normalized_reason text;
+  normalized_status text;
+  before_row public.reporting_partners;
+  after_row public.reporting_partners;
+begin
+  if not public.is_super_admin(auth.uid()) then
+    raise exception 'Admin access required';
+  end if;
+
+  normalized_reason := public.reporting_admin_assert_reason(p_reason);
+  normalized_status := lower(coalesce(nullif(trim(p_status), ''), 'active'));
+
+  if normalized_status not in ('active', 'archived') then
+    raise exception 'Partner status is invalid';
+  end if;
+
+  if trim(coalesce(p_name, '')) = '' then
+    raise exception 'Partner name is required';
+  end if;
+
+  if p_partner_id is not null then
+    select * into before_row from public.reporting_partners where id = p_partner_id;
+  end if;
+
+  if before_row.id is null and normalized_status = 'archived' then
+    raise exception 'Create the partner record first, then use the archive action with a reason';
+  end if;
+
+  if before_row.id is not null
+     and before_row.status is distinct from 'archived'
+     and normalized_status = 'archived' then
+    raise exception 'Use the archive action so cleanup safety checks and audit metadata run';
+  end if;
+
+  if before_row.id is null then
+    insert into public.reporting_partners (
+      name,
+      legal_name,
+      partner_type,
+      primary_contact_name,
+      primary_contact_email,
+      status,
+      notes,
+      created_by
+    )
+    values (
+      trim(p_name),
+      nullif(trim(coalesce(p_legal_name, '')), ''),
+      lower(coalesce(nullif(trim(p_partner_type), ''), 'revenue_share_partner')),
+      nullif(trim(coalesce(p_primary_contact_name, '')), ''),
+      nullif(trim(coalesce(p_primary_contact_email, '')), ''),
+      normalized_status,
+      nullif(trim(coalesce(p_notes, '')), ''),
+      auth.uid()
+    )
+    returning * into after_row;
+  else
+    update public.reporting_partners
+    set
+      name = trim(p_name),
+      legal_name = nullif(trim(coalesce(p_legal_name, '')), ''),
+      partner_type = lower(coalesce(nullif(trim(p_partner_type), ''), 'revenue_share_partner')),
+      primary_contact_name = nullif(trim(coalesce(p_primary_contact_name, '')), ''),
+      primary_contact_email = nullif(trim(coalesce(p_primary_contact_email, '')), ''),
+      status = normalized_status,
+      notes = nullif(trim(coalesce(p_notes, '')), '')
+    where id = before_row.id
+    returning * into after_row;
+  end if;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    auth.uid(),
+    case when before_row.id is null then 'reporting_partner.created' else 'reporting_partner.updated' end,
+    'reporting_partner',
+    after_row.id::text,
+    coalesce(to_jsonb(before_row), '{}'::jsonb),
+    to_jsonb(after_row),
+    jsonb_build_object('reason', normalized_reason)
+  );
+
+  return after_row;
+end;
+$$;
+
+create or replace function public.admin_upsert_reporting_partnership(
+  p_partnership_id uuid,
+  p_name text,
+  p_partnership_type text,
+  p_reporting_week_end_day integer,
+  p_timezone text,
+  p_reporting_frequency text,
+  p_monthly_report_due_days integer,
+  p_invoice_payment_due_days integer,
+  p_payment_method text,
+  p_machine_ownership_model text,
+  p_consumer_pricing_authority text,
+  p_contract_reference text,
+  p_effective_start_date date,
+  p_effective_end_date date,
+  p_status text,
+  p_notes text,
+  p_reason text
+)
+returns public.reporting_partnerships
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  normalized_reason text;
+  normalized_status text;
+  before_row public.reporting_partnerships;
+  after_row public.reporting_partnerships;
+begin
+  if not public.is_super_admin(auth.uid()) then
+    raise exception 'Admin access required';
+  end if;
+
+  normalized_reason := public.reporting_admin_assert_reason(p_reason);
+  normalized_status := lower(coalesce(nullif(trim(p_status), ''), 'draft'));
+
+  if normalized_status not in ('draft', 'active', 'archived') then
+    raise exception 'Partnership status is invalid';
+  end if;
+
+  if trim(coalesce(p_name, '')) = '' then
+    raise exception 'Partnership name is required';
+  end if;
+
+  if p_effective_start_date is null then
+    raise exception 'Effective start date is required';
+  end if;
+
+  if p_partnership_id is not null then
+    select * into before_row from public.reporting_partnerships where id = p_partnership_id;
+  end if;
+
+  if before_row.id is null and normalized_status = 'archived' then
+    raise exception 'Create the partnership first, then use the archive action with a reason';
+  end if;
+
+  if before_row.id is not null
+     and before_row.status is distinct from 'archived'
+     and normalized_status = 'archived' then
+    raise exception 'Use the archive action so cleanup safety checks and audit metadata run';
+  end if;
+
+  if before_row.id is null then
+    insert into public.reporting_partnerships (
+      name,
+      partnership_type,
+      reporting_week_end_day,
+      timezone,
+      reporting_frequency,
+      monthly_report_due_days,
+      invoice_payment_due_days,
+      payment_method,
+      machine_ownership_model,
+      consumer_pricing_authority,
+      contract_reference,
+      effective_start_date,
+      effective_end_date,
+      status,
+      notes,
+      created_by
+    )
+    values (
+      trim(p_name),
+      lower(coalesce(nullif(trim(p_partnership_type), ''), 'revenue_share')),
+      coalesce(p_reporting_week_end_day, 0),
+      coalesce(nullif(trim(p_timezone), ''), 'America/Los_Angeles'),
+      lower(coalesce(nullif(trim(p_reporting_frequency), ''), 'weekly')),
+      p_monthly_report_due_days,
+      p_invoice_payment_due_days,
+      nullif(trim(coalesce(p_payment_method, '')), ''),
+      lower(coalesce(nullif(trim(p_machine_ownership_model), ''), 'unknown')),
+      lower(coalesce(nullif(trim(p_consumer_pricing_authority), ''), 'unknown')),
+      nullif(trim(coalesce(p_contract_reference, '')), ''),
+      p_effective_start_date,
+      p_effective_end_date,
+      normalized_status,
+      nullif(trim(coalesce(p_notes, '')), ''),
+      auth.uid()
+    )
+    returning * into after_row;
+  else
+    update public.reporting_partnerships
+    set
+      name = trim(p_name),
+      partnership_type = lower(coalesce(nullif(trim(p_partnership_type), ''), 'revenue_share')),
+      reporting_week_end_day = coalesce(p_reporting_week_end_day, 0),
+      timezone = coalesce(nullif(trim(p_timezone), ''), 'America/Los_Angeles'),
+      reporting_frequency = lower(coalesce(nullif(trim(p_reporting_frequency), ''), 'weekly')),
+      monthly_report_due_days = p_monthly_report_due_days,
+      invoice_payment_due_days = p_invoice_payment_due_days,
+      payment_method = nullif(trim(coalesce(p_payment_method, '')), ''),
+      machine_ownership_model = lower(coalesce(nullif(trim(p_machine_ownership_model), ''), 'unknown')),
+      consumer_pricing_authority = lower(coalesce(nullif(trim(p_consumer_pricing_authority), ''), 'unknown')),
+      contract_reference = nullif(trim(coalesce(p_contract_reference, '')), ''),
+      effective_start_date = p_effective_start_date,
+      effective_end_date = p_effective_end_date,
+      status = normalized_status,
+      notes = nullif(trim(coalesce(p_notes, '')), '')
+    where id = before_row.id
+    returning * into after_row;
+  end if;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    auth.uid(),
+    case when before_row.id is null then 'reporting_partnership.created' else 'reporting_partnership.updated' end,
+    'reporting_partnership',
+    after_row.id::text,
+    coalesce(to_jsonb(before_row), '{}'::jsonb),
+    to_jsonb(after_row),
+    jsonb_build_object('reason', normalized_reason)
+  );
+
+  return after_row;
+end;
+$$;
+
+create or replace function public.admin_create_partner_report_schedule(
+  p_partnership_id uuid,
+  p_title text default null,
+  p_cadence text default 'weekly',
+  p_timezone text default null,
+  p_send_day_of_week integer default null,
+  p_send_day_of_month integer default null,
+  p_send_time_local time default time '09:00',
+  p_period_delay_days integer default null,
+  p_sender_profile_key text default 'partner_reports',
+  p_reply_to_profile_key text default null,
+  p_delivery_mode text default 'secure_link',
+  p_recipients jsonb default '[]'::jsonb,
+  p_reason text default null
+)
+returns public.partner_report_schedules
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  partnership_row public.reporting_partnerships;
+  schedule_row public.partner_report_schedules;
+  normalized_reason text;
+  normalized_title text;
+  normalized_cadence text;
+  normalized_period_grain text;
+  normalized_timezone text;
+  normalized_sender_profile text;
+  normalized_reply_profile text;
+  normalized_delivery_mode text;
+  normalized_day_of_week integer;
+  normalized_day_of_month integer;
+  normalized_delay_days integer;
+  recipient_value jsonb;
+  recipient_email text;
+  recipient_display_name text;
+  recipient_role text;
+  inserted_recipient_count integer := 0;
+begin
+  if not public.is_super_admin(auth.uid()) then
+    raise exception 'Admin access required';
+  end if;
+
+  normalized_reason := public.reporting_admin_assert_reason(p_reason);
+
+  if p_partnership_id is null then
+    raise exception 'Partnership id is required';
+  end if;
+
+  select *
+  into partnership_row
+  from public.reporting_partnerships partnership
+  where partnership.id = p_partnership_id;
+
+  if partnership_row.id is null then
+    raise exception 'Partnership not found';
+  end if;
+
+  if partnership_row.status <> 'active' then
+    raise exception 'Partner report schedules require an active partnership';
+  end if;
+
+  normalized_cadence := lower(coalesce(nullif(btrim(p_cadence), ''), 'weekly'));
+  if normalized_cadence not in ('weekly', 'monthly') then
+    raise exception 'Cadence must be weekly or monthly';
+  end if;
+
+  normalized_period_grain := case
+    when normalized_cadence = 'weekly' then 'reporting_week'
+    else 'calendar_month'
+  end;
+
+  normalized_timezone := coalesce(
+    nullif(btrim(p_timezone), ''),
+    nullif(btrim(partnership_row.timezone), ''),
+    'America/Los_Angeles'
+  );
+  normalized_sender_profile := lower(coalesce(nullif(btrim(p_sender_profile_key), ''), 'partner_reports'));
+  normalized_reply_profile := nullif(lower(btrim(coalesce(p_reply_to_profile_key, ''))), '');
+  normalized_delivery_mode := lower(coalesce(nullif(btrim(p_delivery_mode), ''), 'secure_link'));
+  normalized_delay_days := coalesce(p_period_delay_days, 1);
+  normalized_title := coalesce(
+    nullif(btrim(p_title), ''),
+    partnership_row.name || ' ' || normalized_cadence || ' partner report'
+  );
+
+  if normalized_delivery_mode <> 'secure_link' then
+    raise exception 'Only secure_link delivery mode is enabled for scheduled partner reports';
+  end if;
+
+  if normalized_delay_days < 0 or normalized_delay_days > 31 then
+    raise exception 'Period delay days must be between 0 and 31';
+  end if;
+
+  if normalized_cadence = 'weekly' then
+    normalized_day_of_week := coalesce(p_send_day_of_week, 1);
+    normalized_day_of_month := null;
+    if normalized_day_of_week < 0 or normalized_day_of_week > 6 then
+      raise exception 'Weekly send day must be 0-6';
+    end if;
+  else
+    normalized_day_of_week := null;
+    normalized_day_of_month := coalesce(p_send_day_of_month, 1);
+    if normalized_day_of_month < 1 or normalized_day_of_month > 28 then
+      raise exception 'Monthly send day must be 1-28';
+    end if;
+  end if;
+
+  if p_recipients is not null and jsonb_typeof(p_recipients) <> 'array' then
+    raise exception 'Recipients must be a JSON array';
+  end if;
+
+  insert into public.partner_report_schedules (
+    partnership_id,
+    title,
+    status,
+    cadence,
+    period_grain,
+    timezone,
+    send_day_of_week,
+    send_day_of_month,
+    send_time_local,
+    period_delay_days,
+    sender_profile_key,
+    reply_to_profile_key,
+    delivery_mode,
+    created_by,
+    paused_at,
+    paused_by,
+    pause_reason
+  )
+  values (
+    partnership_row.id,
+    normalized_title,
+    'paused',
+    normalized_cadence,
+    normalized_period_grain,
+    normalized_timezone,
+    normalized_day_of_week,
+    normalized_day_of_month,
+    coalesce(p_send_time_local, time '09:00'),
+    normalized_delay_days,
+    normalized_sender_profile,
+    normalized_reply_profile,
+    normalized_delivery_mode,
+    auth.uid(),
+    now(),
+    auth.uid(),
+    'New scheduled partner reports start paused until validation passes.'
+  )
+  returning * into schedule_row;
+
+  for recipient_value in
+    select value
+    from jsonb_array_elements(coalesce(p_recipients, '[]'::jsonb)) as recipient(value)
+  loop
+    if jsonb_typeof(recipient_value) = 'string' then
+      recipient_email := public.partner_report_schedule_normalize_email(recipient_value #>> '{}');
+      recipient_display_name := null;
+      recipient_role := null;
+    else
+      recipient_email := public.partner_report_schedule_normalize_email(recipient_value ->> 'email');
+      recipient_display_name := nullif(btrim(coalesce(recipient_value ->> 'displayName', recipient_value ->> 'display_name', '')), '');
+      recipient_role := nullif(btrim(coalesce(recipient_value ->> 'recipientRole', recipient_value ->> 'recipient_role', recipient_value ->> 'role', '')), '');
+    end if;
+
+    if recipient_email = '' then
+      continue;
+    end if;
+
+    if not public.partner_report_schedule_is_valid_email(recipient_email) then
+      raise exception 'Invalid recipient email: %', recipient_email;
+    end if;
+
+    insert into public.partner_report_schedule_recipients (
+      schedule_id,
+      email,
+      display_name,
+      recipient_role,
+      status,
+      added_by
+    )
+    values (
+      schedule_row.id,
+      recipient_email,
+      recipient_display_name,
+      recipient_role,
+      'active',
+      auth.uid()
+    )
+    on conflict (schedule_id, email) where status = 'active'
+    do update
+    set
+      display_name = excluded.display_name,
+      recipient_role = excluded.recipient_role,
+      updated_at = now();
+
+    inserted_recipient_count := inserted_recipient_count + 1;
+  end loop;
+
+  schedule_row := public.partner_report_schedule_refresh_configuration(schedule_row.id, false);
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    target_user_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    auth.uid(),
+    'partner_report_schedule.created',
+    'partner_report_schedule',
+    schedule_row.id::text,
+    null,
+    '{}'::jsonb,
+    to_jsonb(schedule_row),
+    jsonb_build_object(
+      'reason', normalized_reason,
+      'recipient_count', inserted_recipient_count,
+      'configuration_hash', schedule_row.configuration_hash
+    )
+  );
+
+  return schedule_row;
+end;
+$$;
+
+revoke execute on function public.reporting_partnership_archive_dependency_counts(uuid)
+  from public, anon, authenticated;
+revoke execute on function public.reporting_partner_archive_dependency_counts(uuid)
+  from public, anon, authenticated;
+revoke execute on function public.admin_archive_reporting_partnership(uuid, text)
+  from public, anon;
+revoke execute on function public.admin_archive_reporting_partner(uuid, text)
+  from public, anon;
+grant execute on function public.admin_archive_reporting_partnership(uuid, text)
+  to authenticated;
+grant execute on function public.admin_archive_reporting_partner(uuid, text)
+  to authenticated;


### PR DESCRIPTION
﻿## Summary
- Adds super-admin archive RPCs for reporting partner records and reporting partnerships with protected-history blockers and sanitized archive/delete audit entries.
- Adds direct hard-delete guard triggers and hardens generic save/schedule RPCs so active records cannot bypass archive safety checks.
- Adds admin archive confirmation flows and filters archived records out of normal partnership/reporting/dashboard selectors.

Closes #326

## Files changed
- `supabase/migrations/202605070003_partner_record_archive_guardrails.sql`: archive RPCs, dependency checks, hard-delete triggers, upsert/schedule guardrails.
- `src/lib/partnershipReporting.ts`: typed client wrappers for archive RPCs.
- `src/pages/admin/PartnerRecords.tsx`: archive action, reason dialog, active-by-default record list.
- `src/pages/admin/Partnerships.tsx`: archive action, reason dialog, archived partnership/partner selector filtering.
- `Docs/QA_SMOKE_TEST_CHECKLIST.md`: #326 smoke coverage for allowed archive, blocked archive/delete, selector visibility, persona probes, and audit metadata.

## Verification
- `npm ci` - passed; 0 vulnerabilities. npm reported a deprecation warning for `glob@10.5.0`.
- `npm run build` - passed. Vite reported the existing large chunk warning for `Reports`.
- `npm run seo:check` - passed: 22 public routes and 19 private routes validated.
- `npm test --if-present` - passed; no test script output.
- `npm run lint --if-present` - passed with 8 existing Fast Refresh warnings in shared UI/Auth files and 0 errors.
- `npm run db:validate-migrations` - passed after the final `202605070003` migration rename; 80 migration files applied in a disposable Supabase project.
- `npm run db:validate-rpc-surface` - passed: 6 service-role-only helper RPCs remain blocked from browser use.
- `supabase db push --dry-run` - not run: this worktree is not linked to a Supabase project. CLI output: `Cannot find project ref. Have you run supabase link?`

## How to test
1. From this branch, run `npm ci` and `npm run dev`, then open `http://localhost:8080`.
2. Sign in as a super-admin.
3. Open `/admin/partner-records`, create or choose an unused test partner record, click `Archive`, enter a reason, and confirm it disappears from the default active list and appears only under the archived status filter.
4. Open `/admin/partnerships`, create or choose an unused test partnership with no snapshots/schedule runs/sales facts/applied adjustments, click `Archive`, enter a reason, and confirm the partnership leaves the desktop and mobile partnership pickers.
5. Open `/admin/reporting` and confirm imported-machine report/partnership selectors do not offer archived partnerships.
6. Open `/portal/reports` as a super-admin or Corporate Partner test persona and confirm archived partnerships are absent from partner dashboard partnership lists.
7. With suitable fixtures, verify archive/delete is blocked for records with report snapshots, schedule runs, sales facts, applied adjustments, active memberships, active parties, active assignments, or active schedules.
8. Negative probe the archive RPCs/direct deletes as anonymous, non-admin, scoped-admin, `report_manager`, and Corporate Partner sessions; each should fail through RLS or `Admin access required`.

## Risk / overlap notes
- Risk: high. This touches Supabase migrations/RPCs, admin UI, and reporting data safety boundaries.
- Overlap: PR #400 touches `Docs/QA_SMOKE_TEST_CHECKLIST.md` and already uses migration version `202605070002`; this branch intentionally uses `202605070003`. If #400 merges first, sync from `main` and rerun migration validation before final review.
- Overlap: PR #399 also touches `Docs/QA_SMOKE_TEST_CHECKLIST.md`; resolve checklist conflicts by keeping both sets of issue-specific smoke items.
- Rollback: revert the frontend/doc changes and add a forward migration to remove the archive RPCs/delete triggers if production rollback is needed. Archive actions are soft and leave historical records in place.
