### PR TITLE
[codex] Fix admin partnership assignment UX

### DIFF
--- a/src/pages/admin/Machines.tsx
+++ b/src/pages/admin/Machines.tsx
@@ -4,6 +4,7 @@ import {
   CalendarClock,
   CheckCircle2,
   Check,
+  ExternalLink,
   X,
   History,
   Loader2,
@@ -13,7 +14,7 @@ import {
   Search,
   Send,
 } from 'lucide-react';
-import { useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { AppLayout } from '@/components/layout/AppLayout';
@@ -74,6 +75,7 @@ import {
   formatDate,
   getActiveMachineAssignments,
   getCurrentTaxRate,
+  getReportablePartnershipIds,
   getTaxStatus,
   getTaxStatusLabel,
   machineTypes,
@@ -191,6 +193,10 @@ const demoMachineManagerAccounts: AdminAccountSummary[] = [
   },
 ];
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const getPartnershipAssignmentHref = (
+  assignment: PartnershipReportingSetup['assignments'][number]
+) =>
+  `/admin/partnerships?partnershipId=${encodeURIComponent(assignment.partnership_id)}&step=machines`;
 
 const emptyMachineForm = {
   machineId: null as string | null,
@@ -379,6 +385,10 @@ export default function AdminMachinesPage() {
     () => new Map(refundManagerSetup.machines.map((machine) => [machine.id, machine])),
     [refundManagerSetup.machines]
   );
+  const reportablePartnershipIds = useMemo(
+    () => getReportablePartnershipIds(setup),
+    [setup]
+  );
 
   const selectedMachineForEditor =
     editingMachine ??
@@ -402,7 +412,12 @@ export default function AdminMachinesPage() {
       .map((machine) => {
         const taxRate = getCurrentTaxRate(setup.taxRates, machine.id, currentDate);
         const taxStatus = getTaxStatus(taxRate);
-        const activeAssignments = getActiveMachineAssignments(setup, machine.id, currentDate);
+        const activeAssignments = getActiveMachineAssignments(
+          setup,
+          machine.id,
+          currentDate,
+          reportablePartnershipIds
+        );
         const machineWarnings = setup.warnings.filter((warning) => warning.machineId === machine.id);
         const refundSetup = refundManagerSetupByMachineId.get(machine.id);
         const machineManagerEmails = uniqueEmails(
@@ -456,13 +471,27 @@ export default function AdminMachinesPage() {
         }
         return left.taxStatus.localeCompare(right.taxStatus);
       });
-  }, [assignmentFilter, refundManagerSetupByMachineId, search, setup, taxDrafts, taxFilter, sort]);
+  }, [
+    assignmentFilter,
+    refundManagerSetupByMachineId,
+    reportablePartnershipIds,
+    search,
+    setup,
+    taxDrafts,
+    taxFilter,
+    sort,
+  ]);
 
   const readinessCounts = useMemo(() => {
     const currentDate = today();
     const missingTax = setup.machines.filter(
       (machine) =>
-        getActiveMachineAssignments(setup, machine.id, currentDate).length > 0 &&
+        getActiveMachineAssignments(
+          setup,
+          machine.id,
+          currentDate,
+          reportablePartnershipIds
+        ).length > 0 &&
         getTaxStatus(getCurrentTaxRate(setup.taxRates, machine.id, currentDate)) === 'missing'
     ).length;
     const overlappingAssignments = setup.warnings.filter(
@@ -470,7 +499,7 @@ export default function AdminMachinesPage() {
     ).length;
 
     return { missingTax, overlappingAssignments };
-  }, [setup]);
+  }, [reportablePartnershipIds, setup]);
 
   const updateTaxFilter = (nextFilter: MachineTaxFilter) => {
     setTaxFilter(nextFilter);
@@ -847,6 +876,16 @@ export default function AdminMachinesPage() {
         isRefundManagerSetupLoading={isRefundManagerSetupLoading}
         isLocalDemoMode={isLocalDemoMode}
         demoManagerAccounts={demoMachineManagerAccounts}
+        activeAssignments={
+          selectedMachineForEditor
+            ? getActiveMachineAssignments(
+                setup,
+                selectedMachineForEditor.id,
+                today(),
+                reportablePartnershipIds
+              )
+            : []
+        }
         onDemoMachineManagersSaved={saveDemoMachineManagers}
         onDemoRefundReadinessSaved={saveDemoRefundReadiness}
         onSaved={refresh}
@@ -1012,13 +1051,23 @@ function MachineSetupRow({
         ) : (
           <div className="grid gap-1.5">
             {activeAssignments.map((assignment) => (
-              <Badge
-                key={assignment.id}
-                variant="secondary"
-                className="w-fit max-w-full whitespace-normal text-left"
-              >
-                {assignment.partnership_name}
-              </Badge>
+              <div key={assignment.id} className="flex flex-wrap items-center gap-1.5">
+                <Badge
+                  variant="secondary"
+                  className="w-fit max-w-full whitespace-normal text-left"
+                >
+                  {assignment.partnership_name}
+                </Badge>
+                <Button asChild variant="ghost" size="sm" className="h-8 px-2 text-xs">
+                  <Link
+                    to={getPartnershipAssignmentHref(assignment)}
+                    aria-label={`Manage ${assignment.partnership_name} machine assignment`}
+                  >
+                    <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
+                    Manage
+                  </Link>
+                </Button>
+              </div>
             ))}
           </div>
         )}
@@ -1227,6 +1276,7 @@ function MachineDialog({
   isRefundManagerSetupLoading,
   isLocalDemoMode,
   demoManagerAccounts,
+  activeAssignments,
   onDemoMachineManagersSaved,
   onDemoRefundReadinessSaved,
   onSaved,
@@ -1239,6 +1289,7 @@ function MachineDialog({
   isRefundManagerSetupLoading: boolean;
   isLocalDemoMode: boolean;
   demoManagerAccounts: AdminAccountSummary[];
+  activeAssignments: PartnershipReportingSetup['assignments'];
   onDemoMachineManagersSaved: (machineId: string, managerEmails: string[]) => Promise<unknown>;
   onDemoRefundReadinessSaved: (machineId: string, readiness: DemoRefundReadiness) => Promise<unknown>;
   onSaved: () => Promise<unknown>;
@@ -1720,7 +1771,62 @@ function MachineDialog({
             Operations.
           </SheetDescription>
         </SheetHeader>
-        <div className="mt-6 grid gap-4 sm:grid-cols-2">
+        {form.machineId && (
+          <div className="mt-6 rounded-lg border border-border bg-muted/15 p-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <h3 className="font-semibold text-foreground">Partner Report Assignment</h3>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Open the partnership's Machines step to add, remove, or move this machine's
+                  report membership.
+                </p>
+              </div>
+              <Badge variant={activeAssignments.length > 0 ? 'secondary' : 'outline'}>
+                {activeAssignments.length === 0
+                  ? 'Not in partner reports'
+                  : activeAssignments.length === 1
+                    ? '1 assignment'
+                    : `${activeAssignments.length} assignments`}
+              </Badge>
+            </div>
+            <div className="mt-4 grid gap-2">
+              {activeAssignments.length === 0 ? (
+                <div className="flex flex-col gap-3 rounded-md border border-dashed border-border bg-background px-3 py-3 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+                  <span>This machine is not assigned to an active or draft partnership.</span>
+                  <Button asChild variant="outline" size="sm" className="min-h-10 shrink-0">
+                    <Link to="/admin/partnerships">
+                      <ExternalLink className="mr-2 h-4 w-4" />
+                      Open Partnerships
+                    </Link>
+                  </Button>
+                </div>
+              ) : (
+                activeAssignments.map((assignment) => (
+                  <div
+                    key={assignment.id}
+                    className="flex flex-col gap-3 rounded-md border border-border bg-background px-3 py-3 sm:flex-row sm:items-center sm:justify-between"
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium text-foreground">
+                        {assignment.partnership_name}
+                      </p>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Assigned since {formatDate(assignment.effective_start_date)}
+                      </p>
+                    </div>
+                    <Button asChild variant="outline" size="sm" className="min-h-10 shrink-0">
+                      <Link to={getPartnershipAssignmentHref(assignment)}>
+                        <ExternalLink className="mr-2 h-4 w-4" />
+                        Manage Assignment
+                      </Link>
+                    </Button>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        )}
+        <div className={cn('grid gap-4 sm:grid-cols-2', form.machineId ? 'mt-4' : 'mt-6')}>
           <div>
             <Label htmlFor="machine-label">Machine label / alias</Label>
             <Input

--- a/src/pages/admin/PartnerRecords.tsx
+++ b/src/pages/admin/PartnerRecords.tsx
@@ -149,8 +149,8 @@ export default function AdminPartnerRecordsPage() {
                 Partner Records
               </h1>
               <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
-                Manage reusable organizations and contacts. Add them to a partnership as
-                participants when an agreement needs more than one external entity.
+                Manage the reusable partner directory: organizations, legal names, and contacts.
+                Agreements, machine assignments, and payout/reporting setup live in Partnerships.
               </p>
             </div>
             <div className="flex flex-wrap gap-2">

--- a/src/pages/admin/Partnerships.tsx
+++ b/src/pages/admin/Partnerships.tsx
@@ -76,6 +76,7 @@ import {
   formatMoney,
   getActiveMachineAssignments,
   getLastCompletedWeekEndingDate,
+  getReportablePartnershipIds,
   machineOwnershipModels,
   participantRoles,
   partnerTypes,
@@ -1630,14 +1631,21 @@ function MachineAssignmentsSection({
 
   const currentDate = today();
   const machineAlignmentStartDate = selectedPartnership.effective_start_date || today();
+  const reportablePartnershipIds = useMemo(
+    () => getReportablePartnershipIds(setup),
+    [setup]
+  );
 
   const activeAssignmentsByMachineId = useMemo(() => {
     const assignmentMap = new Map<string, ReturnType<typeof getActiveMachineAssignments>>();
     setup.machines.forEach((machine) => {
-      assignmentMap.set(machine.id, getActiveMachineAssignments(setup, machine.id, currentDate));
+      assignmentMap.set(
+        machine.id,
+        getActiveMachineAssignments(setup, machine.id, currentDate, reportablePartnershipIds)
+      );
     });
     return assignmentMap;
-  }, [currentDate, setup]);
+  }, [currentDate, reportablePartnershipIds, setup]);
 
   const activeAssignments = useMemo(
     () =>

--- a/src/pages/admin/reportingSetupUi.ts
+++ b/src/pages/admin/reportingSetupUi.ts
@@ -118,15 +118,25 @@ export const getTaxStatusLabel = (status: TaxStatus) => {
   return 'Configured';
 };
 
+export const getReportablePartnershipIds = (setup: PartnershipReportingSetup) =>
+  new Set(
+    setup.partnerships
+      .filter((partnership) => partnership.status !== 'archived')
+      .map((partnership) => partnership.id)
+  );
+
 export const getActiveMachineAssignments = (
   setup: PartnershipReportingSetup,
   machineId: string,
-  currentDate = today()
-) =>
-  setup.assignments.filter(
+  currentDate = today(),
+  reportablePartnershipIds = getReportablePartnershipIds(setup)
+) => {
+  return setup.assignments.filter(
     (assignment) =>
       assignment.machine_id === machineId &&
+      reportablePartnershipIds.has(assignment.partnership_id) &&
       assignment.status === 'active' &&
       assignment.effective_start_date <= currentDate &&
       (!assignment.effective_end_date || assignment.effective_end_date >= currentDate)
   );
+};


### PR DESCRIPTION
## Summary
- Adds direct Manage links from Admin > Machines partner-report badges to the matching Partnership > Machines step.
- Adds a Partner Report Assignment section inside the machine edit drawer so Edit no longer dead-ends when a machine row shows a partnership.
- Stops archived partnerships from counting as current machine report assignments and clarifies that Partner Records is the reusable directory, not agreement setup.

## Files changed
- `src/pages/admin/Machines.tsx`: row Manage links and edit-drawer assignment context.
- `src/pages/admin/Partnerships.tsx`: shared reportable-partnership assignment filtering for the Machines step.
- `src/pages/admin/reportingSetupUi.ts`: shared helper excludes archived partnerships from active assignment state.
- `src/pages/admin/PartnerRecords.tsx`: page copy clarifies directory vs partnership agreement setup.

## Verification commands + results
- `npm ci` - passed; npm reported existing audit findings: 3 moderate, 1 high.
- `npm run build` - passed; Vite build completed and prerendered 25 public routes plus SEO tags for 25 private routes.
- `npm test --if-present` - passed/no test script output.
- `npm run lint --if-present` - passed.
- `git diff --check` - passed.

## Rendered QA
- Local URL used: `http://127.0.0.1:8082/admin/machines?demo=on`.
- Browser check loaded the app shell and redirected to `/login` because this local worktree has no authenticated Supabase admin session.
- No framework overlay was present after adding local-only placeholder client env values; console showed only existing React Router future-flag warnings on the clean `8082` check.
- Authenticated machine drawer interaction still needs reviewer/UAT validation with a real super-admin session or preview environment.

## How to test
1. From a clean checkout of this branch, create `.env.local` with valid `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` values.
2. Run `npm ci`.
3. Run `npm run dev` and open the printed localhost URL.
4. Sign in as a super-admin.
5. Open `/admin/machines`.
6. Find a machine with a current partner-report assignment. Confirm the Partner reports column shows the partnership badge plus a `Manage` action.
7. Click `Manage`; confirm it opens `/admin/partnerships?partnershipId=<id>&step=machines` for that agreement.
8. Return to `/admin/machines`, click `Edit` on the same machine, and confirm the edit drawer shows `Partner Report Assignment` with a `Manage Assignment` action.
9. Open `/admin/partner-records` and confirm the page copy frames it as the reusable partner directory while agreements/machine assignments remain under Partnerships.

Test credentials: use an existing local/preview super-admin account; no new test credentials are introduced by this PR.