### PR TITLE
P3: Polish ROI payback landed cost copy

### DIFF
--- a/src/data/businessPlaybook.ts
+++ b/src/data/businessPlaybook.ts
@@ -942,7 +942,7 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
             ],
             [
               "Freight, duties, and import fees",
-              "Shipping from China if applicable, tariffs, customs duties, brokerage, landed-cost terms",
+              "International freight if applicable, tariffs, customs duties, brokerage, landed-cost terms",
               "Ask whether these are included in the quote or paid separately",
             ],
             [
@@ -1174,7 +1174,7 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
         body: [
           "The first number in the model is the amount you are trying to recover. Machine price matters, but it is rarely the whole launch budget.",
           "If a list price does not include import fees, tariffs, shipping, duties, customs brokerage, delivery, setup, payment hardware, accessories, sugar, sticks, local readiness, or a small operating buffer, those belong in the worksheet before you calculate payback.",
-          "This is especially important for machines or parts coming from China. Do not assume the quote and the landed cost are the same thing until shipping, tariff, duty, brokerage, and delivery terms are clear.",
+          "This is especially important for imported machines or replacement parts. Do not assume the quote and the landed cost are the same thing until shipping, tariff, duty, brokerage, and delivery terms are clear.",
         ],
         table: {
           caption: "Startup-cost rows to confirm before using any payback model.",

--- a/src/data/businessPlaybookPlanner.ts
+++ b/src/data/businessPlaybookPlanner.ts
@@ -257,7 +257,7 @@ export const plannerBudgetLabels: Record<
   importFreight: {
     label: "Freight, tariffs, duties, and import fees",
     helper:
-      "Use the actual landed-cost quote if these are not already included. Ask about shipping from China, customs duties, tariffs, brokerage, and delivery terms.",
+      "Use the actual landed-cost quote if these are not already included. Ask about international freight, customs duties, tariffs, brokerage, and delivery terms.",
   },
   accessoriesPayment: {
     label: "Accessories and payment hardware",

--- a/src/pages/resources/BusinessPlaybookPaybackPlanner.tsx
+++ b/src/pages/resources/BusinessPlaybookPaybackPlanner.tsx
@@ -831,7 +831,7 @@ export default function BusinessPlaybookPaybackPlannerPage() {
                     const label = paybackStartupCostLabels[key];
                     const helper =
                       key === "importFreight"
-                        ? "Use actual quote terms when known. Ask whether shipping from China, tariffs, duties, customs, brokerage, and delivery are included."
+                        ? "Use actual quote terms when known. Ask whether international freight, tariffs, duties, customs, brokerage, and delivery are included."
                         : label.helper;
 
                     return (


### PR DESCRIPTION
## Summary
- Polishes ROI/payback landed-cost copy to avoid country-specific phrasing while preserving tariff, duty, brokerage, freight, and delivery guidance.
- Keeps the no-promised-ROI/payback guardrails unchanged across the article and planner.

## Files changed
- `src/data/businessPlaybook.ts`
- `src/data/businessPlaybookPlanner.ts`
- `src/pages/resources/BusinessPlaybookPaybackPlanner.tsx`

## Verification commands + results
- `npm ci` - passed; 0 vulnerabilities; existing `glob@10.5.0` deprecation warning.
- `npm run agent:preflight -- --issue 422` - passed; expected changed-files warning before commit.
- `npm run build` - passed.
- `npm run seo:check` - passed after rerunning serially once `dist/robots.txt` existed; the first parallel attempt started before build finished and failed with missing `dist/robots.txt`.
- `npm test --if-present` - passed/no test script output.
- `npm run lint --if-present` - passed.
- `git diff --check` - passed; Git emitted local LF-to-CRLF checkout warnings only.
- Rendered Playwright copy check against `http://127.0.0.1:8082` - passed for the ROI/payback article and Payback Scenario Planner; confirmed updated phrasing appears and the old country-specific phrasing does not render.

## How to test
1. Start localhost from this branch: `npm run dev`.
2. Open `http://localhost:8080/resources/business-playbook/cotton-candy-machine-roi-sales-payback-planning`.
3. Confirm the landed-cost section says `imported machines or replacement parts` and does not use the old country-specific phrasing.
4. Open `http://localhost:8080/resources/business-playbook/payback-planner`.
5. Confirm the startup-cost helper says `international freight` while the planner still avoids revenue, ROI, profit, location-performance, or payback promises.

Closes #422.

## Verification
2026-05-30 QA sweep: GitHub checks are green and git diff --check passed locally. Impeccable passed on the changed payback planner/public copy files without findings.

## Risk And Overlap
Docs/copy-focused public playbook change. Overlap risk is low, mainly with adjacent ROI/payback copy PRs.

## Merge Autonomy
Lane: Green
Owner approval: not required
Rationale: Green lane because checks are green, the PR targets main, and no red-lane labels were inferred.
