### PR TITLE
P2: Polish public machines mobile buyer flow

### DIFF
--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -27,6 +27,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Legacy paths (`/products`, `/products/mini`, `/products/micro`, `/products/commercial-robotic-machine`) return permanent redirects to `/machines*`
 - [ ] No console errors on home page load
 - [ ] Mobile header/nav works (basic)
+- [ ] `/machines` has no horizontal page overflow at `360x800`, `390x844`, or `414x896`; the buyer comparison uses readable mobile cards, and the public header switches to the mobile menu at `768x1024`
 
 ## Refund Operations MVP
 - [ ] Follow the PM/PO shadow-pilot runbook in `Docs/REFUND_OPERATIONS_SHADOW_PILOT.md`; PR `#410` is merged, and Google Form/AppSheet remains live until the cutover gate passes.

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -55,7 +55,7 @@ export function Navbar() {
         </Link>
 
         {/* Desktop Navigation */}
-        <div className="hidden items-center gap-1 md:flex">
+        <div className="hidden items-center gap-1 lg:flex">
           {navLinks.map((link) => (
             <Link
               key={link.href}
@@ -73,7 +73,7 @@ export function Navbar() {
         </div>
 
         {/* Desktop Actions */}
-        <div className="hidden items-center gap-3 md:flex">
+        <div className="hidden items-center gap-3 lg:flex">
           <Link
             to="/cart"
             className="relative p-2 text-muted-foreground hover:text-foreground"
@@ -112,7 +112,7 @@ export function Navbar() {
         </div>
 
         {/* Mobile Menu Button */}
-        <div className="flex items-center gap-3 md:hidden">
+        <div className="flex items-center gap-3 lg:hidden">
           <Link
             to="/cart"
             className="relative p-2 text-muted-foreground hover:text-foreground"
@@ -140,7 +140,7 @@ export function Navbar() {
 
       {/* Mobile Menu */}
       {mobileMenuOpen && (
-        <div id="mobile-navigation-menu" className="border-t border-border bg-background md:hidden">
+        <div id="mobile-navigation-menu" className="border-t border-border bg-background lg:hidden">
           <div className="container-page py-4">
             <div className="flex flex-col gap-2">
               {navLinks.map((link) => (

--- a/src/pages/Products.tsx
+++ b/src/pages/Products.tsx
@@ -204,7 +204,33 @@ export default function ProductsPage() {
                 Use this comparison to narrow the first conversation. Final configuration,
                 payment setup, delivery, and operator handoff are confirmed during quote review.
               </p>
-              <div className="mt-6 overflow-hidden rounded-lg border border-border bg-background">
+              <div className="mt-6 grid gap-3 md:hidden">
+                {comparisonRows.map((row) => (
+                  <article
+                    key={row.model}
+                    className="rounded-lg border border-border bg-background p-4"
+                  >
+                    <h3 className="font-display text-lg font-semibold text-foreground">
+                      {row.model}
+                    </h3>
+                    <dl className="mt-3 grid gap-3 text-sm">
+                      <div>
+                        <dt className="font-semibold text-foreground">Best fit</dt>
+                        <dd className="mt-1 text-muted-foreground">{row.fit}</dd>
+                      </div>
+                      <div>
+                        <dt className="font-semibold text-foreground">Capability</dt>
+                        <dd className="mt-1 text-muted-foreground">{row.capability}</dd>
+                      </div>
+                      <div>
+                        <dt className="font-semibold text-foreground">Buying path</dt>
+                        <dd className="mt-1 text-muted-foreground">{row.buyingPath}</dd>
+                      </div>
+                    </dl>
+                  </article>
+                ))}
+              </div>
+              <div className="mt-6 hidden overflow-hidden rounded-lg border border-border bg-background md:block">
                 <div className="overflow-x-auto">
                   <table className="min-w-full border-collapse text-sm">
                     <thead className="bg-muted/40 text-left">


### PR DESCRIPTION
## Summary
- Keeps the public header in mobile-menu mode until `lg`, preventing the 768px tablet/narrow desktop overflow from the desktop nav/actions row.
- Replaces the `/machines` buyer comparison table with readable mobile cards below `md`, while preserving the desktop/tablet table.
- Adds smoke checklist coverage for the `/machines` mobile buyer flow and 768px public header breakpoint.

## Files changed
- `src/components/layout/Navbar.tsx`: moves desktop nav/actions from `md` to `lg`, keeping tablet widths on the mobile menu.
- `src/pages/Products.tsx`: adds mobile buyer-comparison cards and hides the table on phone widths.
- `Docs/QA_SMOKE_TEST_CHECKLIST.md`: adds the public buyer-flow responsive smoke check.

## Verification commands + results
- `npm ci` - passed.
- `npm run agent:preflight -- --issue 318` - passed.
- `npm run build` - passed.
- `npm test --if-present` - passed.
- `npm run lint --if-present` - passed.
- `npm run seo:check` - passed.
- `git diff --check` - passed with existing LF/CRLF warnings only.
- Rendered breakpoint checks on `http://127.0.0.1:8084/machines` - passed: no horizontal page overflow at `360x800`, `390x844`, `414x896`, `768x1024`, or `1024x768`; mobile comparison cards visible at phone widths; table visible at tablet/desktop widths; 768px menu button opens navigation and Operator Login. In-app Browser was used for breakpoint/overflow verification; its screenshot call timed out on `Page.captureScreenshot`, so regular Playwright captured screenshot artifacts.

Screenshots captured locally:
- `output/playwright/public-mobile-buyer-flow-390.png`
- `output/playwright/public-mobile-buyer-flow-768-header.png`

## How to test
1. Start local dev: `npm run dev -- --host 127.0.0.1 --port 8084 --strictPort`.
2. Open `http://127.0.0.1:8084/machines`.
3. At `390x844`, confirm the buyer comparison appears as stacked cards and the page does not horizontally scroll.
4. At `768x1024`, confirm the header shows the cart/menu controls instead of overflowing desktop links; open the menu and confirm Machines/Supplies/Plus/Resources/About/Contact and Operator Login are available.
5. At desktop width, confirm the normal desktop nav and buyer comparison table still render.

Closes #318

## Verification
2026-05-30 QA sweep: GitHub checks are green, git diff --check passed locally, and Impeccable passed on the changed public buyer-flow files without findings.

## Risk And Overlap
Touches public product page and navbar behavior. Overlap risk is moderate with other public-site/mobile polish work.

## UI / Design Evidence
Impeccable passed on the changed public UI files; existing PR evidence includes mobile breakpoint overflow checks.

## Merge Autonomy
Lane: Yellow
Owner approval: not required
Rationale: Yellow lane due to priority or UI-change scope; checks are green and QA notes above document the review evidence.
