### PR TITLE
P3: Harden GitHub Actions defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,17 @@ name: CI
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Setup Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -10,6 +10,9 @@ on:
       - '.github/workflows/supabase-migrations.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest
@@ -17,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Setup Node
         uses: actions/setup-node@v6
         with:

--- a/Docs/GITHUB_ACTIONS_SECURITY.md
+++ b/Docs/GITHUB_ACTIONS_SECURITY.md
@@ -1,0 +1,21 @@
+# GitHub Actions Security
+
+GitHub Actions workflows should default to least privilege and avoid leaving repository credentials available to steps that do not need them.
+
+## Permissions
+
+- Set explicit workflow-level `permissions`.
+- Use `contents: read` for validation, build, lint, test, migration-check, and scheduled read/sync jobs that do not push commits, create releases, or write issues.
+- Add write permissions only at the job or workflow that needs them, with a comment or PR note explaining why.
+
+## Checkout Credentials
+
+- Set `persist-credentials: false` for `actions/checkout` unless the workflow intentionally pushes to the repository.
+- Workflows that push generated commits or tags must document the write path and keep the write-scoped job separate from read-only validation jobs.
+
+## Action Pinning
+
+- Prefer official GitHub actions or trusted vendor actions with explicit major versions.
+- Third-party actions should be reviewed before adoption and pinned to a version or commit SHA when the publisher, permissions, or supply-chain risk is unclear.
+- When action SHAs are pinned, update them through a small PR that records the upstream release, changelog or commit, and verification result.
+- Do not introduce broad token scopes to compensate for action failures without first confirming the action actually needs the permission.

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -18,6 +18,7 @@ If a static doc disagrees with the board about active status or priority, use th
 - `Docs/LOCAL_DEV.md` - local setup, preflight checks, env guidance, and operational helper commands.
 - `Docs/PRODUCTION_RUNBOOK.md` - production deploy, rollback, and operations guidance.
 - `Docs/QA_SMOKE_TEST_CHECKLIST.md` - reusable smoke coverage for user-facing flows.
+- `Docs/GITHUB_ACTIONS_SECURITY.md` - workflow permission, checkout credential, and action pinning policy.
 - `Docs/ARCHITECTURE.md` - system shape and ownership boundaries.
 - `Docs/MVP_SCOPE.md` and `Docs/POC_NOTES.md` - historical product and POC context.
 - `Docs/CURRENT_STATUS.md` - compact snapshot only; not a running changelog.


### PR DESCRIPTION
## Summary
- Adds explicit read-only workflow permissions to CI and Supabase migration validation.
- Disables checkout credential persistence in those read-only validation workflows.
- Documents the repository policy for workflow permissions, checkout credentials, and action pinning/update review.

## Files changed
- `.github/workflows/ci.yml`: `permissions: contents: read` and checkout `persist-credentials: false`.
- `.github/workflows/supabase-migrations.yml`: `permissions: contents: read` and checkout `persist-credentials: false`.
- `Docs/GITHUB_ACTIONS_SECURITY.md`: CI token/action-pinning policy.
- `Docs/README.md`: durable-docs pointer to the new policy.

## Verification commands + results
- `npm ci` - pass; 0 vulnerabilities reported.
- `npm run agent:preflight -- --issue 295` - pass; expected warning before commit that four files were changed.
- `npm run agent:validate-workflow` - pass.
- `npm run build` - pass.
- `npm test --if-present` - pass; no test script output.
- `npm run lint --if-present` - pass.
- `git diff --check` - pass; line-ending warnings only.

## How to test
1. Open `.github/workflows/ci.yml` and `.github/workflows/supabase-migrations.yml`.
2. Confirm both declare `permissions: contents: read`.
3. Confirm both checkout steps use `persist-credentials: false`.
4. Open `Docs/GITHUB_ACTIONS_SECURITY.md` and confirm it documents least privilege, checkout credential handling, and action pinning/update policy.
5. Confirm CI runs successfully on this PR.

Closes #295.

## Verification
2026-05-30 QA sweep: GitHub checks are green, git diff --check passed locally, and workflow hardening diff was reviewed against the PR scope.

## Risk And Overlap
Touches GitHub Actions permissions and workflow checkout credentials. Overlap risk is low, but merge should happen before relying on the hardened defaults in later PRs.

## Merge Autonomy
Lane: Green
Owner approval: not required
Rationale: Green lane because checks are green, the PR targets main, and no red-lane labels were inferred.
