### PR TITLE
P2: Show report export artifacts by format

### DIFF
--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -465,6 +465,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Super-admin user can access `/admin/reporting`
 - [ ] Admin can create a weekly partner PDF schedule with recipients and sees it in active schedules
 - [ ] Admin reporting shows report export archive, partner report exports, recent sales/refund import runs, and stale/failed sync status clearly
+- [ ] Admin Reporting > Exports shows multi-format partner report artifacts independently, labels PDF as the primary partner-facing report, labels CSV as the finance/reconciliation export, shows generated timestamps, and each artifact has its own Open action
 - [ ] Admin Reporting > Sync shows a refund adjustment review summary/list where ambiguous, unmatched, duplicate, invalid, and missing-status rows require review and do not silently affect settlement
 - [ ] Admin Reporting > Sync shows the latest live refund sync run after the scheduled workflow runs, and open/denied rows remain review-only
 - [ ] Admin reporting does not mark sales import freshness as failed solely because an unrelated historical backfill failed when a recent daily import is fresh

--- a/src/lib/reporting.ts
+++ b/src/lib/reporting.ts
@@ -113,11 +113,24 @@ export type AdminReportViewSnapshot = {
   filters: Record<string, unknown>;
   summary: Record<string, unknown>;
   export_storage_path: string | null;
+  exports: AdminReportExportArtifact[];
   export_status: 'pending' | 'ready' | 'failed';
   error_message: string | null;
   created_at: string;
   created_by: string | null;
   snapshot_type?: 'sales_report' | 'partner_report';
+};
+
+export type AdminReportExportFormat = 'pdf' | 'csv' | 'xlsx' | 'unknown';
+
+export type AdminReportExportArtifact = {
+  format: AdminReportExportFormat;
+  storagePath: string;
+  generatedAt: string | null;
+  fileName: string | null;
+  label: string;
+  description: string;
+  isPrimary: boolean;
 };
 
 export type AdminReportingEntitlement = {
@@ -326,6 +339,153 @@ type ExportSalesReportResponse = {
   storagePath: string;
   signedUrl: string;
   rowCount?: number;
+};
+
+const reportExportBucket = 'sales-report-exports';
+
+const exportFormatOrder: Record<AdminReportExportFormat, number> = {
+  pdf: 0,
+  csv: 1,
+  xlsx: 2,
+  unknown: 3,
+};
+
+const exportFormatLabels: Record<AdminReportExportFormat, { label: string; description: string }> = {
+  pdf: {
+    label: 'PDF',
+    description: 'Primary partner-facing report',
+  },
+  csv: {
+    label: 'CSV',
+    description: 'Finance/reconciliation data export',
+  },
+  xlsx: {
+    label: 'XLSX',
+    description: 'Spreadsheet workbook export',
+  },
+  unknown: {
+    label: 'File',
+    description: 'Report export artifact',
+  },
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+
+const asTrimmedString = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+};
+
+const getFileNameFromStoragePath = (storagePath: string) => {
+  const [pathWithoutQuery] = storagePath.split('?');
+  const segments = pathWithoutQuery.split('/').filter(Boolean);
+  return segments.at(-1) ?? storagePath;
+};
+
+const normalizeReportExportFormat = (
+  format: unknown,
+  storagePath?: string | null,
+  fileName?: string | null
+): AdminReportExportFormat => {
+  const candidate = `${asTrimmedString(format) ?? ''} ${fileName ?? ''} ${storagePath ?? ''}`.toLowerCase();
+
+  if (candidate.includes('pdf')) return 'pdf';
+  if (candidate.includes('csv')) return 'csv';
+  if (candidate.includes('xlsx')) return 'xlsx';
+  return 'unknown';
+};
+
+const buildAdminReportExportArtifact = ({
+  format,
+  storagePath,
+  generatedAt,
+  fileName,
+}: {
+  format: unknown;
+  storagePath: string;
+  generatedAt?: unknown;
+  fileName?: unknown;
+}): AdminReportExportArtifact => {
+  const normalizedFileName = asTrimmedString(fileName) ?? getFileNameFromStoragePath(storagePath);
+  const normalizedFormat = normalizeReportExportFormat(format, storagePath, normalizedFileName);
+  const meta = exportFormatLabels[normalizedFormat];
+
+  return {
+    format: normalizedFormat,
+    storagePath,
+    generatedAt: asTrimmedString(generatedAt),
+    fileName: normalizedFileName,
+    label: meta.label,
+    description: meta.description,
+    isPrimary: normalizedFormat === 'pdf',
+  };
+};
+
+export const mapAdminReportExportArtifacts = ({
+  summary,
+  fallbackStoragePath,
+  fallbackGeneratedAt,
+}: {
+  summary: Record<string, unknown> | null | undefined;
+  fallbackStoragePath?: string | null;
+  fallbackGeneratedAt?: string | null;
+}): AdminReportExportArtifact[] => {
+  const exportsRecord = isRecord(summary?.exports) ? summary.exports : null;
+  const seenPaths = new Set<string>();
+  const artifacts: AdminReportExportArtifact[] = [];
+
+  if (exportsRecord) {
+    Object.entries(exportsRecord).forEach(([format, value]) => {
+      if (!isRecord(value)) return;
+
+      const storagePath = asTrimmedString(value.storagePath);
+      if (!storagePath || seenPaths.has(storagePath)) return;
+
+      seenPaths.add(storagePath);
+      artifacts.push(
+        buildAdminReportExportArtifact({
+          format,
+          storagePath,
+          generatedAt: value.generatedAt,
+          fileName: value.fileName,
+        })
+      );
+    });
+  }
+
+  const fallbackPath = asTrimmedString(fallbackStoragePath);
+  if (artifacts.length === 0 && fallbackPath) {
+    artifacts.push(
+      buildAdminReportExportArtifact({
+        format: null,
+        storagePath: fallbackPath,
+        generatedAt: fallbackGeneratedAt,
+      })
+    );
+  }
+
+  return artifacts.sort((left, right) => {
+    const formatCompare = exportFormatOrder[left.format] - exportFormatOrder[right.format];
+    if (formatCompare !== 0) return formatCompare;
+    return (right.generatedAt ?? '').localeCompare(left.generatedAt ?? '');
+  });
+};
+
+export const createReportExportSignedUrl = async (storagePath: string): Promise<string> => {
+  const path = storagePath.trim();
+  if (!path) throw new Error('Report export path is missing.');
+
+  const { data, error } = await supabaseClient.storage
+    .from(reportExportBucket)
+    .createSignedUrl(path, 60 * 60 * 24 * 7);
+
+  if (error || !data?.signedUrl) {
+    throw new Error(error?.message || 'Unable to create report export download link.');
+  }
+
+  return data.signedUrl;
 };
 
 type UpsertReportingMachineInput = {
@@ -612,6 +772,11 @@ export const fetchAdminReportingOverview = async (): Promise<AdminReportingOverv
 
   const salesSnapshots = ((snapshotsResult.data ?? []) as AdminReportViewSnapshot[]).map((snapshot) => ({
     ...snapshot,
+    exports: mapAdminReportExportArtifacts({
+      summary: snapshot.summary,
+      fallbackStoragePath: snapshot.export_storage_path,
+      fallbackGeneratedAt: snapshot.created_at,
+    }),
     snapshot_type: 'sales_report' as const,
   }));
   const partnerSnapshots = ((partnerSnapshotsResult.data ?? []) as Array<{
@@ -640,6 +805,13 @@ export const fetchAdminReportingOverview = async (): Promise<AdminReportingOverv
         : `week ending ${periodEndDate}`;
     const title = `${partnership?.name ?? 'Partner report'} ${periodLabel}`;
 
+    const summary = snapshot.summary_json ?? {};
+    const exports = mapAdminReportExportArtifacts({
+      summary,
+      fallbackStoragePath: snapshot.export_storage_path,
+      fallbackGeneratedAt: snapshot.generated_at,
+    });
+
     return {
       id: snapshot.id,
       title,
@@ -650,9 +822,10 @@ export const fetchAdminReportingOverview = async (): Promise<AdminReportingOverv
         periodStartDate,
         periodEndDate,
       },
-      summary: snapshot.summary_json ?? {},
+      summary,
       export_storage_path: snapshot.export_storage_path,
-      export_status: snapshot.export_storage_path ? 'ready' : 'pending',
+      exports,
+      export_status: exports.length > 0 ? 'ready' : 'pending',
       error_message: null,
       created_at: snapshot.generated_at,
       created_by: snapshot.generated_by,

--- a/src/pages/admin/Reporting.tsx
+++ b/src/pages/admin/Reporting.tsx
@@ -7,10 +7,13 @@ import {
   CalendarDays,
   CheckCircle2,
   Database,
+  ExternalLink,
+  FileText,
   Info,
   Loader2,
   RefreshCw,
   ShieldCheck,
+  Table,
 } from 'lucide-react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -30,9 +33,11 @@ import { Label } from '@/components/ui/label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   createReportScheduleAdmin,
+  createReportExportSignedUrl,
   fetchAdminReportingOverview,
   mapSourceMachineToPartnershipAdmin,
   setSunzeMachineDiscoveryStatusAdmin,
+  type AdminReportExportArtifact,
   type AdminReportSchedule,
   type AdminReportViewSnapshot,
   type AdminRefundAdjustmentReviewRow,
@@ -91,6 +96,9 @@ const formatCents = (value: unknown) => {
     maximumFractionDigits: 2,
   }).format(cents / 100);
 };
+
+const getExportArtifactIcon = (artifact: AdminReportExportArtifact) =>
+  artifact.format === 'csv' || artifact.format === 'xlsx' ? Table : FileText;
 
 const normalizeComparableText = (value: string | null | undefined) =>
   String(value ?? '')
@@ -1295,6 +1303,25 @@ function ImportRunRow({ run }: { run: AdminReportingImportRun }) {
 }
 
 function ExportsTab({ snapshots }: { snapshots: AdminReportViewSnapshot[] }) {
+  const [openingArtifactKey, setOpeningArtifactKey] = useState<string | null>(null);
+
+  const openArtifact = async (
+    snapshot: AdminReportViewSnapshot,
+    artifact: AdminReportExportArtifact
+  ) => {
+    const artifactKey = `${snapshot.id}:${artifact.storagePath}`;
+    setOpeningArtifactKey(artifactKey);
+
+    try {
+      const signedUrl = await createReportExportSignedUrl(artifact.storagePath);
+      window.open(signedUrl, '_blank', 'noopener,noreferrer');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Unable to open report export.');
+    } finally {
+      setOpeningArtifactKey(null);
+    }
+  };
+
   return (
     <div className="rounded-lg border border-border bg-card">
       <ListHeader title="Recent Export Snapshots" count={snapshots.length} />
@@ -1312,8 +1339,67 @@ function ExportsTab({ snapshots }: { snapshots: AdminReportViewSnapshot[] }) {
               </div>
               <div className="mt-1 text-xs text-muted-foreground">
                 Created {formatDate(snapshot.created_at)} /{' '}
-                {snapshot.export_storage_path ?? 'no file yet'}
+                {snapshot.exports.length === 0
+                  ? 'no files yet'
+                  : snapshot.exports.length === 1
+                    ? '1 artifact'
+                    : `${snapshot.exports.length} artifacts`}
               </div>
+              {snapshot.exports.length > 0 ? (
+                <div className="mt-3 grid gap-2">
+                  {snapshot.exports.map((artifact) => {
+                    const ArtifactIcon = getExportArtifactIcon(artifact);
+                    const artifactKey = `${snapshot.id}:${artifact.storagePath}`;
+                    const isOpening = openingArtifactKey === artifactKey;
+
+                    return (
+                      <div
+                        key={artifactKey}
+                        className={`grid gap-3 rounded-md border p-3 sm:grid-cols-[1fr_auto] sm:items-center ${
+                          artifact.isPrimary
+                            ? 'border-primary/30 bg-primary/5'
+                            : 'border-border bg-background'
+                        }`}
+                      >
+                        <div className="min-w-0">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span className="inline-flex items-center gap-1.5 text-sm font-semibold text-foreground">
+                              <ArtifactIcon className="h-4 w-4" />
+                              {artifact.label}
+                            </span>
+                            {artifact.isPrimary && <Badge>Primary</Badge>}
+                          </div>
+                          <div className="mt-1 text-sm text-muted-foreground">
+                            {artifact.description}
+                          </div>
+                          <div className="mt-1 break-all text-xs text-muted-foreground">
+                            Generated {formatDate(artifact.generatedAt ?? snapshot.created_at)} /{' '}
+                            {artifact.fileName ?? artifact.storagePath}
+                          </div>
+                        </div>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() => void openArtifact(snapshot, artifact)}
+                          disabled={Boolean(openingArtifactKey)}
+                        >
+                          {isOpening ? (
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          ) : (
+                            <ExternalLink className="mr-2 h-4 w-4" />
+                          )}
+                          Open
+                        </Button>
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="mt-3 rounded-md border border-dashed border-border bg-muted/20 p-3 text-sm text-muted-foreground">
+                  No artifact files recorded yet.
+                </div>
+              )}
               {snapshot.error_message && (
                 <div className="mt-2 text-xs text-destructive">{snapshot.error_message}</div>
               )}


### PR DESCRIPTION
## Summary
- Shows each Reporting Operations export artifact independently by format, including multi-format partner snapshots with PDF and CSV rows.
- Treats PDF as the primary partner-facing report and labels CSV as the finance/reconciliation export.
- Keeps legacy single-file snapshots visible through the existing `export_storage_path` fallback and adds a smoke-test checklist item.

## Files changed
- `src/lib/reporting.ts`: maps `summary_json.exports` / legacy `export_storage_path` into normalized export artifacts and creates signed export URLs.
- `src/pages/admin/Reporting.tsx`: renders artifact rows with format, timestamp, file name/path, primary badge, and per-artifact Open actions.
- `Docs/QA_SMOKE_TEST_CHECKLIST.md`: adds Admin Reporting > Exports smoke coverage for multi-format artifacts.

## Verification commands + results
- `npm ci` - passed.
- `npm run agent:preflight -- --issue 215` - passed.
- `npm run build` - passed.
- `npm test --if-present` - passed.
- `npm run lint --if-present` - passed.
- `git diff --check` - passed with existing LF/CRLF warnings only.
- `npm run db:validate-rpc-surface` - passed.
- `npm run db:validate-migrations` - blocked locally because Docker Desktop Linux engine is not running (`npipe:////./pipe/dockerDesktopLinuxEngine` missing).
- Mocked rendered check on `http://127.0.0.1:8083/admin/reporting` - passed for desktop and mobile: verified PDF + CSV artifact rows, primary PDF treatment, finance/reconciliation CSV label, legacy single-artifact fallback, three Open buttons, and PDF Open requesting the PDF storage path. Browser plugin tooling exposed only basic Playwright controls and did not support the mocked Supabase route setup needed for this flow, so regular Playwright was used.

## How to test
1. Start local dev: `npm run dev -- --host 127.0.0.1 --port 8083 --strictPort`.
2. Sign in as a Super Admin and open `http://127.0.0.1:8083/admin/reporting`.
3. Open the `Exports` tab.
4. For a partner snapshot whose `summary_json.exports` contains both `pdf` and `csv`, confirm separate PDF and CSV rows appear with generated timestamps and Open actions.
5. Confirm PDF has the `Primary` badge and `Primary partner-facing report` copy; confirm CSV says `Finance/reconciliation data export`.
6. Confirm an older snapshot with only `export_storage_path` still appears as one artifact with an Open action.

Closes #215

## Verification
2026-05-30 QA sweep: GitHub checks are green, git diff --check passed locally, and Impeccable passed on the changed reporting UI/helper files without findings.

## Risk And Overlap
Touches admin reporting export presentation and reporting helper logic. Overlap risk is moderate with reporting operations branches and RPC/migration validation.

## UI / Design Evidence
Impeccable passed on the changed reporting UI files; export artifact labels remain explicit by format.

## Merge Autonomy
Lane: Yellow
Owner approval: not required
Rationale: Yellow lane due to priority or UI-change scope; checks are green and QA notes above document the review evidence.
