### PR TITLE
Add workflow drift CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
         run: npm ci
       - name: Supabase Migration Version Check
         run: node scripts/check-supabase-migration-versions.mjs
+      - name: Agent Workflow Drift Check
+        run: npm run agent:validate-workflow
       - name: Build
         run: npm run build
       - name: SEO Regression Checks

--- a/scripts/agent-context.mjs
+++ b/scripts/agent-context.mjs
@@ -77,8 +77,15 @@ function isMatch(haystack, pattern) {
   return pattern.test(haystack);
 }
 
+function taskHaystack(issue) {
+  const body = String(issue?.body ?? "")
+    .replace(/## Sensitive data warning[\s\S]*$/i, "")
+    .replace(/## Expected verification[\s\S]*?(?=\n## |$)/i, "");
+  return `${issue?.title ?? ""}\n${body}\n${labelNames(issue)}`.toLowerCase();
+}
+
 function buildDocList(issue) {
-  const haystack = `${issue?.title ?? ""}\n${issue?.body ?? ""}\n${labelNames(issue)}`.toLowerCase();
+  const haystack = taskHaystack(issue);
   const docs = new Set([
     "AGENTS.md",
     "Docs/LOCAL_DEV.md",
@@ -106,7 +113,7 @@ function buildDocList(issue) {
 
 function buildVerification(issue) {
   const issueArg = issue?.number ? ` -- --issue ${issue.number}` : "";
-  const haystack = `${issue?.title ?? ""}\n${issue?.body ?? ""}\n${labelNames(issue)}`.toLowerCase();
+  const haystack = taskHaystack(issue);
   const commands = [
     "npm ci",
     `npm run agent:preflight${issueArg}`,

--- a/scripts/validate-agent-workflow.mjs
+++ b/scripts/validate-agent-workflow.mjs
@@ -94,6 +94,11 @@ if (exists("package.json")) {
   assert(pkg.scripts?.["agent:validate-workflow"], "package.json must include agent:validate-workflow.");
 }
 
+if (exists(".github/workflows/ci.yml")) {
+  const ci = read(".github/workflows/ci.yml");
+  assert(/npm run agent:validate-workflow/.test(ci), "CI must run npm run agent:validate-workflow.");
+}
+
 for (const file of [".github/ISSUE_TEMPLATE/feature_task.yml", ".github/ISSUE_TEMPLATE/bug.yml"]) {
   if (!exists(file)) continue;
   const source = read(file);


### PR DESCRIPTION
## Linked Issue
- Closes #461

## Summary
- Adds `npm run agent:validate-workflow` to CI so workflow/template/config drift fails in PR checks.
- Extends the workflow validator to assert CI keeps that check.
- Fixes `agent:context` heuristics so sensitive-data warnings do not trigger unrelated commerce verification.

## Files Changed
- `.github/workflows/ci.yml` - adds Agent Workflow Drift Check.
- `scripts/validate-agent-workflow.mjs` - validates CI contains the drift check.
- `scripts/agent-context.mjs` - strips sensitive-data and expected-verification sections before heuristic doc/command selection.

## Verification
- [x] `npm ci` - passed; npm reported existing 2 moderate audit findings.
- [x] `npm run agent:context -- --issue 461` - passed; no unrelated commerce preflight in profile.
- [x] `npm run agent:preflight -- --issue 461` - passed before and after commit.
- [x] `npm run agent:validate-workflow` - passed.
- [x] `npm run build` - passed; existing Vite large chunk warning remains.
- [x] `npm test --if-present` - passed; no test script output.
- [x] `npm run lint --if-present` - passed with existing 8 react-refresh warnings.
- [x] `git diff --check` - passed.

## How To Test Locally
1. Run `npm ci`.
2. Run `npm run agent:context -- --issue 461`.
3. Run `npm run agent:validate-workflow`.
4. Inspect `.github/workflows/ci.yml` for the Agent Workflow Drift Check step.

## Risk And Overlap
- Priority/risk: P2, low runtime risk. CI/workflow tooling only.
- Shared files or open PR overlap: touches CI and agent workflow scripts only.
- Rollback: revert this PR.

## UI / Design Evidence
- Not applicable.

## Board Closeout
- Project-board status: issue #461 is on the Bloomjoy project board; PR is ready for review.
- Remaining follow-ups: #462, #463, #464 track separate hygiene work.