### PR TITLE
Fix invited user login flow

### DIFF
--- a/scripts/validate-admin-access-invite-uat.mjs
+++ b/scripts/validate-admin-access-invite-uat.mjs
@@ -583,6 +583,38 @@ const run = async () => {
   });
 
   try {
+    await page.goto(
+      `${args.appUrl}/login?intent=technician&email=${encodeURIComponent(targetEmail)}`,
+      { waitUntil: 'domcontentloaded' }
+    );
+    await page.getByText('Technician invite').waitFor({ timeout: 10000 });
+    await page.screenshot({
+      path: path.join(args.artifactDir, 'technician-invite-login-email-link.png'),
+      fullPage: true,
+    });
+
+    recorder.assert(
+      'Technician invite link opens Email Link sign-in by default',
+      (await page.getByRole('button', { name: 'Email Link', exact: true }).getAttribute('aria-pressed')) === 'true'
+    );
+    recorder.assert(
+      'Technician invite link prefills the invited email',
+      (await page.locator('#email-link').inputValue()) === targetEmail
+    );
+    recorder.assert(
+      'Technician invite link does not start in create-account mode',
+      !(await page.getByRole('button', { name: /Create Account with Password/i }).isVisible().catch(() => false))
+    );
+
+    await page.getByRole('button', { name: /Continue with Email Link/i }).click();
+    await page.getByText('Check your email').waitFor({ timeout: 10000 });
+
+    const inviteLoginBody = await page.locator('body').innerText();
+    recorder.assert(
+      'Technician invite email-link confirmation does not mention signup confirmation',
+      !/signup confirmation/i.test(inviteLoginBody)
+    );
+
     await page.goto(`${args.appUrl}/admin/access`, { waitUntil: 'domcontentloaded' });
     await login(page);
     await page.waitForURL('**/admin/access', { timeout: 20000 });

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -151,7 +151,7 @@ export const translations = {
     'login.checkEmail': 'Check your email',
     'login.sentEmail': 'We sent a sign-in email to {email}. Click the newest link to continue.',
     'login.firstTimeNote':
-      'First-time users may see a signup confirmation email first. After confirming, request a new sign-in link.',
+      'If you requested more than one link, use the newest Bloomjoy email and ignore older links.',
     'login.emailAddress': 'Email address',
     'login.sending': 'Sending...',
     'login.tryAgain': 'Try again in {seconds}s',
@@ -717,7 +717,7 @@ export const translations = {
     'login.emailLink': '邮件链接',
     'login.checkEmail': '请查看邮箱',
     'login.sentEmail': '我们已向 {email} 发送登录邮件。请点击最新链接继续。',
-    'login.firstTimeNote': '首次用户可能会先收到注册确认邮件。确认后请重新获取登录链接。',
+    'login.firstTimeNote': '如果请求了多个链接，请使用最新的 Bloomjoy 邮件并忽略较早的链接。',
     'login.emailAddress': '邮箱地址',
     'login.sending': '发送中...',
     'login.tryAgain': '{seconds} 秒后重试',

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -23,6 +23,7 @@ import type { TranslationKey } from '@/lib/i18n';
 import { toast } from 'sonner';
 
 const RESEND_COOLDOWN_SECONDS = 60;
+const EMAIL_REQUEST_COOLDOWN_STORAGE_PREFIX = 'bloomjoy-login-email-request-cooldown:';
 type AuthMethod = 'password' | 'magic_link';
 type LoginInviteIntent = 'corporate_partner' | 'technician' | 'machine_manager';
 const GOOGLE_GSI_SCRIPT_ID = 'google-gsi-script';
@@ -139,23 +140,68 @@ const getInviteIntentCopy = (intent: LoginInviteIntent) => {
       return {
         title: 'Corporate Partner invite',
         description:
-          'Create an account or sign in with this email to access partner reporting, training, support, and eligible machine reporting.',
+          'Sign in with this email to access partner reporting, training, support, and eligible machine reporting. Use Email Link if you have not set a password yet.',
         icon: BarChart3,
       };
     case 'technician':
       return {
         title: 'Technician invite',
         description:
-          'Create an account or sign in with this email to access training and any assigned machine reporting.',
+          'Sign in with this email to access training and assigned machine reporting. Use Email Link if you have not set a password yet.',
         icon: GraduationCap,
       };
     case 'machine_manager':
       return {
         title: 'Machine Manager invite',
         description:
-          'Create an account or sign in with this email so Bloomjoy can assign you to the right machine for refund review and follow-up.',
+          'Sign in with this email so Bloomjoy can assign you to the right machine for refund review and follow-up. Use Email Link if you have not set a password yet.',
         icon: Wrench,
       };
+  }
+};
+
+const getEmailRequestCooldownStorageKey = (email: string) =>
+  `${EMAIL_REQUEST_COOLDOWN_STORAGE_PREFIX}${email}`;
+
+const readEmailRequestCooldownSeconds = (email: string) => {
+  if (typeof window === 'undefined' || !email) {
+    return 0;
+  }
+
+  try {
+    const key = getEmailRequestCooldownStorageKey(email);
+    const cooldownUntil = Number(window.localStorage.getItem(key));
+
+    if (!Number.isFinite(cooldownUntil)) {
+      window.localStorage.removeItem(key);
+      return 0;
+    }
+
+    const remainingSeconds = Math.ceil((cooldownUntil - Date.now()) / 1000);
+
+    if (remainingSeconds <= 0) {
+      window.localStorage.removeItem(key);
+      return 0;
+    }
+
+    return remainingSeconds;
+  } catch {
+    return 0;
+  }
+};
+
+const storeEmailRequestCooldown = (email: string, seconds = RESEND_COOLDOWN_SECONDS) => {
+  if (typeof window === 'undefined' || !email) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(
+      getEmailRequestCooldownStorageKey(email),
+      String(Date.now() + seconds * 1000)
+    );
+  } catch {
+    // Local storage is a best-effort guard; Supabase remains the source of truth.
   }
 };
 
@@ -318,11 +364,16 @@ export default function LoginPage() {
     }
 
     if (queryIntent) {
-      setAuthMethod('password');
-      setCreateAccountMode(true);
+      setAuthMethod('magic_link');
+      setCreateAccountMode(false);
+      setPassword('');
       setSent(false);
     }
   }, [location.search]);
+
+  useEffect(() => {
+    setCooldownSeconds(readEmailRequestCooldownSeconds(email.trim().toLowerCase()));
+  }, [email]);
 
   useEffect(() => {
     if (!useGisRenderedButton || !googleClientId) {
@@ -458,6 +509,7 @@ export default function LoginPage() {
   const handleMagicLinkSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (cooldownSeconds > 0) {
+      toast.error(getSendLinkErrorMessage({ status: 429 }));
       return;
     }
 
@@ -475,6 +527,7 @@ export default function LoginPage() {
       toast.error(errorMessage);
 
       if (error.status === 429 || error.code === 'over_email_send_rate_limit') {
+        storeEmailRequestCooldown(normalizedEmail);
         setCooldownSeconds(RESEND_COOLDOWN_SECONDS);
       }
 
@@ -484,10 +537,9 @@ export default function LoginPage() {
 
     setEmail(normalizedEmail);
     setSent(true);
+    storeEmailRequestCooldown(normalizedEmail);
     setCooldownSeconds(RESEND_COOLDOWN_SECONDS);
-    toast.success(
-      'Email sent. First-time sign-ins may require confirming signup first, then requesting a fresh link.'
-    );
+    toast.success('Email sent. Use the newest Bloomjoy sign-in email to continue.');
     setLoading(false);
   };
 
@@ -547,15 +599,26 @@ export default function LoginPage() {
       return;
     }
 
+    if (cooldownSeconds > 0) {
+      toast.error(getPasswordResetErrorMessage({ status: 429 }));
+      return;
+    }
+
     setLoading(true);
     const { error } = await requestPasswordReset(normalizedEmail);
 
     if (error) {
       toast.error(getPasswordResetErrorMessage(error));
+      if (error.status === 429 || error.code === 'over_email_send_rate_limit') {
+        storeEmailRequestCooldown(normalizedEmail);
+        setCooldownSeconds(RESEND_COOLDOWN_SECONDS);
+      }
       setLoading(false);
       return;
     }
 
+    storeEmailRequestCooldown(normalizedEmail);
+    setCooldownSeconds(RESEND_COOLDOWN_SECONDS);
     toast.success('Password reset email sent. Use the newest email link to set a new password.');
     setLoading(false);
   };
@@ -857,10 +920,17 @@ export default function LoginPage() {
                     type="button"
                     className="flex min-h-11 w-full items-center rounded-lg px-3 text-left text-sm font-medium text-primary underline-offset-4 hover:bg-primary/5 hover:underline"
                     onClick={handlePasswordResetRequest}
-                    disabled={loading || oauthLoading}
+                    disabled={loading || oauthLoading || cooldownSeconds > 0}
                   >
-                    {t('login.forgotPassword')}
+                    {cooldownSeconds > 0
+                      ? t('login.tryAgain', { seconds: cooldownSeconds })
+                      : t('login.forgotPassword')}
                   </button>
+                  {cooldownSeconds > 0 && (
+                    <p className="text-center text-xs text-muted-foreground">
+                      {t('login.emailLimited')}
+                    </p>
+                  )}
                   <Button
                     type="submit"
                     variant="hero"


### PR DESCRIPTION
﻿## Linked Issue
Closes #526

## Summary
- Prevent access-invite login links from opening in create-account mode.
- Default invite links to the Email Link tab with the invited email prefilled, and persist the short email-request cooldown across reloads for that address.
- Remove confusing signup-confirmation copy from the email-link success state and add a mocked UAT regression check.

## Files changed
- `src/pages/Login.tsx`: invite login defaults, email/reset cooldown guard, invite copy.
- `src/lib/i18n.ts`: email-link confirmation guidance.
- `scripts/validate-admin-access-invite-uat.mjs`: regression coverage for Technician invite login links.

## Verification
- `npm ci` - passed; existing audit output reported 4 vulnerabilities (3 moderate, 1 high).
- `npm run build` - passed.
- `npm test --if-present` - passed; no test script emitted output.
- `npm run lint --if-present` - passed.
- `npm run agent:preflight` - passed; issue/PR linkage warning only before PR creation.
- `npm run auth:preflight` - passed when run with `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` injected from Supabase CLI; `VITE_GOOGLE_CLIENT_ID` warning only.
- `npm run admin-access:validate-invite-uat -- --app-url http://127.0.0.1:8081 --artifact-dir output/playwright/ed-login-qa` - passed, including new Technician invite login assertions.
- Mobile Playwright check for `/login?intent=technician&email=new-partner-manager@example.test` - passed, no horizontal overflow.
- Visual screenshots reviewed: desktop and mobile Technician invite login show Email Link selected with the invited email prefilled and no create-account CTA.
- Production QA: affected invited user is confirmed, successfully signed in after recovery, and still has active viewer entitlements for the three assigned Merlin machines.

## Risk And Overlap
- Risk is low: this only changes invite-login defaults/copy and a browser-side cooldown guard; Supabase Auth remains the source of truth for rate limiting and access.
- Existing non-invite login still defaults to password sign-in.
- Overlap checked against current `main`; touched files are limited to login UI copy/behavior and the existing invite UAT script.

## Merge Autonomy
- Lane: Green
- Owner approval: not required by labels.
- Remote checks are green and local browser QA covers the changed login state.

## How to test
1. Start the UAT server with Supabase env available:
   `npm run dev:uat`
2. Open `http://127.0.0.1:8081/login?intent=technician&email=new-partner-manager@example.test`.
3. Confirm the page shows the Technician invite banner, pre-fills `new-partner-manager@example.test`, selects `Email Link`, and does not show `Create Account with Password`.
4. Run `npm run admin-access:validate-invite-uat -- --app-url http://127.0.0.1:8081` to verify the mocked invite save/send flow and the login-link regression.
