### PR TITLE
Reduce react-refresh lint warnings

### DIFF
--- a/src/components/auth/AdminRoute.tsx
+++ b/src/components/auth/AdminRoute.tsx
@@ -2,7 +2,7 @@ import { Link, Navigate, Outlet, useLocation } from 'react-router-dom';
 import { ShieldAlert } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { PortalLayout } from '@/components/portal/PortalLayout';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '@/contexts/auth-context';
 
 export function AdminRoute() {
   const { adminAccess, loading, isAdmin, isScopedAdmin, isSuperAdmin } = useAuth();

--- a/src/components/auth/MemberRoute.tsx
+++ b/src/components/auth/MemberRoute.tsx
@@ -1,6 +1,6 @@
 import { Link, Outlet, useLocation } from 'react-router-dom';
 import { Lock } from 'lucide-react';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '@/contexts/auth-context';
 import { PortalLayout } from '@/components/portal/PortalLayout';
 import { PortalPageIntro } from '@/components/portal/PortalPageIntro';
 import {

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -1,5 +1,5 @@
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '@/contexts/auth-context';
 
 export function ProtectedRoute() {
   const { isAuthenticated, loading } = useAuth();

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -40,7 +40,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '@/contexts/auth-context';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { getCanonicalUrlForSurface } from '@/lib/appSurface';
 import type { TranslationKey } from '@/lib/i18n';

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -3,7 +3,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { Menu, X, ShoppingCart, User } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useCart } from '@/lib/cart';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '@/contexts/auth-context';
 import { getCanonicalUrlForSurface } from '@/lib/appSurface';
 import { cn } from '@/lib/utils';
 import logo from '@/assets/logo.png';

--- a/src/components/portal/PortalLayout.tsx
+++ b/src/components/portal/PortalLayout.tsx
@@ -12,7 +12,7 @@ import {
   SheetTitle,
   SheetTrigger,
 } from '@/components/ui/sheet';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '@/contexts/auth-context';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { cn } from '@/lib/utils';
 import {

--- a/src/components/portal/TechnicianManagementPanel.tsx
+++ b/src/components/portal/TechnicianManagementPanel.tsx
@@ -34,7 +34,7 @@ import {
 } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Textarea } from '@/components/ui/textarea';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '@/contexts/auth-context';
 import {
   fetchMyTechnicianGrants,
   fetchTechnicianManagementContext,

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
 
 import { cn } from "@/lib/utils";
-import { buttonVariants } from "@/components/ui/button";
+import { buttonVariants } from "@/components/ui/button-variants";
 
 const AlertDialog = AlertDialogPrimitive.Root;
 

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -26,4 +26,4 @@ function Badge({ className, variant, ...props }: BadgeProps) {
   return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
 }
 
-export { Badge, badgeVariants };
+export { Badge };

--- a/src/components/ui/button-variants.ts
+++ b/src/components/ui/button-variants.ts
@@ -1,0 +1,33 @@
+import { cva } from "class-variance-authority";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-semibold ring-offset-background transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-coral-dark shadow-warm hover:shadow-[0_6px_20px_-3px_hsl(16_85%_55%/0.35)]",
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline: "border-2 border-foreground/20 bg-transparent text-foreground hover:border-primary hover:text-primary",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+        hero: "bg-primary text-primary-foreground hover:bg-coral-dark shadow-warm hover:shadow-[0_6px_20px_-3px_hsl(16_85%_55%/0.35)] text-base",
+        "hero-outline": "border-2 border-foreground/20 bg-transparent text-foreground hover:border-primary hover:text-primary text-base",
+        muted: "bg-muted text-muted-foreground hover:bg-muted/80",
+      },
+      size: {
+        default: "h-10 px-5 py-2",
+        sm: "h-9 rounded-md px-4",
+        lg: "h-12 rounded-lg px-8",
+        xl: "h-14 rounded-lg px-10 text-base",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+export { buttonVariants };

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,38 +1,9 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
-import { cva, type VariantProps } from "class-variance-authority";
+import type { VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
-
-const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-semibold ring-offset-background transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
-  {
-    variants: {
-      variant: {
-        default: "bg-primary text-primary-foreground hover:bg-coral-dark shadow-warm hover:shadow-[0_6px_20px_-3px_hsl(16_85%_55%/0.35)]",
-        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-        outline: "border-2 border-foreground/20 bg-transparent text-foreground hover:border-primary hover:text-primary",
-        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
-        hero: "bg-primary text-primary-foreground hover:bg-coral-dark shadow-warm hover:shadow-[0_6px_20px_-3px_hsl(16_85%_55%/0.35)] text-base",
-        "hero-outline": "border-2 border-foreground/20 bg-transparent text-foreground hover:border-primary hover:text-primary text-base",
-        muted: "bg-muted text-muted-foreground hover:bg-muted/80",
-      },
-      size: {
-        default: "h-10 px-5 py-2",
-        sm: "h-9 rounded-md px-4",
-        lg: "h-12 rounded-lg px-8",
-        xl: "h-14 rounded-lg px-10 text-base",
-        icon: "h-10 w-10",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  },
-);
+import { buttonVariants } from "@/components/ui/button-variants";
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
@@ -48,4 +19,4 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 );
 Button.displayName = "Button";
 
-export { Button, buttonVariants };
+export { Button };

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -3,7 +3,7 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 import { DayPicker } from "react-day-picker";
 
 import { cn } from "@/lib/utils";
-import { buttonVariants } from "@/components/ui/button";
+import { buttonVariants } from "@/components/ui/button-variants";
 
 export type CalendarProps = React.ComponentProps<typeof DayPicker>;
 

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -126,4 +126,4 @@ const FormMessage = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<
 );
 FormMessage.displayName = "FormMessage";
 
-export { useFormField, Form, FormItem, FormLabel, FormControl, FormDescription, FormMessage, FormField };
+export { Form, FormItem, FormLabel, FormControl, FormDescription, FormMessage, FormField };

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -108,7 +108,6 @@ const NavigationMenuIndicator = React.forwardRef<
 NavigationMenuIndicator.displayName = NavigationMenuPrimitive.Indicator.displayName;
 
 export {
-  navigationMenuTriggerStyle,
   NavigationMenu,
   NavigationMenuList,
   NavigationMenuItem,

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -2,7 +2,8 @@ import * as React from "react";
 import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react";
 
 import { cn } from "@/lib/utils";
-import { ButtonProps, buttonVariants } from "@/components/ui/button";
+import { type ButtonProps } from "@/components/ui/button";
+import { buttonVariants } from "@/components/ui/button-variants";
 
 const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
   <nav

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -633,5 +633,4 @@ export {
   SidebarRail,
   SidebarSeparator,
   SidebarTrigger,
-  useSidebar,
 };

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,5 +1,5 @@
 import { useTheme } from "next-themes";
-import { Toaster as Sonner, toast } from "sonner";
+import { Toaster as Sonner } from "sonner";
 
 type ToasterProps = React.ComponentProps<typeof Sonner>;
 
@@ -24,4 +24,4 @@ const Toaster = ({ ...props }: ToasterProps) => {
   );
 };
 
-export { Toaster, toast };
+export { Toaster };

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -3,7 +3,7 @@ import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
 import { type VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
-import { toggleVariants } from "@/components/ui/toggle";
+import { toggleVariants } from "@/components/ui/toggle-variants";
 
 const ToggleGroupContext = React.createContext<VariantProps<typeof toggleVariants>>({
   size: "default",

--- a/src/components/ui/toggle-variants.ts
+++ b/src/components/ui/toggle-variants.ts
@@ -1,0 +1,24 @@
+import { cva } from "class-variance-authority";
+
+const toggleVariants = cva(
+  "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline: "border border-input bg-transparent hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-10 px-3",
+        sm: "h-9 px-2.5",
+        lg: "h-11 px-5",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+export { toggleVariants };

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -1,29 +1,9 @@
 import * as React from "react";
 import * as TogglePrimitive from "@radix-ui/react-toggle";
-import { cva, type VariantProps } from "class-variance-authority";
+import type { VariantProps } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
-
-const toggleVariants = cva(
-  "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground",
-  {
-    variants: {
-      variant: {
-        default: "bg-transparent",
-        outline: "border border-input bg-transparent hover:bg-accent hover:text-accent-foreground",
-      },
-      size: {
-        default: "h-10 px-3",
-        sm: "h-9 px-2.5",
-        lg: "h-11 px-5",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  },
-);
+import { toggleVariants } from "@/components/ui/toggle-variants";
 
 const Toggle = React.forwardRef<
   React.ElementRef<typeof TogglePrimitive.Root>,
@@ -34,4 +14,4 @@ const Toggle = React.forwardRef<
 
 Toggle.displayName = TogglePrimitive.Root.displayName;
 
-export { Toggle, toggleVariants };
+export { Toggle };

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
-import React, { createContext, useContext, useState, useEffect, useRef, ReactNode } from 'react';
+import React, { useState, useEffect, useRef, ReactNode } from 'react';
 import type { AuthError, User as SupabaseUser } from '@supabase/supabase-js';
 import { useQueryClient } from '@tanstack/react-query';
+import { AuthContext, type AdminAccessContext, type User } from '@/contexts/auth-context';
 import { supabaseClient } from '@/lib/supabaseClient';
 import { trackEvent, identifyUser } from '@/lib/analytics';
 import { getCanonicalUrlForSurface } from '@/lib/appSurface';
@@ -20,72 +21,8 @@ import {
 } from '@/lib/reporting';
 import { resolveMyTechnicianEntitlements } from '@/lib/technicianEntitlements';
 
-interface User {
-  id: string;
-  email: string;
-  membershipStatus?: MembershipStatus;
-  membershipPlan?: string;
-  portalAccessTier: PortalAccessTier;
-  isTrainingOperator: boolean;
-  canManageOperatorTraining: boolean;
-  isCorporatePartner: boolean;
-  hasSupplyDiscount: boolean;
-  canRequestSupport: boolean;
-  canManageTechnicians: boolean;
-  capabilities: string[];
-  effectivePresets: string[];
-  plusAccess: PlusAccessSummary;
-  reportingAccess: ReportingAccessContext;
-  isAdmin: boolean;
-  isSuperAdmin: boolean;
-  isScopedAdmin: boolean;
-  adminAccess: AdminAccessContext;
-}
-
-interface AuthContextType {
-  user: User | null;
-  loading: boolean;
-  signInWithMagicLink: (email: string) => Promise<{ error: AuthError | null }>;
-  signInWithPassword: (email: string, password: string) => Promise<{ error: AuthError | null }>;
-  signUpWithPassword: (email: string, password: string) => Promise<{ error: AuthError | null }>;
-  signInWithGoogle: () => Promise<{ error: AuthError | null }>;
-  signInWithGoogleIdToken: (idToken: string) => Promise<{ error: AuthError | null }>;
-  requestPasswordReset: (email: string) => Promise<{ error: AuthError | null }>;
-  updatePassword: (password: string) => Promise<{ error: AuthError | null }>;
-  signIn: (email: string) => Promise<{ error: AuthError | null }>;
-  signOut: () => Promise<void>;
-  isAuthenticated: boolean;
-  isMember: boolean;
-  portalAccessTier: PortalAccessTier;
-  canAccessTraining: boolean;
-  isTrainingOperator: boolean;
-  canManageOperatorTraining: boolean;
-  isCorporatePartner: boolean;
-  hasSupplyDiscount: boolean;
-  canRequestSupport: boolean;
-  canManageTechnicians: boolean;
-  capabilities: string[];
-  effectivePresets: string[];
-  hasReportingAccess: boolean;
-  reportingMachineCount: number;
-  reportingLocationCount: number;
-  canManageReporting: boolean;
-  isAdmin: boolean;
-  isSuperAdmin: boolean;
-  isScopedAdmin: boolean;
-  adminAccess: AdminAccessContext;
-}
-
 type AdminRoleRecord = {
   role: string;
-};
-
-type AdminAccessContext = {
-  isSuperAdmin: boolean;
-  isScopedAdmin: boolean;
-  canAccessAdmin: boolean;
-  allowedSurfaces: string[];
-  scopedMachineIds: string[];
 };
 
 type AdminAccessContextRpc = {
@@ -109,8 +46,6 @@ type PortalAccessContextRecord = {
   capabilities?: string[] | null;
   effective_presets?: string[] | null;
 };
-
-const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 const getDevAdminEmailAllowlist = (): Set<string> => {
   if (!import.meta.env.DEV) {
@@ -512,12 +447,4 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       {children}
     </AuthContext.Provider>
   );
-}
-
-export function useAuth() {
-  const context = useContext(AuthContext);
-  if (context === undefined) {
-    throw new Error('useAuth must be used within an AuthProvider');
-  }
-  return context;
 }

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -9,7 +9,7 @@ import {
   useState,
   type ReactNode,
 } from 'react';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '@/contexts/auth-context';
 import {
   DEFAULT_LANGUAGE,
   LANGUAGE_STORAGE_KEY,

--- a/src/contexts/auth-context.ts
+++ b/src/contexts/auth-context.ts
@@ -1,0 +1,78 @@
+import { createContext, useContext } from 'react';
+import type { AuthError } from '@supabase/supabase-js';
+import type { MembershipStatus, PlusAccessSummary, PortalAccessTier } from '@/lib/membership';
+import type { ReportingAccessContext } from '@/lib/reporting';
+
+export type AdminAccessContext = {
+  isSuperAdmin: boolean;
+  isScopedAdmin: boolean;
+  canAccessAdmin: boolean;
+  allowedSurfaces: string[];
+  scopedMachineIds: string[];
+};
+
+export interface User {
+  id: string;
+  email: string;
+  membershipStatus?: MembershipStatus;
+  membershipPlan?: string;
+  portalAccessTier: PortalAccessTier;
+  isTrainingOperator: boolean;
+  canManageOperatorTraining: boolean;
+  isCorporatePartner: boolean;
+  hasSupplyDiscount: boolean;
+  canRequestSupport: boolean;
+  canManageTechnicians: boolean;
+  capabilities: string[];
+  effectivePresets: string[];
+  plusAccess: PlusAccessSummary;
+  reportingAccess: ReportingAccessContext;
+  isAdmin: boolean;
+  isSuperAdmin: boolean;
+  isScopedAdmin: boolean;
+  adminAccess: AdminAccessContext;
+}
+
+interface AuthContextType {
+  user: User | null;
+  loading: boolean;
+  signInWithMagicLink: (email: string) => Promise<{ error: AuthError | null }>;
+  signInWithPassword: (email: string, password: string) => Promise<{ error: AuthError | null }>;
+  signUpWithPassword: (email: string, password: string) => Promise<{ error: AuthError | null }>;
+  signInWithGoogle: () => Promise<{ error: AuthError | null }>;
+  signInWithGoogleIdToken: (idToken: string) => Promise<{ error: AuthError | null }>;
+  requestPasswordReset: (email: string) => Promise<{ error: AuthError | null }>;
+  updatePassword: (password: string) => Promise<{ error: AuthError | null }>;
+  signIn: (email: string) => Promise<{ error: AuthError | null }>;
+  signOut: () => Promise<void>;
+  isAuthenticated: boolean;
+  isMember: boolean;
+  portalAccessTier: PortalAccessTier;
+  canAccessTraining: boolean;
+  isTrainingOperator: boolean;
+  canManageOperatorTraining: boolean;
+  isCorporatePartner: boolean;
+  hasSupplyDiscount: boolean;
+  canRequestSupport: boolean;
+  canManageTechnicians: boolean;
+  capabilities: string[];
+  effectivePresets: string[];
+  hasReportingAccess: boolean;
+  reportingMachineCount: number;
+  reportingLocationCount: number;
+  canManageReporting: boolean;
+  isAdmin: boolean;
+  isSuperAdmin: boolean;
+  isScopedAdmin: boolean;
+  adminAccess: AdminAccessContext;
+}
+
+export const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -13,7 +13,7 @@ import {
   getSugarPricePerKg,
   isSugarSku,
 } from '@/lib/sugar';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '@/contexts/auth-context';
 import { toast } from 'sonner';
 
 export default function CartPage() {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -15,7 +15,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { AppLayout } from '@/components/layout/AppLayout';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '@/contexts/auth-context';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { getCanonicalUrlForSurface } from '@/lib/appSurface';
 import type { TranslationKey } from '@/lib/i18n';

--- a/src/pages/Plus.tsx
+++ b/src/pages/Plus.tsx
@@ -8,7 +8,7 @@ import { trackEvent } from '@/lib/analytics';
 import { trackBusinessPlaybookCtaClick } from '@/lib/businessPlaybookAnalytics';
 import { startPlusCheckout } from '@/lib/stripeCheckout';
 import { toast } from 'sonner';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '@/contexts/auth-context';
 
 const benefits = [
   {

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -4,7 +4,7 @@ import { Loader2, LockKeyhole } from 'lucide-react';
 import { AppLayout } from '@/components/layout/AppLayout';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '@/contexts/auth-context';
 import { supabaseClient } from '@/lib/supabaseClient';
 import { toast } from 'sonner';
 

--- a/src/pages/Supplies.tsx
+++ b/src/pages/Supplies.tsx
@@ -10,7 +10,7 @@ import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Textarea } from '@/components/ui/textarea';
 import sugarProduct from '@/assets/real/sugar-product.jpg';
 import sticksProduct from '@/assets/real/sticks-product.jpg';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '@/contexts/auth-context';
 import { trackEvent } from '@/lib/analytics';
 import { useCart } from '@/lib/cart';
 import {

--- a/src/pages/admin/Access.tsx
+++ b/src/pages/admin/Access.tsx
@@ -18,7 +18,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '@/contexts/auth-context';
 import {
   fetchAdminAccountSummaries,
   fetchMachineInventoryForAccount,

--- a/src/pages/admin/accessPersonConsole.tsx
+++ b/src/pages/admin/accessPersonConsole.tsx
@@ -34,7 +34,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '@/contexts/auth-context';
 import {
   fetchAccessInviteDeliveries,
   sendAccessInvite,

--- a/src/pages/portal/Account.tsx
+++ b/src/pages/portal/Account.tsx
@@ -13,7 +13,7 @@ import { PortalLayout } from '@/components/portal/PortalLayout';
 import { PortalPageIntro } from '@/components/portal/PortalPageIntro';
 import { TechnicianManagementPanel } from '@/components/portal/TechnicianManagementPanel';
 import { LanguagePreferenceControl } from '@/components/i18n/LanguagePreferenceControl';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '@/contexts/auth-context';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { openCustomerPortal } from '@/lib/stripeCheckout';
 import { hasPlusAccess } from '@/lib/membership';

--- a/src/pages/portal/Dashboard.tsx
+++ b/src/pages/portal/Dashboard.tsx
@@ -18,7 +18,7 @@ import {
   portalDestinations,
   type PortalAccessLevel,
 } from '@/components/portal/portalNavigation';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '@/contexts/auth-context';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { trackEvent } from '@/lib/analytics';
 import type { TranslationKey } from '@/lib/i18n';

--- a/src/pages/portal/Onboarding.tsx
+++ b/src/pages/portal/Onboarding.tsx
@@ -4,7 +4,7 @@ import { Check, ArrowRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { PortalLayout } from '@/components/portal/PortalLayout';
 import { PortalPageIntro } from '@/components/portal/PortalPageIntro';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '@/contexts/auth-context';
 import { trackEvent } from '@/lib/analytics';
 import {
   OnboardingStepWithState,

--- a/src/pages/portal/Reports.tsx
+++ b/src/pages/portal/Reports.tsx
@@ -58,7 +58,7 @@ import {
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { PortalLayout } from '@/components/portal/PortalLayout';
 import { PortalPageIntro } from '@/components/portal/PortalPageIntro';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '@/contexts/auth-context';
 import { useLanguage } from '@/contexts/LanguageContext';
 import {
   emptyReportingAccessContext,

--- a/src/pages/portal/Support.tsx
+++ b/src/pages/portal/Support.tsx
@@ -7,7 +7,7 @@ import { PortalLayout } from '@/components/portal/PortalLayout';
 import { PortalPageIntro } from '@/components/portal/PortalPageIntro';
 import { trackEvent } from '@/lib/analytics';
 import { createSupportRequest } from '@/lib/supportRequests';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '@/contexts/auth-context';
 import { useLanguage } from '@/contexts/LanguageContext';
 import type { TranslationKey } from '@/lib/i18n';
 import { toast } from 'sonner';

--- a/src/pages/portal/Training.tsx
+++ b/src/pages/portal/Training.tsx
@@ -25,7 +25,7 @@ import {
   CollapsibleTrigger,
 } from '@/components/ui/collapsible';
 import { PortalLayout } from '@/components/portal/PortalLayout';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '@/contexts/auth-context';
 import { useLanguage } from '@/contexts/LanguageContext';
 import { downloadTrainingCertificateSvg } from '@/lib/trainingCertificate';
 import { trackEvent } from '@/lib/analytics';

--- a/src/pages/portal/TrainingDetail.tsx
+++ b/src/pages/portal/TrainingDetail.tsx
@@ -25,7 +25,7 @@ import {
   useTrainingLibrary,
   useTrainingProgress,
 } from '@/lib/trainingRepository';
-import { useAuth } from '@/contexts/AuthContext';
+import { useAuth } from '@/contexts/auth-context';
 import type { TrainingExperienceItem, TrainingResource } from '@/lib/trainingTypes';
 import { toast } from 'sonner';
 


### PR DESCRIPTION
## Linked issue
Closes #463

## Summary
- Moved shared button/toggle variant exports into non-component modules so Fast Refresh sees component-only exports.
- Moved Auth context/useAuth exports into a non-TSX context module while leaving AuthProvider in the existing provider file.
- Removed unused shared exports from shadcn wrapper modules that only consume them internally.

## Files changed
- `src/components/ui/*`: variant/helper export cleanup for react-refresh compatibility.
- `src/contexts/*`: split auth context/hook definitions from AuthProvider.
- `src/components/**`, `src/pages/**`: updated `useAuth` import paths.

## Verification
- `npm ci` passed; reports the existing 2 moderate audit findings that are addressed separately in PR #467.
- `npm run agent:preflight -- --issue 463` passed.
- `npm run agent:validate-workflow` passed.
- `npm run build` passed; still shows the existing Reports chunk warning tracked by #464.
- `npm test --if-present` passed.
- `npm run lint --if-present` passed with zero warnings.
- `git diff --check` and `git diff --cached --check` passed.

## How to test
1. `npm ci`
2. `npm run lint --if-present`
3. `npm run build`
4. Optional localhost check: `npm run dev`, then visit `/`, `/login`, and `/portal` to confirm routing still loads.

## Risk / overlap
- No runtime UI behavior intended; this is module-boundary cleanup for lint/tooling.
- Overlaps with #464 only through `src/pages/portal/Reports.tsx` import path if both PRs modify that file.

## UI / design evidence
- Not applicable; no visible UI changes intended.