### PR TITLE
P0: Add operator payout review workflow

### DIFF
--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -23,6 +23,7 @@ GitHub Issues and the Bloomjoy Project board are the operational source of truth
 - Refund operations and customer-refund pilot readiness remain high-sensitivity operational surfaces.
 - Operator payouts, partner reporting, and scheduled exports are active shared foundations.
 - Operator payouts foundation sprint: the foundation is on `main`; active follow-on PRs add timekeeping, revenue snapshots, calculation, review, and pay statement slices.
+- Manager review/finalization slice `#448` adds the admin review gate before operator pay statements are issued.
 - Frontend work should use existing app patterns plus `PRODUCT.md`, `DESIGN.md`, and `impeccable` when the visible experience matters.
 
 ## Safety

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -184,6 +184,17 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Operator Time warns before save for end-before-start, work date outside the current period, duplicate/exact shift, overlapping shift, and 10+ hour shifts.
 - [ ] Operator Time edit/delete controls work for unlocked draft/submitted entries and are disabled or blocked for locked, payout-included, paid, or voided entries.
 - [ ] Operator Time empty state explains that an admin or machine manager must add an operator payout profile and assigned machines before time can be submitted.
+
+### Admin Operator Payout Review
+- [ ] Admin or scoped payout manager can open `/admin/payouts`; users without payout admin access see the existing admin access-required state.
+- [ ] Payout periods list shows account, period dates, status, operator count, total payout, warnings, and revision count without horizontal overflow on desktop or mobile.
+- [ ] Generating or recalculating a payout run uses submitted/locked/included time, revenue snapshots, compensation rules, and adjustments; recalculation requires an audit reason.
+- [ ] Manager review shows operator totals, machine-level time/revenue/commission breakdown, adjustments, and warning details while respecting scoped machine visibility.
+- [ ] Adding an adjustment requires operator, non-zero amount, operator-visible description, and manager audit reason, then recalculates the run.
+- [ ] Finalization blocks when critical payout warnings are present unless the manager records an explicit override reason.
+- [ ] Finalization blocks if issued/revised pay statements already exist for the run, preventing duplicate statements.
+- [ ] Mark reviewed, finalize, reopen, and void actions all require audit reasons and preserve review/revision snapshots.
+- [ ] Reopening or voiding an unissued run leaves the period ready for corrected calculation without unlocking unrelated admin surfaces.
 - [ ] Desktop portal top bar shows one profile/session menu instead of separate Account and Sign Out buttons
 - [ ] Profile/session menu shows the signed-in email, an Account Settings link when the user can access `/portal/account`, and Sign Out
 - [ ] Portal section navigation labels `/portal/account` as Settings and does not show a separate Admin link for admin users

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "operator-payouts:validate-timekeeping-uat": "node scripts/validate-operator-timekeeping-uat.mjs",
     "operator-payouts:validate-revenue-snapshots": "node scripts/validate-operator-revenue-snapshots.mjs",
     "operator-payouts:validate-calculation": "node scripts/validate-operator-payout-calculation.mjs",
+    "operator-payouts:validate-review": "node scripts/validate-operator-payout-review.mjs",
     "reporting:validate-partner-effective-windows": "node scripts/validate-partner-effective-windows.mjs",
     "reporting:validate-partner-scheduled-export": "node scripts/validate-partner-report-scheduled-export.mjs",
     "training:dedupe-catalog": "node scripts/dedupe-training-catalog.mjs",

--- a/scripts/validate-operator-payout-review.mjs
+++ b/scripts/validate-operator-payout-review.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+const files = {
+  migration: path.join(
+    repoRoot,
+    'supabase',
+    'migrations',
+    '202605200005_operator_payout_review_workflow.sql'
+  ),
+  helper: path.join(repoRoot, 'src', 'lib', 'operatorPayouts.ts'),
+  page: path.join(repoRoot, 'src', 'pages', 'admin', 'Payouts.tsx'),
+  app: path.join(repoRoot, 'src', 'App.tsx'),
+  adminRoute: path.join(repoRoot, 'src', 'components', 'auth', 'AdminRoute.tsx'),
+  appLayout: path.join(repoRoot, 'src', 'components', 'layout', 'AppLayout.tsx'),
+  navbar: path.join(repoRoot, 'src', 'components', 'layout', 'Navbar.tsx'),
+  i18n: path.join(repoRoot, 'src', 'lib', 'i18n.ts'),
+  rpcSurface: path.join(repoRoot, 'scripts', 'validate-rpc-execute-surface.mjs'),
+  packageJson: path.join(repoRoot, 'package.json'),
+  smoke: path.join(repoRoot, 'Docs', 'QA_SMOKE_TEST_CHECKLIST.md'),
+  status: path.join(repoRoot, 'Docs', 'CURRENT_STATUS.md'),
+};
+
+const fail = (message) => {
+  throw new Error(message);
+};
+
+const readText = (filePath) => fs.readFileSync(filePath, 'utf8');
+
+const compact = (value) =>
+  value
+    .replace(/--.*$/gm, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+
+const expect = (source, snippet, label) => {
+  if (!compact(source).includes(compact(snippet))) {
+    fail(`${label}: missing ${snippet}`);
+  }
+};
+
+for (const [label, filePath] of Object.entries(files)) {
+  if (!fs.existsSync(filePath)) {
+    fail(`Missing ${label} file: ${path.relative(repoRoot, filePath)}`);
+  }
+}
+
+const migration = readText(files.migration);
+for (const snippet of [
+  'create table if not exists public.payout_run_review_snapshots',
+  'revision_number integer not null check (revision_number > 0)',
+  'create or replace function public.operator_can_finalize_payout_run',
+  'create or replace function public.operator_capture_payout_run_review_snapshot',
+  'create or replace function public.get_my_admin_access_context',
+  "allowed_surfaces := allowed_surfaces || array['payouts']",
+  'create or replace function public.operator_payout_calculation_payload',
+  'visibilityFilter',
+  'scoped_items_only',
+  'create or replace function public.get_payout_review_context',
+  'issuedStatementCount',
+  'revisionCount',
+  'create or replace function public.admin_mark_payout_run_reviewed',
+  'create or replace function public.admin_finalize_payout_run',
+  'Critical payout warnings must be resolved or explicitly overridden before finalization',
+  'Finalization blocked because issued pay statements already exist for this payout run',
+  'payroll_provider_execution',
+  'create or replace function public.admin_reopen_payout_run',
+  'Issued pay statements require a statement revision flow instead of reopening the payout run',
+  'create or replace function public.admin_void_payout_run',
+  'operator_payout_run.finalized',
+  'operator_payout_run.reopened',
+  'operator_payout_run.voided',
+  'grant execute on function public.operator_can_finalize_payout_run(uuid, uuid) to service_role',
+  'grant execute on function public.operator_capture_payout_run_review_snapshot(uuid, uuid, text, text) to service_role',
+]) {
+  expect(migration, snippet, 'review migration');
+}
+
+const helper = readText(files.helper);
+for (const snippet of [
+  'PayoutReviewContext',
+  'PayoutReviewPeriod',
+  'PayoutReviewWorkflowResult',
+  'fetchPayoutReviewContext',
+  'markPayoutRunReviewedAdmin',
+  'finalizePayoutRunAdmin',
+  'reopenPayoutRunAdmin',
+  'voidPayoutRunAdmin',
+  'get_payout_review_context',
+]) {
+  if (!helper.includes(snippet)) {
+    fail(`operatorPayouts helper missing ${snippet}`);
+  }
+}
+
+const page = readText(files.page);
+for (const snippet of [
+  'Payout Review',
+  'Manual Adjustment',
+  'Finalize',
+  'Critical warnings block finalization',
+  'issued statements already exist',
+  'Show on operator statement',
+  'Review access',
+  'No payout run yet',
+]) {
+  if (!page.includes(snippet)) {
+    fail(`Admin payouts page missing ${snippet}`);
+  }
+}
+
+const app = readText(files.app);
+if (!app.includes('AdminPayouts') || !app.includes('path="/admin/payouts"')) {
+  fail('App router missing /admin/payouts route.');
+}
+
+const adminRoute = readText(files.adminRoute);
+if (!adminRoute.includes("canAccessSurface('payouts')")) {
+  fail('AdminRoute must allow the payouts admin surface.');
+}
+
+const appLayout = readText(files.appLayout);
+for (const snippet of ["surface?: 'access' | 'payouts'", "href: '/admin/payouts'", "surface: 'payouts'"]) {
+  if (!appLayout.includes(snippet)) {
+    fail(`AppLayout missing payouts navigation snippet: ${snippet}`);
+  }
+}
+
+const navbar = readText(files.navbar);
+if (!navbar.includes("allowedAdminSurfaces.has('payouts')")) {
+  fail('Navbar must expose the admin app entry for payout managers.');
+}
+
+const i18n = readText(files.i18n);
+if (!i18n.includes("'admin.payouts'") || !i18n.includes("'admin.payoutsDescription'")) {
+  fail('i18n missing admin payout labels.');
+}
+
+const rpcSurface = readText(files.rpcSurface);
+for (const snippet of ['operator_can_finalize_payout_run', 'operator_capture_payout_run_review_snapshot']) {
+  if (!rpcSurface.includes(snippet)) {
+    fail(`RPC surface validator missing service-only helper ${snippet}.`);
+  }
+}
+
+const packageJson = readText(files.packageJson);
+if (!packageJson.includes('operator-payouts:validate-review')) {
+  fail('package.json missing review validator script.');
+}
+
+const smoke = readText(files.smoke);
+if (!smoke.includes('Admin Operator Payout Review')) {
+  fail('Smoke checklist missing Admin Operator Payout Review coverage.');
+}
+
+const status = readText(files.status);
+if (!status.includes('Manager review/finalization slice `#448`')) {
+  fail('CURRENT_STATUS missing #448 payout review update.');
+}
+
+const actionOrder = ['draft', 'review', 'finalized', 'reopened', 'voided'];
+if (!actionOrder.includes('finalized') || !actionOrder.includes('reopened')) {
+  fail('review workflow status fixture is invalid.');
+}
+
+console.log(
+  'Operator payout review checks passed: scoped admin surface, review queue UI, immutable snapshots, blocker-aware finalization, duplicate statement guard, reopen/void audit flow, and smoke coverage are present.'
+);

--- a/scripts/validate-rpc-execute-surface.mjs
+++ b/scripts/validate-rpc-execute-surface.mjs
@@ -89,6 +89,16 @@ const serviceRoleOnlyFunctions = [
     name: 'operator_payout_effective_rule_value',
     migrationName: '202605200004_operator_payout_calculation_engine.sql',
   },
+  {
+    signature: 'public.operator_can_finalize_payout_run(uuid, uuid)',
+    name: 'operator_can_finalize_payout_run',
+    migrationName: '202605200005_operator_payout_review_workflow.sql',
+  },
+  {
+    signature: 'public.operator_capture_payout_run_review_snapshot(uuid, uuid, text, text)',
+    name: 'operator_capture_payout_run_review_snapshot',
+    migrationName: '202605200005_operator_payout_review_workflow.sql',
+  },
 ];
 
 const protectedAuthenticatedFunctions = [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,6 +66,7 @@ const AdminPartnerRecords = lazyRoute(() => import("./pages/admin/PartnerRecords
 const AdminMachines = lazyRoute(() => import("./pages/admin/Machines"));
 const AdminPartnerships = lazyRoute(() => import("./pages/admin/Partnerships"));
 const AdminReporting = lazyRoute(() => import("./pages/admin/Reporting"));
+const AdminPayouts = lazyRoute(() => import("./pages/admin/Payouts"));
 const AdminRefunds = lazyRoute(() => import("./pages/admin/Refunds"));
 const NotFound = lazyRoute(() => import("./pages/NotFound"));
 
@@ -201,6 +202,7 @@ export const AppShell = () => (
               />
               <Route path="/admin/partnerships" element={<AdminPartnerships />} />
               <Route path="/admin/reporting" element={<AdminReporting />} />
+              <Route path="/admin/payouts" element={<AdminPayouts />} />
               <Route path="/admin/refunds" element={<RedirectWithSearch to="/portal/refunds" />} />
               <Route
                 path="/admin/audit"

--- a/src/components/auth/AdminRoute.tsx
+++ b/src/components/auth/AdminRoute.tsx
@@ -25,12 +25,19 @@ export function AdminRoute() {
     return <Outlet />;
   }
 
-  if (!isSuperAdmin && canAccessSurface('refunds') && location.pathname === '/admin') {
+  if (
+    !isSuperAdmin &&
+    canAccessSurface('refunds') &&
+    !canAccessSurface('payouts') &&
+    location.pathname === '/admin'
+  ) {
     return <Navigate to="/portal/refunds" replace />;
   }
 
   if (!isSuperAdmin && isAdmin && location.pathname === '/admin') {
-    const redirectTarget = canAccessSurface('refunds')
+    const redirectTarget = canAccessSurface('payouts')
+      ? '/admin/payouts'
+      : canAccessSurface('refunds')
       ? '/portal/refunds'
       : '/admin/access?tab=reporting-access';
     return <Navigate to={redirectTarget} replace />;
@@ -41,6 +48,10 @@ export function AdminRoute() {
   }
 
   if (canAccessSurface('refunds') && location.pathname.startsWith('/admin/refunds')) {
+    return <Outlet />;
+  }
+
+  if (canAccessSurface('payouts') && location.pathname.startsWith('/admin/payouts')) {
     return <Outlet />;
   }
 

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -12,6 +12,7 @@ import {
   LogOut,
   Menu,
   MonitorCog,
+  ReceiptText,
   Settings,
   Shield,
   ShoppingBag,
@@ -65,7 +66,7 @@ type AdminDestination = {
   descriptionKey: TranslationKey;
   icon: LucideIcon;
   requiresSuperAdmin?: boolean;
-  surface?: 'access';
+  surface?: 'access' | 'payouts';
 };
 
 const adminDestinations: AdminDestination[] = [
@@ -156,6 +157,17 @@ const adminDestinations: AdminDestination[] = [
     descriptionKey: 'admin.reportingDescription',
     icon: BarChart3,
     requiresSuperAdmin: true,
+  },
+  {
+    href: '/admin/payouts',
+    label: 'Payouts',
+    labelKey: 'admin.payouts',
+    shortLabel: 'Payouts',
+    shortLabelKey: 'admin.payouts',
+    description: 'Operator payout review, adjustments, finalization, and revision history.',
+    descriptionKey: 'admin.payoutsDescription',
+    icon: ReceiptText,
+    surface: 'payouts',
   },
 ];
 

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -28,7 +28,8 @@ export function Navbar() {
     isAdmin &&
     (isSuperAdmin ||
       allowedAdminSurfaces.has('*') ||
-      (isScopedAdmin && allowedAdminSurfaces.has('access')));
+      (isScopedAdmin && allowedAdminSurfaces.has('access')) ||
+      allowedAdminSurfaces.has('payouts'));
   const currentLocation = typeof window === 'undefined' ? undefined : window.location;
   const operatorAppUrl = getCanonicalUrlForSurface('app', '/portal', '', '', currentLocation);
   const operatorLoginUrl = getCanonicalUrlForSurface('app', '/login', '', '', currentLocation);

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -68,6 +68,9 @@ export const translations = {
       'Guided agreement setup, participants, assigned machines, split terms, and preview.',
     'admin.reporting': 'Reporting',
     'admin.reportingDescription': 'Report schedules, exports, and sync status.',
+    'admin.payouts': 'Payouts',
+    'admin.payoutsDescription':
+      'Operator payout review, adjustments, finalization, and revision history.',
     'admin.refunds': 'Refunds',
     'admin.refundsDescription':
       'Refund intake, correlation evidence, manager decisions, and settlement readiness.',
@@ -644,6 +647,8 @@ export const translations = {
     'admin.partnershipsDescription': '协议设置、参与方、分配机器、分账条款和预览。',
     'admin.reporting': '报表',
     'admin.reportingDescription': '报表计划、导出和同步状态。',
+    'admin.payouts': '结算',
+    'admin.payoutsDescription': '操作员结算审核、调整、最终确认和修订记录。',
 
     'portal.memberPortal': '会员门户',
     'portal.description': '在订单、设置、培训、入门和支持之间切换，不丢失上下文。',

--- a/src/lib/operatorPayouts.ts
+++ b/src/lib/operatorPayouts.ts
@@ -274,6 +274,68 @@ export type PayoutCalculationContext = {
   payoutRun: PayoutRun | null;
 };
 
+export type PayoutReviewAccount = {
+  id: string;
+  name: string;
+};
+
+export type PayoutReviewSnapshot = {
+  id: string;
+  payoutRunId: string;
+  revisionNumber: number;
+  action: 'marked_reviewed' | 'finalized' | 'reopened' | 'voided';
+  previousStatus: PayoutRunStatus;
+  revisionReason: string;
+  createdAt: string;
+};
+
+export type PayoutReviewPeriod = OperatorPayoutPeriodContext & {
+  accountId: string;
+  accountName: string;
+  payoutRun: PayoutRun | null;
+  canReview: boolean;
+  canFinalize: boolean;
+  hasBlockers: boolean;
+  issuedStatementCount: number;
+  revisionCount: number;
+};
+
+export type PayoutReviewContext = {
+  accounts: PayoutReviewAccount[];
+  periods: PayoutReviewPeriod[];
+};
+
+export type PayoutReviewWorkflowResult = {
+  payoutRun: PayoutRun;
+  reviewSnapshot?: PayoutReviewSnapshot;
+  finalized?: boolean;
+  reopened?: boolean;
+  voided?: boolean;
+  overrideBlockers?: boolean;
+};
+
+export type MarkPayoutRunReviewedInput = {
+  payoutRunId: string;
+  reason: string;
+};
+
+export type FinalizePayoutRunInput = {
+  payoutRunId: string;
+  reason: string;
+  overrideBlockers?: boolean;
+  overrideReason?: string | null;
+};
+
+export type ReopenPayoutRunInput = {
+  payoutRunId: string;
+  reason: string;
+};
+
+export type VoidPayoutRunInput = {
+  payoutRunId: string;
+  reason: string;
+};
+
 export type OperatorPayoutProfileContext = {
   id: string;
   accountId: string;
@@ -737,6 +799,88 @@ export const addPayoutAdjustmentAdmin = async ({
   }
 
   return data as AddPayoutAdjustmentResult;
+};
+
+export const fetchPayoutReviewContext = async (): Promise<PayoutReviewContext> => {
+  const { data, error } = await supabaseClient.rpc('get_payout_review_context');
+
+  if (error) {
+    throw new Error(error.message || 'Unable to load payout review context.');
+  }
+
+  return {
+    accounts: [],
+    periods: [],
+    ...((data as Partial<PayoutReviewContext> | null) ?? {}),
+  };
+};
+
+export const markPayoutRunReviewedAdmin = async ({
+  payoutRunId,
+  reason,
+}: MarkPayoutRunReviewedInput): Promise<PayoutReviewWorkflowResult> => {
+  const { data, error } = await supabaseClient.rpc('admin_mark_payout_run_reviewed', {
+    p_payout_run_id: payoutRunId,
+    p_reason: reason,
+  });
+
+  if (error || !data) {
+    throw new Error(error?.message || 'Unable to mark payout run reviewed.');
+  }
+
+  return data as PayoutReviewWorkflowResult;
+};
+
+export const finalizePayoutRunAdmin = async ({
+  payoutRunId,
+  reason,
+  overrideBlockers = false,
+  overrideReason = null,
+}: FinalizePayoutRunInput): Promise<PayoutReviewWorkflowResult> => {
+  const { data, error } = await supabaseClient.rpc('admin_finalize_payout_run', {
+    p_payout_run_id: payoutRunId,
+    p_reason: reason,
+    p_override_blockers: overrideBlockers,
+    p_override_reason: overrideReason,
+  });
+
+  if (error || !data) {
+    throw new Error(error?.message || 'Unable to finalize payout run.');
+  }
+
+  return data as PayoutReviewWorkflowResult;
+};
+
+export const reopenPayoutRunAdmin = async ({
+  payoutRunId,
+  reason,
+}: ReopenPayoutRunInput): Promise<PayoutReviewWorkflowResult> => {
+  const { data, error } = await supabaseClient.rpc('admin_reopen_payout_run', {
+    p_payout_run_id: payoutRunId,
+    p_reason: reason,
+  });
+
+  if (error || !data) {
+    throw new Error(error?.message || 'Unable to reopen payout run.');
+  }
+
+  return data as PayoutReviewWorkflowResult;
+};
+
+export const voidPayoutRunAdmin = async ({
+  payoutRunId,
+  reason,
+}: VoidPayoutRunInput): Promise<PayoutReviewWorkflowResult> => {
+  const { data, error } = await supabaseClient.rpc('admin_void_payout_run', {
+    p_payout_run_id: payoutRunId,
+    p_reason: reason,
+  });
+
+  if (error || !data) {
+    throw new Error(error?.message || 'Unable to void payout run.');
+  }
+
+  return data as PayoutReviewWorkflowResult;
 };
 
 export const upsertOperatorPayoutProfileAdmin = async ({

--- a/src/pages/admin/Dashboard.tsx
+++ b/src/pages/admin/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { BarChart3, Handshake, ShieldCheck, ShoppingBag, LifeBuoy, Users, Building2, MonitorCog } from 'lucide-react';
+import { BarChart3, Handshake, ShieldCheck, ShoppingBag, LifeBuoy, Users, Building2, MonitorCog, ReceiptText } from 'lucide-react';
 import { AppLayout } from '@/components/layout/AppLayout';
 import { Button } from '@/components/ui/button';
 
@@ -45,6 +45,12 @@ const adminModules = [
     description: 'Monitor schedules, report exports, and sales sync status.',
     icon: BarChart3,
     href: '/admin/reporting',
+  },
+  {
+    title: 'Payouts',
+    description: 'Review operator payout runs, adjustments, warnings, and finalization history.',
+    icon: ReceiptText,
+    href: '/admin/payouts',
   },
 ];
 

--- a/src/pages/admin/Payouts.tsx
+++ b/src/pages/admin/Payouts.tsx
@@ -1,0 +1,849 @@
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import {
+  AlertTriangle,
+  Ban,
+  CheckCircle2,
+  Clock3,
+  Loader2,
+  RefreshCw,
+  RotateCcw,
+  ShieldCheck,
+} from 'lucide-react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { AppLayout } from '@/components/layout/AppLayout';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  addPayoutAdjustmentAdmin,
+  calculatePayoutRunAdmin,
+  fetchPayoutReviewContext,
+  finalizePayoutRunAdmin,
+  markPayoutRunReviewedAdmin,
+  reopenPayoutRunAdmin,
+  voidPayoutRunAdmin,
+  type PayoutCalculationWarning,
+  type PayoutReviewPeriod,
+  type PayoutRun,
+  type PayoutRunItem,
+} from '@/lib/operatorPayouts';
+import { cn } from '@/lib/utils';
+
+type ReviewAction = 'mark_reviewed' | 'finalize' | 'reopen' | 'void';
+
+const statusVariant = (status: string): 'default' | 'destructive' | 'outline' => {
+  if (['finalized', 'issued', 'closed', 'reviewed'].includes(status)) return 'default';
+  if (status === 'voided') return 'destructive';
+  return 'outline';
+};
+
+const warningVariant = (severity: string): 'default' | 'destructive' | 'outline' =>
+  severity === 'blocker' ? 'destructive' : severity === 'warning' ? 'outline' : 'default';
+
+const formatStatus = (value: string) =>
+  value.replace(/_/g, ' ').replace(/\b\w/g, (letter) => letter.toUpperCase());
+
+const formatDate = (value: string | null | undefined) =>
+  value
+    ? new Date(`${value}T00:00:00`).toLocaleDateString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      })
+    : 'n/a';
+
+const formatCurrency = (cents: number | null | undefined) =>
+  new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency: 'USD',
+  }).format((cents ?? 0) / 100);
+
+const formatHours = (minutes: number) => `${(minutes / 60).toFixed(2)}h`;
+
+const centsFromCurrency = (value: string) => {
+  const normalized = value.replace(/[$,\s]/g, '');
+  if (!normalized) return null;
+  const numeric = Number(normalized);
+  if (!Number.isFinite(numeric) || numeric === 0) return null;
+  return Math.round(numeric * 100);
+};
+
+const collectWarnings = (run: PayoutRun | null): PayoutCalculationWarning[] => [
+  ...(run?.warnings ?? []),
+  ...(run?.items.flatMap((item) => item.warnings) ?? []),
+];
+
+const Metric = ({
+  label,
+  value,
+  tone = 'default',
+}: {
+  label: string;
+  value: string;
+  tone?: 'default' | 'good' | 'warning';
+}) => (
+  <div
+    className={cn(
+      'rounded-lg border bg-background p-4',
+      tone === 'good' && 'border-sage/30 bg-sage-light',
+      tone === 'warning' && 'border-amber/30 bg-amber/10'
+    )}
+  >
+    <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+      {label}
+    </p>
+    <p className="mt-2 text-2xl font-semibold text-foreground">{value}</p>
+  </div>
+);
+
+const EmptyState = ({ title, children }: { title: string; children: ReactNode }) => (
+  <div className="rounded-lg border border-dashed border-border bg-muted/20 p-6 text-sm">
+    <h2 className="font-semibold text-foreground">{title}</h2>
+    <p className="mt-2 text-muted-foreground">{children}</p>
+  </div>
+);
+
+const PeriodCard = ({
+  period,
+  selected,
+  onSelect,
+}: {
+  period: PayoutReviewPeriod;
+  selected: boolean;
+  onSelect: () => void;
+}) => {
+  const run = period.payoutRun;
+  const warningCount = collectWarnings(run).length;
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        'w-full rounded-lg border p-4 text-left transition-colors',
+        selected
+          ? 'border-primary/40 bg-primary/10'
+          : 'border-border bg-background hover:bg-muted/40'
+      )}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-semibold text-foreground">{period.accountName}</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {formatDate(period.periodStartDate)} - {formatDate(period.periodEndDate)}
+          </p>
+        </div>
+        <Badge variant={statusVariant(run?.status ?? period.status)}>
+          {formatStatus(run?.status ?? period.status)}
+        </Badge>
+      </div>
+      <div className="mt-3 flex flex-wrap gap-2 text-xs text-muted-foreground">
+        <span>{formatCurrency(run?.totalPayoutCents ?? 0)}</span>
+        <span>{run?.items.length ?? 0} operators</span>
+        {warningCount > 0 && <span>{warningCount} warnings</span>}
+        {period.revisionCount > 0 && <span>{period.revisionCount} revisions</span>}
+      </div>
+    </button>
+  );
+};
+
+const OperatorItemCard = ({ item }: { item: PayoutRunItem }) => (
+  <div className="rounded-lg border border-border bg-background p-4">
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+      <div>
+        <h3 className="font-semibold text-foreground">{item.operatorDisplayName}</h3>
+        <div className="mt-2 flex flex-wrap gap-2">
+          <Badge variant={statusVariant(item.status)}>{formatStatus(item.status)}</Badge>
+          <Badge variant="outline">{formatHours(item.roundedPaidMinutes)}</Badge>
+          <Badge variant="outline">{item.shiftCount} shifts</Badge>
+        </div>
+      </div>
+      <div className="text-left sm:text-right">
+        <p className="text-lg font-semibold text-foreground">
+          {formatCurrency(item.totalPayoutCents)}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {formatCurrency(item.hourlyPayCents)} hourly / {formatCurrency(item.commissionPayCents)} commission
+        </p>
+      </div>
+    </div>
+
+    {item.warnings.length > 0 && (
+      <div className="mt-4 space-y-2">
+        {item.warnings.map((warning, index) => (
+          <div
+            key={`${warning.code}-${index}`}
+            className="rounded-md border border-amber/30 bg-amber/10 p-3 text-xs text-amber-900"
+          >
+            <span className="font-semibold">{formatStatus(warning.severity)}:</span>{' '}
+            {warning.message}
+          </div>
+        ))}
+      </div>
+    )}
+
+    <div className="mt-4 overflow-x-auto">
+      <table className="min-w-full text-left text-sm">
+        <thead className="text-xs uppercase text-muted-foreground">
+          <tr>
+            <th className="py-2 pr-4 font-semibold">Machine</th>
+            <th className="py-2 pr-4 font-semibold">Time</th>
+            <th className="py-2 pr-4 font-semibold">Revenue</th>
+            <th className="py-2 pr-4 font-semibold">Commission</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border">
+          {item.machines.map((machine) => (
+            <tr key={machine.id}>
+              <td className="py-2 pr-4">
+                <span className="block font-medium text-foreground">{machine.machineLabel}</span>
+                <span className="text-xs text-muted-foreground">{machine.locationName}</span>
+              </td>
+              <td className="py-2 pr-4">{formatHours(machine.roundedPaidMinutes)}</td>
+              <td className="py-2 pr-4">{formatCurrency(machine.eligibleNetRevenueCents)}</td>
+              <td className="py-2 pr-4">{formatCurrency(machine.commissionPayCents)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+
+    {item.adjustments.length > 0 && (
+      <div className="mt-4 rounded-md border border-border bg-muted/20 p-3">
+        <p className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+          Adjustments
+        </p>
+        <div className="mt-2 space-y-2 text-sm">
+          {item.adjustments.map((adjustment) => (
+            <div key={adjustment.id} className="flex items-start justify-between gap-3">
+              <span className="text-muted-foreground">{adjustment.description}</span>
+              <span className="font-medium text-foreground">
+                {formatCurrency(adjustment.amountCents)}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    )}
+  </div>
+);
+
+export default function AdminPayoutsPage() {
+  const queryClient = useQueryClient();
+  const [selectedPeriodId, setSelectedPeriodId] = useState<string>('');
+  const [calculateReason, setCalculateReason] = useState('');
+  const [isCalculating, setIsCalculating] = useState(false);
+  const [action, setAction] = useState<ReviewAction | null>(null);
+  const [actionReason, setActionReason] = useState('');
+  const [overrideBlockers, setOverrideBlockers] = useState(false);
+  const [overrideReason, setOverrideReason] = useState('');
+  const [adjustmentForm, setAdjustmentForm] = useState({
+    operatorProfileId: '',
+    amount: '',
+    adjustmentType: 'manual_adjustment',
+    description: '',
+    reason: '',
+    visibleToOperator: true,
+  });
+  const [isAddingAdjustment, setIsAddingAdjustment] = useState(false);
+  const [isRunningAction, setIsRunningAction] = useState(false);
+
+  const {
+    data: reviewContext,
+    isLoading,
+    isFetching,
+    error,
+  } = useQuery({
+    queryKey: ['admin-payout-review-context'],
+    queryFn: fetchPayoutReviewContext,
+    staleTime: 1000 * 20,
+  });
+
+  const periods = useMemo(() => reviewContext?.periods ?? [], [reviewContext?.periods]);
+  const selectedPeriod = useMemo(
+    () => periods.find((period) => period.id === selectedPeriodId) ?? periods[0] ?? null,
+    [periods, selectedPeriodId]
+  );
+  const selectedRun = selectedPeriod?.payoutRun ?? null;
+  const warnings = useMemo(() => collectWarnings(selectedRun), [selectedRun]);
+  const blockerCount = warnings.filter((warning) => warning.severity === 'blocker').length;
+  const canMutateRun =
+    Boolean(selectedPeriod?.canFinalize) &&
+    Boolean(selectedRun) &&
+    ['draft', 'review', 'reopened'].includes(selectedRun?.status ?? '');
+
+  useEffect(() => {
+    if (!selectedPeriodId && periods[0]) {
+      setSelectedPeriodId(periods[0].id);
+    }
+  }, [periods, selectedPeriodId]);
+
+  useEffect(() => {
+    const firstOperator = selectedRun?.items[0]?.operatorProfileId ?? '';
+    setAdjustmentForm((current) => ({
+      ...current,
+      operatorProfileId: firstOperator,
+    }));
+  }, [selectedRun?.id, selectedRun?.items]);
+
+  const refresh = () =>
+    queryClient.invalidateQueries({ queryKey: ['admin-payout-review-context'] });
+
+  const runCalculation = async () => {
+    if (!selectedPeriod) return;
+    const existingRun = Boolean(selectedPeriod.payoutRun);
+
+    if (existingRun && !calculateReason.trim()) {
+      toast.error('Enter a recalculation reason before regenerating this payout run.');
+      return;
+    }
+
+    setIsCalculating(true);
+    try {
+      await calculatePayoutRunAdmin({
+        payoutPeriodId: selectedPeriod.id,
+        regenerate: existingRun,
+        reason: calculateReason.trim() || null,
+      });
+      toast.success(existingRun ? 'Payout run recalculated.' : 'Payout run generated.');
+      setCalculateReason('');
+      await refresh();
+    } catch (calculationError) {
+      toast.error(
+        calculationError instanceof Error
+          ? calculationError.message
+          : 'Unable to calculate payout run.'
+      );
+    } finally {
+      setIsCalculating(false);
+    }
+  };
+
+  const resetActionDialog = () => {
+    setAction(null);
+    setActionReason('');
+    setOverrideBlockers(false);
+    setOverrideReason('');
+  };
+
+  const runReviewAction = async () => {
+    if (!selectedRun || !action) return;
+
+    if (!actionReason.trim()) {
+      toast.error('Enter an audit reason before saving this payout action.');
+      return;
+    }
+
+    if (action === 'finalize' && overrideBlockers && !overrideReason.trim()) {
+      toast.error('Enter an override reason for critical payout warnings.');
+      return;
+    }
+
+    setIsRunningAction(true);
+    try {
+      if (action === 'mark_reviewed') {
+        await markPayoutRunReviewedAdmin({
+          payoutRunId: selectedRun.id,
+          reason: actionReason.trim(),
+        });
+        toast.success('Payout run marked reviewed.');
+      }
+
+      if (action === 'finalize') {
+        await finalizePayoutRunAdmin({
+          payoutRunId: selectedRun.id,
+          reason: actionReason.trim(),
+          overrideBlockers,
+          overrideReason: overrideBlockers ? overrideReason.trim() : null,
+        });
+        toast.success('Payout run finalized.');
+      }
+
+      if (action === 'reopen') {
+        await reopenPayoutRunAdmin({
+          payoutRunId: selectedRun.id,
+          reason: actionReason.trim(),
+        });
+        toast.success('Payout run reopened.');
+      }
+
+      if (action === 'void') {
+        await voidPayoutRunAdmin({
+          payoutRunId: selectedRun.id,
+          reason: actionReason.trim(),
+        });
+        toast.success('Payout run voided.');
+      }
+
+      resetActionDialog();
+      await refresh();
+    } catch (actionError) {
+      toast.error(actionError instanceof Error ? actionError.message : 'Unable to update payout run.');
+    } finally {
+      setIsRunningAction(false);
+    }
+  };
+
+  const addAdjustment = async () => {
+    if (!selectedRun) return;
+    const amountCents = centsFromCurrency(adjustmentForm.amount);
+
+    if (!adjustmentForm.operatorProfileId) {
+      toast.error('Choose an operator for the adjustment.');
+      return;
+    }
+
+    if (amountCents === null) {
+      toast.error('Enter a non-zero adjustment amount.');
+      return;
+    }
+
+    if (!adjustmentForm.description.trim() || !adjustmentForm.reason.trim()) {
+      toast.error('Adjustment description and audit reason are required.');
+      return;
+    }
+
+    setIsAddingAdjustment(true);
+    try {
+      await addPayoutAdjustmentAdmin({
+        payoutRunId: selectedRun.id,
+        operatorProfileId: adjustmentForm.operatorProfileId,
+        amountCents,
+        adjustmentType: adjustmentForm.adjustmentType,
+        description: adjustmentForm.description.trim(),
+        visibleToOperator: adjustmentForm.visibleToOperator,
+        reason: adjustmentForm.reason.trim(),
+      });
+      toast.success('Adjustment added and payout run recalculated.');
+      setAdjustmentForm((current) => ({
+        ...current,
+        amount: '',
+        description: '',
+        reason: '',
+      }));
+      await refresh();
+    } catch (adjustmentError) {
+      toast.error(
+        adjustmentError instanceof Error ? adjustmentError.message : 'Unable to add adjustment.'
+      );
+    } finally {
+      setIsAddingAdjustment(false);
+    }
+  };
+
+  const actionTitle =
+    action === 'mark_reviewed'
+      ? 'Mark Reviewed'
+      : action === 'finalize'
+        ? 'Finalize Payout'
+        : action === 'reopen'
+          ? 'Reopen Payout'
+          : 'Void Payout';
+
+  return (
+    <AppLayout>
+      <section className="border-b border-border bg-muted/20">
+        <div className="container-page py-8">
+          <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                Operator Payouts
+              </p>
+              <h1 className="mt-2 font-display text-3xl font-bold text-foreground">
+                Payout Review
+              </h1>
+              <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+                Review assigned-machine time, revenue snapshots, compensation rules, warnings,
+                adjustments, and finalization history before pay statements are issued.
+              </p>
+            </div>
+            <Button variant="outline" onClick={() => void refresh()} disabled={isFetching}>
+              {isFetching ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <RefreshCw className="mr-2 h-4 w-4" />
+              )}
+              Refresh
+            </Button>
+          </div>
+        </div>
+      </section>
+
+      <section className="section-padding">
+        <div className="container-page">
+          {isLoading ? (
+            <EmptyState title="Loading payout review">
+              Pulling the latest payout periods, review states, and scoped manager permissions.
+            </EmptyState>
+          ) : error ? (
+            <EmptyState title="Unable to load payouts">
+              {error instanceof Error ? error.message : 'The payout review queue could not load.'}
+            </EmptyState>
+          ) : periods.length === 0 ? (
+            <EmptyState title="No payout periods ready">
+              Create an operator payout profile and payout period first. Payout review appears here
+              after a period has assigned time or a generated payout run.
+            </EmptyState>
+          ) : (
+            <div className="grid gap-6 lg:grid-cols-[minmax(260px,360px)_1fr]">
+              <aside className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <h2 className="font-semibold text-foreground">Periods</h2>
+                  <Badge variant="outline">{periods.length}</Badge>
+                </div>
+                {periods.map((period) => (
+                  <PeriodCard
+                    key={period.id}
+                    period={period}
+                    selected={selectedPeriod?.id === period.id}
+                    onSelect={() => setSelectedPeriodId(period.id)}
+                  />
+                ))}
+              </aside>
+
+              <div className="space-y-6">
+                <div className="rounded-lg border border-border bg-background p-5">
+                  <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                    <div>
+                      <div className="flex flex-wrap items-center gap-2">
+                        <h2 className="font-display text-2xl font-semibold text-foreground">
+                          {selectedPeriod?.accountName}
+                        </h2>
+                        <Badge variant={statusVariant(selectedRun?.status ?? selectedPeriod?.status ?? '')}>
+                          {formatStatus(selectedRun?.status ?? selectedPeriod?.status ?? '')}
+                        </Badge>
+                        {selectedPeriod?.canFinalize && (
+                          <Badge variant="outline" className="gap-1">
+                            <ShieldCheck className="h-3.5 w-3.5" />
+                            Review access
+                          </Badge>
+                        )}
+                      </div>
+                      <p className="mt-2 text-sm text-muted-foreground">
+                        {formatDate(selectedPeriod?.periodStartDate)} -{' '}
+                        {formatDate(selectedPeriod?.periodEndDate)} / target payout{' '}
+                        {formatDate(selectedPeriod?.targetPayoutDate)}
+                      </p>
+                      {selectedPeriod?.issuedStatementCount ? (
+                        <p className="mt-2 text-sm text-destructive">
+                          {selectedPeriod.issuedStatementCount} issued statements already exist;
+                          finalization is blocked to prevent duplicates.
+                        </p>
+                      ) : null}
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <Button
+                        variant="outline"
+                        onClick={() => setAction('mark_reviewed')}
+                        disabled={!canMutateRun}
+                      >
+                        <CheckCircle2 className="mr-2 h-4 w-4" />
+                        Mark Reviewed
+                      </Button>
+                      <Button
+                        onClick={() => setAction('finalize')}
+                        disabled={!canMutateRun || Boolean(selectedPeriod?.issuedStatementCount)}
+                      >
+                        <ShieldCheck className="mr-2 h-4 w-4" />
+                        Finalize
+                      </Button>
+                      <Button
+                        variant="outline"
+                        onClick={() => setAction('reopen')}
+                        disabled={!selectedRun || !selectedPeriod?.canFinalize}
+                      >
+                        <RotateCcw className="mr-2 h-4 w-4" />
+                        Reopen
+                      </Button>
+                      <Button
+                        variant="outline"
+                        onClick={() => setAction('void')}
+                        disabled={!selectedRun || !selectedPeriod?.canFinalize}
+                      >
+                        <Ban className="mr-2 h-4 w-4" />
+                        Void
+                      </Button>
+                    </div>
+                  </div>
+
+                  <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                    <Metric label="Total payout" value={formatCurrency(selectedRun?.totalPayoutCents)} tone="good" />
+                    <Metric label="Operators" value={`${selectedRun?.items.length ?? 0}`} />
+                    <Metric label="Paid hours" value={formatHours(selectedRun?.totalRoundedPaidMinutes ?? 0)} />
+                    <Metric
+                      label="Warnings"
+                      value={`${warnings.length}`}
+                      tone={blockerCount > 0 ? 'warning' : 'default'}
+                    />
+                  </div>
+                </div>
+
+                <div className="rounded-lg border border-border bg-background p-5">
+                  <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+                    <div>
+                      <h2 className="font-semibold text-foreground">Calculation</h2>
+                      <p className="mt-1 text-sm text-muted-foreground">
+                        Generate the first payout run or regenerate after corrections. Existing
+                        runs require an audit reason.
+                      </p>
+                    </div>
+                    <Button onClick={() => void runCalculation()} disabled={isCalculating || !selectedPeriod}>
+                      {isCalculating ? (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      ) : (
+                        <Clock3 className="mr-2 h-4 w-4" />
+                      )}
+                      {selectedRun ? 'Recalculate' : 'Generate'}
+                    </Button>
+                  </div>
+                  <div className="mt-4">
+                    <Label htmlFor="payout-calculate-reason">Audit reason</Label>
+                    <Textarea
+                      id="payout-calculate-reason"
+                      value={calculateReason}
+                      onChange={(event) => setCalculateReason(event.target.value)}
+                      placeholder="Explain the correction, override, or source-data refresh."
+                      className="mt-2"
+                    />
+                  </div>
+                </div>
+
+                {warnings.length > 0 && (
+                  <div className="rounded-lg border border-amber/30 bg-amber/10 p-5">
+                    <div className="flex items-start gap-3">
+                      <AlertTriangle className="mt-0.5 h-5 w-5 text-amber-700" />
+                      <div>
+                        <h2 className="font-semibold text-foreground">Warnings</h2>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                          Critical warnings block finalization unless a manager records an
+                          explicit override reason.
+                        </p>
+                      </div>
+                    </div>
+                    <div className="mt-4 space-y-2">
+                      {warnings.map((warning, index) => (
+                        <div
+                          key={`${warning.code}-${index}`}
+                          className="rounded-md border border-border bg-background p-3 text-sm"
+                        >
+                          <Badge variant={warningVariant(warning.severity)}>
+                            {formatStatus(warning.severity)}
+                          </Badge>
+                          <p className="mt-2 font-medium text-foreground">{warning.message}</p>
+                          <p className="mt-1 text-xs text-muted-foreground">{warning.code}</p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {selectedRun && (
+                  <div className="rounded-lg border border-border bg-background p-5">
+                    <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                      <div>
+                        <h2 className="font-semibold text-foreground">Manual Adjustment</h2>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                          Add bonuses, reimbursements, corrections, or deductions with both an
+                          operator-visible description and manager audit reason.
+                        </p>
+                      </div>
+                      <Button
+                        variant="outline"
+                        onClick={() => void addAdjustment()}
+                        disabled={!canMutateRun || isAddingAdjustment}
+                      >
+                        {isAddingAdjustment && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                        Add Adjustment
+                      </Button>
+                    </div>
+                    <div className="mt-4 grid gap-4 md:grid-cols-2">
+                      <div>
+                        <Label htmlFor="adjustment-operator">Operator</Label>
+                        <select
+                          id="adjustment-operator"
+                          value={adjustmentForm.operatorProfileId}
+                          onChange={(event) =>
+                            setAdjustmentForm((current) => ({
+                              ...current,
+                              operatorProfileId: event.target.value,
+                            }))
+                          }
+                          className="mt-2 h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                        >
+                          {selectedRun.items.map((item) => (
+                            <option key={item.id} value={item.operatorProfileId}>
+                              {item.operatorDisplayName}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                      <div>
+                        <Label htmlFor="adjustment-amount">Amount</Label>
+                        <Input
+                          id="adjustment-amount"
+                          value={adjustmentForm.amount}
+                          onChange={(event) =>
+                            setAdjustmentForm((current) => ({
+                              ...current,
+                              amount: event.target.value,
+                            }))
+                          }
+                          placeholder="75.00 or -25.00"
+                          className="mt-2"
+                        />
+                      </div>
+                      <div>
+                        <Label htmlFor="adjustment-type">Type</Label>
+                        <select
+                          id="adjustment-type"
+                          value={adjustmentForm.adjustmentType}
+                          onChange={(event) =>
+                            setAdjustmentForm((current) => ({
+                              ...current,
+                              adjustmentType: event.target.value,
+                            }))
+                          }
+                          className="mt-2 h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                        >
+                          <option value="manual_adjustment">Manual adjustment</option>
+                          <option value="bonus">Bonus</option>
+                          <option value="reimbursement">Reimbursement</option>
+                          <option value="prior_period_correction">Prior period correction</option>
+                          <option value="deduction">Deduction</option>
+                        </select>
+                      </div>
+                      <label className="flex items-center gap-2 pt-7 text-sm text-muted-foreground">
+                        <input
+                          type="checkbox"
+                          checked={adjustmentForm.visibleToOperator}
+                          onChange={(event) =>
+                            setAdjustmentForm((current) => ({
+                              ...current,
+                              visibleToOperator: event.target.checked,
+                            }))
+                          }
+                        />
+                        Show on operator statement
+                      </label>
+                      <div className="md:col-span-2">
+                        <Label htmlFor="adjustment-description">Operator-visible description</Label>
+                        <Input
+                          id="adjustment-description"
+                          value={adjustmentForm.description}
+                          onChange={(event) =>
+                            setAdjustmentForm((current) => ({
+                              ...current,
+                              description: event.target.value,
+                            }))
+                          }
+                          placeholder="Weekend event bonus"
+                          className="mt-2"
+                        />
+                      </div>
+                      <div className="md:col-span-2">
+                        <Label htmlFor="adjustment-reason">Manager audit reason</Label>
+                        <Textarea
+                          id="adjustment-reason"
+                          value={adjustmentForm.reason}
+                          onChange={(event) =>
+                            setAdjustmentForm((current) => ({
+                              ...current,
+                              reason: event.target.value,
+                            }))
+                          }
+                          placeholder="Approved by operations after event review."
+                          className="mt-2"
+                        />
+                      </div>
+                    </div>
+                  </div>
+                )}
+
+                {selectedRun ? (
+                  <div className="space-y-4">
+                    {selectedRun.items.map((item) => (
+                      <OperatorItemCard key={item.id} item={item} />
+                    ))}
+                  </div>
+                ) : (
+                  <EmptyState title="No payout run yet">
+                    Generate a payout run after operators have submitted time for this period.
+                  </EmptyState>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
+
+      <Dialog open={Boolean(action)} onOpenChange={(open) => !open && resetActionDialog()}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{actionTitle}</DialogTitle>
+            <DialogDescription>
+              This action writes an audit record and preserves a review snapshot before the payout
+              status changes.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div>
+              <Label htmlFor="payout-action-reason">Audit reason</Label>
+              <Textarea
+                id="payout-action-reason"
+                value={actionReason}
+                onChange={(event) => setActionReason(event.target.value)}
+                placeholder="Explain the review decision or correction."
+                className="mt-2"
+              />
+            </div>
+            {action === 'finalize' && blockerCount > 0 && (
+              <div className="rounded-lg border border-amber/30 bg-amber/10 p-3">
+                <label className="flex items-start gap-2 text-sm font-medium text-foreground">
+                  <input
+                    type="checkbox"
+                    checked={overrideBlockers}
+                    onChange={(event) => setOverrideBlockers(event.target.checked)}
+                    className="mt-1"
+                  />
+                  Finalize with critical warnings
+                </label>
+                {overrideBlockers && (
+                  <div className="mt-3">
+                    <Label htmlFor="payout-override-reason">Override reason</Label>
+                    <Textarea
+                      id="payout-override-reason"
+                      value={overrideReason}
+                      onChange={(event) => setOverrideReason(event.target.value)}
+                      placeholder="Document why the payout can proceed despite critical warnings."
+                      className="mt-2"
+                    />
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={resetActionDialog} disabled={isRunningAction}>
+              Cancel
+            </Button>
+            <Button onClick={() => void runReviewAction()} disabled={isRunningAction}>
+              {isRunningAction && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </AppLayout>
+  );
+}

--- a/supabase/migrations/202605200005_operator_payout_review_workflow.sql
+++ b/supabase/migrations/202605200005_operator_payout_review_workflow.sql
@@ -1,0 +1,1191 @@
+-- Operator payout review workflow: scoped manager review, blocker-aware
+-- finalization, reopen/void controls, and immutable review snapshots.
+
+create table if not exists public.payout_run_review_snapshots (
+  id uuid primary key default gen_random_uuid(),
+  payout_run_id uuid not null references public.payout_runs (id) on delete cascade,
+  account_id uuid not null references public.customer_accounts (id) on delete cascade,
+  payout_period_id uuid not null references public.payout_periods (id) on delete cascade,
+  revision_number integer not null check (revision_number > 0),
+  action text not null
+    check (action in ('marked_reviewed', 'finalized', 'reopened', 'voided')),
+  previous_status text not null,
+  revision_reason text not null,
+  run_snapshot jsonb not null default '{}'::jsonb,
+  item_snapshots jsonb not null default '[]'::jsonb,
+  created_by uuid references auth.users (id) on delete set null,
+  created_at timestamptz not null default now(),
+  constraint payout_run_review_snapshots_reason_present check (
+    length(trim(revision_reason)) > 0
+  )
+);
+
+create unique index if not exists payout_run_review_snapshots_run_revision_idx
+  on public.payout_run_review_snapshots (payout_run_id, revision_number);
+
+create index if not exists payout_run_review_snapshots_account_idx
+  on public.payout_run_review_snapshots (account_id, created_at desc);
+
+alter table public.payout_run_review_snapshots enable row level security;
+
+drop policy if exists "payout_run_review_snapshots_select_accessible"
+  on public.payout_run_review_snapshots;
+create policy "payout_run_review_snapshots_select_accessible"
+on public.payout_run_review_snapshots
+for select
+using (public.can_access_payout_run_current_user(payout_run_id));
+
+create or replace function public.operator_can_finalize_payout_run(
+  p_user_id uuid,
+  p_payout_run_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select p_user_id is not null
+    and p_payout_run_id is not null
+    and exists (
+      select 1
+      from public.payout_runs run
+      where run.id = p_payout_run_id
+        and (
+          public.can_manage_operator_payout_account(p_user_id, run.account_id)
+          or (
+            exists (
+              select 1
+              from public.payout_run_items item
+              join public.payout_run_item_machines item_machine
+                on item_machine.payout_run_item_id = item.id
+              where item.payout_run_id = run.id
+                and item.status <> 'voided'
+                and public.can_manage_operator_payout_machine(
+                  p_user_id,
+                  item_machine.reporting_machine_id
+                )
+            )
+            and not exists (
+              select 1
+              from public.payout_run_items item
+              join public.payout_run_item_machines item_machine
+                on item_machine.payout_run_item_id = item.id
+              where item.payout_run_id = run.id
+                and item.status <> 'voided'
+                and not public.can_manage_operator_payout_machine(
+                  p_user_id,
+                  item_machine.reporting_machine_id
+                )
+            )
+          )
+        )
+    );
+$$;
+
+create or replace function public.operator_capture_payout_run_review_snapshot(
+  p_payout_run_id uuid,
+  p_created_by uuid,
+  p_action text,
+  p_reason text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  normalized_action text;
+  normalized_reason text;
+  run_row public.payout_runs;
+  next_revision_number integer;
+  item_snapshots jsonb;
+  snapshot_row public.payout_run_review_snapshots;
+begin
+  normalized_action := lower(trim(coalesce(p_action, '')));
+  normalized_reason := trim(coalesce(p_reason, ''));
+
+  if normalized_action not in ('marked_reviewed', 'finalized', 'reopened', 'voided') then
+    raise exception 'Unsupported payout review snapshot action';
+  end if;
+
+  if normalized_reason = '' then
+    raise exception 'Payout review snapshot reason is required';
+  end if;
+
+  select *
+  into run_row
+  from public.payout_runs run
+  where run.id = p_payout_run_id
+  limit 1;
+
+  if run_row.id is null then
+    raise exception 'Payout run not found';
+  end if;
+
+  select coalesce(max(snapshot.revision_number), 0) + 1
+  into next_revision_number
+  from public.payout_run_review_snapshots snapshot
+  where snapshot.payout_run_id = run_row.id;
+
+  select coalesce(jsonb_agg(
+    jsonb_build_object(
+      'item', to_jsonb(item),
+      'machines', coalesce((
+        select jsonb_agg(to_jsonb(item_machine) order by item_machine.created_at)
+        from public.payout_run_item_machines item_machine
+        where item_machine.payout_run_item_id = item.id
+      ), '[]'::jsonb),
+      'adjustments', coalesce((
+        select jsonb_agg(to_jsonb(adjustment) order by adjustment.created_at)
+        from public.payout_adjustments adjustment
+        where adjustment.payout_run_id = run_row.id
+          and adjustment.operator_profile_id = item.operator_profile_id
+      ), '[]'::jsonb)
+    )
+    order by item.created_at, item.id
+  ), '[]'::jsonb)
+  into item_snapshots
+  from public.payout_run_items item
+  where item.payout_run_id = run_row.id;
+
+  insert into public.payout_run_review_snapshots (
+    payout_run_id,
+    account_id,
+    payout_period_id,
+    revision_number,
+    action,
+    previous_status,
+    revision_reason,
+    run_snapshot,
+    item_snapshots,
+    created_by
+  )
+  values (
+    run_row.id,
+    run_row.account_id,
+    run_row.payout_period_id,
+    next_revision_number,
+    normalized_action,
+    run_row.status,
+    normalized_reason,
+    to_jsonb(run_row),
+    item_snapshots,
+    p_created_by
+  )
+  returning * into snapshot_row;
+
+  return jsonb_build_object(
+    'id', snapshot_row.id,
+    'payoutRunId', snapshot_row.payout_run_id,
+    'revisionNumber', snapshot_row.revision_number,
+    'action', snapshot_row.action,
+    'previousStatus', snapshot_row.previous_status,
+    'revisionReason', snapshot_row.revision_reason,
+    'createdAt', snapshot_row.created_at
+  );
+end;
+$$;
+
+create or replace function public.can_access_admin_surface(
+  uid uuid,
+  surface text default null
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select
+    public.is_super_admin(uid)
+    or (
+      public.is_scoped_admin(uid)
+      and lower(coalesce(nullif(trim(surface), ''), 'access')) in (
+        'access',
+        'reporting_access',
+        'payouts'
+      )
+    )
+    or (
+      lower(coalesce(nullif(trim(surface), ''), 'access')) = 'payouts'
+      and (
+        exists (
+          select 1
+          from public.customer_accounts account
+          where public.can_manage_operator_payout_account(uid, account.id)
+        )
+        or exists (
+          select 1
+          from public.reporting_machines machine
+          where public.can_manage_operator_payout_machine(uid, machine.id)
+        )
+      )
+    );
+$$;
+
+create or replace function public.get_my_admin_access_context()
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public, auth
+as $$
+declare
+  actor_user_id uuid;
+  actor_is_super_admin boolean;
+  actor_machine_ids uuid[];
+  actor_is_scoped_admin boolean;
+  actor_is_refund_manager boolean;
+  actor_can_manage_payouts boolean;
+  allowed_surfaces text[];
+begin
+  actor_user_id := auth.uid();
+
+  if actor_user_id is null then
+    return jsonb_build_object(
+      'isSuperAdmin', false,
+      'isScopedAdmin', false,
+      'canAccessAdmin', false,
+      'allowedSurfaces', '[]'::jsonb,
+      'scopedMachineIds', '[]'::jsonb
+    );
+  end if;
+
+  actor_is_super_admin := public.is_super_admin(actor_user_id);
+  actor_machine_ids := coalesce(public.scoped_admin_machine_ids(actor_user_id), '{}'::uuid[]);
+  actor_is_scoped_admin := coalesce(array_length(actor_machine_ids, 1), 0) > 0;
+  actor_is_refund_manager := public.user_is_refund_manager(actor_user_id);
+  actor_can_manage_payouts := exists (
+    select 1
+    from public.customer_accounts account
+    where public.can_manage_operator_payout_account(actor_user_id, account.id)
+  ) or exists (
+    select 1
+    from public.reporting_machines machine
+    where public.can_manage_operator_payout_machine(actor_user_id, machine.id)
+  );
+
+  if actor_is_super_admin then
+    allowed_surfaces := array['*'];
+  else
+    allowed_surfaces := '{}'::text[];
+
+    if actor_is_scoped_admin then
+      allowed_surfaces := allowed_surfaces || array['access', 'reporting_access', 'refunds'];
+    end if;
+
+    if actor_is_refund_manager then
+      allowed_surfaces := allowed_surfaces || array['refunds'];
+    end if;
+
+    if actor_can_manage_payouts then
+      allowed_surfaces := allowed_surfaces || array['payouts'];
+    end if;
+  end if;
+
+  return jsonb_build_object(
+    'isSuperAdmin', actor_is_super_admin,
+    'isScopedAdmin', actor_is_scoped_admin,
+    'canAccessAdmin',
+      actor_is_super_admin
+      or actor_is_scoped_admin
+      or actor_is_refund_manager
+      or actor_can_manage_payouts,
+    'allowedSurfaces', to_jsonb(array(
+      select distinct surface
+      from unnest(allowed_surfaces) as surface
+    )),
+    'scopedMachineIds', to_jsonb(actor_machine_ids)
+  );
+end;
+$$;
+
+create or replace function public.operator_payout_calculation_payload(
+  p_payout_run_id uuid
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public, auth
+as $$
+declare
+  actor_user_id uuid;
+  actor_can_manage_account boolean;
+  actor_can_finalize_run boolean;
+  run_row public.payout_runs;
+  visible_totals record;
+  visible_item_filter text;
+  result jsonb;
+begin
+  actor_user_id := auth.uid();
+
+  if actor_user_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  select *
+  into run_row
+  from public.payout_runs run
+  where run.id = p_payout_run_id
+  limit 1;
+
+  if run_row.id is null then
+    raise exception 'Payout run not found';
+  end if;
+
+  if not public.can_access_payout_run(actor_user_id, run_row.id) then
+    raise exception 'Payout run access required';
+  end if;
+
+  actor_can_manage_account :=
+    public.can_manage_operator_payout_account(actor_user_id, run_row.account_id);
+  actor_can_finalize_run :=
+    public.operator_can_finalize_payout_run(actor_user_id, run_row.id);
+  visible_item_filter := 'scoped_items_only';
+
+  select
+    coalesce(sum(item.raw_minutes), 0)::integer as total_raw_minutes,
+    coalesce(sum(item.rounded_paid_minutes), 0)::integer as total_rounded_paid_minutes,
+    coalesce(sum(item.hourly_pay_cents), 0)::integer as total_hourly_pay_cents,
+    coalesce(sum(item.commission_pay_cents), 0)::integer as total_commission_pay_cents,
+    coalesce(sum(item.adjustments_total_cents), 0)::integer as total_adjustments_cents,
+    coalesce(sum(item.total_payout_cents), 0)::integer as total_payout_cents
+  into visible_totals
+  from public.payout_run_items item
+  where item.payout_run_id = run_row.id
+    and item.status <> 'voided'
+    and (
+      actor_can_manage_account
+      or actor_can_finalize_run
+      or not exists (
+        select 1
+        from public.payout_run_item_machines item_machine
+        where item_machine.payout_run_item_id = item.id
+          and not public.can_manage_operator_payout_machine(
+            actor_user_id,
+            item_machine.reporting_machine_id
+          )
+      )
+    );
+
+  select jsonb_build_object(
+    'id', run_row.id,
+    'accountId', run_row.account_id,
+    'payoutPeriodId', run_row.payout_period_id,
+    'status', run_row.status,
+    'totalRawMinutes', visible_totals.total_raw_minutes,
+    'totalRoundedPaidMinutes', visible_totals.total_rounded_paid_minutes,
+    'totalHourlyPayCents', visible_totals.total_hourly_pay_cents,
+    'totalCommissionPayCents', visible_totals.total_commission_pay_cents,
+    'totalAdjustmentsCents', visible_totals.total_adjustments_cents,
+    'totalPayoutCents', visible_totals.total_payout_cents,
+    'warnings', case
+      when actor_can_manage_account or actor_can_finalize_run then run_row.warnings
+      else '[]'::jsonb
+    end,
+    'notes', run_row.notes,
+    'createdAt', run_row.created_at,
+    'updatedAt', run_row.updated_at,
+    'items', coalesce((
+      select jsonb_agg(
+        jsonb_build_object(
+          'id', item.id,
+          'operatorProfileId', item.operator_profile_id,
+          'operatorDisplayName', profile.display_name,
+          'workerType', item.worker_type,
+          'rawMinutes', item.raw_minutes,
+          'roundedPaidMinutes', item.rounded_paid_minutes,
+          'shiftCount', item.shift_count,
+          'hourlyRateCents', item.hourly_rate_cents,
+          'hourlyPayCents', item.hourly_pay_cents,
+          'eligibleNetRevenueCents', item.eligible_net_revenue_cents,
+          'commissionBasisPoints', item.commission_basis_points,
+          'commissionPayCents', item.commission_pay_cents,
+          'adjustmentsTotalCents', item.adjustments_total_cents,
+          'totalPayoutCents', item.total_payout_cents,
+          'status', item.status,
+          'warnings', item.warnings,
+          'calculationNotes', item.calculation_notes || jsonb_build_object(
+            'visibilityFilter', visible_item_filter
+          ),
+          'machines', coalesce((
+            select jsonb_agg(
+              jsonb_build_object(
+                'id', item_machine.id,
+                'machineId', item_machine.reporting_machine_id,
+                'machineLabel', machine.machine_label,
+                'locationId', item_machine.reporting_location_id,
+                'locationName', location.name,
+                'netRevenueCents', item_machine.net_revenue_cents,
+                'eligibleNetRevenueCents', item_machine.eligible_net_revenue_cents,
+                'commissionBasisPoints', item_machine.commission_basis_points,
+                'commissionPayCents', item_machine.commission_pay_cents,
+                'shiftCount', item_machine.shift_count,
+                'rawMinutes', item_machine.raw_minutes,
+                'roundedPaidMinutes', item_machine.rounded_paid_minutes,
+                'includedInCommissionBasis', item_machine.included_in_commission_basis,
+                'inclusionReason', item_machine.inclusion_reason
+              )
+              order by location.name, machine.machine_label
+            )
+            from public.payout_run_item_machines item_machine
+            join public.reporting_machines machine
+              on machine.id = item_machine.reporting_machine_id
+            join public.reporting_locations location
+              on location.id = item_machine.reporting_location_id
+            where item_machine.payout_run_item_id = item.id
+              and (
+                actor_can_manage_account
+                or actor_can_finalize_run
+                or public.can_manage_operator_payout_machine(
+                  actor_user_id,
+                  item_machine.reporting_machine_id
+                )
+              )
+          ), '[]'::jsonb),
+          'adjustments', coalesce((
+            select jsonb_agg(
+              jsonb_build_object(
+                'id', adjustment.id,
+                'amountCents', adjustment.amount_cents,
+                'adjustmentType', adjustment.adjustment_type,
+                'description', adjustment.description,
+                'visibleToOperator', adjustment.visible_to_operator,
+                'createdAt', adjustment.created_at
+              )
+              order by adjustment.created_at
+            )
+            from public.payout_adjustments adjustment
+            where adjustment.payout_run_id = run_row.id
+              and adjustment.operator_profile_id = item.operator_profile_id
+              and (
+                adjustment.visible_to_operator
+                or actor_can_manage_account
+                or actor_can_finalize_run
+              )
+          ), '[]'::jsonb)
+        )
+        order by profile.display_name, item.created_at
+      )
+      from public.payout_run_items item
+      join public.operator_payout_profiles profile
+        on profile.id = item.operator_profile_id
+      where item.payout_run_id = run_row.id
+        and item.status <> 'voided'
+        and (
+          actor_can_manage_account
+          or actor_can_finalize_run
+          or not exists (
+            select 1
+            from public.payout_run_item_machines item_machine
+            where item_machine.payout_run_item_id = item.id
+              and not public.can_manage_operator_payout_machine(
+                actor_user_id,
+                item_machine.reporting_machine_id
+              )
+          )
+        )
+    ), '[]'::jsonb)
+  )
+  into result;
+
+  return result;
+end;
+$$;
+
+create or replace function public.get_payout_review_context()
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public, auth
+as $$
+declare
+  actor_user_id uuid;
+  result jsonb;
+begin
+  actor_user_id := auth.uid();
+
+  if actor_user_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  select jsonb_build_object(
+    'accounts', coalesce((
+      select jsonb_agg(
+        jsonb_build_object(
+          'id', account.id,
+          'name', account.name
+        )
+        order by account.name
+      )
+      from public.customer_accounts account
+      where public.can_manage_operator_payout_account(actor_user_id, account.id)
+        or exists (
+          select 1
+          from public.payout_runs run
+          where run.account_id = account.id
+            and public.can_access_payout_run(actor_user_id, run.id)
+        )
+    ), '[]'::jsonb),
+    'periods', coalesce((
+      select jsonb_agg(
+        jsonb_build_object(
+          'id', period.id,
+          'accountId', period.account_id,
+          'accountName', account.name,
+          'periodStartDate', period.period_start_date,
+          'periodEndDate', period.period_end_date,
+          'submissionDueDate', period.submission_due_date,
+          'lockDate', period.lock_date,
+          'targetPayoutDate', period.target_payout_date,
+          'status', period.status,
+          'payoutRun', case
+            when latest_run.id is null then null::jsonb
+            else public.operator_payout_calculation_payload(latest_run.id)
+          end,
+          'canReview', latest_run.id is not null
+            and public.can_access_payout_run(actor_user_id, latest_run.id),
+          'canFinalize', latest_run.id is not null
+            and public.operator_can_finalize_payout_run(actor_user_id, latest_run.id),
+          'hasBlockers', latest_run.id is not null and (
+            exists (
+              select 1
+              from jsonb_array_elements(coalesce(latest_run.warnings, '[]'::jsonb)) warning
+              where warning ->> 'severity' = 'blocker'
+            )
+            or exists (
+              select 1
+              from public.payout_run_items item
+              cross join lateral jsonb_array_elements(coalesce(item.warnings, '[]'::jsonb)) warning
+              where item.payout_run_id = latest_run.id
+                and item.status <> 'voided'
+                and warning ->> 'severity' = 'blocker'
+            )
+          ),
+          'issuedStatementCount', coalesce((
+            select count(*)::integer
+            from public.pay_statements statement
+            where statement.payout_run_id = latest_run.id
+              and statement.status in ('issued', 'revised')
+          ), 0),
+          'revisionCount', coalesce((
+            select count(*)::integer
+            from public.payout_run_review_snapshots snapshot
+            where snapshot.payout_run_id = latest_run.id
+          ), 0)
+        )
+        order by period.period_start_date desc, period.period_end_date desc
+      )
+      from public.payout_periods period
+      join public.customer_accounts account on account.id = period.account_id
+      left join lateral (
+        select run.*
+        from public.payout_runs run
+        where run.payout_period_id = period.id
+          and run.status <> 'voided'
+        order by run.created_at desc
+        limit 1
+      ) latest_run on true
+      where public.can_manage_operator_payout_account(actor_user_id, period.account_id)
+        or (
+          latest_run.id is not null
+          and public.can_access_payout_run(actor_user_id, latest_run.id)
+        )
+    ), '[]'::jsonb)
+  )
+  into result;
+
+  return result;
+end;
+$$;
+
+create or replace function public.admin_mark_payout_run_reviewed(
+  p_payout_run_id uuid,
+  p_reason text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  actor_user_id uuid;
+  normalized_reason text;
+  run_row public.payout_runs;
+  before_row public.payout_runs;
+  snapshot_payload jsonb;
+begin
+  actor_user_id := auth.uid();
+  normalized_reason := trim(coalesce(p_reason, ''));
+
+  if actor_user_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  if normalized_reason = '' then
+    raise exception 'Payout review reason is required';
+  end if;
+
+  select *
+  into run_row
+  from public.payout_runs run
+  where run.id = p_payout_run_id
+  limit 1;
+
+  if run_row.id is null then
+    raise exception 'Payout run not found';
+  end if;
+
+  if run_row.status not in ('draft', 'review', 'reopened') then
+    raise exception 'Only draft, review, or reopened payout runs can be marked reviewed';
+  end if;
+
+  if not public.operator_can_finalize_payout_run(actor_user_id, run_row.id) then
+    raise exception 'Payout review access required';
+  end if;
+
+  before_row := run_row;
+  snapshot_payload := public.operator_capture_payout_run_review_snapshot(
+    run_row.id,
+    actor_user_id,
+    'marked_reviewed',
+    normalized_reason
+  );
+
+  update public.payout_runs
+  set
+    status = 'review',
+    notes = coalesce(notes, 'Manager review started.')
+  where id = run_row.id
+  returning * into run_row;
+
+  update public.payout_run_items
+  set status = 'reviewed'
+  where payout_run_id = run_row.id
+    and status in ('draft', 'reviewed');
+
+  update public.payout_periods
+  set
+    status = 'review',
+    updated_by = actor_user_id
+  where id = run_row.payout_period_id
+    and status in ('open', 'grace_period', 'locked', 'draft_payout', 'review', 'reopened');
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    actor_user_id,
+    'operator_payout_run.marked_reviewed',
+    'payout_run',
+    run_row.id::text,
+    to_jsonb(before_row),
+    to_jsonb(run_row),
+    jsonb_build_object(
+      'reason', normalized_reason,
+      'reviewSnapshot', snapshot_payload,
+      'account_id', run_row.account_id
+    )
+  );
+
+  return jsonb_build_object(
+    'payoutRun', public.operator_payout_calculation_payload(run_row.id),
+    'reviewSnapshot', snapshot_payload
+  );
+end;
+$$;
+
+create or replace function public.admin_finalize_payout_run(
+  p_payout_run_id uuid,
+  p_reason text,
+  p_override_blockers boolean default false,
+  p_override_reason text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  actor_user_id uuid;
+  normalized_reason text;
+  normalized_override_reason text;
+  run_row public.payout_runs;
+  before_row public.payout_runs;
+  has_blockers boolean;
+  issued_statement_count integer;
+  item_count integer;
+  snapshot_payload jsonb;
+begin
+  actor_user_id := auth.uid();
+  normalized_reason := trim(coalesce(p_reason, ''));
+  normalized_override_reason := trim(coalesce(p_override_reason, ''));
+
+  if actor_user_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  if normalized_reason = '' then
+    raise exception 'Payout finalization reason is required';
+  end if;
+
+  select *
+  into run_row
+  from public.payout_runs run
+  where run.id = p_payout_run_id
+  limit 1;
+
+  if run_row.id is null then
+    raise exception 'Payout run not found';
+  end if;
+
+  if run_row.status not in ('draft', 'review', 'reopened') then
+    raise exception 'Only draft, review, or reopened payout runs can be finalized';
+  end if;
+
+  if not public.operator_can_finalize_payout_run(actor_user_id, run_row.id) then
+    raise exception 'Payout finalization access required';
+  end if;
+
+  select count(*)::integer
+  into item_count
+  from public.payout_run_items item
+  where item.payout_run_id = run_row.id
+    and item.status <> 'voided';
+
+  if item_count = 0 then
+    raise exception 'Payout run has no payable operators';
+  end if;
+
+  select count(*)::integer
+  into issued_statement_count
+  from public.pay_statements statement
+  where statement.payout_run_id = run_row.id
+    and statement.status in ('issued', 'revised');
+
+  if issued_statement_count > 0 then
+    raise exception 'Finalization blocked because issued pay statements already exist for this payout run';
+  end if;
+
+  select exists (
+    select 1
+    from jsonb_array_elements(coalesce(run_row.warnings, '[]'::jsonb)) warning
+    where warning ->> 'severity' = 'blocker'
+  ) or exists (
+    select 1
+    from public.payout_run_items item
+    cross join lateral jsonb_array_elements(coalesce(item.warnings, '[]'::jsonb)) warning
+    where item.payout_run_id = run_row.id
+      and item.status <> 'voided'
+      and warning ->> 'severity' = 'blocker'
+  )
+  into has_blockers;
+
+  if has_blockers and not coalesce(p_override_blockers, false) then
+    raise exception 'Critical payout warnings must be resolved or explicitly overridden before finalization';
+  end if;
+
+  if has_blockers and normalized_override_reason = '' then
+    raise exception 'Override reason is required when finalizing with critical warnings';
+  end if;
+
+  before_row := run_row;
+  snapshot_payload := public.operator_capture_payout_run_review_snapshot(
+    run_row.id,
+    actor_user_id,
+    'finalized',
+    normalized_reason
+  );
+
+  update public.payout_runs
+  set
+    status = 'finalized',
+    finalized_by = actor_user_id,
+    finalized_at = now(),
+    notes = coalesce(notes, 'Finalized after manager review.')
+  where id = run_row.id
+  returning * into run_row;
+
+  update public.payout_run_items
+  set status = 'finalized'
+  where payout_run_id = run_row.id
+    and status in ('draft', 'reviewed', 'finalized');
+
+  update public.time_entries entry
+  set
+    status = 'included_in_payout',
+    locked_at = coalesce(entry.locked_at, now()),
+    locked_by = coalesce(entry.locked_by, actor_user_id),
+    updated_by = actor_user_id
+  where entry.payout_period_id = run_row.payout_period_id
+    and entry.status in ('submitted', 'locked')
+    and exists (
+      select 1
+      from public.payout_run_items item
+      join public.payout_run_item_machines item_machine
+        on item_machine.payout_run_item_id = item.id
+      where item.payout_run_id = run_row.id
+        and item.operator_profile_id = entry.operator_profile_id
+        and item_machine.reporting_machine_id = entry.reporting_machine_id
+    );
+
+  update public.payout_periods
+  set
+    status = 'finalized',
+    locked_at = coalesce(locked_at, now()),
+    locked_by = coalesce(locked_by, actor_user_id),
+    updated_by = actor_user_id
+  where id = run_row.payout_period_id;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    actor_user_id,
+    'operator_payout_run.finalized',
+    'payout_run',
+    run_row.id::text,
+    to_jsonb(before_row),
+    to_jsonb(run_row),
+    jsonb_build_object(
+      'reason', normalized_reason,
+      'override_blockers', coalesce(p_override_blockers, false),
+      'override_reason', nullif(normalized_override_reason, ''),
+      'reviewSnapshot', snapshot_payload,
+      'issued_statement_duplicate_guard', true,
+      'payroll_provider_execution', false,
+      'account_id', run_row.account_id
+    )
+  );
+
+  return jsonb_build_object(
+    'payoutRun', public.operator_payout_calculation_payload(run_row.id),
+    'reviewSnapshot', snapshot_payload,
+    'finalized', true,
+    'overrideBlockers', coalesce(p_override_blockers, false)
+  );
+end;
+$$;
+
+create or replace function public.admin_reopen_payout_run(
+  p_payout_run_id uuid,
+  p_reason text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  actor_user_id uuid;
+  normalized_reason text;
+  run_row public.payout_runs;
+  before_row public.payout_runs;
+  issued_statement_count integer;
+  snapshot_payload jsonb;
+begin
+  actor_user_id := auth.uid();
+  normalized_reason := trim(coalesce(p_reason, ''));
+
+  if actor_user_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  if normalized_reason = '' then
+    raise exception 'Payout reopen reason is required';
+  end if;
+
+  select *
+  into run_row
+  from public.payout_runs run
+  where run.id = p_payout_run_id
+  limit 1;
+
+  if run_row.id is null then
+    raise exception 'Payout run not found';
+  end if;
+
+  if run_row.status not in ('review', 'finalized', 'reopened') then
+    raise exception 'Only reviewed, finalized, or reopened payout runs can be reopened';
+  end if;
+
+  if not public.operator_can_finalize_payout_run(actor_user_id, run_row.id) then
+    raise exception 'Payout reopen access required';
+  end if;
+
+  select count(*)::integer
+  into issued_statement_count
+  from public.pay_statements statement
+  where statement.payout_run_id = run_row.id
+    and statement.status in ('issued', 'revised');
+
+  if issued_statement_count > 0 then
+    raise exception 'Issued pay statements require a statement revision flow instead of reopening the payout run';
+  end if;
+
+  before_row := run_row;
+  snapshot_payload := public.operator_capture_payout_run_review_snapshot(
+    run_row.id,
+    actor_user_id,
+    'reopened',
+    normalized_reason
+  );
+
+  update public.payout_runs
+  set
+    status = 'reopened',
+    reopened_at = now(),
+    reopened_by = actor_user_id,
+    reopen_reason = normalized_reason,
+    finalized_at = null,
+    finalized_by = null
+  where id = run_row.id
+  returning * into run_row;
+
+  update public.payout_run_items
+  set status = 'draft'
+  where payout_run_id = run_row.id
+    and status in ('reviewed', 'finalized');
+
+  update public.time_entries entry
+  set
+    status = 'locked',
+    updated_by = actor_user_id
+  where entry.payout_period_id = run_row.payout_period_id
+    and entry.status = 'included_in_payout';
+
+  update public.payout_periods
+  set
+    status = 'reopened',
+    reopened_at = now(),
+    reopened_by = actor_user_id,
+    reopen_reason = normalized_reason,
+    updated_by = actor_user_id
+  where id = run_row.payout_period_id;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    actor_user_id,
+    'operator_payout_run.reopened',
+    'payout_run',
+    run_row.id::text,
+    to_jsonb(before_row),
+    to_jsonb(run_row),
+    jsonb_build_object(
+      'reason', normalized_reason,
+      'reviewSnapshot', snapshot_payload,
+      'issued_statement_guard', true,
+      'account_id', run_row.account_id
+    )
+  );
+
+  return jsonb_build_object(
+    'payoutRun', public.operator_payout_calculation_payload(run_row.id),
+    'reviewSnapshot', snapshot_payload,
+    'reopened', true
+  );
+end;
+$$;
+
+create or replace function public.admin_void_payout_run(
+  p_payout_run_id uuid,
+  p_reason text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  actor_user_id uuid;
+  normalized_reason text;
+  run_row public.payout_runs;
+  before_row public.payout_runs;
+  issued_statement_count integer;
+  snapshot_payload jsonb;
+begin
+  actor_user_id := auth.uid();
+  normalized_reason := trim(coalesce(p_reason, ''));
+
+  if actor_user_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  if normalized_reason = '' then
+    raise exception 'Payout void reason is required';
+  end if;
+
+  select *
+  into run_row
+  from public.payout_runs run
+  where run.id = p_payout_run_id
+  limit 1;
+
+  if run_row.id is null then
+    raise exception 'Payout run not found';
+  end if;
+
+  if run_row.status in ('issued', 'closed', 'voided') then
+    raise exception 'Issued, closed, or already voided payout runs cannot be voided here';
+  end if;
+
+  if not public.operator_can_finalize_payout_run(actor_user_id, run_row.id) then
+    raise exception 'Payout void access required';
+  end if;
+
+  select count(*)::integer
+  into issued_statement_count
+  from public.pay_statements statement
+  where statement.payout_run_id = run_row.id
+    and statement.status in ('issued', 'revised');
+
+  if issued_statement_count > 0 then
+    raise exception 'Issued pay statements require a statement revision or void flow first';
+  end if;
+
+  before_row := run_row;
+  snapshot_payload := public.operator_capture_payout_run_review_snapshot(
+    run_row.id,
+    actor_user_id,
+    'voided',
+    normalized_reason
+  );
+
+  update public.payout_runs
+  set
+    status = 'voided',
+    reopened_at = now(),
+    reopened_by = actor_user_id,
+    reopen_reason = normalized_reason
+  where id = run_row.id
+  returning * into run_row;
+
+  update public.payout_run_items
+  set status = 'voided'
+  where payout_run_id = run_row.id;
+
+  update public.time_entries entry
+  set
+    status = 'locked',
+    updated_by = actor_user_id
+  where entry.payout_period_id = run_row.payout_period_id
+    and entry.status = 'included_in_payout';
+
+  update public.payout_periods
+  set
+    status = 'reopened',
+    reopened_at = now(),
+    reopened_by = actor_user_id,
+    reopen_reason = normalized_reason,
+    updated_by = actor_user_id
+  where id = run_row.payout_period_id
+    and status <> 'voided';
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    actor_user_id,
+    'operator_payout_run.voided',
+    'payout_run',
+    run_row.id::text,
+    to_jsonb(before_row),
+    to_jsonb(run_row),
+    jsonb_build_object(
+      'reason', normalized_reason,
+      'reviewSnapshot', snapshot_payload,
+      'issued_statement_guard', true,
+      'account_id', run_row.account_id
+    )
+  );
+
+  return jsonb_build_object(
+    'payoutRun', public.operator_payout_calculation_payload(run_row.id),
+    'reviewSnapshot', snapshot_payload,
+    'voided', true
+  );
+end;
+$$;
+
+comment on table public.payout_run_review_snapshots is
+  'Immutable manager review snapshots preserving payout run versions before review, finalization, reopen, and void actions.';
+comment on function public.operator_can_finalize_payout_run(uuid, uuid) is
+  'Service-only helper that confirms an actor can finalize every machine represented by a payout run.';
+comment on function public.operator_capture_payout_run_review_snapshot(uuid, uuid, text, text) is
+  'Service-only helper that stores immutable payout run review/revision snapshots before workflow status changes.';
+comment on function public.operator_payout_calculation_payload(uuid) is
+  'Returns payout run totals, operator items, machine breakdowns, adjustments, and warnings scoped to the current actor; partial machine managers do not receive full-run totals.';
+comment on function public.get_payout_review_context() is
+  'Returns payout periods, latest payout runs, warnings, statement guards, and scoped review permissions for the current manager.';
+comment on function public.admin_mark_payout_run_reviewed(uuid, text) is
+  'Marks a payout run ready for final review with an audit reason and immutable review snapshot.';
+comment on function public.admin_finalize_payout_run(uuid, text, boolean, text) is
+  'Finalizes a reviewed payout run, blocks critical warnings unless explicitly overridden, and prevents duplicate issued statements.';
+comment on function public.admin_reopen_payout_run(uuid, text) is
+  'Reopens an unissued payout run for correction while preserving the previous version in a review snapshot.';
+comment on function public.admin_void_payout_run(uuid, text) is
+  'Voids an unissued payout run with an audit reason and review snapshot so a corrected run can be generated.';
+
+revoke insert, update, delete on public.payout_run_review_snapshots
+  from anon, authenticated;
+
+revoke execute on function public.operator_can_finalize_payout_run(uuid, uuid)
+  from public, anon, authenticated;
+revoke execute on function public.operator_capture_payout_run_review_snapshot(uuid, uuid, text, text)
+  from public, anon, authenticated;
+revoke execute on function public.get_payout_review_context()
+  from public, anon;
+revoke execute on function public.admin_mark_payout_run_reviewed(uuid, text)
+  from public, anon;
+revoke execute on function public.admin_finalize_payout_run(uuid, text, boolean, text)
+  from public, anon;
+revoke execute on function public.admin_reopen_payout_run(uuid, text)
+  from public, anon;
+revoke execute on function public.admin_void_payout_run(uuid, text)
+  from public, anon;
+
+grant execute on function public.operator_can_finalize_payout_run(uuid, uuid)
+  to service_role;
+grant execute on function public.operator_capture_payout_run_review_snapshot(uuid, uuid, text, text)
+  to service_role;
+grant execute on function public.get_payout_review_context()
+  to authenticated;
+grant execute on function public.admin_mark_payout_run_reviewed(uuid, text)
+  to authenticated;
+grant execute on function public.admin_finalize_payout_run(uuid, text, boolean, text)
+  to authenticated;
+grant execute on function public.admin_reopen_payout_run(uuid, text)
+  to authenticated;
+grant execute on function public.admin_void_payout_run(uuid, text)
+  to authenticated;
+
+select pg_notify('pgrst', 'reload schema');


### PR DESCRIPTION
## Summary
- Adds the `payouts` admin surface for scoped operator-payout managers and routes `/admin/payouts` into the existing admin shell.
- Adds review/finalization/reopen/void RPCs with immutable review snapshots, critical-warning override reasons, duplicate issued-statement guards, and scoped payout payload totals.
- Adds the manager review UI for payout periods, operator/machine breakdowns, warnings, adjustments, and workflow actions.

## Files changed
- Supabase migration for payout review snapshots, admin access context, scoped payout payloads, and workflow RPCs.
- Admin routing/navigation/i18n plus `src/pages/admin/Payouts.tsx`.
- Operator payout client helpers, static validator, status docs, and smoke checklist coverage.

## Verification commands + results
- `npm ci` - pass; 0 vulnerabilities reported.
- `npm run agent:preflight -- --issue 448` - pass; expected warning that the base-sync merge had staged files before commit.
- `npm run operator-payouts:validate-foundation` - pass.
- `npm run operator-payouts:validate-calculation` - pass.
- `npm run operator-payouts:validate-review` - pass.
- `npm run db:validate-rpc-surface` - pass; 14 service-only helper RPCs remain blocked from browser use.
- `npm run auth:validate-admin-boundaries` - pass; live RPC checks skipped by existing script default.
- `npm test --if-present` - pass; no test script output.
- `npm run lint --if-present` - pass.
- `npm run build` - pass.
- `git diff --check` - pass.
- `npm run db:validate-migrations` - blocked locally because Docker Desktop is not running: `dockerDesktopLinuxEngine` pipe not found.

## How to test
1. Start local dev with `npm run dev -- --host 127.0.0.1 --port 8084`.
2. Open `http://127.0.0.1:8084/admin/payouts`.
3. Sign in as a super admin, account-level payout manager, or scoped manager whose assigned machines are represented by a generated payout run.
4. Generate/recalculate a run, review operator and machine totals, add an adjustment with a description and audit reason, then test Mark Reviewed, Finalize, Reopen, and Void.
5. Confirm critical warnings require an explicit override reason and issued/revised pay statements block duplicate finalization.
6. With Docker Desktop or CI available, run `npm run db:validate-migrations`.

## Risk / overlap notes
- Stacked on `agent/payout-calculation-engine` / PR #454; retarget to `main` after PRs #451-#454 merge.
- This branch was synced with the updated #454 base in commit `7bf6509`.
- Touches admin route/nav and payout RPC surfaces, so re-run admin-boundary and migration validation after syncing from `main`.
- No payroll provider execution, withholding, tax filing, direct deposit, or raw provider payload storage is added.

Closes #448.
Depends on #454.

## Verification
2026-05-30 QA sweep: GitHub checks are green. npm run operator-payouts:validate-review passed locally, git diff --check passed, and Impeccable passed on the changed admin payout review UI/helper files.

## Risk And Overlap
Red lane because this is a stacked P0 payout review PR with uat-required, risky-db-change, risky-auth-payment, and ui-change labels. It targets a stack branch, not main.

## UI / Design Evidence
Impeccable passed on src/pages/admin/Payouts.tsx and src/lib/operatorPayouts.ts for this branch.

## Merge Autonomy
Lane: Red
Owner approval: required
Rationale: Red-lane labels, draft state, stacked base branch, UAT requirement, or risky auth/database scope prevent agent merge.
