### PR TITLE
Improve imported machine setup UX

### DIFF
--- a/scripts/sunze/sync-orders.mjs
+++ b/scripts/sunze/sync-orders.mjs
@@ -532,25 +532,68 @@ const sanitizeMachineCode = (value) => {
   return text;
 };
 
-const extractMachineCodesFromText = (text) => {
+const machineListNameNoise = new Set([
+  'more',
+  'normal',
+  'abnormal',
+  'online',
+  'offline',
+  'machine id',
+]);
+
+const sanitizeMachineName = (value) => {
+  const text = String(value ?? '').replace(/\s+/g, ' ').trim();
+  if (!text || text.length > 200) return null;
+  const normalized = text.toLowerCase().replace(/[:：]\s*$/, '');
+  if (machineListNameNoise.has(normalized)) return null;
+  if (/^(heating temp|internal temp|humidity)\s*[:：]/i.test(text)) return null;
+  if (/^machine\s*id\s*[:：]?/i.test(text)) return null;
+  return text;
+};
+
+const findMachineNameBeforeLine = (lines, index) => {
+  for (
+    let previousIndex = index - 1;
+    previousIndex >= 0 && previousIndex >= index - 5;
+    previousIndex -= 1
+  ) {
+    const name = sanitizeMachineName(lines[previousIndex]);
+    if (name) return name;
+  }
+  return null;
+};
+
+const extractMachinesFromText = (text) => {
   const lines = String(text ?? '')
     .split(/\r?\n/)
     .map((line) => line.trim())
     .filter(Boolean);
-  const codes = new Set();
+  const machinesByCode = new Map();
 
   for (let index = 0; index < lines.length; index += 1) {
     const inlineMatch = lines[index].match(/Machine\s*ID\s*(?::|\uFF1A)?\s*([A-Za-z0-9][A-Za-z0-9._-]{1,79})/i);
     const inlineCode = sanitizeMachineCode(inlineMatch?.[1]);
-    if (inlineCode) codes.add(inlineCode);
+    if (inlineCode) {
+      machinesByCode.set(inlineCode, {
+        machineCode: inlineCode,
+        machineName: findMachineNameBeforeLine(lines, index),
+      });
+    }
 
     if (/^Machine\s*ID\s*(?::|\uFF1A)?$/i.test(lines[index])) {
       const nextCode = sanitizeMachineCode(lines[index + 1]);
-      if (nextCode) codes.add(nextCode);
+      if (nextCode) {
+        machinesByCode.set(nextCode, {
+          machineCode: nextCode,
+          machineName: findMachineNameBeforeLine(lines, index),
+        });
+      }
     }
   }
 
-  return [...codes].sort();
+  return [...machinesByCode.values()].sort((left, right) =>
+    left.machineCode.localeCompare(right.machineCode)
+  );
 };
 
 const summaryMachineCodes = [
@@ -627,13 +670,13 @@ const readMachineListDiagnostic = async (page) =>
       .slice(0, 5);
   });
 
-const readVisibleSunzeMachineCodes = async (page, baseUrl) => {
+const readVisibleSunzeMachines = async (page, baseUrl) => {
   await page.goto(`${baseUrl}#/device`, { waitUntil: 'domcontentloaded' });
   assertAllowedSunzeRoute(page);
   await page.waitForLoadState('networkidle').catch(() => {});
   await page.waitForTimeout(2500);
 
-  const visibleMachineCodes = new Set();
+  const visibleMachinesByCode = new Map();
   let pagesScanned = 0;
   let nextClicks = 0;
   let scrollAttempts = 0;
@@ -641,12 +684,16 @@ const readVisibleSunzeMachineCodes = async (page, baseUrl) => {
   for (let pageIndex = 0; pageIndex < 20; pageIndex += 1) {
     pagesScanned += 1;
     const bodyText = await page.locator('body').innerText();
-    for (const machineCode of extractMachineCodesFromText(bodyText)) {
-      visibleMachineCodes.add(machineCode);
+    for (const machine of extractMachinesFromText(bodyText)) {
+      const existing = visibleMachinesByCode.get(machine.machineCode);
+      visibleMachinesByCode.set(machine.machineCode, {
+        machineCode: machine.machineCode,
+        machineName: machine.machineName ?? existing?.machineName ?? null,
+      });
     }
 
     for (let scrollIndex = 0; scrollIndex < 10; scrollIndex += 1) {
-      const beforeScrollCount = visibleMachineCodes.size;
+      const beforeScrollCount = visibleMachinesByCode.size;
       const scrolled = await scrollTopLevelMachineList(page);
       if (!scrolled) break;
 
@@ -655,11 +702,15 @@ const readVisibleSunzeMachineCodes = async (page, baseUrl) => {
       await page.waitForTimeout(1000);
 
       const scrolledBodyText = await page.locator('body').innerText();
-      for (const machineCode of extractMachineCodesFromText(scrolledBodyText)) {
-        visibleMachineCodes.add(machineCode);
+      for (const machine of extractMachinesFromText(scrolledBodyText)) {
+        const existing = visibleMachinesByCode.get(machine.machineCode);
+        visibleMachinesByCode.set(machine.machineCode, {
+          machineCode: machine.machineCode,
+          machineName: machine.machineName ?? existing?.machineName ?? null,
+        });
       }
 
-      if (visibleMachineCodes.size === beforeScrollCount) break;
+      if (visibleMachinesByCode.size === beforeScrollCount) break;
     }
 
     const clickedNextPage = await clickNextMachineListPage(page);
@@ -670,7 +721,10 @@ const readVisibleSunzeMachineCodes = async (page, baseUrl) => {
     await page.waitForTimeout(1500);
   }
 
-  const machineCodes = [...visibleMachineCodes].sort();
+  const visibleMachines = [...visibleMachinesByCode.values()].sort((left, right) =>
+    left.machineCode.localeCompare(right.machineCode)
+  );
+  const machineCodes = visibleMachines.map((machine) => machine.machineCode);
   const paginationDiagnostic = (await readMachineListDiagnostic(page))
     .map(sanitizeDiagnosticText)
     .join(' | ');
@@ -704,7 +758,7 @@ const readVisibleSunzeMachineCodes = async (page, baseUrl) => {
     );
   }
 
-  return machineCodes;
+  return visibleMachines;
 };
 
 const routeBaseMatches = (url, expectedBaseUrl) => {
@@ -1602,12 +1656,14 @@ const exportOrdersWorkbook = async () => {
     const filePath = join(downloadRoot, filename);
     await download.saveAs(filePath);
     downloadedFilePath = filePath;
-    const visibleSunzeMachineCodes = await readVisibleSunzeMachineCodes(page, baseUrl);
+    const visibleSunzeMachines = await readVisibleSunzeMachines(page, baseUrl);
+    const visibleSunzeMachineCodes = visibleSunzeMachines.map((machine) => machine.machineCode);
     succeeded = true;
 
     return {
       filePath,
       uiSummaries: [preExportUiSummary],
+      visibleSunzeMachines,
       visibleSunzeMachineCodes,
       exportTaskCreatedAtMs: task.createdAtMs,
       cleanupPath: downloadDirArg ? filePath : downloadRoot,
@@ -1765,6 +1821,7 @@ const loadOrdersSource = async () => {
     const source = {
       filePath: resolve(parseFilePath),
       uiSummaries: [],
+      visibleSunzeMachines: [],
       visibleSunzeMachineCodes: [],
       cleanupPath: null,
       cleanupMode: null,
@@ -1899,6 +1956,7 @@ try {
       requestedWindowEnd: requestedWindow?.uiWindowEnd ?? null,
       dateWindowFilterApplied,
       outOfWindowRowCount,
+      visibleSunzeMachines: source.visibleSunzeMachines,
       visibleSunzeMachineCodes: source.visibleSunzeMachineCodes,
       visibleSunzeMachineCount,
       expectedVisibleMachineCount: parseFilePath ? null : expectedVisibleMachineCount,

--- a/scripts/sunze/sync-orders.mjs
+++ b/scripts/sunze/sync-orders.mjs
@@ -539,6 +539,9 @@ const machineListNameNoise = new Set([
   'online',
   'offline',
   'machine id',
+  'machine name',
+  'device id',
+  'device name',
 ]);
 
 const sanitizeMachineName = (value) => {
@@ -548,6 +551,8 @@ const sanitizeMachineName = (value) => {
   if (machineListNameNoise.has(normalized)) return null;
   if (/^(heating temp|internal temp|humidity)\s*[:：]/i.test(text)) return null;
   if (/^machine\s*id\s*[:：]?/i.test(text)) return null;
+  if (/^machine\s*name\s*[:：]?/i.test(text)) return null;
+  if (/^device\s*(id|name)\s*[:：]?/i.test(text)) return null;
   return text;
 };
 

--- a/src/pages/admin/Reporting.tsx
+++ b/src/pages/admin/Reporting.tsx
@@ -1,12 +1,16 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
 import {
   AlertTriangle,
+  ArrowRight,
   CalendarDays,
   CheckCircle2,
   Database,
+  Info,
   Loader2,
   RefreshCw,
+  ShieldCheck,
 } from 'lucide-react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -88,6 +92,74 @@ const formatCents = (value: unknown) => {
   }).format(cents / 100);
 };
 
+const normalizeComparableText = (value: string | null | undefined) =>
+  String(value ?? '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+
+const partnershipMachineNameHints: Record<string, string[]> = {
+  'merlin revenue share': ['merlin', 'madame tussauds', 'legoland', 'sea life'],
+  'bubble planet revenue share': ['bubble planet'],
+  'bloomjoy mini california': ['bloomjoy mini', 'mini california'],
+};
+
+const getImportedMachineDisplayName = (machine: AdminSunzeMachineQueueItem | null) =>
+  machine?.sunzeMachineName?.trim() || machine?.sunzeMachineId || 'Imported machine';
+
+const getRecommendedPartnership = (
+  machine: AdminSunzeMachineQueueItem | null,
+  partnerships: AdminReportingPartnershipOption[]
+) => {
+  if (!machine) return null;
+
+  const machineText = normalizeComparableText(
+    `${machine.sunzeMachineName ?? ''} ${machine.sunzeMachineId}`
+  );
+  if (!machineText) return null;
+
+  const scored = partnerships
+    .filter((partnership) => partnership.status === 'active')
+    .map((partnership) => {
+      const partnershipText = normalizeComparableText(partnership.name);
+      const hints = [
+        ...partnershipText.split(' ').filter((token) => token.length >= 4),
+        ...(partnershipMachineNameHints[partnershipText] ?? []),
+      ];
+      const matchedHint = hints.find((hint) => machineText.includes(normalizeComparableText(hint)));
+      return {
+        partnership,
+        matchedHint,
+        score: matchedHint ? 1 : 0,
+      };
+    })
+    .filter((item) => item.score > 0)
+    .sort(
+      (left, right) =>
+        right.score - left.score || left.partnership.name.localeCompare(right.partnership.name)
+    );
+
+  const best = scored[0];
+  if (!best) return null;
+
+  return {
+    partnership: best.partnership,
+    reason: best.matchedHint
+      ? `Suggested from source machine name match: ${best.matchedHint}`
+      : 'Suggested from source machine details',
+  };
+};
+
+const inferImportedMachineLocationName = (machine: AdminSunzeMachineQueueItem | null) => {
+  const machineText = normalizeComparableText(machine?.sunzeMachineName);
+  if (!machineText) return '';
+  if (machineText.includes('las vegas') || machineText.includes('vegas')) return 'Las Vegas';
+  if (machineText.includes('minneapolis')) return 'Minneapolis';
+  if (machineText.includes('chicago')) return 'Chicago';
+  if (machineText.includes('dallas')) return 'Dallas';
+  return '';
+};
+
 const getImportedMachineSetupSummary = (result: MapSourceMachineToPartnershipResult) =>
   `${result.machineLabel} is ready for ${result.partnershipName}. ${result.promotedRowCount} queued row${
     result.promotedRowCount === 1 ? '' : 's'
@@ -123,6 +195,8 @@ export default function AdminReportingPage() {
   const [updatingSunzeMachineId, setUpdatingSunzeMachineId] = useState<string | null>(null);
   const [setupMachine, setSetupMachine] = useState<AdminSunzeMachineQueueItem | null>(null);
   const [isSettingUpMachine, setIsSettingUpMachine] = useState(false);
+  const [lastSetupResult, setLastSetupResult] =
+    useState<MapSourceMachineToPartnershipResult | null>(null);
 
   const {
     data: overview,
@@ -234,6 +308,7 @@ export default function AdminReportingPage() {
         promoted_revenue_cents: result.promotedRevenueCents,
       });
       toast.success(getImportedMachineSetupSummary(result));
+      setLastSetupResult(result);
       setSetupMachine(null);
       await Promise.all([
         refresh(),
@@ -397,6 +472,13 @@ export default function AdminReportingPage() {
             />
           </div>
 
+          {lastSetupResult && (
+            <ImportedMachineSetupReceipt
+              result={lastSetupResult}
+              onDismiss={() => setLastSetupResult(null)}
+            />
+          )}
+
           <Tabs defaultValue="schedules" className="mt-6">
             <TabsList className="h-auto flex-wrap justify-start">
               <TabsTrigger value="schedules">Schedules</TabsTrigger>
@@ -484,6 +566,74 @@ function LoadingCard() {
   return (
     <div className="rounded-lg border border-border bg-card p-6 text-sm text-muted-foreground">
       Loading reporting operations...
+    </div>
+  );
+}
+
+function ImportedMachineSetupReceipt({
+  result,
+  onDismiss,
+}: {
+  result: MapSourceMachineToPartnershipResult;
+  onDismiss: () => void;
+}) {
+  return (
+    <div className="mt-6 rounded-lg border border-primary/25 bg-primary/5 p-4">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <ShieldCheck className="h-5 w-5 text-primary" />
+            <h2 className="font-semibold text-foreground">Imported machine setup complete</h2>
+          </div>
+          <p className="mt-2 text-sm text-muted-foreground">
+            {result.machineLabel} is assigned to {result.partnershipName}.{' '}
+            {result.promotedRowCount} queued row{result.promotedRowCount === 1 ? '' : 's'} /{' '}
+            {formatCents(result.promotedRevenueCents)} moved into reporting.
+          </p>
+          <dl className="mt-3 grid gap-2 text-sm sm:grid-cols-2 lg:grid-cols-4">
+            <div>
+              <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                External ID
+              </dt>
+              <dd className="mt-1 break-all text-foreground">{result.externalMachineId}</dd>
+            </div>
+            <div>
+              <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Account
+              </dt>
+              <dd className="mt-1 text-foreground">{result.accountName}</dd>
+            </div>
+            <div>
+              <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Location
+              </dt>
+              <dd className="mt-1 text-foreground">{result.locationName}</dd>
+            </div>
+            <div>
+              <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Access
+              </dt>
+              <dd className="mt-1 text-foreground">Review scoped admins separately</dd>
+            </div>
+          </dl>
+          <div className="mt-3 flex items-start gap-2 rounded-md border border-border bg-background/70 p-3 text-sm text-muted-foreground">
+            <Info className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+            Partnership assignment controls reporting and settlement grouping. It does not
+            automatically grant admin, tax, or scoped management rights.
+          </div>
+        </div>
+        <div className="flex shrink-0 flex-wrap gap-2 lg:justify-end">
+          <Button asChild>
+            <Link to="/admin/access">
+              Review Access
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Link>
+          </Button>
+          <Button variant="outline" onClick={onDismiss}>
+            Dismiss
+          </Button>
+        </div>
+      </div>
     </div>
   );
 }
@@ -693,12 +843,28 @@ function SyncTab({
           sunzeMachineQueue.map((machine) => (
             <Row key={machine.sunzeMachineId}>
               <div>
-                <div className="font-medium text-foreground">
-                  {machine.sunzeMachineName ?? machine.sunzeMachineId}
+                <div className="flex flex-wrap items-center gap-2">
+                  <div className="font-medium text-foreground">
+                    {getImportedMachineDisplayName(machine)}
+                  </div>
+                  {!machine.sunzeMachineName && (
+                    <Badge variant="outline" className="text-amber-700">
+                      Name missing
+                    </Badge>
+                  )}
+                  {machine.pendingRowCount === 0 && (
+                    <Badge variant="outline">No queued sales</Badge>
+                  )}
                 </div>
                 <div className="mt-1 text-xs text-muted-foreground">
                   External machine ID {machine.sunzeMachineId} / status {machine.status}
                 </div>
+                {!machine.sunzeMachineName && (
+                  <div className="mt-1 text-xs text-muted-foreground">
+                    Confirm the provider machine name before setup when multiple new IDs appeared
+                    together.
+                  </div>
+                )}
                 {machine.ignoreReason && (
                   <div className="mt-1 text-xs text-muted-foreground">
                     Ignored: {machine.ignoreReason}
@@ -779,18 +945,22 @@ function ImportedMachineSetupDialog({
   onSave: (form: ImportedMachineSetupForm) => void;
 }) {
   const [form, setForm] = useState<ImportedMachineSetupForm>(emptyImportedMachineSetupForm);
+  const recommendedPartnership = useMemo(
+    () => getRecommendedPartnership(machine, partnerships),
+    [machine, partnerships]
+  );
   const selectedPartnership = partnerships.find(
     (partnership) => partnership.id === form.partnershipId
   );
 
   useEffect(() => {
     if (!machine) return;
-    const defaultPartnership =
-      partnerships.find((partnership) => partnership.status === 'active') ?? partnerships[0];
+    const recommended = getRecommendedPartnership(machine, partnerships);
     setForm({
       ...emptyImportedMachineSetupForm,
-      partnershipId: defaultPartnership?.id ?? '',
+      partnershipId: recommended?.partnership.id ?? '',
       machineLabel: machine.sunzeMachineName ?? '',
+      locationName: inferImportedMachineLocationName(machine),
     });
   }, [machine, partnerships]);
 
@@ -815,6 +985,33 @@ function ImportedMachineSetupDialog({
             <div className="mt-1 text-xs text-muted-foreground">
               {machine?.pendingRowCount ?? 0} queued rows /{' '}
               {formatCents(machine?.pendingRevenueCents ?? 0)}
+            </div>
+          </div>
+          {recommendedPartnership && (
+            <div className="rounded-md border border-primary/20 bg-primary/5 p-3 text-sm">
+              <div className="flex items-start gap-2">
+                <ShieldCheck className="mt-0.5 h-4 w-4 text-primary" />
+                <div>
+                  <div className="font-medium text-foreground">
+                    Suggested report: {recommendedPartnership.partnership.name}
+                  </div>
+                  <div className="mt-1 text-xs text-muted-foreground">
+                    {recommendedPartnership.reason}. Confirm this before finishing setup.
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+          <div className="rounded-md border border-border bg-muted/20 p-3 text-sm">
+            <div className="flex items-start gap-2">
+              <Info className="mt-0.5 h-4 w-4 text-muted-foreground" />
+              <div>
+                <div className="font-medium text-foreground">Access review is separate</div>
+                <div className="mt-1 text-xs text-muted-foreground">
+                  This assignment controls reporting and settlement grouping only. Review scoped
+                  admin access after setup for users who need tax or machine management rights.
+                </div>
+              </div>
             </div>
           </div>
           <div className="grid gap-4 sm:grid-cols-2">
@@ -849,7 +1046,7 @@ function ImportedMachineSetupDialog({
                 id="imported-machine-label"
                 value={form.machineLabel}
                 onChange={(event) => setForm({ ...form, machineLabel: event.target.value })}
-                placeholder="Merlin Minneapolis"
+                placeholder={machine?.sunzeMachineName ?? 'Machine label'}
               />
             </div>
             <div>
@@ -858,7 +1055,7 @@ function ImportedMachineSetupDialog({
                 id="imported-machine-location"
                 value={form.locationName}
                 onChange={(event) => setForm({ ...form, locationName: event.target.value })}
-                placeholder="Minneapolis"
+                placeholder="Las Vegas"
               />
             </div>
             <div>
@@ -914,7 +1111,7 @@ function ImportedMachineSetupDialog({
           </Button>
           <Button
             onClick={() => onSave(form)}
-            disabled={isSaving || !machine || partnerships.length === 0}
+            disabled={isSaving || !machine || partnerships.length === 0 || !form.partnershipId}
           >
             {isSaving ? (
               <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/supabase/functions/sunze-sales-ingest/index.ts
+++ b/supabase/functions/sunze-sales-ingest/index.ts
@@ -36,6 +36,11 @@ type SunzeIngestRow = {
   sourceStatus?: unknown;
 };
 
+type VisibleSunzeMachine = {
+  machineCode: string;
+  machineName: string | null;
+};
+
 type ReportingMachine = {
   id: string;
   location_id: string;
@@ -103,6 +108,41 @@ const sanitizeCodeArray = (value: unknown) =>
         ),
       ].sort()
     : [];
+
+const sanitizeMachineCode = (value: unknown) => {
+  const code = sanitizeText(value, 100);
+  return /^[A-Za-z0-9][A-Za-z0-9._-]{1,99}$/.test(code) ? code : null;
+};
+
+const normalizeVisibleSunzeMachines = (value: unknown): VisibleSunzeMachine[] => {
+  if (!Array.isArray(value)) return [];
+
+  const byCode = new Map<string, VisibleSunzeMachine>();
+
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+
+    const record = entry as Record<string, unknown>;
+    const machineCode = sanitizeMachineCode(
+      record.machineCode ?? record.sunzeMachineId ?? record.code ?? record.id
+    );
+    if (!machineCode) continue;
+
+    const machineName = sanitizeText(
+      record.machineName ?? record.sunzeMachineName ?? record.name,
+      200
+    );
+
+    byCode.set(machineCode.toLowerCase(), {
+      machineCode,
+      machineName: machineName || null,
+    });
+  }
+
+  return [...byCode.values()].sort((left, right) =>
+    left.machineCode.localeCompare(right.machineCode)
+  );
+};
 
 const safeInteger = (value: unknown): number | null => {
   if (value === null || value === undefined || value === "") return null;
@@ -277,7 +317,11 @@ const summarizeMachineCoverage = ({
   machineBySunzeId: Map<string, ReportingMachine>;
   rowMachineCodes: string[];
 }) => {
-  const visibleCodes = sanitizeCodeArray(meta.visibleSunzeMachineCodes);
+  const visibleMachineRows = normalizeVisibleSunzeMachines(meta.visibleSunzeMachines);
+  const visibleCodes = uniqueCodes([
+    ...sanitizeCodeArray(meta.visibleSunzeMachineCodes),
+    ...visibleMachineRows.map((machine) => machine.machineCode),
+  ]);
   const expectedCount = safeInteger(meta.expectedVisibleMachineCount);
   const coverageRequired = meta.machineCoverageRequired === true;
   const coverageVerified = visibleCodes.length > 0;
@@ -323,6 +367,18 @@ const buildMachineNameMap = (rows: SunzeIngestRow[]) => {
     const machineName = sanitizeText(row.machineName, 200);
     if (machineName) {
       namesByCode.set(machineCode.toLowerCase(), machineName);
+    }
+  }
+
+  return namesByCode;
+};
+
+const buildVisibleMachineNameMap = (meta: Record<string, unknown>) => {
+  const namesByCode = new Map<string, string>();
+
+  for (const machine of normalizeVisibleSunzeMachines(meta.visibleSunzeMachines)) {
+    if (machine.machineName) {
+      namesByCode.set(machine.machineCode.toLowerCase(), machine.machineName);
     }
   }
 
@@ -774,6 +830,9 @@ serve(async (req) => {
       parsed_machine_count: safeInteger(bodyMeta.parsedMachineCount),
       parsed_order_amount_cents: safeInteger(bodyMeta.parsedOrderAmountCents),
       visible_sunze_machine_count: safeInteger(bodyMeta.visibleSunzeMachineCount),
+      visible_sunze_machine_name_count: normalizeVisibleSunzeMachines(
+        bodyMeta.visibleSunzeMachines
+      ).filter((machine) => machine.machineName).length,
       expected_visible_machine_count: safeInteger(bodyMeta.expectedVisibleMachineCount),
       machine_coverage_required: bodyMeta.machineCoverageRequired === true,
       machine_coverage_verified: bodyMeta.machineCoverageVerified === true,
@@ -799,9 +858,13 @@ serve(async (req) => {
       machineBySunzeId,
       rowMachineCodes,
     });
+    const machineNamesByCode = new Map([
+      ...buildMachineNameMap(rows),
+      ...buildVisibleMachineNameMap(bodyMeta),
+    ]);
     const discoveryState = await upsertSunzeMachineDiscoveries({
       machineCodes: machineCoverage.discoveredMachineCodes,
-      machineNamesByCode: buildMachineNameMap(rows),
+      machineNamesByCode,
       machineBySunzeId,
       importRunId,
       write: !dryRun,

--- a/supabase/functions/sunze-sales-ingest/index.ts
+++ b/supabase/functions/sunze-sales-ingest/index.ts
@@ -133,9 +133,12 @@ const normalizeVisibleSunzeMachines = (value: unknown): VisibleSunzeMachine[] =>
       200
     );
 
-    byCode.set(machineCode.toLowerCase(), {
+    const key = machineCode.toLowerCase();
+    const existing = byCode.get(key);
+
+    byCode.set(key, {
       machineCode,
-      machineName: machineName || null,
+      machineName: machineName || existing?.machineName || null,
     });
   }
 


### PR DESCRIPTION
## Summary
- Carry Sunze Machine Center display names into imported-machine discovery so setup rows can show provider names before any sales-row mapping exists.
- Improve `/admin/reporting` imported-machine setup with active-partnership suggestions, location inference, missing-name/no-sales cues, and an access-review warning.
- Add a post-setup receipt with a direct `Review Access` path so admins do not assume partnership assignment grants scoped admin/tax rights.

## Files changed
- `scripts/sunze/sync-orders.mjs`: extracts visible machine names alongside Machine Center IDs and includes them in ingest metadata.
- `supabase/functions/sunze-sales-ingest/index.ts`: normalizes visible Machine Center metadata and uses it when upserting discovered Sunze machines.
- `src/pages/admin/Reporting.tsx`: updates queue display, setup dialog defaults/warnings, and post-setup receipt UX.

## Verification commands + results
- `npm ci` - passed; npm audit reports 2 moderate vulnerabilities.
- `npm run build` - passed; Vite still reports existing large chunk warnings.
- `npm test --if-present` - passed; no test script is configured.
- `npm run lint --if-present` - passed with 8 existing Fast Refresh warnings in shared UI/Auth files.
- `npm run reporting:validate-provider-parser` - passed.
- `npm run reporting:validate-sync-diagnostics` - passed.
- `node --check scripts/sunze/sync-orders.mjs` - passed.
- `git diff --check` - passed.
- Mocked browser smoke test against local Vite - passed: Sync queue shows `Madame Tussauds Vegas`, setup suggests `Merlin Revenue Share`, location is inferred as `Las Vegas`, access review copy is visible, Finish Setup is enabled, and there were no browser console errors.
- `npm run auth:preflight` - failed in this clean worktree because no `.env`/`.env.local` is present; missing `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`, with `VITE_GOOGLE_CLIENT_ID` warning.

## How to test
1. From this branch/worktree, configure local env per `Docs/LOCAL_DEV.md`, then run `npm ci` and `npm run dev`.
2. Open `http://localhost:8080/admin/reporting` as a super admin.
3. Go to `Sync` and confirm imported machines show provider Machine Center names when available, plus `Name missing` or `No queued sales` badges when applicable.
4. For a machine named `Madame Tussauds Vegas`, click `Set up` and confirm the dialog suggests `Merlin Revenue Share`, pre-fills `Madame Tussauds Vegas`, infers `Las Vegas`, and explains that access review is separate.
5. Complete setup and confirm the receipt appears with the `Review Access` link to `/admin/access`.
