### PR TITLE
Resolve safe npm audit findings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3346,9 +3346,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6934,9 +6934,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
## Linked Issue
- Closes #462

## Summary
- Applies a lockfile-only `npm audit fix` for the existing moderate findings.
- Updates transitive `brace-expansion` from 5.0.5 to 5.0.6.
- Updates transitive `ws` from 8.19.0 to 8.21.0.

## Files Changed
- `package-lock.json` - transitive dependency patch updates only.

## Verification
- [x] `npm ci` - passed; found 0 vulnerabilities.
- [x] `npm audit` - passed; found 0 vulnerabilities.
- [x] `npm run agent:preflight -- --issue 462` - passed before and after commit.
- [x] `npm run agent:validate-workflow` - passed.
- [x] `npm run build` - passed; existing Vite large chunk warning remains.
- [x] `npm test --if-present` - passed; no test script output.
- [x] `npm run lint --if-present` - passed with existing 8 react-refresh warnings.
- [x] `git diff --check` - passed.

## How To Test Locally
1. Run `npm ci`.
2. Run `npm audit`.
3. Run the standard verification commands above.

## Risk And Overlap
- Priority/risk: P2, low runtime risk. Lockfile-only transitive patch updates.
- Shared files or open PR overlap: may overlap any PR touching `package-lock.json`.
- Rollback: revert this PR.

## UI / Design Evidence
- Not applicable.

## Board Closeout
- Project-board status: issue #462 is on the Bloomjoy project board; PR is ready for review.
- Remaining follow-ups: #463 tracks lint warning cleanup; #464 tracks build chunk warning.