### PR TITLE
Add agent GitHub hygiene report

### DIFF
--- a/.agents/skills/bloomjoy-agent-workflow/SKILL.md
+++ b/.agents/skills/bloomjoy-agent-workflow/SKILL.md
@@ -38,6 +38,7 @@ description: Use for Bloomjoy Hub GitHub issue or PR work, agent workflow upgrad
 ## Verification and Closeout
 
 - Use the verification profile from `npm run agent:context -- --issue <number>`.
+- For board hygiene, run `npm run agent:github-hygiene` and summarize the report in the issue or PR comment.
 - For workflow/template changes, also run `npm run agent:validate-workflow`.
 - Every repo change gets a PR into `main` with linked issue, summary, files changed, verification results, risk/overlap, and how-to-test steps.
 - Before an agent-initiated merge, run `npm run agent:merge-gate -- --pr <number>` and record the result in the PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ If docs and the GitHub board disagree on active task state, the board wins. If d
 - Use branch names in the form `agent/<short-task-slug>`.
 - Run `npm run agent:preflight` before edits and again before PR closeout.
 - Run `npm run agent:context -- --issue <number>` at kickoff when an issue number is available.
+- Run `npm run agent:github-hygiene` for weekly or as-requested issue board hygiene sweeps.
 - Run `npm run agent:merge-gate -- --pr <number>` before agent-merging a PR.
 - Run `npm run agent:validate-workflow` when changing agent docs, templates, Codex config, skills, or workflow scripts.
 - Keep PRs small and focused: one feature, fix, workflow upgrade, or vertical slice per PR.

--- a/Docs/AI_WORKFLOW.md
+++ b/Docs/AI_WORKFLOW.md
@@ -42,6 +42,7 @@ Before any agent-initiated merge, run `npm run agent:merge-gate -- --pr <number>
 
 ## Weekly hygiene
 Agents should periodically:
+- run `npm run agent:github-hygiene` and use the report as the starting point;
 - list stale PRs and recommend close, merge, park, or rebuild;
 - close/supersede stale PRs after owner approval when needed;
 - prune branches and worktrees only after confirming no uncommitted work remains;

--- a/Docs/LOCAL_DEV.md
+++ b/Docs/LOCAL_DEV.md
@@ -293,6 +293,7 @@ Privacy guardrails:
 ## Agent best practices (plain language)
 - Start from a GitHub issue and Bloomjoy Project board item. Those are the source of truth for active status, priority, blockers, and acceptance.
 - Generate compact kickoff context with `npm run agent:context -- --issue <number>`.
+- Run `npm run agent:github-hygiene` for weekly or as-requested GitHub issue/board hygiene reports.
 - Use `/goal` for multi-step, multi-PR, high-risk, or ambiguous work. Use `/plan` first if acceptance is unclear.
 - Each agent uses its own worktree and its own `.env` file.
 - Do not copy another person's `.env`; create your own from `.env.example`.
@@ -353,6 +354,7 @@ Use this after a PR is merged or intentionally closed. Do not remove a worktree 
 - Keep repo docs light: `Docs/CURRENT_STATUS.md` is a short, plain-language snapshot and `Docs/BACKLOG.md` is only a historical pointer.
 - Capture task status, handoffs, and test evidence in issue/PR comments instead of static markdown.
 - Use `npm run agent:context -- --issue <number>` to summarize issue, project, linked PR, docs, and verification context before asking agents to implement.
+- Use `npm run agent:github-hygiene` to surface missing board items, stale active work, stale P0/P1 status comments, red-lane PRs, and open PRs needing cleanup.
 - If you keep personal notes, store them locally and do not commit them.
 
 

--- a/Docs/TASK_TEMPLATE.md
+++ b/Docs/TASK_TEMPLATE.md
@@ -63,6 +63,7 @@ PR requirements:
 Board closeout:
 - Move/update the project-board item
 - Add closeout evidence to the issue or PR
+- Run `npm run agent:github-hygiene` when the task is board, stale PR, or issue hygiene work
 - Note remaining follow-ups as GitHub issues, not static backlog entries
 ```
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "auth:preflight": "node scripts/auth-preflight.mjs",
     "agent:preflight": "node scripts/agent-preflight.mjs",
     "agent:context": "node scripts/agent-context.mjs",
+    "agent:github-hygiene": "node scripts/agent-github-hygiene.mjs",
     "agent:merge-gate": "node scripts/agent-merge-gate.mjs",
     "agent:validate-workflow": "node scripts/validate-agent-workflow.mjs",
     "auth:validate-admin-boundaries": "node scripts/validate-admin-permission-boundaries.mjs",

--- a/scripts/agent-github-hygiene.mjs
+++ b/scripts/agent-github-hygiene.mjs
@@ -1,0 +1,436 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+
+const args = parseArgs(process.argv.slice(2));
+const repo = args.repo || process.env.AGENT_REPO || "ethtri/bloomjoy-hub";
+const projectOwner = args["project-owner"] || process.env.AGENT_PROJECT_OWNER || "ethtri";
+const projectNumber = args["project-number"] || process.env.AGENT_PROJECT_NUMBER || "2";
+const maxItems = Number(args["max-items"] || 15);
+const inProgressDays = Number(args["in-progress-days"] || 7);
+const priorityDays = Number(args["priority-days"] || 7);
+const todoDays = Number(args["todo-days"] || 30);
+const prDays = Number(args["pr-days"] || 7);
+const outputJson = Boolean(args.json);
+const failOnFindings = Boolean(args["fail-on-findings"]);
+const now = new Date();
+
+const priorityLabels = ["P0", "P1", "P2", "P3"];
+const redLabels = new Set([
+  "blocked",
+  "blocked-external",
+  "needs-owner-decision",
+  "risky-auth-payment",
+  "risky-db-change",
+  "uat-required",
+]);
+const blockerLabels = new Set(["blocked", "blocked-external", "needs-owner-decision", "parked"]);
+
+function parseArgs(argv) {
+  const parsed = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith("--")) continue;
+
+    const [rawKey, rawValue] = arg.slice(2).split("=");
+    if (rawValue !== undefined) {
+      parsed[rawKey] = rawValue;
+      continue;
+    }
+
+    const next = argv[index + 1];
+    if (next && !next.startsWith("--")) {
+      parsed[rawKey] = next;
+      index += 1;
+    } else {
+      parsed[rawKey] = "true";
+    }
+  }
+  return parsed;
+}
+
+function runJson(command, commandArgs) {
+  try {
+    const stdout = execFileSync(command, commandArgs, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+    return stdout ? JSON.parse(stdout) : null;
+  } catch (error) {
+    const stderr = error.stderr?.toString().trim() || error.message;
+    throw new Error(`Command failed: ${command} ${commandArgs.join(" ")}\n${stderr}`);
+  }
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function labelNames(item) {
+  return asArray(item?.labels).map((label) => (typeof label === "string" ? label : label.name));
+}
+
+function hasLabel(item, label) {
+  return labelNames(item).includes(label);
+}
+
+function hasAnyLabel(item, labels) {
+  const names = labelNames(item);
+  return names.some((label) => labels.has(label));
+}
+
+function daysSince(dateValue) {
+  if (!dateValue) return Number.POSITIVE_INFINITY;
+  const date = new Date(dateValue);
+  if (Number.isNaN(date.valueOf())) return Number.POSITIVE_INFINITY;
+  return Math.max(0, Math.floor((now.valueOf() - date.valueOf()) / 86_400_000));
+}
+
+function latestCommentAt(issue) {
+  const comments = asArray(issue.comments)
+    .map((comment) => comment.createdAt)
+    .filter(Boolean)
+    .sort();
+  return comments.at(-1) || "";
+}
+
+function linkedIssueNumbers(body) {
+  const numbers = new Set();
+  const regex = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|issue|linked issue)?\s*#(\d+)/gi;
+  let match;
+  while ((match = regex.exec(String(body ?? "")))) numbers.add(Number(match[1]));
+  return [...numbers];
+}
+
+function projectIssueItems(project) {
+  return asArray(project.items).filter((item) => item.content?.type === "Issue" && item.content?.repository === repo);
+}
+
+function countBy(items, select) {
+  const counts = {};
+  for (const item of items) {
+    const key = select(item) || "(none)";
+    counts[key] = (counts[key] || 0) + 1;
+  }
+  return counts;
+}
+
+function priorityRank(issue) {
+  const names = labelNames(issue);
+  const index = priorityLabels.findIndex((label) => names.includes(label));
+  return index === -1 ? 99 : index;
+}
+
+function formatIssue(issue, extra = "") {
+  const suffix = extra ? ` - ${extra}` : "";
+  return `- [#${issue.number} ${issue.title}](${issue.url})${suffix}`;
+}
+
+function formatPr(pr, extra = "") {
+  const suffix = extra ? ` - ${extra}` : "";
+  return `- [#${pr.number} ${pr.title}](${pr.url})${suffix}`;
+}
+
+function renderList(title, items, formatter) {
+  const lines = [`### ${title}`, ""];
+  if (!items.length) {
+    lines.push("- None");
+    lines.push("");
+    return lines;
+  }
+
+  const visible = items.slice(0, maxItems);
+  for (const item of visible) lines.push(formatter(item));
+  if (items.length > visible.length) lines.push(`- ...and ${items.length - visible.length} more`);
+  lines.push("");
+  return lines;
+}
+
+function collectPrLabels(pr, issuesByNumber) {
+  const labels = new Set(labelNames(pr));
+  for (const issueNumber of linkedIssueNumbers(pr.body)) {
+    for (const label of labelNames(issuesByNumber.get(issueNumber))) labels.add(label);
+  }
+  return [...labels];
+}
+
+function prAttentionReasons(pr, issuesByNumber) {
+  const reasons = [];
+  const linkedIssues = linkedIssueNumbers(pr.body);
+  const labels = collectPrLabels(pr, issuesByNumber);
+  const red = labels.filter((label) => redLabels.has(label));
+  const age = daysSince(pr.updatedAt);
+
+  if (!linkedIssues.length) reasons.push("no linked issue in PR body");
+  if (pr.isDraft) reasons.push("draft");
+  if (pr.baseRefName !== "main") reasons.push(`targets ${pr.baseRefName}, not main`);
+  if (!["CLEAN", "HAS_HOOKS"].includes(pr.mergeStateStatus)) reasons.push(`merge state ${pr.mergeStateStatus}`);
+  if (red.length) reasons.push(`red-lane labels: ${red.join(", ")}`);
+  if (age >= prDays) reasons.push(`${age}d since PR update`);
+
+  return {
+    linkedIssues,
+    labels,
+    reasons,
+  };
+}
+
+function issueStatusCommentAge(issue) {
+  return daysSince(latestCommentAt(issue) || issue.createdAt);
+}
+
+const issues = runJson("gh", [
+  "issue",
+  "list",
+  "--repo",
+  repo,
+  "--state",
+  "open",
+  "--limit",
+  "1000",
+  "--json",
+  "number,title,url,labels,createdAt,updatedAt,comments,projectItems",
+]);
+
+const prs = runJson("gh", [
+  "pr",
+  "list",
+  "--repo",
+  repo,
+  "--state",
+  "open",
+  "--limit",
+  "200",
+  "--json",
+  "number,title,url,body,labels,isDraft,mergeStateStatus,updatedAt,headRefName,baseRefName",
+]);
+
+const project = runJson("gh", [
+  "project",
+  "item-list",
+  projectNumber,
+  "--owner",
+  projectOwner,
+  "--limit",
+  "1000",
+  "--format",
+  "json",
+]);
+
+const issuesByNumber = new Map(issues.map((issue) => [Number(issue.number), issue]));
+const openIssueNumbers = new Set(issues.map((issue) => Number(issue.number)));
+const projectItems = projectIssueItems(project);
+const projectByNumber = new Map(projectItems.map((item) => [Number(item.content.number), item]));
+const openProjectItems = projectItems.filter((item) => openIssueNumbers.has(Number(item.content.number)));
+
+const missingProject = issues
+  .filter((issue) => !projectByNumber.has(Number(issue.number)))
+  .sort((a, b) => priorityRank(a) - priorityRank(b) || Number(a.number) - Number(b.number));
+
+const missingPriority = issues.filter(
+  (issue) => labelNames(issue).filter((label) => priorityLabels.includes(label)).length === 0,
+);
+const multiplePriority = issues.filter(
+  (issue) => labelNames(issue).filter((label) => priorityLabels.includes(label)).length > 1,
+);
+
+const openDone = openProjectItems.filter((item) => item.status === "Done");
+const openNoStatus = openProjectItems.filter((item) => !item.status);
+const staleInProgress = openProjectItems
+  .filter((item) => item.status === "In Progress")
+  .map((item) => {
+    const issue = issuesByNumber.get(Number(item.content.number));
+    const reasons = [];
+    const issueAge = daysSince(issue?.updatedAt);
+    const statusAge = issue ? issueStatusCommentAge(issue) : Number.POSITIVE_INFINITY;
+    const linkedPrs = asArray(item["linked pull requests"]);
+
+    if (issueAge >= inProgressDays) reasons.push(`${issueAge}d since issue update`);
+    if (statusAge >= inProgressDays) reasons.push(`${statusAge}d since status comment`);
+    if (issue && hasAnyLabel(issue, blockerLabels)) {
+      reasons.push(`blocker label: ${labelNames(issue).filter((label) => blockerLabels.has(label)).join(", ")}`);
+    }
+    if (!linkedPrs.length && issueAge >= inProgressDays) reasons.push("no linked PR on board item");
+
+    return { issue, reasons };
+  })
+  .filter((item) => item.issue && item.reasons.length)
+  .sort((a, b) => priorityRank(a.issue) - priorityRank(b.issue) || daysSince(b.issue.updatedAt) - daysSince(a.issue.updatedAt));
+
+const stalePriorityIssues = issues
+  .filter((issue) => hasLabel(issue, "P0") || hasLabel(issue, "P1"))
+  .map((issue) => ({ issue, statusAge: issueStatusCommentAge(issue) }))
+  .filter(({ statusAge }) => statusAge >= priorityDays)
+  .sort((a, b) => priorityRank(a.issue) - priorityRank(b.issue) || b.statusAge - a.statusAge);
+
+const staleLowerPriorityTodo = openProjectItems
+  .filter((item) => item.status === "Todo")
+  .map((item) => issuesByNumber.get(Number(item.content.number)))
+  .filter((issue) => issue && !hasLabel(issue, "P0") && !hasLabel(issue, "P1"))
+  .map((issue) => ({ issue, age: daysSince(issue.updatedAt) }))
+  .filter(({ age, issue }) => age >= todoDays && !hasAnyLabel(issue, blockerLabels))
+  .sort((a, b) => b.age - a.age);
+
+const ownerDecisionQueue = issues
+  .filter((issue) => hasAnyLabel(issue, blockerLabels))
+  .sort((a, b) => priorityRank(a) - priorityRank(b) || daysSince(b.updatedAt) - daysSince(a.updatedAt));
+
+const prAttention = prs
+  .map((pr) => ({ pr, ...prAttentionReasons(pr, issuesByNumber) }))
+  .filter((item) => item.reasons.length)
+  .sort((a, b) => daysSince(b.pr.updatedAt) - daysSince(a.pr.updatedAt));
+
+const statusCounts = countBy(project.items ?? [], (item) => item.status);
+const openStatusCounts = countBy(openProjectItems, (item) => item.status);
+const priorityCounts = Object.fromEntries(
+  priorityLabels.map((label) => [label, issues.filter((issue) => hasLabel(issue, label)).length]),
+);
+const riskCounts = Object.fromEntries(
+  [...redLabels, "parked", "ui-change", "docs-only"].map((label) => [
+    label,
+    issues.filter((issue) => hasLabel(issue, label)).length,
+  ]),
+);
+
+const findingGroups = [
+  missingProject,
+  missingPriority,
+  multiplePriority,
+  openDone,
+  openNoStatus,
+  staleInProgress,
+  stalePriorityIssues,
+  staleLowerPriorityTodo,
+  ownerDecisionQueue,
+  prAttention,
+];
+const findingCount = findingGroups.reduce((total, items) => total + items.length, 0);
+
+const report = {
+  generatedAt: now.toISOString(),
+  repo,
+  project: `${projectOwner}/${projectNumber}`,
+  thresholds: {
+    inProgressDays,
+    priorityDays,
+    todoDays,
+    prDays,
+  },
+  summary: {
+    openIssues: issues.length,
+    openPrs: prs.length,
+    projectItems: project.totalCount ?? asArray(project.items).length,
+    projectStatusCounts: statusCounts,
+    openIssueProjectStatusCounts: openStatusCounts,
+    priorityCounts,
+    riskCounts,
+    findingCount,
+  },
+  findings: {
+    missingProject,
+    missingPriority,
+    multiplePriority,
+    openDone,
+    openNoStatus,
+    staleInProgress,
+    stalePriorityIssues,
+    staleLowerPriorityTodo,
+    ownerDecisionQueue,
+    prAttention,
+  },
+};
+
+if (outputJson) {
+  console.log(JSON.stringify(report, null, 2));
+} else {
+  const lines = [];
+  lines.push("# GitHub Hygiene Report");
+  lines.push("");
+  lines.push(`Generated: ${report.generatedAt}`);
+  lines.push(`Repo: ${repo}`);
+  lines.push(`Project: ${projectOwner}/${projectNumber}`);
+  lines.push("");
+  lines.push("## Summary");
+  lines.push("");
+  lines.push(`- Open issues: ${issues.length}`);
+  lines.push(`- Open PRs: ${prs.length}`);
+  lines.push(`- Project items: ${report.summary.projectItems}`);
+  lines.push(
+    `- Open issue board status: ${Object.entries(openStatusCounts)
+      .map(([status, count]) => `${status} ${count}`)
+      .join(", ") || "none"}`,
+  );
+  lines.push(
+    `- Open priority split: ${priorityLabels.map((label) => `${label} ${priorityCounts[label]}`).join(", ")}`,
+  );
+  lines.push(`- Findings: ${findingCount}`);
+  lines.push("");
+
+  lines.push("## Findings");
+  lines.push("");
+  lines.push(
+    ...renderList("Open Issues Missing From Project Board", missingProject, (issue) =>
+      formatIssue(issue, labelNames(issue).join(", ")),
+    ),
+  );
+  lines.push(
+    ...renderList("Priority Label Problems", [...missingPriority, ...multiplePriority], (issue) => {
+      const priorities = labelNames(issue).filter((label) => priorityLabels.includes(label));
+      return formatIssue(issue, priorities.length ? `priority labels: ${priorities.join(", ")}` : "missing priority label");
+    }),
+  );
+  lines.push(
+    ...renderList("Open Issues With Board Status Problems", [...openDone, ...openNoStatus], (item) =>
+      formatIssue(item.content, `board status: ${item.status || "none"}`),
+    ),
+  );
+  lines.push(
+    ...renderList("Stale Or Blocked In Progress Issues", staleInProgress, ({ issue, reasons }) =>
+      formatIssue(issue, reasons.join("; ")),
+    ),
+  );
+  lines.push(
+    ...renderList("P0/P1 Issues Needing Fresh Status Comment", stalePriorityIssues, ({ issue, statusAge }) =>
+      formatIssue(issue, `${statusAge}d since latest issue comment`),
+    ),
+  );
+  lines.push(
+    ...renderList("Older P2/P3 Todo Items To Park, Reprioritize, Or Close", staleLowerPriorityTodo, ({ issue, age }) =>
+      formatIssue(issue, `${age}d since issue update`),
+    ),
+  );
+  lines.push(
+    ...renderList("Owner Decision Or Blocker Queue", ownerDecisionQueue, (issue) =>
+      formatIssue(issue, labelNames(issue).filter((label) => blockerLabels.has(label)).join(", ")),
+    ),
+  );
+  lines.push(
+    ...renderList("Open PRs Needing Hygiene Attention", prAttention, ({ pr, reasons }) =>
+      formatPr(pr, reasons.join("; ")),
+    ),
+  );
+
+  lines.push("## Healthy Checks");
+  lines.push("");
+  lines.push(
+    missingPriority.length || multiplePriority.length
+      ? "- Priority labeling needs cleanup."
+      : "- Every open issue has exactly one P0-P3 priority label.",
+  );
+  lines.push(missingProject.length ? "- Some open issues are missing from the project board." : "- Every open issue is on the project board.");
+  lines.push(openDone.length ? "- Some open issues are marked Done on the board." : "- No open issue is marked Done on the board.");
+  lines.push("");
+  lines.push("## Recommended Sweep Actions");
+  lines.push("");
+  lines.push("1. Add missing open issues to the Bloomjoy Project board.");
+  lines.push("2. Move blocked or parked work out of active In Progress unless an agent is actively unblocking it.");
+  lines.push("3. Add short status comments to stale P0/P1 issues, especially owner/blocker items.");
+  lines.push("4. Close, park, or rebuild stale PRs after merge-gate and owner-approval rules are applied.");
+  lines.push("5. Keep task chronology in issue/PR comments; update repo docs only for durable decisions or compact launch snapshots.");
+  lines.push("");
+
+  console.log(lines.join("\n"));
+}
+
+if (failOnFindings && findingCount > 0) {
+  process.exitCode = 1;
+}

--- a/scripts/validate-agent-workflow.mjs
+++ b/scripts/validate-agent-workflow.mjs
@@ -45,6 +45,7 @@ const requiredFiles = [
   ".github/ISSUE_TEMPLATE/bug.yml",
   "scripts/agent-preflight.mjs",
   "scripts/agent-context.mjs",
+  "scripts/agent-github-hygiene.mjs",
   "scripts/agent-merge-gate.mjs",
   "scripts/validate-agent-workflow.mjs",
 ];
@@ -92,6 +93,7 @@ if (exists("package.json")) {
   const pkg = JSON.parse(read("package.json"));
   assert(pkg.scripts?.["agent:preflight"], "package.json must include agent:preflight.");
   assert(pkg.scripts?.["agent:context"], "package.json must include agent:context.");
+  assert(pkg.scripts?.["agent:github-hygiene"], "package.json must include agent:github-hygiene.");
   assert(pkg.scripts?.["agent:merge-gate"], "package.json must include agent:merge-gate.");
   assert(pkg.scripts?.["agent:validate-workflow"], "package.json must include agent:validate-workflow.");
 }
@@ -115,6 +117,19 @@ if (exists(".github/PULL_REQUEST_TEMPLATE.md")) {
   const prTemplate = read(".github/PULL_REQUEST_TEMPLATE.md");
   assert(/Merge Autonomy/.test(prTemplate), "PR template must include Merge Autonomy.");
   assert(/agent:merge-gate/.test(prTemplate), "PR template must mention npm run agent:merge-gate.");
+}
+
+const hygieneDocs = [
+  "AGENTS.md",
+  "Docs/LOCAL_DEV.md",
+  "Docs/AI_WORKFLOW.md",
+  ".agents/skills/bloomjoy-agent-workflow/SKILL.md",
+];
+
+for (const file of hygieneDocs) {
+  if (!exists(file)) continue;
+  const source = read(file);
+  assert(/agent:github-hygiene/.test(source), `${file} must mention npm run agent:github-hygiene.`);
 }
 
 const workflowDocs = [


### PR DESCRIPTION
## Linked Issue
Closes #203

## Summary
- Adds `npm run agent:github-hygiene`, a read-only Markdown/JSON GitHub issue-board hygiene report for weekly or as-requested agent sweeps.
- Checks project-board membership, P0-P3 priority hygiene, stale In Progress/P0/P1 work, older P2/P3 Todo items, owner/blocker queues, and open PRs needing cleanup.
- Documents the command in agent workflow guidance and adds validator coverage so the command stays part of the workflow contract.

## Files Changed
- `scripts/agent-github-hygiene.mjs`: new read-only `gh`-backed hygiene report command.
- `package.json`: adds `agent:github-hygiene`.
- `scripts/validate-agent-workflow.mjs`: requires the command and docs references.
- `AGENTS.md`, `Docs/LOCAL_DEV.md`, `Docs/AI_WORKFLOW.md`, `Docs/TASK_TEMPLATE.md`, `.agents/skills/bloomjoy-agent-workflow/SKILL.md`: document when agents should run the hygiene sweep.

## Verification
- `npm ci` - passed; 0 vulnerabilities.
- `npm run agent:preflight -- --issue 203` - passed; expected warning for changed files before commit.
- `node --check scripts/agent-github-hygiene.mjs` - passed.
- `npm run agent:github-hygiene -- --max-items 8` - passed and produced the expected live report.
- `npm run agent:validate-workflow` - passed.
- `npm run build` - passed; prerender completed.
- `npm test --if-present` - passed; no test script present.
- `npm run lint --if-present` - passed.
- `git diff --check` - passed with line-ending warnings only.

## How To Test
1. From this branch, run `npm ci`.
2. Run `npm run agent:github-hygiene`.
3. Confirm the report includes open issue/project counts, missing board items, stale active issues, owner/blocker queue, and open PR hygiene findings.
4. Optional: run `npm run agent:github-hygiene -- --json` for machine-readable output.
5. Optional: run `npm run agent:github-hygiene -- --fail-on-findings` when an automation should fail if the board needs cleanup.

## Risk And Overlap
- Green-lane workflow/tooling change only; no runtime product behavior changes.
- Read-only by default: the script reports hygiene findings but does not mutate labels, issues, PRs, branches, or project-board items.
- Requires local `gh` auth with repo/project access, matching the existing agent workflow scripts.
- Overlap risk is low; this touches agent workflow docs/scripts only.

## Rollback
- Revert this PR to remove the npm command, script, docs references, and validator requirement.

## UI / Design Evidence
- Not applicable; no visible product UI changes.

## Merge Autonomy
- Lane: Green
- Owner approval: Not required
- Merge gate: Passed with `npm run agent:merge-gate -- --pr 472`.
- Board closeout: Issue #203 is in progress and will close through this PR.