### PR TITLE
Document Nayax Lynx API status

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,7 @@ INTERNAL_NOTIFICATION_FROM_EMAIL=
 # Ethan and Ian are always included by the Edge Function email helper.
 INTERNAL_NOTIFICATION_RECIPIENTS=etrifari@bloomjoysweets.com,ian@bloomjoysweets.com
 VIMEO_ACCESS_TOKEN=
+NAYAX_LYNX_API_TOKEN=
 
 # Sales reporting automation (server-only)
 REPORT_SCHEDULER_SECRET=

--- a/Docs/ARCHITECTURE.md
+++ b/Docs/ARCHITECTURE.md
@@ -8,6 +8,7 @@
 
 ## Why a server-side surface exists (even with a SPA)
 Stripe Checkout session creation and webhook handling must run with **secret keys**.
+External operational APIs such as Nayax Lynx also use backend-only tokens.
 That means we need one of:
 - Serverless functions (Vercel/Netlify) OR
 - Supabase Edge Functions OR
@@ -63,6 +64,6 @@ Portal (auth-gated):
 
 ## Security baseline (non-negotiable)
 - Never commit secrets
-- Never expose Stripe secret keys to the client (no `VITE_` secret keys)
+- Never expose Stripe, Nayax, or other backend tokens to the client (no `VITE_` secret keys)
 - RLS policies for user-owned tables (Supabase)
 - Validate inputs on the server-side function endpoints

--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -6,6 +6,18 @@
 - First priority is to **stabilize the POC** and align it to the MVP routing + docs workflow.
 - Write updates in plain language so non-technical readers can follow.
 
+## Nayax Lynx API discovery (2026-05-11)
+- Production Nayax token was added to Supabase project `ygbzkgxktzqsiygjlqyg` as server-only secret `NAYAX_LYNX_API_TOKEN`.
+- Current working production base path is `https://lynx.nayax.com/operational/v1`; tested `/operational/api/v1` paths returned `404` for current calls.
+- Verified live read access:
+  - `GET /machines?ResultsLimit=1000` returns `200` and exposed 43 machines in the tested account.
+  - `GET /machines/{MachineID}/lastSales` returns `200` for all 43 checked machines and provides recent transaction fields needed for a polling-based sales sync.
+- Still blocked by Nayax permissions:
+  - `GET /devices?pageSize=1` returns `403` with `You are not allowed to view this content`.
+  - `GET /dashboard/widgets?screenTypeId=1` and `screenTypeId=2` return `403`, so historical/reporting-widget access is not enabled yet.
+- Current conclusion: devices are not required for the first useful machine/sales sync. Reporting widgets are the more important next permission if Bloomjoy needs clean date-range revenue dashboards instead of polling recent `lastSales`.
+- Agent-facing details live in `Docs/NAYAX_LYNX_API.md`.
+
 ## Supply order notification hardening (2026-05-06)
 - Paid sugar and 5+ box branded-stick checkouts continue to persist in `orders`, send customer confirmations, and alert internal fulfillment through email plus WeCom when WeCom delivery is allowed.
 - Under-5 branded-stick requests and custom-stick requests now send internal procurement notifications from `lead-submission-intake`; those requests already persist as `lead_submissions`, and notification failures are recorded without losing the submission.
@@ -420,6 +432,7 @@ Execution order is based on launch risk and dependency overlap.
 - Clear support boundary copy must be reviewed early (to prevent support overload)
 - Production credential execution remains owner-controlled (Google/Supabase/SMTP/DNS changes must be completed in dashboard tools before launch sign-off).
 - Internal notification pipeline is restored for quote/procurement submissions and paid supply orders, but ongoing reliability still depends on keeping Resend/Supabase function secrets valid (`RESEND_API_KEY`, verified sender).
+- Nayax Lynx machine and recent-sales endpoints work with `NAYAX_LYNX_API_TOKEN`, but Nayax still needs to enable device access and reporting widget access if future scope requires hardware inventory or date-range dashboard rollups.
 - WeCom alert dispatch reliability now depends on owner-managed app policy as well as valid secrets/recipient scope; current live failure is `60020: not allow to access from your ip`.
 - WeChat onboarding concierge UX is live, but operational effectiveness still depends on documented referral-buddy process/SLA ownership (tracked in issue `#110`).
 - `#78` currently blocked on Supabase side: Custom Domain add-on is not enabled yet for project `ygbzkgxktzqsiygjlqyg`, so domain create/activate commands cannot run.

--- a/Docs/LOCAL_DEV.md
+++ b/Docs/LOCAL_DEV.md
@@ -131,6 +131,22 @@ Notes:
 - Admins set up newly discovered Sunze IDs from `/admin/reporting` by choosing the report/partnership, confirming machine label/location/type/tax, and saving once. Pending rows for unconfigured machines are quarantined in normalized form and replayed into `machine_sales_facts` after the Sunze ID is connected to a report-ready machine.
 - Never prefix Sunze, Google, service-role, or scheduler secrets with `VITE_`.
 
+## Nayax Lynx API notes
+Use `Docs/NAYAX_LYNX_API.md` as the current agent-facing source for Nayax status, endpoint coverage, and permission gaps.
+
+Current server-only secret:
+- Supabase production project `ygbzkgxktzqsiygjlqyg`: `NAYAX_LYNX_API_TOKEN`
+
+Set or rotate it with:
+
+```bash
+supabase secrets set NAYAX_LYNX_API_TOKEN=... --project-ref ygbzkgxktzqsiygjlqyg
+```
+
+For local-only endpoint testing, store the token in your own `.env` as `NAYAX_LYNX_API_TOKEN` or another clearly named local key. Do not commit it, do not paste it into chat, and never prefix it with `VITE_`.
+
+As of 2026-05-11, `GET https://lynx.nayax.com/operational/v1/machines` and `GET /machines/{MachineID}/lastSales` work. `GET /devices` and dashboard widget endpoints return `403`, so future agents should not block a first machine/sales sync on device access.
+
 ## Training document upload helper
 Use this after the training experience migration is applied and `training-documents` exists.
 

--- a/Docs/NAYAX_LYNX_API.md
+++ b/Docs/NAYAX_LYNX_API.md
@@ -1,0 +1,137 @@
+# Nayax Lynx API Notes
+
+Last updated: 2026-05-11
+
+## Purpose
+Bloomjoy is evaluating Nayax Lynx as the server-side source for machine inventory and machine-level sales activity.
+
+Do not call Nayax directly from the browser. Any implementation should run through Supabase Edge Functions or another backend-only surface.
+
+## Current Production Credential Status
+- Production Supabase project: `ygbzkgxktzqsiygjlqyg`
+- Server-only Supabase secret name: `NAYAX_LYNX_API_TOKEN`
+- Local development may use `.env` only on the agent machine. Never commit token values.
+- Never prefix this token with `VITE_`; Vite exposes `VITE_` values to the browser.
+
+The secret was added to Supabase on 2026-05-11 and verified by name/digest with:
+
+```bash
+supabase secrets list --project-ref ygbzkgxktzqsiygjlqyg
+```
+
+Edge Functions should read the token with:
+
+```ts
+const nayaxToken = Deno.env.get("NAYAX_LYNX_API_TOKEN");
+```
+
+## Verified Endpoint Status
+Base path that works in production:
+
+```text
+https://lynx.nayax.com/operational/v1
+```
+
+Do not use `/operational/api/v1` for the currently tested production calls. That path returned `404` for last-sales checks.
+
+Live API validation on 2026-05-11:
+
+| Endpoint | Status | Notes |
+| --- | --- | --- |
+| `GET /machines?ResultsLimit=1000` | `200` | Returned 43 machines. |
+| `GET /machines/{MachineID}/lastSales` | `200` | Returned `200` for all 43 checked machines. Some machines have no recent sales. |
+| `GET /devices?pageSize=1` | `403` | Nayax permission gap. Latest message: `You are not allowed to view this content`. |
+| `GET /dashboard/widgets?screenTypeId=1` | `403` | Reporting widget permission gap. |
+| `GET /dashboard/widgets?screenTypeId=2` | `403` | Reporting widget permission gap. |
+
+Recent device failure correlation IDs captured during support testing:
+- `M7XIgFESb0Oy5GOO`
+- `wr1Q9ak1vUKZRrn8`
+- `0eLcPE8l5kqc305I`
+
+## Field Coverage From Working Calls
+`GET /machines?ResultsLimit=1000` returned the machine identifiers needed for a first integration:
+- `MachineID`
+- `ActorID`
+- `OperatorActorID`
+- `MachineName`
+- `MachineNumber`
+- `MachineStatusBit`
+- `MachineTypeID`
+- `VPOSSerialNumber`
+- `DeviceSerialNumber`
+- `VPOSID`
+- `DeviceID`
+
+Observed coverage:
+- 43 of 43 machines had `MachineID`, `MachineName`, `MachineNumber`, `MachineStatusBit`, and `MachineTypeID`.
+- 34 of 43 machines had `VPOSSerialNumber`, `DeviceSerialNumber`, `VPOSID`, and `DeviceID`.
+
+`GET /machines/{MachineID}/lastSales` returned transaction fields suitable for recent sales ingestion:
+- `TransactionID`
+- `PaymentServiceTransactionID`
+- `PaymentServiceProviderName`
+- `MachineID`
+- `MachineName`
+- `MachineNumber`
+- `AuthorizationValue`
+- `SettlementValue`
+- `CurrencyCode`
+- `PaymentMethod`
+- `RecognitionMethod`
+- `ProductName`
+- `Quantity`
+- `AuthorizationDateTimeGMT`
+- `MachineAuthorizationTime`
+- `SettlementDateTimeGMT`
+
+Observed sales validation:
+- 43 of 43 machine last-sales calls returned `200`.
+- 29 of 43 machines returned at least one recent sale in the tested response.
+- 2,886 recent sales were fetched across the checked machines.
+
+## Do We Need Devices?
+Not for the first useful integration.
+
+Use `machines` plus `machines/{MachineID}/lastSales` for:
+- machine sync
+- machine ID/name/number/status mapping
+- Bloomjoy customer or reporting-machine mapping
+- recent sales ingestion
+- basic transaction and revenue views if the sync runs regularly and stores results
+
+The `devices` endpoint is only needed for hardware/payment-terminal management, such as:
+- full terminal inventory
+- IMEI, chip ID, board serial, or hardware serial details
+- device transfer or disable workflows
+- payment-reader troubleshooting separate from the machine record
+
+## Bigger Permission Gap
+The next permission to request from Nayax is probably reporting widgets, not devices.
+
+`lastSales` is a recent/latest transaction endpoint. It is useful for polling and storing sales, but it is not the same as a clean historical reporting API with date ranges and rollups.
+
+Ask Nayax to enable or confirm access to:
+- `GET /operational/v1/dashboard/widgets?screenTypeId=1`
+- `GET /operational/v1/dashboard/widgets?screenTypeId=2`
+- `POST /operational/v1/dashboard/get-widget-data`
+
+## Implementation Guidance
+Recommended first slice:
+1. Add a Supabase Edge Function that reads `NAYAX_LYNX_API_TOKEN`.
+2. Pull `GET /machines?ResultsLimit=1000`.
+3. Store or map `MachineID`, `MachineName`, `MachineNumber`, and status fields to Bloomjoy reporting/admin records.
+4. Poll `GET /machines/{MachineID}/lastSales` per known machine.
+5. Upsert by `TransactionID` to avoid duplicates.
+6. Store only reporting-safe transaction fields. Avoid storing card digits or customer/payment identifiers unless there is a documented need.
+
+Do not build browser-side Nayax calls, and do not expose Nayax raw responses in public or customer-facing pages without a privacy review.
+
+## Retest Commands
+Use a local-only `.env` value. Do not paste tokens into chat, issues, PRs, or docs.
+
+```powershell
+supabase secrets list --project-ref ygbzkgxktzqsiygjlqyg | Select-String -Pattern 'NAYAX|LYNX'
+```
+
+For local endpoint checks, prefer scripts that print only HTTP status, response shape, counts, and correlation IDs. Do not print raw sales rows.


### PR DESCRIPTION
## Summary
- Adds `Docs/NAYAX_LYNX_API.md` with verified Nayax Lynx endpoint status, permission gaps, and first-slice implementation guidance.
- Records that `NAYAX_LYNX_API_TOKEN` is a server-only Supabase secret and must not be exposed through `VITE_` env vars.
- Updates current status, local dev, architecture, and `.env.example` so future agents can discover the Nayax setup quickly.

## Files changed
- `Docs/NAYAX_LYNX_API.md`: new agent-facing Nayax API notes.
- `Docs/CURRENT_STATUS.md`: current API validation snapshot and known permission gap.
- `Docs/LOCAL_DEV.md`: server-only secret setup and local testing guidance.
- `Docs/ARCHITECTURE.md`: backend-only token guidance.
- `.env.example`: placeholder for `NAYAX_LYNX_API_TOKEN`.

## Verification commands + results
- `npm ci` - passed; 0 vulnerabilities reported.
- `npm run build` - passed; existing chunk-size warning remains.
- `npm test --if-present` - passed; no test script output.
- `npm run lint --if-present` - passed with 8 existing fast-refresh warnings in shared UI/auth files.

Additional preflight:
- `npm run auth:preflight` - attempted before edits per local preflight guidance; failed in the fresh worktree because no local `.env`/`.env.local` exists there (`VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` missing). This branch does not touch auth/OAuth behavior.

## How to test
1. From a clean checkout/worktree of this branch, run `npm ci`.
2. Run `npm run build`.
3. Open `Docs/NAYAX_LYNX_API.md` and confirm it documents:
   - Supabase secret name `NAYAX_LYNX_API_TOKEN`.
   - Working base path `https://lynx.nayax.com/operational/v1`.
   - Working `machines` and `lastSales` endpoints.
   - Current `devices` and dashboard-widget `403` permission gaps.
4. Optional localhost check: run `npm run dev` and open the printed localhost URL, usually `http://localhost:8080`. This PR is docs/config-sample only, so there are no user-facing route changes.