### PR TITLE
P3: Polish auth mobile touch targets

### DIFF
--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -140,13 +140,13 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Login flow works (magic link or configured method)
 - [ ] Canonical operator login lives at `https://app.bloomjoyusa.com/login`
 - [ ] Temporary alias `https://app.bloomjoyusa.com/login/operator` resolves to `/login`
-- [ ] On mobile `/login`, the sign-in form appears before the operator-feature highlights and the top app header stays compact without an extra context row pushing content below the fold
+- [ ] On mobile `/login`, the sign-in form appears before the operator-feature highlights, the top app header stays compact without an extra context row pushing content below the fold, and visible auth/header/menu controls have touch-friendly hit areas
 - [ ] Login errors show actionable copy (for example: expired link, send rate-limit)
 - [ ] Language selector on `/login` switches between English and Simplified Chinese and the selected language persists after refresh on desktop
 - [ ] Magic link email is received in the configured inbox and login completes via Supabase auth callback
 - [ ] First-time sign-in copy clearly explains signup-confirmation-first behavior when applicable
 - [ ] Password sign-in works for an existing email/password user
-- [ ] Forgot-password flow sends reset email and `/reset-password` successfully updates password
+- [ ] Forgot-password flow sends reset email and `/reset-password` successfully updates password; on mobile, reset links and actions have touch-friendly hit areas with no horizontal overflow
 - [ ] Google sign-in works when Supabase Google provider is enabled
 - [ ] Google sign-in returns to the app host `/portal` route (for production: `https://app.bloomjoyusa.com/portal`, not `http://localhost:3000`)
 - [ ] On Vercel preview UAT, Google or magic-link sign-in returns to the same preview host at `/portal` instead of `https://app.bloomjoyusa.com/portal`; if it falls back to production, confirm Supabase Additional Redirect URLs include `https://*-snapcase.vercel.app/**`

--- a/src/components/i18n/LanguagePreferenceControl.tsx
+++ b/src/components/i18n/LanguagePreferenceControl.tsx
@@ -55,12 +55,12 @@ export function LanguagePreferenceControl({
               aria-pressed={isActive}
               title={t('language.current', { language: supportedLanguage.label })}
               className={cn(
-                'min-h-8 rounded-full px-2.5 text-xs font-semibold transition-colors sm:px-3',
-                compact && 'min-h-7 min-w-9 px-2 text-[11px]',
+                'min-h-10 rounded-full px-2.5 text-xs font-semibold transition-colors sm:px-3',
+                compact && 'min-h-11 min-w-11 px-2 text-[11px]',
                 isActive
                   ? 'bg-primary text-primary-foreground'
                   : 'text-muted-foreground hover:bg-muted hover:text-foreground',
-                fullWidth && !showText && 'flex-1'
+                fullWidth && !showText && 'min-h-11 flex-1'
               )}
               onClick={() => setLanguage(supportedLanguage.code)}
             >

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -462,7 +462,7 @@ export function AppLayout({ children }: AppLayoutProps) {
       <header className="sticky top-0 z-50 border-b border-border/60 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/85">
         <div className="container-page py-2.5 sm:py-4">
           <div className="flex items-center justify-between gap-4">
-            <Link to={homeUrl} className="flex min-w-0 items-center gap-2.5 sm:gap-3">
+            <Link to={homeUrl} className="flex min-h-11 min-w-0 items-center gap-2.5 sm:gap-3">
               <img
                 src={logo}
                 alt="Bloomjoy Sweets"
@@ -493,7 +493,7 @@ export function AppLayout({ children }: AppLayoutProps) {
 
               <a
                 href={marketingHomeUrl}
-                className="inline-flex items-center gap-1 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+                className="inline-flex min-h-11 items-center gap-1 rounded-full px-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
               >
                 {t('app.mainSite')}
                 <ExternalLink className="h-4 w-4" />

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -57,7 +57,7 @@ const SheetContent = React.forwardRef<React.ElementRef<typeof SheetPrimitive.Con
       <SheetOverlay />
       <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
         {children}
-        <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity data-[state=open]:bg-secondary hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+        <SheetPrimitive.Close className="absolute right-3 top-3 flex h-11 w-11 items-center justify-center rounded-xl opacity-70 ring-offset-background transition-opacity data-[state=open]:bg-secondary hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
           <X className="h-4 w-4" />
           <span className="sr-only">Close</span>
         </SheetPrimitive.Close>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -618,7 +618,10 @@ export default function LoginPage() {
               <div className="mt-6 rounded-[22px] border border-border bg-background/90 p-4 shadow-[var(--shadow-sm)]">
                 <p className="text-sm text-muted-foreground">
                   {t('login.productDetailsPrompt')}{' '}
-                  <a href={mainSiteUrl} className="font-medium text-primary hover:underline">
+                  <a
+                    href={mainSiteUrl}
+                    className="-mx-3 inline-flex min-h-11 items-center rounded-full px-3 font-medium text-primary underline-offset-4 hover:bg-primary/5 hover:underline"
+                  >
                     {t('login.visitPublicSite')}
                   </a>
                 </p>
@@ -727,7 +730,7 @@ export default function LoginPage() {
                   <button
                     type="button"
                     aria-pressed={authMethod === 'password'}
-                    className={`rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+                    className={`min-h-11 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
                       authMethod === 'password'
                         ? 'bg-primary text-primary-foreground'
                         : 'text-muted-foreground hover:bg-muted'
@@ -739,7 +742,7 @@ export default function LoginPage() {
                   <button
                     type="button"
                     aria-pressed={authMethod === 'magic_link'}
-                    className={`rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+                    className={`min-h-11 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
                       authMethod === 'magic_link'
                         ? 'bg-primary text-primary-foreground'
                         : 'text-muted-foreground hover:bg-muted'
@@ -777,7 +780,7 @@ export default function LoginPage() {
                         value={email}
                         onChange={(e) => setEmail(e.target.value)}
                         required
-                        className="mt-1"
+                        className="mt-1 h-11"
                       />
                     </div>
                     <Button
@@ -821,7 +824,7 @@ export default function LoginPage() {
                       value={email}
                       onChange={(e) => setEmail(e.target.value)}
                       required
-                      className="mt-1"
+                      className="mt-1 h-11"
                     />
                   </div>
                   <div>
@@ -835,12 +838,12 @@ export default function LoginPage() {
                       value={password}
                       onChange={(e) => setPassword(e.target.value)}
                       required
-                      className="mt-1"
+                      className="mt-1 h-11"
                     />
                   </div>
                   <button
                     type="button"
-                    className="w-full text-left text-sm font-medium text-primary hover:underline"
+                    className="flex min-h-11 w-full items-center rounded-lg px-3 text-left text-sm font-medium text-primary underline-offset-4 hover:bg-primary/5 hover:underline"
                     onClick={handlePasswordResetRequest}
                     disabled={loading || oauthLoading}
                   >
@@ -872,7 +875,7 @@ export default function LoginPage() {
                   </Button>
                   <button
                     type="button"
-                    className="w-full text-sm font-medium text-primary hover:underline"
+                    className="flex min-h-11 w-full items-center justify-center rounded-lg px-3 text-sm font-medium text-primary underline-offset-4 hover:bg-primary/5 hover:underline"
                     onClick={() => setCreateAccountMode((current) => !current)}
                     disabled={loading || oauthLoading}
                   >
@@ -888,7 +891,10 @@ export default function LoginPage() {
 
               <p className="text-center text-sm text-muted-foreground">
                 {t('login.plusPrompt')}{' '}
-                <a href={plusUrl} className="font-medium text-primary hover:underline">
+                <a
+                  href={plusUrl}
+                  className="-mx-3 inline-flex min-h-11 items-center rounded-full px-3 font-medium text-primary underline-offset-4 hover:bg-primary/5 hover:underline"
+                >
                   {t('login.learnPlus')}
                 </a>
               </p>

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -122,7 +122,7 @@ export default function ResetPasswordPage() {
                       onChange={(event) => setPassword(event.target.value)}
                       placeholder="At least 8 characters"
                       required
-                      className="mt-1"
+                      className="mt-1 h-11"
                     />
                   </div>
 
@@ -140,7 +140,7 @@ export default function ResetPasswordPage() {
                       onChange={(event) => setConfirmPassword(event.target.value)}
                       placeholder="Re-enter your new password"
                       required
-                      className="mt-1"
+                      className="mt-1 h-11"
                     />
                   </div>
 
@@ -159,12 +159,14 @@ export default function ResetPasswordPage() {
                 <div className="space-y-3 text-sm text-muted-foreground">
                   <p>No active password reset session was found.</p>
                   <p>
-                    Return to{' '}
-                    <Link to="/login" className="font-medium text-primary hover:underline">
-                      login
-                    </Link>{' '}
-                    and request a new password reset email.
+                    Return to the login screen and request a new password reset email.
                   </p>
+                  <Link
+                    to="/login"
+                    className="-mx-3 inline-flex min-h-11 items-center rounded-full px-3 font-medium text-primary underline-offset-4 hover:bg-primary/5 hover:underline"
+                  >
+                    Return to login
+                  </Link>
                 </div>
               )}
             </div>


### PR DESCRIPTION
## Summary
- Enlarges mobile auth/header/menu hit areas for `/login`, `/login/operator`, and `/reset-password` without changing auth behavior.
- Keeps the mobile login form above operator-feature highlights while making secondary text actions and inputs touch-friendly.
- Updates the auth smoke checklist for mobile touch-target and reset-link coverage.

## Files changed
- `src/pages/Login.tsx`: touch-sized auth method tabs, auth inputs, forgot-password/create-account buttons, and inline Plus/public-site links.
- `src/pages/ResetPassword.tsx`: touch-sized reset inputs and standalone return-to-login action.
- `src/components/i18n/LanguagePreferenceControl.tsx`, `src/components/layout/AppLayout.tsx`, `src/components/ui/sheet.tsx`: touch-sized app-shell language buttons, header links, and sheet close/menu controls.
- `Docs/QA_SMOKE_TEST_CHECKLIST.md`: auth mobile regression checklist updates.

## Verification commands + results
- `npm ci` � passed; 410 packages audited, 0 vulnerabilities. Existing `glob@10.5.0` deprecation warning only.
- `npm run agent:preflight -- --issue 321` � passed; expected warning that the working tree had changed files before commit.
- `npm run build` � passed; Vite build and public-route prerender completed.
- `npm test --if-present` � passed; no test script output.
- `npm run lint --if-present` � passed.
- `npm run seo:check` � passed; 25 public routes and 23 private routes validated.
- `git diff --check` � passed; Git reported LF-to-CRLF working-copy warnings only.

## Rendered verification
- Local server: `http://127.0.0.1:8086` with dummy Vite Supabase env values.
- Browser DOM/page-health checks passed for `/login` and `/reset-password`; no current-page console warnings/errors were reported.
- Playwright mobile audit passed at `360x800`, `390x844`, and `414x896` for `/login`, `/login/operator`, and `/reset-password`:
  - `overflowX: 0` on every checked route/viewport.
  - `smallTargets: []` after the change for visible `a`, `button`, and `input` controls.
  - Login form remained before operator-feature highlights in viewport metrics.
- Mobile menu audit at `390x844` passed for `/login` and `/reset-password`: sheet opened, no horizontal overflow, and no sub-44px visible menu/header controls.
- Before/after screenshots captured locally under `output/playwright/`:
  - `auth-mobile-before-login-390.png`
  - `auth-mobile-before-reset-390.png`
  - `auth-mobile-after-login-390.png`
  - `auth-mobile-after-reset-390.png`

## How to test
1. `npm ci`
2. Start local dev with required client env values, for example:
   `VITE_SUPABASE_URL=https://example.supabase.co VITE_SUPABASE_ANON_KEY=prerender-anon-key npm run dev -- --host 127.0.0.1 --port 8086 --strictPort`
3. Open `http://127.0.0.1:8086/login` at `390x844`; confirm the form appears before operator-feature cards, has no horizontal scrolling, and the language switcher/menu/text actions are easy to tap.
4. Open `http://127.0.0.1:8086/login/operator`; confirm it resolves to the same touch-friendly login entry.
5. Open `http://127.0.0.1:8086/reset-password`; confirm the no-session state has a touch-friendly `Return to login` action and no horizontal scrolling.
6. Open the mobile menu from both auth routes and confirm the menu controls are touch-friendly.

## Risk / overlap
- No auth provider, redirect, domain, email, password, Google, magic-link, or reset behavior changed.
- Shared `Sheet` close and language-control sizing changes improve app-shell touch targets and may slightly increase menu/header control height where those shared components appear.

Closes #321

## Verification
2026-05-30 QA sweep: GitHub checks are green, git diff --check passed locally, and Impeccable passed on the changed auth/mobile UI files without findings.

## Risk And Overlap
Touches auth screens, language preference controls, app layout, and sheet behavior. Overlap risk is moderate because shared auth/layout components are involved.

## UI / Design Evidence
Impeccable passed on the changed auth and layout files; the existing PR verification includes rendered mobile checks.

## Merge Autonomy
Lane: Yellow
Owner approval: not required
Rationale: Yellow lane due to priority or UI-change scope; checks are green and QA notes above document the review evidence.
