### PR TITLE
P2: Portal non-reporting mobile workflow polish

### DIFF
--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -197,6 +197,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] `/portal/orders` loads real `orders` data for the logged-in user (no mock rows)
 - [ ] `/portal/account` shows live membership status and period from `subscriptions` (no hardcoded next billing date)
 - [ ] `/portal/account` has no horizontal page overflow on mobile viewports (360x800, 390x844, 414x896)
+- [ ] `/portal/orders`, `/portal/account`, `/portal/support`, `/portal/onboarding`, and `/portal/training` keep page actions, form controls, filters, order-card actions, Technician controls, and checklist toggles at touch-friendly sizes on mobile viewports (360x800, 390x844, 414x896)
 - [ ] `/portal/account` profile save persists and reloads from `customer_profiles`
 - [ ] `/portal/account` shipping save persists and reloads from `customer_profiles`
 - [ ] Plus Account Owner sees Technician Access in Settings (`/portal/account`) with seat usage, owned machines, and current Technician grants

--- a/src/components/auth/MemberRoute.tsx
+++ b/src/components/auth/MemberRoute.tsx
@@ -70,11 +70,11 @@ export function MemberRoute() {
                 </div>
                 <div className="mt-6 flex flex-col gap-3 sm:flex-row">
                   {lockedDestination.access !== 'baseline' && !isReportingRoute && (
-                    <Button asChild>
+                    <Button asChild className="min-h-11">
                       <Link to="/plus">View Plus Membership</Link>
                     </Button>
                   )}
-                  <Button asChild variant="outline">
+                  <Button asChild variant="outline" className="min-h-11">
                     <Link to="/portal">Back to Dashboard</Link>
                   </Button>
                 </div>

--- a/src/components/portal/PortalPageIntro.tsx
+++ b/src/components/portal/PortalPageIntro.tsx
@@ -80,7 +80,7 @@ export function PortalPageIntro({
           )}
         </div>
         {actions && (
-          <div className="flex w-full shrink-0 flex-col gap-3 sm:w-auto sm:flex-row sm:flex-wrap sm:justify-end [&>*]:w-full sm:[&>*]:w-auto">
+          <div className="flex w-full shrink-0 flex-col gap-3 sm:w-auto sm:flex-row sm:flex-wrap sm:justify-end [&>*]:min-h-11 [&>*]:w-full sm:[&>*]:w-auto">
             {actions}
           </div>
         )}

--- a/src/components/portal/TechnicianManagementPanel.tsx
+++ b/src/components/portal/TechnicianManagementPanel.tsx
@@ -430,7 +430,7 @@ export function TechnicianManagementPanel() {
                         value={getAccountSelectionKey(selectedAccount)}
                         onValueChange={setSelectedAccountId}
                       >
-                        <SelectTrigger id="technician-account" className="mt-2">
+                        <SelectTrigger id="technician-account" className="mt-2 min-h-11">
                           <SelectValue placeholder="Select account" />
                         </SelectTrigger>
                         <SelectContent>
@@ -487,7 +487,7 @@ export function TechnicianManagementPanel() {
                         value={technicianEmail}
                         onChange={(event) => setTechnicianEmail(event.target.value)}
                         placeholder="technician@example.com"
-                        className="mt-2"
+                        className="mt-2 h-11"
                         disabled={grantMutation.isPending}
                       />
                       <p className="mt-2 text-xs leading-5 text-muted-foreground">
@@ -500,7 +500,7 @@ export function TechnicianManagementPanel() {
                         id="technician-reason"
                         value={grantReason}
                         onChange={(event) => setGrantReason(event.target.value)}
-                        className="mt-2"
+                        className="mt-2 h-11"
                         disabled={grantMutation.isPending}
                       />
                     </div>
@@ -543,7 +543,7 @@ export function TechnicianManagementPanel() {
                         : 'No machines selected; this Technician will receive training only.'}
                     </p>
                     <Button
-                      className="w-full sm:w-auto"
+                      className="min-h-11 w-full sm:w-auto"
                       onClick={handleAddTechnician}
                       disabled={
                         grantMutation.isPending ||
@@ -655,6 +655,7 @@ export function TechnicianManagementPanel() {
             <Button
               type="button"
               variant="outline"
+              className="min-h-11"
               onClick={() => setRevokeTarget(null)}
               disabled={revokeMutation.isPending}
             >
@@ -663,6 +664,7 @@ export function TechnicianManagementPanel() {
             <Button
               type="button"
               variant="destructive"
+              className="min-h-11"
               onClick={handleRevoke}
               disabled={revokeMutation.isPending || !revokeReason.trim()}
             >
@@ -744,7 +746,7 @@ function TechnicianGrantRow({
             size="sm"
             onClick={onStartEdit}
             disabled={isSaving}
-            className="w-full sm:w-auto"
+            className="min-h-11 w-full sm:w-auto"
           >
             <Pencil className="mr-1.5 h-4 w-4" />
             Edit Access
@@ -755,7 +757,7 @@ function TechnicianGrantRow({
             size="sm"
             onClick={onRevoke}
             disabled={isSaving}
-            className="w-full sm:w-auto"
+            className="min-h-11 w-full sm:w-auto"
           >
             <UserMinus className="mr-1.5 h-4 w-4" />
             Revoke
@@ -778,7 +780,7 @@ function TechnicianGrantRow({
               id={`edit-reason-${grant.grantId}`}
               value={editReason}
               onChange={(event) => onChangeEditReason(event.target.value)}
-              className="mt-2"
+              className="mt-2 h-11"
               disabled={isSaving}
             />
           </div>
@@ -789,11 +791,18 @@ function TechnicianGrantRow({
                 : 'One assigned machine selected.'}
             </p>
             <div className="flex flex-col gap-2 sm:flex-row">
-              <Button type="button" variant="outline" onClick={onCancelEdit} disabled={isSaving}>
+              <Button
+                type="button"
+                variant="outline"
+                className="min-h-11"
+                onClick={onCancelEdit}
+                disabled={isSaving}
+              >
                 Cancel
               </Button>
               <Button
                 type="button"
+                className="min-h-11"
                 onClick={onSaveEdit}
                 disabled={isSaving}
               >
@@ -841,7 +850,7 @@ function LegacyTrainingGrantRow({
           size="sm"
           onClick={onRevoke}
           disabled={isRevoking}
-          className="w-full sm:w-auto lg:shrink-0"
+          className="min-h-11 w-full sm:w-auto lg:shrink-0"
         >
           <UserMinus className="mr-1.5 h-4 w-4" />
           Revoke
@@ -911,7 +920,7 @@ function MachineAssignmentPicker({
         <label
           htmlFor={`${name}-training-only`}
           className={cn(
-            'flex cursor-pointer items-start gap-3 border-b border-border/60 p-3',
+            'flex min-h-12 cursor-pointer items-start gap-3 border-b border-border/60 p-3',
             disabled && 'cursor-not-allowed opacity-70'
           )}
         >
@@ -942,7 +951,7 @@ function MachineAssignmentPicker({
                   key={machine.machineId}
                   htmlFor={radioId}
                   className={cn(
-                    'flex cursor-pointer items-start gap-3 border-b border-border/60 p-3 last:border-b-0',
+                    'flex min-h-12 cursor-pointer items-start gap-3 border-b border-border/60 p-3 last:border-b-0',
                     disabled && 'cursor-not-allowed opacity-70'
                   )}
                 >

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -42,7 +42,7 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity data-[state=open]:bg-accent data-[state=open]:text-muted-foreground hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+      <DialogPrimitive.Close className="absolute right-3 top-3 flex h-11 w-11 items-center justify-center rounded-md opacity-70 ring-offset-background transition-opacity data-[state=open]:bg-accent data-[state=open]:text-muted-foreground hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none sm:right-4 sm:top-4">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/src/pages/portal/Account.tsx
+++ b/src/pages/portal/Account.tsx
@@ -247,13 +247,14 @@ export default function AccountPage() {
               isCorporatePartnerOnly ? undefined : hasPaidBilling ? (
                 <Button
                   variant="outline"
+                  className="min-h-11"
                   onClick={handleManageBilling}
                   disabled={isOpeningPortal || isMembershipLoading}
                 >
                   {isOpeningPortal ? 'Opening billing...' : 'Manage Billing'}
                 </Button>
               ) : !isMember ? (
-                <Button asChild variant="outline">
+                <Button asChild variant="outline" className="min-h-11">
                   <Link to="/plus">View Plus Membership</Link>
                 </Button>
               ) : undefined
@@ -284,7 +285,7 @@ export default function AccountPage() {
                 <div className="mt-6 grid gap-4 sm:grid-cols-2">
                   <div>
                     <label className="block text-sm font-medium text-foreground">{t('account.email')}</label>
-                    <Input value={user?.email || ''} disabled className="mt-1" />
+                    <Input value={user?.email || ''} disabled className="mt-1 h-11" />
                   </div>
                   <div>
                     <label className="block text-sm font-medium text-foreground">{t('account.name')}</label>
@@ -292,7 +293,7 @@ export default function AccountPage() {
                       value={profileForm.fullName}
                       onChange={(event) => updateProfileField('fullName', event.target.value)}
                       placeholder={t('account.namePlaceholder')}
-                      className="mt-1"
+                      className="mt-1 h-11"
                       disabled={isProfileLoading}
                     />
                   </div>
@@ -302,7 +303,7 @@ export default function AccountPage() {
                       value={profileForm.companyName}
                       onChange={(event) => updateProfileField('companyName', event.target.value)}
                       placeholder={t('account.companyPlaceholder')}
-                      className="mt-1"
+                      className="mt-1 h-11"
                       disabled={isProfileLoading}
                     />
                   </div>
@@ -312,13 +313,13 @@ export default function AccountPage() {
                       value={profileForm.phone}
                       onChange={(event) => updateProfileField('phone', event.target.value)}
                       placeholder={t('account.phonePlaceholder')}
-                      className="mt-1"
+                      className="mt-1 h-11"
                       disabled={isProfileLoading}
                     />
                   </div>
                 </div>
                 <Button
-                  className="mt-6 w-full sm:w-auto"
+                  className="mt-6 min-h-11 w-full sm:w-auto"
                   onClick={saveProfileSection}
                   disabled={saveProfileMutation.isPending || isProfileLoading}
                 >
@@ -343,7 +344,7 @@ export default function AccountPage() {
                       value={profileForm.shippingStreet1}
                       onChange={(event) => updateProfileField('shippingStreet1', event.target.value)}
                       placeholder={t('account.streetPlaceholder')}
-                      className="mt-1"
+                      className="mt-1 h-11"
                       disabled={isProfileLoading}
                     />
                   </div>
@@ -355,7 +356,7 @@ export default function AccountPage() {
                       value={profileForm.shippingStreet2}
                       onChange={(event) => updateProfileField('shippingStreet2', event.target.value)}
                       placeholder={t('account.apartmentPlaceholder')}
-                      className="mt-1"
+                      className="mt-1 h-11"
                       disabled={isProfileLoading}
                     />
                   </div>
@@ -365,7 +366,7 @@ export default function AccountPage() {
                       value={profileForm.shippingCity}
                       onChange={(event) => updateProfileField('shippingCity', event.target.value)}
                       placeholder={t('account.cityPlaceholder')}
-                      className="mt-1"
+                      className="mt-1 h-11"
                       disabled={isProfileLoading}
                     />
                   </div>
@@ -375,7 +376,7 @@ export default function AccountPage() {
                       value={profileForm.shippingState}
                       onChange={(event) => updateProfileField('shippingState', event.target.value)}
                       placeholder={t('account.statePlaceholder')}
-                      className="mt-1"
+                      className="mt-1 h-11"
                       disabled={isProfileLoading}
                     />
                   </div>
@@ -387,7 +388,7 @@ export default function AccountPage() {
                         updateProfileField('shippingPostalCode', event.target.value)
                       }
                       placeholder={t('account.zipPlaceholder')}
-                      className="mt-1"
+                      className="mt-1 h-11"
                       disabled={isProfileLoading}
                     />
                   </div>
@@ -397,13 +398,13 @@ export default function AccountPage() {
                       value={profileForm.shippingCountry}
                       onChange={(event) => updateProfileField('shippingCountry', event.target.value)}
                       placeholder={t('account.countryPlaceholder')}
-                      className="mt-1"
+                      className="mt-1 h-11"
                       disabled={isProfileLoading}
                     />
                   </div>
                 </div>
                 <Button
-                  className="mt-6 w-full sm:w-auto"
+                  className="mt-6 min-h-11 w-full sm:w-auto"
                   onClick={saveShippingSection}
                   disabled={saveProfileMutation.isPending || isProfileLoading}
                 >
@@ -436,7 +437,7 @@ export default function AccountPage() {
                 {hasPaidBilling ? (
                   <Button
                     variant="outline"
-                    className="mt-4 w-full"
+                    className="mt-4 min-h-11 w-full"
                     onClick={handleManageBilling}
                     disabled={isOpeningPortal || !user?.email || isMembershipLoading}
                   >
@@ -444,7 +445,7 @@ export default function AccountPage() {
                     {isOpeningPortal ? 'Opening...' : 'Open Billing Portal'}
                   </Button>
                 ) : !isMember ? (
-                  <Button asChild variant="outline" className="mt-4 w-full">
+                  <Button asChild variant="outline" className="mt-4 min-h-11 w-full">
                     <Link to="/plus">View Plus Membership</Link>
                   </Button>
                 ) : null}

--- a/src/pages/portal/Onboarding.tsx
+++ b/src/pages/portal/Onboarding.tsx
@@ -52,7 +52,7 @@ export default function OnboardingPage() {
                 { label: `${progressPercent}% ready`, tone: 'muted' },
               ]}
               actions={
-                <Button asChild variant="outline">
+                <Button asChild variant="outline" className="min-h-11">
                   <Link to="/portal/training">
                     Go to Training
                     <ArrowRight className="ml-2 h-4 w-4" />
@@ -105,11 +105,13 @@ export default function OnboardingPage() {
                     step.completed && 'bg-muted/50'
                   )}
                 >
-                  <div className="flex items-start gap-4">
+                  <div className="flex items-start gap-3 sm:gap-4">
                     <button
+                      type="button"
+                      aria-label={`${step.completed ? 'Mark incomplete' : 'Mark complete'}: ${step.title}`}
                       onClick={() => toggleStep(step.id)}
                       className={cn(
-                        'mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border-2 transition-colors',
+                        'flex h-11 w-11 shrink-0 items-center justify-center rounded-full border-2 transition-colors',
                         step.completed
                           ? 'border-sage bg-sage text-sage-light'
                           : 'border-border hover:border-primary'
@@ -129,7 +131,7 @@ export default function OnboardingPage() {
                       <p className="mt-1 text-sm text-muted-foreground">{step.description}</p>
                       {step.action && !step.completed && (
                         <Link to={step.action.href} className="mt-3 inline-block w-full sm:w-auto">
-                          <Button variant="outline" size="sm" className="w-full sm:w-auto">
+                          <Button variant="outline" size="sm" className="min-h-11 w-full sm:w-auto">
                             {step.action.label}
                             <ArrowRight className="ml-2 h-4 w-4" />
                           </Button>

--- a/src/pages/portal/Orders.tsx
+++ b/src/pages/portal/Orders.tsx
@@ -79,10 +79,15 @@ export default function OrdersPage() {
             ]}
             actions={
               <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:flex-wrap">
-                <Button asChild variant="outline">
+                <Button asChild variant="outline" className="min-h-11">
                   <a href={reorderSuppliesUrl}>Reorder Supplies</a>
                 </Button>
-                <Button variant="outline" onClick={refreshOrders} disabled={isFetching}>
+                <Button
+                  variant="outline"
+                  className="min-h-11"
+                  onClick={refreshOrders}
+                  disabled={isFetching}
+                >
                   {isFetching ? (
                     <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                   ) : (
@@ -115,14 +120,16 @@ export default function OrdersPage() {
               {!isLoading &&
                 orders.map((order) => (
                   <div key={order.id} className="card-elevated p-4 sm:p-5">
-                    <div className="flex items-start justify-between gap-3">
-                      <div>
-                        <p className="font-semibold text-foreground">{getOrderReference(order)}</p>
+                    <div className="flex flex-col gap-2 min-[390px]:flex-row min-[390px]:items-start min-[390px]:justify-between">
+                      <div className="min-w-0">
+                        <p className="break-words font-semibold text-foreground">
+                          {getOrderReference(order)}
+                        </p>
                         <p className="mt-1 text-sm text-muted-foreground">
                           {formatDate(order.created_at)}
                         </p>
                       </div>
-                      <span className="rounded-full bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">
+                      <span className="self-start rounded-full bg-primary/10 px-2.5 py-1 text-xs font-medium text-primary">
                         {order.fulfillment_status}
                       </span>
                     </div>
@@ -133,11 +140,12 @@ export default function OrdersPage() {
                       </p>
                       <p>Payment: {order.status}</p>
                     </div>
-                    <div className="mt-4 flex gap-2 [&>*]:flex-1">
+                    <div className="mt-4 flex flex-col gap-2 min-[390px]:flex-row [&>*]:flex-1">
                       <Button
                         asChild={Boolean(order.receipt_url)}
                         variant="outline"
                         size="sm"
+                        className="min-h-11"
                         disabled={!order.receipt_url}
                       >
                         {order.receipt_url ? (
@@ -152,6 +160,7 @@ export default function OrdersPage() {
                         asChild={Boolean(order.fulfillment_tracking_url)}
                         variant="ghost"
                         size="sm"
+                        className="min-h-11"
                         disabled={!order.fulfillment_tracking_url}
                       >
                         {order.fulfillment_tracking_url ? (

--- a/src/pages/portal/Support.tsx
+++ b/src/pages/portal/Support.tsx
@@ -237,7 +237,7 @@ export default function SupportPage() {
               </p>
               <Button
                 variant="outline"
-                className="mt-4 w-full"
+                className="mt-4 min-h-11 w-full"
                 onClick={() => setActiveForm('wechat')}
               >
                 {t('support.viewSetupGuide')}
@@ -256,7 +256,7 @@ export default function SupportPage() {
               <p className="mt-2 text-sm text-muted-foreground">
                 {t('support.wechatHelpDescription')}
               </p>
-              <Button className="mt-4 w-full" onClick={openWeChatOnboardingForm}>
+              <Button className="mt-4 min-h-11 w-full" onClick={openWeChatOnboardingForm}>
                 {t('support.requestOnboarding')}
               </Button>
             </div>
@@ -272,7 +272,7 @@ export default function SupportPage() {
               <p className="mt-2 text-sm text-muted-foreground">
                 {t('support.conciergeDescription')}
               </p>
-              <Button className="mt-4 w-full" onClick={() => setActiveForm('concierge')}>
+              <Button className="mt-4 min-h-11 w-full" onClick={() => setActiveForm('concierge')}>
                 {t('support.submitRequest')}
               </Button>
             </div>
@@ -288,7 +288,11 @@ export default function SupportPage() {
               <p className="mt-2 text-sm text-muted-foreground">
                 {t('support.partsDescription')}
               </p>
-              <Button variant="outline" className="mt-4 w-full" onClick={() => setActiveForm('parts')}>
+              <Button
+                variant="outline"
+                className="mt-4 min-h-11 w-full"
+                onClick={() => setActiveForm('parts')}
+              >
                 {t('support.requestParts')}
               </Button>
             </div>
@@ -374,13 +378,13 @@ export default function SupportPage() {
               <div className="mt-6 flex flex-col gap-3 sm:flex-row">
                 <Button
                   variant="outline"
-                  className="w-full sm:w-auto"
+                  className="min-h-11 w-full sm:w-auto"
                   onClick={() => setActiveForm(null)}
                 >
                   {t('support.close')}
                 </Button>
                 <Button
-                  className="w-full sm:w-auto"
+                  className="min-h-11 w-full sm:w-auto"
                   onClick={openWeChatOnboardingForm}
                 >
                   {t('support.needOnboardingHelp')}
@@ -414,7 +418,7 @@ export default function SupportPage() {
                     }
                     placeholder={t('support.wechatSubjectPlaceholder')}
                     required
-                    className="mt-1"
+                    className="mt-1 h-11"
                   />
                 </div>
 
@@ -431,7 +435,7 @@ export default function SupportPage() {
                       }
                       placeholder="+1"
                       required
-                      className="mt-1"
+                      className="mt-1 h-11"
                     />
                   </div>
                   <div>
@@ -446,7 +450,7 @@ export default function SupportPage() {
                       }
                       placeholder={t('support.phoneNumberPlaceholder')}
                       required
-                      className="mt-1"
+                      className="mt-1 h-11"
                     />
                   </div>
                 </div>
@@ -462,7 +466,7 @@ export default function SupportPage() {
                           deviceType: e.target.value as WeChatDeviceType,
                         })
                       }
-                      className="mt-1 h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                      className="mt-1 h-11 w-full rounded-md border border-input bg-background px-3 text-sm"
                     >
                       {(Object.keys(deviceLabelKeyMap) as WeChatDeviceType[]).map((value) => (
                         <option key={value} value={value}>
@@ -481,7 +485,7 @@ export default function SupportPage() {
                           blockedStep: e.target.value as WeChatBlockedStep,
                         })
                       }
-                      className="mt-1 h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                      className="mt-1 h-11 w-full rounded-md border border-input bg-background px-3 text-sm"
                     >
                       {(Object.keys(blockedStepLabelKeyMap) as WeChatBlockedStep[]).map((value) => (
                         <option key={value} value={value}>
@@ -502,7 +506,7 @@ export default function SupportPage() {
                           referralNeeded: e.target.value as 'yes' | 'no' | 'unsure',
                         })
                       }
-                      className="mt-1 h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                      className="mt-1 h-11 w-full rounded-md border border-input bg-background px-3 text-sm"
                     >
                       <option value="yes">{t('support.yes')}</option>
                       <option value="no">{t('support.no')}</option>
@@ -524,7 +528,7 @@ export default function SupportPage() {
                       })
                     }
                     placeholder={t('support.wechatIdPlaceholder')}
-                    className="mt-1"
+                    className="mt-1 h-11"
                   />
                 </div>
 
@@ -545,13 +549,13 @@ export default function SupportPage() {
                 </div>
 
                 <div className="flex flex-col gap-3 sm:flex-row">
-                  <Button type="submit" className="w-full sm:w-auto" disabled={loading}>
+                  <Button type="submit" className="min-h-11 w-full sm:w-auto" disabled={loading}>
                     {loading ? t('support.submitting') : t('support.submitOnboarding')}
                   </Button>
                   <Button
                     type="button"
                     variant="outline"
-                    className="w-full sm:w-auto"
+                    className="min-h-11 w-full sm:w-auto"
                     onClick={() => setActiveForm(null)}
                   >
                     {t('support.cancel')}
@@ -584,7 +588,7 @@ export default function SupportPage() {
                     onChange={(e) => setFormData({ ...formData, subject: e.target.value })}
                     placeholder={t('support.subjectPlaceholder')}
                     required
-                    className="mt-1"
+                    className="mt-1 h-11"
                   />
                 </div>
                 <div>
@@ -599,13 +603,13 @@ export default function SupportPage() {
                   />
                 </div>
                 <div className="flex flex-col gap-3 sm:flex-row">
-                  <Button type="submit" className="w-full sm:w-auto" disabled={loading}>
+                  <Button type="submit" className="min-h-11 w-full sm:w-auto" disabled={loading}>
                     {loading ? t('support.submitting') : t('support.submitRequest')}
                   </Button>
                   <Button
                     type="button"
                     variant="outline"
-                    className="w-full sm:w-auto"
+                    className="min-h-11 w-full sm:w-auto"
                     onClick={() => setActiveForm(null)}
                   >
                     {t('support.cancel')}
@@ -638,7 +642,7 @@ export default function SupportPage() {
                     onChange={(e) => setFormData({ ...formData, subject: e.target.value })}
                     placeholder={t('support.partNamePlaceholder')}
                     required
-                    className="mt-1"
+                    className="mt-1 h-11"
                   />
                 </div>
                 <div>
@@ -652,13 +656,13 @@ export default function SupportPage() {
                   />
                 </div>
                 <div className="flex flex-col gap-3 sm:flex-row">
-                  <Button type="submit" className="w-full sm:w-auto" disabled={loading}>
+                  <Button type="submit" className="min-h-11 w-full sm:w-auto" disabled={loading}>
                     {loading ? t('support.submitting') : t('support.submitRequest')}
                   </Button>
                   <Button
                     type="button"
                     variant="outline"
-                    className="w-full sm:w-auto"
+                    className="min-h-11 w-full sm:w-auto"
                     onClick={() => setActiveForm(null)}
                   >
                     {t('support.cancel')}

--- a/src/pages/portal/Training.tsx
+++ b/src/pages/portal/Training.tsx
@@ -730,7 +730,7 @@ export default function TrainingPage() {
                   <button
                     type="button"
                     onClick={() => focusLibraryExplorer()}
-                    className="inline-flex items-center justify-center gap-2 text-sm font-medium text-primary hover:text-primary/80"
+                    className="inline-flex min-h-11 items-center justify-center gap-2 text-sm font-medium text-primary hover:text-primary/80"
                   >
                     {t('training.searchInstead')}
                     <ArrowRight className="h-4 w-4" />
@@ -756,7 +756,7 @@ export default function TrainingPage() {
                 </div>
                 <Button
                   variant="ghost"
-                  className="w-full justify-start px-0 text-primary hover:bg-transparent sm:w-fit"
+                  className="min-h-11 w-full justify-start px-0 text-primary hover:bg-transparent sm:w-fit"
                   onClick={() => focusLibraryExplorer()}
                 >
                   {t('training.exploreFullLibrary')}
@@ -805,7 +805,7 @@ export default function TrainingPage() {
                     key={trackDefinition.id}
                     type="button"
                     onClick={() => handleSelectTrack(trackDefinition.id)}
-                    className={`rounded-2xl border p-4 text-left transition-all ${
+                    className={`min-h-24 rounded-2xl border p-4 text-left transition-all ${
                       isActive
                         ? 'border-primary/30 bg-primary/5 shadow-sm'
                         : 'border-border bg-background hover:border-primary/20 hover:bg-muted/20'
@@ -913,14 +913,14 @@ export default function TrainingPage() {
                     placeholder={t('training.searchPlaceholder')}
                     value={search}
                     onChange={(event) => setSearch(event.target.value)}
-                    className="pl-10"
+                    className="h-11 pl-10"
                   />
                 </div>
 
                 <div className="flex w-full flex-wrap items-center gap-3 lg:w-auto">
                   <Collapsible open={advancedFiltersOpen} onOpenChange={setAdvancedFiltersOpen}>
                     <CollapsibleTrigger asChild>
-                      <Button variant="outline" className="w-full sm:w-auto">
+                      <Button variant="outline" className="min-h-11 w-full sm:w-auto">
                         {t('training.moreFilters')}
                         {activeFilterCount > 0 && (
                           <span className="ml-2 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-semibold text-primary">
@@ -944,7 +944,7 @@ export default function TrainingPage() {
                             <div className="mt-3 flex flex-wrap gap-2">
                               <button
                                 onClick={() => setSelectedModule('All modules')}
-                                className={`rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+                                className={`min-h-11 rounded-full px-3 py-1 text-sm font-medium transition-colors ${
                                   selectedModule === 'All modules'
                                     ? 'bg-primary text-primary-foreground'
                                     : 'bg-muted text-muted-foreground hover:bg-muted/80'
@@ -956,7 +956,7 @@ export default function TrainingPage() {
                                 <button
                                   key={moduleLabel}
                                   onClick={() => setSelectedModule(moduleLabel)}
-                                  className={`rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+                                  className={`min-h-11 rounded-full px-3 py-1 text-sm font-medium transition-colors ${
                                     selectedModule === moduleLabel
                                       ? 'bg-primary text-primary-foreground'
                                       : 'bg-muted text-muted-foreground hover:bg-muted/80'
@@ -976,7 +976,7 @@ export default function TrainingPage() {
                           <div className="mt-3 flex flex-wrap gap-2">
                             <button
                               onClick={() => setSelectedFormat('All formats')}
-                              className={`rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+                              className={`min-h-11 rounded-full px-3 py-1 text-sm font-medium transition-colors ${
                                 selectedFormat === 'All formats'
                                   ? 'bg-primary text-primary-foreground'
                                   : 'bg-muted text-muted-foreground hover:bg-muted/80'
@@ -988,7 +988,7 @@ export default function TrainingPage() {
                               <button
                                 key={formatLabel}
                                 onClick={() => setSelectedFormat(formatLabel)}
-                                className={`rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+                                className={`min-h-11 rounded-full px-3 py-1 text-sm font-medium transition-colors ${
                                   selectedFormat === formatLabel
                                     ? 'bg-primary text-primary-foreground'
                                     : 'bg-muted text-muted-foreground hover:bg-muted/80'
@@ -1009,7 +1009,7 @@ export default function TrainingPage() {
                               <button
                                 key={tag}
                                 onClick={() => toggleTopicTag(tag)}
-                                className={`rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+                                className={`min-h-11 rounded-full px-3 py-1 text-sm font-medium transition-colors ${
                                   selectedTopicTags.includes(tag)
                                     ? 'bg-primary text-primary-foreground'
                                     : 'bg-muted text-muted-foreground hover:bg-muted/80'
@@ -1023,7 +1023,11 @@ export default function TrainingPage() {
                       </div>
 
                       {activeFilterCount > 0 && (
-                        <Button variant="ghost" className="mt-4 px-0 text-primary" onClick={resetFilters}>
+                        <Button
+                          variant="ghost"
+                          className="mt-4 min-h-11 px-0 text-primary"
+                          onClick={resetFilters}
+                        >
                           {t('training.resetFilters')}
                         </Button>
                       )}
@@ -1175,7 +1179,7 @@ export default function TrainingPage() {
                 </p>
                 <Button
                   variant="outline"
-                  className="mt-5"
+                  className="mt-5 min-h-11"
                   onClick={() => {
                     setSearch('');
                     setSelectedTrack('all');
@@ -1220,7 +1224,11 @@ export default function TrainingPage() {
                         }),
                       })}
                     </p>
-                    <Button variant="outline" className="mt-4 w-full sm:w-auto" onClick={handleDownloadCertificate}>
+                    <Button
+                      variant="outline"
+                      className="mt-4 min-h-11 w-full sm:w-auto"
+                      onClick={handleDownloadCertificate}
+                    >
                       {t('training.downloadCertificate')}
                     </Button>
                   </div>
@@ -1249,7 +1257,7 @@ export default function TrainingPage() {
                     </label>
                     <Button
                       variant="outline"
-                      className="mt-4 w-full sm:w-auto"
+                      className="mt-4 min-h-11 w-full sm:w-auto"
                       onClick={handleUnlockCertificate}
                       disabled={
                         completedRequiredCount !== requiredTrackItems.length ||
@@ -1279,7 +1287,7 @@ export default function TrainingPage() {
                     {t('training.goSupportTip')}
                   </p>
                 </div>
-                <Button asChild variant="outline" className="mt-6 w-full sm:w-auto">
+                <Button asChild variant="outline" className="mt-6 min-h-11 w-full sm:w-auto">
                   <Link to="/portal/support">{t('training.goToSupport')}</Link>
                 </Button>
               </div>


### PR DESCRIPTION
Closes #319.

## Summary
- Raises mobile portal workflow controls to touch-friendly sizes across orders, account settings, support, onboarding, training, locked states, and Technician management.
- Makes mobile order cards safer for long references and cramped 360px action rows.
- Adds smoke coverage for the non-reporting portal mobile workflow group.

## Files changed
- Portal shared/route wrappers: `PortalPageIntro`, locked `MemberRoute`, dialog close target.
- Portal pages: orders, account, support, onboarding, training, Technician management panel.
- QA checklist: portal mobile touch-target smoke item.

## Verification commands + results
- `npm ci` - passed; 410 packages audited, 0 vulnerabilities; existing `glob@10.5.0` deprecation warning.
- `npm run agent:preflight -- --issue 319` - passed; final run warned only that staged working-tree files were present before commit.
- `npm run build` - passed; Vite build and public/private route prerender completed.
- `npm test --if-present` - passed; no test script output.
- `npm run lint --if-present` - passed.
- `npm run seo:check` - passed; 25 public routes and 23 private routes validated.
- `git diff --check` - passed; Git reported expected LF-to-CRLF working-copy warnings only.
- In-app browser health check: `http://127.0.0.1:8096/portal/orders` redirected to `/login`; 0 console errors.
- Mocked authenticated Playwright audit passed for `/portal/orders`, `/portal/account`, `/portal/support`, `/portal/onboarding`, and `/portal/training` at 360x800, 390x844, and 414x844 with no horizontal overflow and no visible sub-44px workflow controls.
- Mocked locked-state Playwright audit passed for baseline `/portal/support`, `/portal/onboarding`, `/portal/training` and training-only `/portal/training`, `/portal/support` at 390x844.
- Screenshots saved locally under `output/playwright/portal-mobile-319-*.png`.

## How to test
1. `npm ci`
2. Set local Supabase env vars in `.env` from `.env.example`.
3. `npm run dev -- --host 127.0.0.1 --port 8096 --strictPort`
4. Sign in with a Plus-capable test account and inspect mobile widths 360, 390, and 414 for:
   - `http://127.0.0.1:8096/portal/orders`
   - `http://127.0.0.1:8096/portal/account`
   - `http://127.0.0.1:8096/portal/support`
   - `http://127.0.0.1:8096/portal/onboarding`
   - `http://127.0.0.1:8096/portal/training`
5. Confirm intro actions stack, order-card actions wrap safely, support forms and training filters remain tappable, checklist toggles are easy to tap, and locked-state CTAs are still clear for non-Plus/training-only users.

## Verification
2026-05-30 QA sweep: GitHub checks are green, git diff --check passed locally, and Impeccable passed on the changed portal UI files without findings.

## Risk And Overlap
Touches portal route guard, dialog behavior, portal intro, technician management, and several portal screens. Overlap risk is moderate with portal/navigation polish branches.

## UI / Design Evidence
Impeccable passed on the changed portal UI files; the existing PR verification includes rendered responsive checks.

## Merge Autonomy
Lane: Yellow
Owner approval: not required
Rationale: Yellow lane due to priority or UI-change scope; checks are green and QA notes above document the review evidence.
