### PR TITLE
P1: Compact current status snapshot

### DIFF
--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -1,25 +1,29 @@
 # Current Status
 
-Last compacted: 2026-05-29
+Last compacted: 2026-05-30
 
 GitHub Issues and the Bloomjoy Project board are the operational source of truth for active work, priority, blockers, acceptance criteria, and closeout evidence.
 
-## Snapshot
+## Live Work
 
-- Bloomjoy Hub is past MVP and is being operated through focused PRs into `main`.
-- Static docs are now durable references and compact snapshots, not the active task ledger.
-- Workflow upgrade issue: https://github.com/ethtri/bloomjoy-hub/issues/459
-- Board audit at workflow-upgrade kickoff: 179 items, 46 Todo, 7 In Progress, 126 Done. Treat these counts as time-sensitive and verify against the live board before planning.
-- Open PRs at kickoff included stacked Operator Payouts PRs `#451` through `#457` and Mini draft `#442`.
+- Run `npm run agent:github-hygiene` before planning sprint work, branch syncs, or broad closeout.
+- Use issue labels, project status, PR checks, and latest issue/PR comments instead of static docs for task state.
+- Keep active blockers, UAT evidence, and closeout notes on the issue or PR where the work is happening.
+- Do not add running task chronology, stale PR lists, old branch names, or historical completed-work ledgers here.
 
-## Current Work Themes
+## Durable References
+
+- Product and decisions: `PRODUCT.md`, `Docs/DECISIONS.md`
+- Local setup and verification: `Docs/LOCAL_DEV.md`, `Docs/QA_SMOKE_TEST_CHECKLIST.md`
+- Production operations: `Docs/PRODUCTION_RUNBOOK.md`
+- Architecture and scope: `Docs/ARCHITECTURE.md`, `Docs/MVP_SCOPE.md`
+
+## Current Themes
 
 - Refund operations and customer-refund pilot readiness remain high-sensitivity operational surfaces.
 - Operator payouts, partner reporting, and scheduled exports are active shared foundations.
 - Frontend work should use existing app patterns plus `PRODUCT.md`, `DESIGN.md`, and `impeccable` when the visible experience matters.
 
-## Blocker Policy
+## Safety
 
-- Put live blockers on the GitHub issue or PR where the work is happening.
-- Use this file only for compact launch-level blockers or cross-cutting context that should survive beyond a single issue.
 - Never paste secrets, raw customer data, payment IDs, vendor exports, or free-text complaint content into docs, issues, PRs, or chat.

--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -13,7 +13,7 @@ GitHub Issues and the Bloomjoy Project board are the operational source of truth
 
 ## Durable References
 
-- Product and decisions: `PRODUCT.md`, `Docs/DECISIONS.md`
+- Product and decisions: `Docs/DECISIONS.md`; use `PRODUCT.md` or `DESIGN.md` only when they exist in the repo
 - Local setup and verification: `Docs/LOCAL_DEV.md`, `Docs/QA_SMOKE_TEST_CHECKLIST.md`
 - Production operations: `Docs/PRODUCTION_RUNBOOK.md`
 - Architecture and scope: `Docs/ARCHITECTURE.md`, `Docs/MVP_SCOPE.md`


### PR DESCRIPTION
## Summary
- Converts `Docs/CURRENT_STATUS.md` into a compact source-of-truth snapshot/index.
- Removes stale kickoff PR/count references and points agents to the live GitHub hygiene command plus durable docs.
- Keeps safety guidance for secrets, customer data, payment IDs, vendor exports, and free-text complaint content.

## Files changed
- `Docs/CURRENT_STATUS.md`: compact live-work guidance, durable-reference links, current themes, and safety note.

## Verification commands + results
- `npm ci` - pass; 0 vulnerabilities reported.
- `npm run agent:preflight -- --issue 473` - pass; expected warning before commit that one file was changed.
- `npm run agent:validate-workflow` - pass.
- `npm run build` - pass.
- `npm test --if-present` - pass; no test script output.
- `npm run lint --if-present` - pass.
- `git diff --check` - pass; line-ending warning only.

## How to test
1. Open `Docs/CURRENT_STATUS.md`.
2. Confirm it is under 50 lines and reads as a snapshot/index rather than a task log.
3. Confirm it says GitHub Issues and the Bloomjoy Project board are authoritative for active work state.
4. Confirm it points agents to `npm run agent:github-hygiene` and durable references such as `Docs/DECISIONS.md`, `Docs/LOCAL_DEV.md`, `Docs/PRODUCTION_RUNBOOK.md`, and `Docs/QA_SMOKE_TEST_CHECKLIST.md`.

Closes #473.

## Verification
2026-05-30 QA sweep: GitHub checks are green after commit 688fdbd. npm run agent:validate-workflow, npm run build, npm test --if-present, npm run lint --if-present, and git diff --check passed locally.

## Risk And Overlap
P1 docs-only branch that changes the agent status source of truth. Overlap risk is moderate with other docs/process PRs; QA issue #486 was fixed and closed.

## Merge Autonomy
Lane: Yellow
Owner approval: not required
Rationale: Yellow lane due to priority or UI-change scope; checks are green and QA notes above document the review evidence.
