### PR TITLE
Unify Technician management UX

### DIFF
--- a/Docs/ACCESS_MANAGEMENT_RECOVERY_UAT.md
+++ b/Docs/ACCESS_MANAGEMENT_RECOVERY_UAT.md
@@ -28,7 +28,7 @@ Use the localhost URL printed by `npm run dev`, usually `http://localhost:8080`.
 | --- | --- |
 | Login | `/login` |
 | Portal home | `/portal` |
-| Portal account / Technician Access | `/portal/account` |
+| Portal Team / Technician Access | `/portal/team` |
 | Portal training | `/portal/training` |
 | Portal reports | `/portal/reports` |
 | Admin home | `/admin` |
@@ -44,7 +44,7 @@ Use seeded or temporary QA users for each persona. Record the email, source gran
 | Persona | Must succeed | Must be blocked or absent | Evidence required |
 | --- | --- | --- | --- |
 | Super Admin | Open `/admin/access`; search by email/user ID; see one selected-person workspace with Plus Customer, Corporate Partner, Technician, Scoped Admin, Super Admin, and manual reporting source cards; grant/update/renew/revoke eligible sources, including Technician access, with preview and reason. | Technician controls cannot grant broader than training-only or explicitly selected reporting machines in this recovery. Technician controls cannot grant Plus, Corporate Partner, billing, supply, admin, or global reporting privileges. Rare global actions are visually de-emphasized and require a reason. | Desktop and mobile screenshots of search, selected-person workspace, preview/reason state, and Activity/audit entry. |
-| Plus Customer | Open `/portal/account`; see Technician Access with seat usage, owned machines, and active grants; add/update/revoke a Technician only for owned machines; access Plus training/support/supply benefits and assigned reporting. | Cannot open `/admin`; cannot manage unrelated customer accounts or machines; cannot access partner settlement/setup or global reporting. | Screenshots of Technician Access on desktop/mobile, owned-machine selector, cap/error state if applicable, and blocked `/admin` route. |
+| Plus Customer | Open `/portal/team`; see Technician Access with seat usage, owned machines, and active grants; add/update/revoke a Technician only for owned machines; access Plus training/support/supply benefits and assigned reporting. | Cannot open `/admin`; cannot manage unrelated customer accounts or machines; cannot access partner settlement/setup or global reporting. | Screenshots of Technician Access on desktop/mobile, owned-machine selector, cap/error state if applicable, Account Settings link to Team, and blocked `/admin` route. |
 | Corporate Partner | Open partner-facing `/portal/reports` for active portal-enabled partnership machines; use partner-authorized Technician management for derived machines; access training/support/member supply tier where capability checks allow it. | Cannot open `/admin`; cannot see inactive or non-portal-enabled partnerships; cannot edit tax, payout rules, imports, schedules, billing, or unrelated machines. | Screenshots of partner dashboard scope, Technician management scope, and blocked admin/setup routes. |
 | Technician | Open `/portal` and `/portal/training`; if assigned machines exist, open `/portal/reports` and see only assigned machines; if no machines are assigned, remain training-only. | Cannot open `/admin`; cannot see Plus discounts, billing, account-owner tools, Technician management, partner dashboard, or unassigned machines. | Screenshots of training access, assigned-machine reporting filters/results, training-only no-reporting state, and blocked admin/account-owner paths. |
 | Scoped Admin | Open `/admin/access?tab=reporting-access`; see only Access in admin navigation; manage manual reporting grants only inside assigned machine scope; open `/portal/reports` for scoped machines; open training; see partner dashboard only when a partnership is fully covered by scoped machines. | Cannot open global-only admin routes, global roles, partnerships, reporting operations, unrelated machines, Plus billing/commerce benefits, or revoke Technician-derived reporting grants. | Screenshots of scoped reporting-access view, machine-scope limits, blocked global admin URLs, and audit entry for scoped-admin action. |
@@ -59,7 +59,7 @@ Use seeded or temporary QA users for each persona. Record the email, source gran
 - Selecting a person shows Who/What/Where/Why/When, effective presets, capabilities, warnings, source cards, and machine/partner scope in one workspace.
 - The workspace distinguishes paid Plus subscription, admin-granted Plus Customer access, Corporate Partner membership, Technician-derived access, Scoped Admin scope, Super Admin, and manual reporting access.
 - The manual reporting card edits machine-scoped reporting access with one save and does not remove other users or Technician-derived grants.
-- The Technician card exposes Super Admin mutation controls in Admin Access while customer/partner self-service mutation work remains in Portal > Settings > Technician Access.
+- The Technician card exposes Super Admin mutation controls in Admin Access while customer/partner self-service mutation work remains in Portal > Team > Technician Access.
 
 ### Grant And Revoke Safety
 - Granting or extending Plus Customer access requires a future expiry date and reason, and does not override an active paid Stripe subscription.
@@ -90,7 +90,7 @@ Minimum screenshot set for `#368` recovery:
 - One grant/update preview with required reason.
 - One revoke preview with required reason.
 - Scoped Admin limited admin navigation and blocked global admin route.
-- Portal account Technician Access on desktop and mobile.
+- Portal Team Technician Access on desktop and mobile.
 - Portal reports showing assigned-machine scope for Technician, Corporate Partner, Scoped Admin, or Reporting User as applicable.
 - Clear blocked state for non-admin access to `/admin`.
 

--- a/Docs/ADMIN_ACCESS_REDESIGN_PLAN.md
+++ b/Docs/ADMIN_ACCESS_REDESIGN_PLAN.md
@@ -96,7 +96,7 @@ Not included:
 - Building a raw permission matrix.
 - Building granular per-user overrides.
 - Changing Corporate Partner, Technician, Plus Customer, or Scoped Admin authorization semantics.
-- Moving customer-managed Technician workflows out of `/portal/account`.
+- Moving customer-managed Technician workflows into `/admin` or duplicating the `/portal/team` workflow in another customer surface.
 
 ## Phase 2 Scope
 Issue `#331` should follow the redesign with:

--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -22,6 +22,7 @@ GitHub Issues and the Bloomjoy Project board are the operational source of truth
 
 - Refund operations and customer-refund pilot readiness remain high-sensitivity operational surfaces.
 - Access grants that create user-facing Corporate Partner or Technician access must prove both the saved grant and the invite-email attempt; rollout signoff also needs provider/inbox/activation evidence in the linked issue or PR.
+- Technician management IA uses `/portal/team` for Plus Customer and Corporate Partner self-service, while `/admin/access` remains the Super Admin override surface. Plus/partner users should not receive `/admin` just to manage Technicians.
 - Operator payouts, partner reporting, and scheduled exports are active shared foundations.
 - Operator payouts foundation sprint: the foundation is on `main`; active follow-on PRs add timekeeping, revenue snapshots, calculation, review, and pay statement slices.
 - Manager review/finalization slice `#448` adds the admin review gate before operator pay statements are issued.

--- a/Docs/DECISIONS.md
+++ b/Docs/DECISIONS.md
@@ -1,5 +1,20 @@
 # Decisions
 
+## 2026-06-24 - Technician management uses role-appropriate entry points, not duplicated customer admin
+Technician management should be discoverable in one customer-facing place and one internal override place, backed by the same capability and shared UI patterns.
+
+**Canonical behavior**
+- Plus Customer owners and Corporate Partners manage Technicians from `/portal/team` when `can_manage_technicians` is true.
+- Account Settings (`/portal/account`) should link to Team for eligible users, but should stay focused on profile, billing, shipping, and language preferences.
+- Super Admins may grant or repair Technician access from `/admin/access` using the Technician preset/source card.
+- Plus Customer and Corporate Partner users should not receive an `/admin` page just to manage Technicians.
+- Scoped Admins do not receive Technician grant authority unless a later explicit owner decision expands the role.
+
+**Why this choice**
+- Users expect team/staff management to live under a Team area, not buried inside settings or exposed through an internal admin console.
+- Duplicating the same customer workflow across Settings, Admin, and partner-specific surfaces increases support cost, copy drift, and authorization risk.
+- Keeping the shared machine-assignment UI underneath role-appropriate routes gives Plus owners, Corporate Partners, and Super Admins the same scope semantics without making their information architecture identical.
+
 ## 2026-06-20 - Technician assigned-machine grants can include multiple machines
 Technician remains a training-first, read-only reporting persona, but a single Technician grant may now carry zero or more assigned reporting machines.
 

--- a/Docs/ENTITLEMENTS_PERSONA_ROADMAP.md
+++ b/Docs/ENTITLEMENTS_PERSONA_ROADMAP.md
@@ -13,7 +13,7 @@ The near-term goal is to let super-admins make fast, auditable access decisions 
 - Corporate Partner portal access is explicit and does not come from payout/legal participant metadata alone.
 - `/admin` stays internal-only until Scoped Admin is explicitly implemented.
 - `/admin/access` is the near-term person-first management surface for presets, effective-access previews, internal grants, Corporate Partner access, Plus Customer access, reporting access, and audit review.
-- Customer account and Technician management stays under `/portal/account` for now; a future `/portal/team` can replace it when customer team management grows.
+- Customer account settings stay under `/portal/account`; customer and partner Technician management lives under `/portal/team` for users with `technicians.manage` / `can_manage_technicians`.
 - Corporate Partner reporting surfaces live under `/portal/reports`, not under `/admin`.
 - Partnership setup must not grant portal access by itself.
 - `report_manager` is reporting-only. It must not be used as a Scoped Admin workaround.
@@ -41,7 +41,7 @@ Use this model for new entitlement design, issue writing, and implementation rev
 - `super_admin` exists through `admin_roles` and remains the current internal owner/admin mechanism.
 - Bloomjoy Plus Customer access exists through paid subscriptions, admin-managed Plus Customer access, and super-admin-derived access.
 - Training-only access is now represented as a Technician with no machines assigned. Existing `operator_training_grants` remain the underlying training source.
-- Technician access is partially implemented through `technician_grants`, `technician_machine_assignments`, source-aware reporting entitlements, RPCs, and `/portal/account` UI. Production verification/restoration remains tracked in `#214`.
+- Technician access is partially implemented through `technician_grants`, `technician_machine_assignments`, source-aware reporting entitlements, RPCs, and `/portal/team` UI. Production verification/restoration remains tracked in `#214`.
 - Machine-level reporting entitlements exist with `viewer` and `report_manager` access levels.
 - `customer_account_memberships` includes planning vocabulary such as `account_admin`, `billing_manager`, `report_viewer`, `report_manager`, and `partner_viewer`, but those are not all productized flows.
 - Corporate Partner access is implemented through `corporate_partner_memberships`, portal-enabled `reporting_partnership_parties`, server capability helpers, and `/admin/access?tab=presets`.
@@ -75,7 +75,7 @@ Use this model for new entitlement design, issue writing, and implementation rev
 - `/admin/access` remains the near-term person-first place for internal entitlement administration.
 - The target `/admin/access` workflow is: find a person, review effective access, manage access source cards, preview impact, then save with a reason.
 - Avoid adding more peer tabs for individual access sources. Consolidate Plus Customer, Corporate Partner, Technician, Scoped Admin, Super Admin, and manual reporting access into one selected-person workspace.
-- `/portal/account` remains the current customer place for Technician management.
+- `/portal/team` is the current customer and Corporate Partner place for Technician management. `/portal/account` may link to it for eligible users but should not duplicate the workflow.
 - `/portal/reports` remains the operator/reporting surface for assigned machines.
 - Corporate Partner reporting appears in `/portal/reports` as a permissioned partner-dashboard view.
 - Users without partner-dashboard visibility should not see disabled partner tabs or upsell-style placeholders.
@@ -95,6 +95,13 @@ Use this model for new entitlement design, issue writing, and implementation rev
 | `#214` | Technician entitlement resolution in production | Production verification/restoration for Technician invite resolution. |
 | `#123` | Plus operator access and invite flow | Closed definition issue that informed customer/owner team-management direction. |
 | `#183` | Machine-scoped Technician reporting entitlements | Closed definition/spec issue; `Docs/TECHNICIAN_ENTITLEMENTS_SPEC.md` remains the detailed implementation reference. |
+| `#528` | Unified Technician management UX | P0 umbrella for moving Technician management to role-appropriate, shared UI entry points. |
+| `#529` | Shared Technician management UI patterns | P0 implementation issue for shared machine assignment controls across portal and admin. |
+| `#530` | Customer-facing Team page | P0 route/IA issue for `/portal/team` and portal navigation. |
+| `#531` | Admin Add Technician discoverability | P0 admin UX issue for direct Technician entry in `/admin/access`. |
+| `#532` | Scoped Admin Technician authority decision | Owner-decision issue; current decision is no Scoped Admin Technician authority. |
+| `#533` | Unified Technician UX QA | P1 QA/UAT issue for portal/admin role boundaries. |
+| `#534` | Technician IA docs and smoke coverage | P1 docs/checklist issue for keeping UAT and smoke docs aligned. |
 
 ## Acceptance Criteria
 - The roadmap maps MVP personas to capability dimensions and linked issues.

--- a/Docs/MOBILE_UX_ROADMAP.md
+++ b/Docs/MOBILE_UX_ROADMAP.md
@@ -10,7 +10,7 @@ Automated browser audit covered 30 routes across:
 - Tablet/narrow desktop checks: `768x1024`, `1024x768`
 - Public/storefront: `/`, `/machines`, machine detail pages, `/supplies`, `/plus`, `/resources`, `/contact`, `/cart`
 - Auth: `/login`, `/reset-password`
-- Portal: `/portal`, `/portal/orders`, `/portal/account`, `/portal/training`, `/portal/support`, `/portal/onboarding`, plus a spot check of `/portal/reports`
+- Portal: `/portal`, `/portal/orders`, `/portal/account`, `/portal/team`, `/portal/training`, `/portal/support`, `/portal/onboarding`, plus a spot check of `/portal/reports`
 - Admin: `/admin`, `/admin/orders`, `/admin/support`, `/admin/access`, `/admin/partner-records`, `/admin/machines`, `/admin/partnerships`, `/admin/reporting`
 
 Admin audit is currently surfaced through `/admin/access?tab=audit`; `/admin/audit` redirects there. No dedicated `/admin/leads` route exists in this checkout, so lead-related mobile work remains tied to the public contact/procurement flows and server-side submission pipeline rather than a separate admin leads surface.
@@ -44,7 +44,7 @@ Workflow: Plus account owners, baseline users, training-only operators, technici
 
 Findings:
 
-- `/portal`, `/portal/orders`, `/portal/account`, `/portal/training`, `/portal/support`, and `/portal/onboarding` did not show broad page-level overflow in the mocked automated pass.
+- `/portal`, `/portal/orders`, `/portal/account`, `/portal/team`, `/portal/training`, `/portal/support`, and `/portal/onboarding` did not show broad page-level overflow in the mocked automated pass.
 - Follow-up work should focus on real workflow ergonomics: stacked page actions, order/account card readability, support/onboarding forms, training navigation, checkbox/action hit areas, and locked-state clarity.
 - `/portal/reports` was spot-checked only. Do not reopen detailed reporting mobile work here because #274 already handled that route.
 - Portal home should not be reopened broadly unless a regression appears; #273 already handled the reporting-era portal-home UX/CX pass.

--- a/Docs/PARTNER_TECHNICIAN_ACCESS_CX_AUDIT.md
+++ b/Docs/PARTNER_TECHNICIAN_ACCESS_CX_AUDIT.md
@@ -1,6 +1,6 @@
 # Partner Technician Access CX Audit
 
-Scope: `/portal/account` Technician Access, Technician invite delivery/acceptance, `/portal/training`, and `/portal/reports` for assigned-machine Technicians.
+Scope: `/portal/team` Technician Access, Technician invite delivery/acceptance, `/portal/training`, and `/portal/reports` for assigned-machine Technicians.
 
 ## Audit Health Score
 
@@ -71,4 +71,4 @@ Support/Admin:
 - Staging send/resend email delivery with real Resend secrets.
 - Same-email signup/sign-in after clicking the email.
 - Revocation after a real session refresh or sign-out/sign-in.
-- Keyboard-only pass on `/portal/account` for account selection, machine picker, row actions, and revoke dialog.
+- Keyboard-only pass on `/portal/team` for account selection, machine picker, row actions, and revoke dialog.

--- a/Docs/PARTNER_TECHNICIAN_ACCESS_UAT.md
+++ b/Docs/PARTNER_TECHNICIAN_ACCESS_UAT.md
@@ -20,7 +20,7 @@ The script uses mocked Supabase Auth, REST, RPC, and Edge Function responses. It
 
 ## Agent UAT Coverage
 
-- Corporate Partner manager reaches `/portal/account`.
+- Corporate Partner manager reaches `/portal/team`.
 - Partner scope is visible as a partner portfolio, not global reporting access.
 - Partner creates a Technician assigned to in-scope machines.
 - New Technician saves automatically call `access-invite` with `inviteType=technician`.
@@ -46,7 +46,7 @@ Personas:
 
 Checklist:
 
-- [ ] Partner manager opens `/portal/account` and sees Technician Access.
+- [ ] Partner manager opens `/portal/team` and sees Technician Access.
 - [ ] Partner account selector only lists current partner portfolio accounts.
 - [ ] Partner can add two Technicians to the same machine, assign one Technician to multiple machines, and each save sends an invite attempt.
 - [ ] Partner can add a training-only Technician, and save sends an invite attempt.
@@ -58,6 +58,7 @@ Checklist:
 - [ ] Assigned-machine Technician reaches `/portal/reports` for only assigned machines.
 - [ ] Training-only Technician reaches `/portal/training` and does not receive machine reporting.
 - [ ] Technician users do not see partner dashboard controls.
+- [ ] Technician users cannot open `/portal/team` or manage Technician grants.
 - [ ] Revoking a Technician removes Technician-sourced training/reporting after refresh or sign-out/sign-in.
 
 ## Live Environment Notes

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -214,9 +214,9 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] User without reporting access does not see Reporting in portal navigation or dashboard quick actions
 - [ ] On mobile app routes, page-intro actions stack cleanly full width instead of squeezing side-by-side on `/portal`, `/portal/orders`, `/portal/account`, `/portal/onboarding`, `/portal/support`, and `/portal/training`
 - [ ] Non-Plus login can access baseline pages (`/portal`, `/portal/orders`, `/portal/account`)
-- [ ] Non-Plus login is blocked from gated pages (`/portal/training`, `/portal/onboarding`, `/portal/support`) with clear access messaging
+- [ ] Non-Plus login is blocked from gated pages (`/portal/training`, `/portal/onboarding`, `/portal/support`, `/portal/team`) with clear access messaging
 - [ ] Non-Plus login still sees Plus/training gated destinations in portal navigation and dashboard action cards with clear locked/access-tier treatment; Reporting stays hidden unless reporting access is granted
-- [ ] Active Plus member sees Technician Access as the customer team-management surface in Settings (`/portal/account`) with no separate Operator Training Access panel
+- [ ] Active Plus member sees Team in portal navigation and Technician Access on `/portal/team`; Settings (`/portal/account`) links to Team without duplicating the Technician workflow
 - [ ] Adding training-only Technician access sends the Technician an invite email with a login link
 - [ ] Technician Access shows active, pending, and legacy training-only people in one list with a clear setup message when the database rollout is missing
 - [ ] Training-only access is represented as a Technician with no assigned machines
@@ -226,10 +226,10 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] `/portal/orders` loads real `orders` data for the logged-in user (no mock rows)
 - [ ] `/portal/account` shows live membership status and period from `subscriptions` (no hardcoded next billing date)
 - [ ] `/portal/account` has no horizontal page overflow on mobile viewports (360x800, 390x844, 414x896)
-- [ ] `/portal/orders`, `/portal/account`, `/portal/support`, `/portal/onboarding`, and `/portal/training` keep page actions, form controls, filters, order-card actions, Technician controls, and checklist toggles at touch-friendly sizes on mobile viewports (360x800, 390x844, 414x896)
+- [ ] `/portal/orders`, `/portal/account`, `/portal/team`, `/portal/support`, `/portal/onboarding`, and `/portal/training` keep page actions, form controls, filters, order-card actions, Technician controls, and checklist toggles at touch-friendly sizes on mobile viewports (360x800, 390x844, 414x896)
 - [ ] `/portal/account` profile save persists and reloads from `customer_profiles`
 - [ ] `/portal/account` shipping save persists and reloads from `customer_profiles`
-- [ ] Plus Account Owner sees Technician Access in Settings (`/portal/account`) with seat usage, owned machines, and current Technician grants
+- [ ] Plus Account Owner sees Technician Access in Team (`/portal/team`) with seat usage, owned machines, and current Technician grants
 - [ ] Plus Account Owner can add a Technician with either training-only access or selected owned machines, then edit that Technician's machine assignments
 - [ ] Pending Technician invite resolves on first login so the Technician gets training plus assigned-machine reporting without admin repair
 - [ ] Authenticated `/portal` and `/admin` route loads do not show `404` or `PGRST202` for `resolve_my_technician_entitlements` in the browser network log or console
@@ -363,13 +363,14 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Access-management PR verification is recorded: `npm ci`, `npm run build`, `npm test --if-present`, `npm run lint --if-present`; DB-touching work also records `npm run db:validate-migrations`, `supabase db push --dry-run` when linked, and direct RPC checks for no `404`/`PGRST202`.
 - [ ] Access-management PR includes desktop and mobile screenshots for affected flows, including desktop selected-person workspace and mobile `390x844` source-card layout with no horizontal scrolling or clipped controls.
 - [ ] Admin Access invite UAT: run `npm run admin-access:validate-invite-uat -- --app-url http://127.0.0.1:8081` against `npm run dev:uat` and attach desktop/mobile screenshots from `output/playwright` to the PR.
+- [ ] Admin Access exposes a direct Add Technician action on `/admin/access` in addition to the generic Add or invite access launcher.
 - [ ] Access Launcher opens from `/admin/access` and deep links from `/admin/access?action=add-access`, with preset links for `corporate_partner`, `technician`, `scoped_admin`, `super_admin`, and `plus_customer`.
 - [ ] Access Launcher Corporate Partner preset can grant email-based access for a never-authenticated email, send the invite email, and write both `access_invite_deliveries` and `admin_audit_log` evidence.
 - [ ] Access Launcher Technician preset can grant training-only access or selected machines, send the invite email, and preserve the assigned-machine Technician reporting boundary.
 - [ ] Admin Access Corporate Partner source card uses one primary `Grant and send invite` action; the selected-person flow does not leave a saved active membership without an invite attempt unless the UI reports invite failure and shows resend/copy recovery.
 - [ ] Admin Access Corporate Partner source card keeps partner-wide portal setup separate from the person invite transaction; partner portal setup has its own reason, preview, and save action.
 - [ ] Admin Access Technician source card uses `Save and send Technician invite`; if invite delivery fails after the grant is saved, the UI reports the split state instead of only saying access saved.
-- [ ] Partner Technician Access: corporate partner on `/portal/account` can create two Technicians for the same in-scope machine, and can assign one Technician to multiple in-scope machines; each new Technician save automatically sends the invite, and row-level resend/copy remains available for recovery.
+- [ ] Partner Technician Access: corporate partner on `/portal/team` can create two Technicians for the same in-scope machine, and can assign one Technician to multiple in-scope machines; each new Technician save automatically sends the invite, and row-level resend/copy remains available for recovery.
 - [ ] Partner Technician Access: training-only Technician invite copy says training library only, assigned-machine Technician invite copy says training plus assigned-machine reporting, and neither invite promises partner-wide reporting.
 - [ ] Partner Technician Access: run `npm run partner-technicians:validate-uat -- --app-url http://127.0.0.1:8081` against `npm run dev:uat` and attach desktop/mobile screenshots from `output/playwright` to the PR.
 - [ ] Access invite email copy stays source-specific without overstating access: Corporate Partner copy stays generic to available tools, Technician copy may mention training and assigned-machine reporting, and no invite promises broad partner-wide reporting unless the source grants it.

--- a/Docs/TECHNICIAN_ENTITLEMENTS_SPEC.md
+++ b/Docs/TECHNICIAN_ENTITLEMENTS_SPEC.md
@@ -80,7 +80,7 @@ Not V1 grant authority:
 - Reporting `report_manager`, unless a later decision explicitly expands this role.
 - Account admin or delegated team manager, unless a later decision adds delegated customer team management.
 
-The customer-facing flow should live in `/portal/account` or a future `/portal/team`, not in `/admin`. Internal override and audit review can stay in `/admin/access`.
+The customer-facing flow lives in `/portal/team`, not in `/admin`. Account Settings may link to Team for eligible users, but should not duplicate the Technician management workflow. Internal override and audit review can stay in `/admin/access`.
 
 ## Plus Account Owner Limits
 
@@ -207,7 +207,7 @@ RPC requirements:
 Add super-admin override RPCs only if the internal UI needs them in the same slice. Otherwise keep internal override as a later PR.
 
 ### 3. Customer UX
-Add the customer flow under `/portal/account` or a future `/portal/team`.
+Add the customer flow under `/portal/team`.
 
 V1 UX should show:
 

--- a/Docs/UAT_PERSONA_PLAYBOOK.md
+++ b/Docs/UAT_PERSONA_PLAYBOOK.md
@@ -71,6 +71,7 @@ Key routes:
 - `/portal`
 - `/portal/orders`
 - `/portal/account`
+- `/portal/team`
 - `/portal/onboarding`
 - `/portal/support`
 - `/portal/training`
@@ -81,7 +82,7 @@ Owner UAT focus:
 - Plus benefits and limits are clear.
 - Account, billing, order, support, onboarding, and training flows are usable.
 - Reporting shows only machines the owner should control.
-- Technician management, when present, only allows assigned machines the owner already controls.
+- Technician management on `/portal/team`, when present, only allows assigned machines the owner already controls.
 - The default Technician cap is clear when reached.
 
 ### Technician
@@ -131,6 +132,7 @@ Use this persona for Merlin/Bubble Planet-style partner users with explicit Corp
 Expected route direction:
 
 - `/portal/reports` for permissioned partner/reporting views.
+- `/portal/team` for partner-authorized Technician management.
 - Approved report artifacts or dashboards only after the product flow supports them.
 
 Owner UAT focus:

--- a/scripts/validate-admin-access-invite-uat.mjs
+++ b/scripts/validate-admin-access-invite-uat.mjs
@@ -620,6 +620,11 @@ const run = async () => {
     await page.waitForURL('**/admin/access', { timeout: 20000 });
     await page.getByRole('heading', { name: 'Access' }).waitFor({ timeout: 10000 });
 
+    recorder.assert(
+      'Admin Access exposes a direct Add Technician action',
+      await page.getByRole('button', { name: 'Add Technician' }).isVisible()
+    );
+
     await page.getByLabel('Search by email or user ID').fill(targetEmail);
     await page.getByRole('button', { name: 'Search' }).click();
     await page.getByRole('button', { name: 'Open email workspace' }).click();

--- a/scripts/validate-admin-access-invite-uat.mjs
+++ b/scripts/validate-admin-access-invite-uat.mjs
@@ -624,6 +624,17 @@ const run = async () => {
       'Admin Access exposes a direct Add Technician action',
       await page.getByRole('button', { name: 'Add Technician' }).isVisible()
     );
+    await page.getByRole('button', { name: 'Add Technician' }).click();
+    await page.getByRole('heading', { name: 'Add Technician' }).waitFor({ timeout: 10000 });
+    recorder.assert(
+      'Direct Add Technician opens the focused Technician launcher',
+      await page.getByText(/Invite a Technician with training access/i).isVisible()
+    );
+    await page.getByRole('button', { name: 'Cancel' }).click();
+    await page.getByRole('heading', { name: 'Add Technician' }).waitFor({
+      state: 'hidden',
+      timeout: 10000,
+    });
 
     await page.getByLabel('Search by email or user ID').fill(targetEmail);
     await page.getByRole('button', { name: 'Search' }).click();

--- a/scripts/validate-partner-technician-access-uat.mjs
+++ b/scripts/validate-partner-technician-access-uat.mjs
@@ -602,9 +602,9 @@ const runPartnerUat = async ({ args, browser, recorder }) => {
   });
 
   try {
-    await page.goto(`${args.appUrl}/portal/account`, { waitUntil: 'domcontentloaded' });
+    await page.goto(`${args.appUrl}/portal/team`, { waitUntil: 'domcontentloaded' });
     await login(page, partnerUser);
-    await page.waitForURL('**/portal/account', { timeout: 20000 });
+    await page.waitForURL('**/portal/team', { timeout: 20000 });
     try {
       await page.getByRole('heading', { name: 'Technician Access' }).waitFor({ timeout: 10000 });
     } catch (error) {
@@ -615,7 +615,7 @@ const runPartnerUat = async ({ args, browser, recorder }) => {
       throw error;
     }
 
-    recorder.assert('Partner lands on portal account page', pathname(page) === '/portal/account', page.url());
+    recorder.assert('Partner lands on portal Team page', pathname(page) === '/portal/team', page.url());
     recorder.assert(
       'Partner scope is explicit',
       await page.getByText(/Bubble Planet can manage Technicians only for the machines shown here/i).isVisible()
@@ -802,6 +802,15 @@ const runTechnicianUat = async ({ args, browser, recorder }) => {
 
     await page.screenshot({
       path: path.join(args.artifactDir, 'technician-reporting-scope.png'),
+      fullPage: true,
+    });
+
+    await page.goto(`${args.appUrl}/portal/team`, { waitUntil: 'domcontentloaded' });
+    await page.getByRole('heading', { name: /Team requires Team access/i }).waitFor({ timeout: 10000 });
+    recorder.assert('Technician cannot open Team management', pathname(page) === '/portal/team', page.url());
+
+    await page.screenshot({
+      path: path.join(args.artifactDir, 'technician-team-denied.png'),
       fullPage: true,
     });
 

--- a/scripts/validate-partner-technician-access-uat.mjs
+++ b/scripts/validate-partner-technician-access-uat.mjs
@@ -658,6 +658,7 @@ const runPartnerUat = async ({ args, browser, recorder }) => {
     );
 
     await page.fill('#technician-email', trainingOnlyEmail);
+    await page.locator('label[for="technician-training-only-confirm"]').click();
     await page.getByRole('button', { name: 'Save and send invite' }).click();
     await technicianRow(page, trainingOnlyEmail).waitFor({ timeout: 10000 });
     await waitForCondition(() => state.accessInviteBodies.length === 3, 'training-only Technician auto-invite');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,6 +56,7 @@ const PortalSupport = lazyRoute(() => import("./pages/portal/Support"));
 const PortalOnboarding = lazyRoute(() => import("./pages/portal/Onboarding"));
 const PortalOrders = lazyRoute(() => import("./pages/portal/Orders"));
 const PortalAccount = lazyRoute(() => import("./pages/portal/Account"));
+const PortalTeam = lazyRoute(() => import("./pages/portal/Team"));
 const PortalReports = lazyRoute(() => import("./pages/portal/Reports"));
 const PortalTime = lazyRoute(() => import("./pages/portal/Time"));
 const AdminDashboard = lazyRoute(() => import("./pages/admin/Dashboard"));
@@ -185,6 +186,7 @@ export const AppShell = () => (
               <Route path="/portal/time/new" element={<PortalTime />} />
               <Route path="/portal/time/:entryId/edit" element={<PortalTime />} />
               <Route path="/portal/account" element={<PortalAccount />} />
+              <Route path="/portal/team" element={<PortalTeam />} />
               <Route path="/portal/reports" element={<PortalReports />} />
               <Route path="/portal/training" element={<PortalTraining />} />
               <Route path="/portal/training/:id" element={<PortalTrainingDetail />} />

--- a/src/components/auth/MemberRoute.tsx
+++ b/src/components/auth/MemberRoute.tsx
@@ -11,11 +11,13 @@ import {
 import { Button } from '@/components/ui/button';
 
 export function MemberRoute() {
-  const { capabilities, hasReportingAccess, loading, portalAccessTier } = useAuth();
+  const { canManageTechnicians, capabilities, hasReportingAccess, loading, portalAccessTier } =
+    useAuth();
   const location = useLocation();
   const lockedDestination = getPortalDestinationByPath(location.pathname);
   const accessLabel = getAccessLevelLabel(lockedDestination.access);
   const isReportingRoute = lockedDestination.access === 'reporting';
+  const isTeamRoute = lockedDestination.access === 'team';
 
   if (loading) {
     return (
@@ -30,7 +32,9 @@ export function MemberRoute() {
       portalAccessTier,
       lockedDestination.access,
       hasReportingAccess,
-      capabilities
+      capabilities,
+      false,
+      canManageTechnicians
     )
   ) {
     return <Outlet />;
@@ -64,12 +68,14 @@ export function MemberRoute() {
                     <p className="mt-2 text-sm leading-6 text-muted-foreground">
                       {isReportingRoute
                         ? 'Sales reporting access is granted by account, location, or specific machine. Ask Bloomjoy to add reporting permissions for the machines you should be able to view.'
+                        : isTeamRoute
+                          ? 'Team management is reserved for Plus account owners and eligible Corporate Partner managers. Technicians can use training and assigned reporting without access to customer team controls.'
                         : 'Technicians without assigned machines can use the training hub. Customer account tools, onboarding, support, and billing stay reserved for account owners and eligible partners.'}
                     </p>
                   </div>
                 </div>
                 <div className="mt-6 flex flex-col gap-3 sm:flex-row">
-                  {lockedDestination.access !== 'baseline' && !isReportingRoute && (
+                  {lockedDestination.access !== 'baseline' && !isReportingRoute && !isTeamRoute && (
                     <Button asChild className="min-h-11">
                       <Link to="/plus">View Plus Membership</Link>
                     </Button>

--- a/src/components/portal/PortalLayout.tsx
+++ b/src/components/portal/PortalLayout.tsx
@@ -27,8 +27,15 @@ interface PortalLayoutProps {
 }
 
 export function PortalLayout({ children }: PortalLayoutProps) {
-  const { adminAccess, capabilities, hasReportingAccess, isCorporatePartner, isSuperAdmin, portalAccessTier } =
-    useAuth();
+  const {
+    adminAccess,
+    canManageTechnicians,
+    capabilities,
+    hasReportingAccess,
+    isCorporatePartner,
+    isSuperAdmin,
+    portalAccessTier,
+  } = useAuth();
   const { t } = useLanguage();
   const location = useLocation();
   const currentDestination = getPortalDestinationByPath(location.pathname);
@@ -44,11 +51,13 @@ export function PortalLayout({ children }: PortalLayoutProps) {
       access,
       hasReportingAccess,
       capabilities,
-      hasRefundOperationsAccess
+      hasRefundOperationsAccess,
+      canManageTechnicians
     );
   const visibleDestinations = sortedDestinations
     .filter((destination) => destination.access !== 'reporting' || canAccessDestination(destination.access))
     .filter((destination) => destination.access !== 'refunds' || canAccessDestination(destination.access))
+    .filter((destination) => destination.access !== 'team' || canAccessDestination(destination.access))
     .filter((destination) =>
       portalAccessTier === 'training'
         ? canAccessDestination(destination.access)

--- a/src/components/portal/TechnicianManagementPanel.tsx
+++ b/src/components/portal/TechnicianManagementPanel.tsx
@@ -15,6 +15,7 @@ import { toast } from 'sonner';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
   Dialog,
   DialogContent,
@@ -160,6 +161,7 @@ export function TechnicianManagementPanel() {
   const [technicianEmail, setTechnicianEmail] = useState('');
   const [selectedMachineIds, setSelectedMachineIds] = useState<string[]>([]);
   const [grantReason, setGrantReason] = useState(DEFAULT_TECHNICIAN_REASON);
+  const [trainingOnlyConfirmed, setTrainingOnlyConfirmed] = useState(false);
   const [editingGrantId, setEditingGrantId] = useState<string | null>(null);
   const [editingMachineIds, setEditingMachineIds] = useState<string[]>([]);
   const [editReason, setEditReason] = useState(DEFAULT_UPDATE_REASON);
@@ -311,6 +313,16 @@ export function TechnicianManagementPanel() {
     );
   }, [selectedAccountMachineIds]);
 
+  useEffect(() => {
+    setTrainingOnlyConfirmed(false);
+  }, [selectedAccount?.accountId, selectedAccount?.partnerId]);
+
+  useEffect(() => {
+    if (selectedMachineIds.length > 0) {
+      setTrainingOnlyConfirmed(false);
+    }
+  }, [selectedMachineIds.length]);
+
   const invalidateTechnicianQueries = async () => {
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: ['technician-management-context', user?.id] }),
@@ -372,6 +384,11 @@ export function TechnicianManagementPanel() {
       return;
     }
 
+    if (selectedMachineIds.length === 0 && !trainingOnlyConfirmed) {
+      toast.error('Confirm training-only access before sending this Technician invite.');
+      return;
+    }
+
     try {
       const grant = await grantMutation.mutateAsync({
         technicianEmail: normalizedEmail,
@@ -382,6 +399,7 @@ export function TechnicianManagementPanel() {
       });
       setTechnicianEmail('');
       setSelectedMachineIds([]);
+      setTrainingOnlyConfirmed(false);
       setGrantReason(DEFAULT_TECHNICIAN_REASON);
       setRecentlySavedGrantId(grant.grantId);
       await invalidateTechnicianQueries();
@@ -749,6 +767,32 @@ export function TechnicianManagementPanel() {
                     />
                   )}
 
+                  {selectedMachineIds.length === 0 && (
+                    <label
+                      htmlFor="technician-training-only-confirm"
+                      className={cn(
+                        'flex min-h-11 cursor-pointer items-start gap-3 rounded-md border border-amber/40 bg-amber/10 p-3 text-sm',
+                        (addBlockedByCap || grantMutation.isPending) && 'cursor-not-allowed opacity-70'
+                      )}
+                    >
+                      <Checkbox
+                        id="technician-training-only-confirm"
+                        checked={trainingOnlyConfirmed}
+                        onCheckedChange={(checked) => setTrainingOnlyConfirmed(checked === true)}
+                        disabled={addBlockedByCap || grantMutation.isPending}
+                      />
+                      <span className="min-w-0">
+                        <span className="block font-medium text-foreground">
+                          Send as training-only access
+                        </span>
+                        <span className="mt-1 block text-xs leading-5 text-muted-foreground">
+                          I understand this Technician will not see machine reporting until machines
+                          are assigned later.
+                        </span>
+                      </span>
+                    </label>
+                  )}
+
                   <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                     <p className="text-xs leading-5 text-muted-foreground">
                       {selectedMachineIds.length > 0
@@ -761,7 +805,8 @@ export function TechnicianManagementPanel() {
                       disabled={
                         grantMutation.isPending ||
                         addBlockedByCap ||
-                        !technicianEmail.trim()
+                        !technicianEmail.trim() ||
+                        (selectedMachineIds.length === 0 && !trainingOnlyConfirmed)
                       }
                     >
                       {grantMutation.isPending ? (

--- a/src/components/portal/TechnicianManagementPanel.tsx
+++ b/src/components/portal/TechnicianManagementPanel.tsx
@@ -6,7 +6,6 @@ import {
   Copy,
   Loader2,
   Pencil,
-  Search,
   Send,
   UserMinus,
   UserPlus,
@@ -16,7 +15,6 @@ import { toast } from 'sonner';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
 import {
   Dialog,
   DialogContent,
@@ -37,6 +35,8 @@ import {
 } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Textarea } from '@/components/ui/textarea';
+import { TechnicianMachineAssignmentPicker } from '@/components/technicians/TechnicianMachineAssignmentPicker';
+import { formatTechnicianScopePreview } from '@/components/technicians/technicianMachineAssignmentCopy';
 import { useAuth } from '@/contexts/auth-context';
 import {
   fetchMyTechnicianGrants,
@@ -126,13 +126,6 @@ const haveSameMachineIds = (left: string[], right: string[]) => {
 };
 
 const uniqueSortedValues = (items: string[]) => [...new Set(items)].sort((a, b) => a.localeCompare(b));
-
-const toggleMachineId = (machineIds: string[], machineId: string, checked: boolean) => {
-  const next = new Set(machineIds);
-  if (checked) next.add(machineId);
-  else next.delete(machineId);
-  return uniqueSortedValues([...next]);
-};
 
 const buildLocalTechnicianInviteDelivery = ({
   sourceId,
@@ -747,11 +740,11 @@ export function TechnicianManagementPanel() {
                       </AlertDescription>
                     </Alert>
                   ) : (
-                    <MachineAssignmentPicker
-                      name="add-technician-machine"
+                    <TechnicianMachineAssignmentPicker
+                      idPrefix="add-technician-machine"
                       machines={selectedAccount.machines}
-                      selectedIds={selectedMachineIds}
-                      onChange={setSelectedMachineIds}
+                      selectedMachineIds={selectedMachineIds}
+                      onSelectedMachineIdsChange={setSelectedMachineIds}
                       disabled={addBlockedByCap || grantMutation.isPending}
                     />
                   )}
@@ -1062,11 +1055,11 @@ function TechnicianGrantRow({
 
       {isEditing && (
         <div className="mt-4 flex flex-col gap-4 rounded-md border border-border bg-background p-4">
-          <MachineAssignmentPicker
-            name={`edit-technician-${grant.grantId}-machine`}
+          <TechnicianMachineAssignmentPicker
+            idPrefix={`edit-technician-${grant.grantId}-machine`}
             machines={machines}
-            selectedIds={editingMachineIds}
-            onChange={onChangeEditMachines}
+            selectedMachineIds={editingMachineIds}
+            onSelectedMachineIdsChange={onChangeEditMachines}
             disabled={isSaving}
           />
           <div>
@@ -1081,9 +1074,7 @@ function TechnicianGrantRow({
           </div>
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <p className="text-xs leading-5 text-muted-foreground">
-              {editingMachineIds.length === 0
-                ? 'No machines selected; saving will keep this Technician training-only.'
-                : `This Technician will see reporting for ${pluralize(editingMachineIds.length, 'selected machine')} only.`}
+              {formatTechnicianScopePreview(editingMachineIds.length)} after save.
             </p>
             <div className="flex flex-col gap-2 sm:flex-row">
               <Button
@@ -1150,159 +1141,6 @@ function LegacyTrainingGrantRow({
           <UserMinus className="mr-1.5 h-4 w-4" />
           Revoke
         </Button>
-      </div>
-    </div>
-  );
-}
-
-function MachineAssignmentPicker({
-  name,
-  machines,
-  selectedIds,
-  onChange,
-  disabled = false,
-}: {
-  name: string;
-  machines: TechnicianManagementMachine[];
-  selectedIds: string[];
-  onChange: (machineIds: string[]) => void;
-  disabled?: boolean;
-}) {
-  const selectedIdSet = useMemo(() => new Set(selectedIds), [selectedIds]);
-  const [machineSearch, setMachineSearch] = useState('');
-  const normalizedMachineSearch = machineSearch.trim().toLowerCase();
-  const filteredMachines = useMemo(() => {
-    if (!normalizedMachineSearch) return machines;
-
-    return machines.filter((machine) =>
-      [
-        machine.machineLabel,
-        machine.machineType,
-        machine.locationName,
-        machine.status,
-      ]
-        .join(' ')
-        .toLowerCase()
-        .includes(normalizedMachineSearch)
-    );
-  }, [machines, normalizedMachineSearch]);
-  const groupedMachines = useMemo(() => {
-    const groups = new Map<
-      string,
-      { key: string; locationName: string; machines: TechnicianManagementMachine[] }
-    >();
-
-    filteredMachines.forEach((machine) => {
-      const key = machine.locationId || machine.locationName;
-      const existingGroup =
-        groups.get(key) ??
-        {
-          key,
-          locationName: machine.locationName,
-          machines: [],
-        };
-
-      existingGroup.machines.push(machine);
-      groups.set(key, existingGroup);
-    });
-
-    return Array.from(groups.values()).sort((left, right) =>
-      left.locationName.localeCompare(right.locationName)
-    );
-  }, [filteredMachines]);
-
-  if (machines.length === 0) {
-    return (
-      <p className="rounded-md border border-border bg-muted/20 px-3 py-3 text-sm text-muted-foreground">
-        No machines are available for this account.
-      </p>
-    );
-  }
-
-  return (
-    <div className="flex flex-col gap-3">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <Label>Machine reporting</Label>
-        <div className="flex items-center gap-2">
-          <span className="text-xs text-muted-foreground">
-            {selectedIds.length > 0
-              ? pluralize(selectedIds.length, 'selected machine')
-              : 'Training-only when none are selected'}
-          </span>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={() => onChange([])}
-            disabled={disabled || selectedIds.length === 0}
-          >
-            Clear
-          </Button>
-        </div>
-      </div>
-      {machines.length > 6 && (
-        <div>
-          <Label htmlFor={`${name}-search`} className="sr-only">
-            Search machines
-          </Label>
-          <div className="relative">
-            <Search className="pointer-events-none absolute left-3 top-3.5 h-4 w-4 text-muted-foreground" />
-            <Input
-              id={`${name}-search`}
-              value={machineSearch}
-              onChange={(event) => setMachineSearch(event.target.value)}
-              placeholder="Search machines"
-              className="h-11 pl-9"
-              disabled={disabled}
-            />
-          </div>
-        </div>
-      )}
-      <div className="max-h-72 overflow-y-auto rounded-md border border-border">
-        {groupedMachines.length === 0 ? (
-          <p className="px-3 py-3 text-sm text-muted-foreground">
-            No machines match this search.
-          </p>
-        ) : (
-          groupedMachines.map((group) => (
-            <div key={group.key} className="border-b border-border last:border-b-0">
-              <div className="bg-muted/40 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                {group.locationName}
-              </div>
-              {group.machines.map((machine) => {
-                const checkboxId = `${name}-${machine.machineId}`;
-
-                return (
-                  <label
-                    key={machine.machineId}
-                    htmlFor={checkboxId}
-                    className={cn(
-                      'flex min-h-12 cursor-pointer items-start gap-3 border-b border-border/60 p-3 last:border-b-0',
-                      disabled && 'cursor-not-allowed opacity-70'
-                    )}
-                  >
-                    <Checkbox
-                      id={checkboxId}
-                      checked={selectedIdSet.has(machine.machineId)}
-                      onCheckedChange={(checked) =>
-                        onChange(toggleMachineId(selectedIds, machine.machineId, checked === true))
-                      }
-                      disabled={disabled}
-                    />
-                    <span className="min-w-0 flex-1">
-                      <span className="block break-words text-sm font-medium text-foreground">
-                        {machine.machineLabel}
-                      </span>
-                      <span className="mt-1 block text-xs text-muted-foreground">
-                        {machine.machineType} - {machine.status}
-                      </span>
-                    </span>
-                  </label>
-                );
-              })}
-            </div>
-          ))
-        )}
       </div>
     </div>
   );

--- a/src/components/portal/portalNavigation.ts
+++ b/src/components/portal/portalNavigation.ts
@@ -9,6 +9,7 @@ import {
   ReceiptText,
   Settings,
   ShoppingBag,
+  Users,
 } from 'lucide-react';
 import type { PortalAccessTier } from '@/lib/membership';
 import type { TranslationKey } from '@/lib/i18n';
@@ -20,7 +21,8 @@ export type PortalAccessLevel =
   | 'plus'
   | 'support'
   | 'reporting'
-  | 'refunds';
+  | 'refunds'
+  | 'team';
 
 export interface PortalDestination {
   href: string;
@@ -79,6 +81,16 @@ export const portalDestinations: PortalDestination[] = [
     mobileOrder: 4,
   },
   {
+    href: '/portal/team',
+    label: 'Team',
+    labelKey: 'portal.nav.team',
+    description: 'Add Technicians and manage assigned-machine reporting access.',
+    descriptionKey: 'portal.nav.teamDescription',
+    icon: Users,
+    access: 'team',
+    mobileOrder: 5,
+  },
+  {
     href: '/portal/reports',
     label: 'Reporting',
     labelKey: 'portal.nav.reporting',
@@ -86,7 +98,7 @@ export const portalDestinations: PortalDestination[] = [
     descriptionKey: 'portal.nav.reportingDescription',
     icon: BarChart3,
     access: 'reporting',
-    mobileOrder: 5,
+    mobileOrder: 6,
     upsellCopy: 'Sales reporting is available only for machines Bloomjoy has granted to this account.',
     upsellCopyKey: 'portal.nav.reportingUpsell',
   },
@@ -98,7 +110,7 @@ export const portalDestinations: PortalDestination[] = [
     descriptionKey: 'portal.nav.refundsDescription',
     icon: ReceiptText,
     access: 'refunds',
-    mobileOrder: 6,
+    mobileOrder: 7,
   },
   {
     href: '/portal/training',
@@ -108,7 +120,7 @@ export const portalDestinations: PortalDestination[] = [
     descriptionKey: 'portal.nav.trainingDescription',
     icon: BookOpen,
     access: 'training',
-    mobileOrder: 7,
+    mobileOrder: 8,
     upsellCopy: 'Unlock the operator hub, quick aids, and certificate path.',
     upsellCopyKey: 'portal.nav.trainingUpsell',
   },
@@ -120,7 +132,7 @@ export const portalDestinations: PortalDestination[] = [
     descriptionKey: 'portal.nav.onboardingDescription',
     icon: ListChecks,
     access: 'plus',
-    mobileOrder: 8,
+    mobileOrder: 9,
     upsellCopy: 'Unlock guided setup steps and first-spin milestones.',
     upsellCopyKey: 'portal.nav.onboardingUpsell',
   },
@@ -132,7 +144,7 @@ export const portalDestinations: PortalDestination[] = [
     descriptionKey: 'portal.nav.supportDescription',
     icon: HeadphonesIcon,
     access: 'support',
-    mobileOrder: 9,
+    mobileOrder: 10,
     upsellCopy: 'Unlock guided support requests and concierge escalation.',
     upsellCopyKey: 'portal.nav.supportUpsell',
   },
@@ -150,7 +162,8 @@ export const canAccessPortalLevel = (
   accessLevel: PortalAccessLevel,
   hasReportingAccess = false,
   capabilities: string[] = [],
-  hasRefundOperationsAccess = false
+  hasRefundOperationsAccess = false,
+  canManageTechnicians = false
 ): boolean => {
   const hasCapability = (capability: string) => capabilities.includes(capability);
 
@@ -178,6 +191,8 @@ export const canAccessPortalLevel = (
       return hasReportingAccess || hasCapability('reports.partner.view');
     case 'refunds':
       return hasRefundOperationsAccess || hasCapability('refunds.manage');
+    case 'team':
+      return canManageTechnicians || hasCapability('technicians.manage');
     default:
       return false;
   }
@@ -197,6 +212,8 @@ export const getAccessLevelLabel = (accessLevel: PortalAccessLevel) => {
       return 'Reporting';
     case 'refunds':
       return 'Refunds';
+    case 'team':
+      return 'Team';
     case 'all':
     default:
       return 'Open';
@@ -217,6 +234,8 @@ export const getAccessLevelLabelKey = (accessLevel: PortalAccessLevel): Translat
       return 'portal.access.reporting';
     case 'refunds':
       return 'portal.access.refunds';
+    case 'team':
+      return 'portal.access.team';
     case 'all':
     default:
       return 'portal.access.open';

--- a/src/components/technicians/TechnicianMachineAssignmentPicker.tsx
+++ b/src/components/technicians/TechnicianMachineAssignmentPicker.tsx
@@ -1,0 +1,219 @@
+import { useMemo, useState } from 'react';
+import { Search } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { pluralizeTechnicianMachine } from '@/components/technicians/technicianMachineAssignmentCopy';
+import { cn } from '@/lib/utils';
+
+export type TechnicianAssignableMachine = {
+  machineId: string;
+  machineLabel: string;
+  machineType?: string | null;
+  locationId?: string | null;
+  locationName?: string | null;
+  status?: string | null;
+};
+
+type TechnicianMachineAssignmentPickerProps<TMachine extends TechnicianAssignableMachine> = {
+  idPrefix: string;
+  machines: TMachine[];
+  selectedMachineIds: string[];
+  onSelectedMachineIdsChange: (machineIds: string[]) => void;
+  disabled?: boolean;
+  label?: string;
+  emptyMessage?: string;
+  searchPlaceholder?: string;
+  clearLabel?: string;
+  searchThreshold?: number;
+  groupByLocation?: boolean;
+  className?: string;
+};
+
+const uniqueSortedValues = (items: string[]) =>
+  [...new Set(items)].sort((left, right) => left.localeCompare(right));
+
+const toggleMachineId = (machineIds: string[], machineId: string, checked: boolean) => {
+  const next = new Set(machineIds);
+  if (checked) next.add(machineId);
+  else next.delete(machineId);
+  return uniqueSortedValues([...next]);
+};
+
+const getMachineLocationKey = (machine: TechnicianAssignableMachine) =>
+  machine.locationId || machine.locationName || 'unassigned';
+
+const getMachineLocationName = (machine: TechnicianAssignableMachine) =>
+  machine.locationName || 'Unassigned location';
+
+const getMachineMeta = (machine: TechnicianAssignableMachine) =>
+  [machine.locationName, machine.machineType, machine.status].filter(Boolean).join(' / ');
+
+export function TechnicianMachineAssignmentPicker<TMachine extends TechnicianAssignableMachine>({
+  idPrefix,
+  machines,
+  selectedMachineIds,
+  onSelectedMachineIdsChange,
+  disabled = false,
+  label = 'Machine reporting',
+  emptyMessage = 'No active machines are available for this account.',
+  searchPlaceholder = 'Search machines',
+  clearLabel = 'Clear',
+  searchThreshold = 6,
+  groupByLocation = true,
+  className,
+}: TechnicianMachineAssignmentPickerProps<TMachine>) {
+  const selectedIdSet = useMemo(() => new Set(selectedMachineIds), [selectedMachineIds]);
+  const [machineSearch, setMachineSearch] = useState('');
+  const normalizedMachineSearch = machineSearch.trim().toLowerCase();
+  const filteredMachines = useMemo(() => {
+    if (!normalizedMachineSearch) return machines;
+
+    return machines.filter((machine) =>
+      [
+        machine.machineLabel,
+        machine.machineType,
+        machine.locationName,
+        machine.status,
+      ]
+        .join(' ')
+        .toLowerCase()
+        .includes(normalizedMachineSearch)
+    );
+  }, [machines, normalizedMachineSearch]);
+  const groupedMachines = useMemo(() => {
+    if (!groupByLocation) {
+      return [
+        {
+          key: 'all',
+          locationName: '',
+          machines: filteredMachines,
+        },
+      ];
+    }
+
+    const groups = new Map<string, { key: string; locationName: string; machines: TMachine[] }>();
+
+    filteredMachines.forEach((machine) => {
+      const key = getMachineLocationKey(machine);
+      const existingGroup =
+        groups.get(key) ??
+        {
+          key,
+          locationName: getMachineLocationName(machine),
+          machines: [],
+        };
+
+      existingGroup.machines.push(machine);
+      groups.set(key, existingGroup);
+    });
+
+    return Array.from(groups.values()).sort((left, right) =>
+      left.locationName.localeCompare(right.locationName)
+    );
+  }, [filteredMachines, groupByLocation]);
+
+  if (machines.length === 0) {
+    return (
+      <p className="rounded-md border border-border bg-muted/20 px-3 py-3 text-sm text-muted-foreground">
+        {emptyMessage}
+      </p>
+    );
+  }
+
+  return (
+    <div className={cn('flex flex-col gap-3', className)}>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <Label>{label}</Label>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground">
+            {selectedMachineIds.length > 0
+              ? pluralizeTechnicianMachine(selectedMachineIds.length, 'selected machine')
+              : 'Training-only when none are selected'}
+          </span>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => onSelectedMachineIdsChange([])}
+            disabled={disabled || selectedMachineIds.length === 0}
+          >
+            {clearLabel}
+          </Button>
+        </div>
+      </div>
+      {machines.length > searchThreshold && (
+        <div>
+          <Label htmlFor={`${idPrefix}-search`} className="sr-only">
+            Search machines
+          </Label>
+          <div className="relative">
+            <Search className="pointer-events-none absolute left-3 top-3.5 h-4 w-4 text-muted-foreground" />
+            <Input
+              id={`${idPrefix}-search`}
+              value={machineSearch}
+              onChange={(event) => setMachineSearch(event.target.value)}
+              placeholder={searchPlaceholder}
+              className="h-11 pl-9"
+              disabled={disabled}
+            />
+          </div>
+        </div>
+      )}
+      <div className="max-h-72 overflow-y-auto rounded-md border border-border">
+        {groupedMachines.length === 0 || filteredMachines.length === 0 ? (
+          <p className="px-3 py-3 text-sm text-muted-foreground">
+            No machines match this search.
+          </p>
+        ) : (
+          groupedMachines.map((group) => (
+            <div key={group.key} className="border-b border-border last:border-b-0">
+              {groupByLocation && (
+                <div className="bg-muted/40 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  {group.locationName}
+                </div>
+              )}
+              {group.machines.map((machine) => {
+                const checkboxId = `${idPrefix}-${machine.machineId}`;
+                const machineMeta = getMachineMeta(machine);
+
+                return (
+                  <label
+                    key={machine.machineId}
+                    htmlFor={checkboxId}
+                    className={cn(
+                      'flex min-h-12 cursor-pointer items-start gap-3 border-b border-border/60 p-3 last:border-b-0',
+                      disabled && 'cursor-not-allowed opacity-70'
+                    )}
+                  >
+                    <Checkbox
+                      id={checkboxId}
+                      checked={selectedIdSet.has(machine.machineId)}
+                      onCheckedChange={(checked) =>
+                        onSelectedMachineIdsChange(
+                          toggleMachineId(selectedMachineIds, machine.machineId, checked === true)
+                        )
+                      }
+                      disabled={disabled}
+                    />
+                    <span className="min-w-0 flex-1">
+                      <span className="block break-words text-sm font-medium text-foreground">
+                        {machine.machineLabel}
+                      </span>
+                      {machineMeta && (
+                        <span className="mt-1 block text-xs text-muted-foreground">
+                          {machineMeta}
+                        </span>
+                      )}
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/technicians/technicianMachineAssignmentCopy.ts
+++ b/src/components/technicians/technicianMachineAssignmentCopy.ts
@@ -1,0 +1,7 @@
+export const pluralizeTechnicianMachine = (count: number, noun = 'machine') =>
+  `${count} ${noun}${count === 1 ? '' : 's'}`;
+
+export const formatTechnicianScopePreview = (count: number) =>
+  count > 0
+    ? `Training plus read-only reporting for ${pluralizeTechnicianMachine(count, 'selected machine')}`
+    : 'Training-only access';

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -9,6 +9,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
   return (
     <Sonner
       theme={theme as ToasterProps["theme"]}
+      position="top-right"
       className="toaster group"
       toastOptions={{
         classNames: {

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -91,6 +91,7 @@ export const translations = {
     'portal.access.support': 'Support',
     'portal.access.reporting': 'Reporting',
     'portal.access.refunds': 'Refunds',
+    'portal.access.team': 'Team',
     'portal.access.open': 'Open',
 
     'portal.nav.dashboard': 'Dashboard',
@@ -102,6 +103,9 @@ export const translations = {
       'Submit assigned-machine shifts and review current payout-period time.',
     'portal.nav.account': 'Account Settings',
     'portal.nav.accountDescription': 'Profile, billing, shipping, and language preferences.',
+    'portal.nav.team': 'Team',
+    'portal.nav.teamDescription':
+      'Add Technicians and manage assigned-machine reporting access.',
     'portal.nav.reporting': 'Reporting',
     'portal.nav.reportingDescription': 'Machine sales, location rollups, and available reporting views.',
     'portal.nav.reportingUpsell':
@@ -580,6 +584,9 @@ export const translations = {
     'account.title': 'Account Settings',
     'account.description':
       'Manage the profile information, shipping address, and language preference that keep portal work running smoothly.',
+    'team.title': 'Team',
+    'team.description':
+      'Add Technicians, send invites, and manage which machines each person can report on.',
     'account.profile': 'Profile',
     'account.email': 'Email',
     'account.name': 'Name',
@@ -667,6 +674,7 @@ export const translations = {
     'portal.access.support': '支持',
     'portal.access.reporting': '报表',
     'portal.access.refunds': '退款',
+    'portal.access.team': '团队',
     'portal.access.open': '开放',
 
     'portal.nav.dashboard': '仪表盘',
@@ -675,6 +683,8 @@ export const translations = {
     'portal.nav.ordersDescription': '收据、总额和物流跟踪。',
     'portal.nav.account': '账户设置 / Account Settings',
     'portal.nav.accountDescription': '资料、账单、收货信息和语言偏好。',
+    'portal.nav.team': '团队 / Team',
+    'portal.nav.teamDescription': '添加 Technician，并管理已分配机器的报表权限。',
     'portal.nav.reporting': '报表',
     'portal.nav.reportingDescription': '机器销售、地点汇总和可用报表视图。',
     'portal.nav.reportingUpsell': '销售报表仅对 Bloomjoy 授权给此账号的机器开放。',
@@ -1073,6 +1083,8 @@ export const translations = {
 
     'account.title': '账户设置 / Account Settings',
     'account.description': '管理资料、收货地址和语言偏好，让门户工作更顺畅。',
+    'team.title': '团队 / Team',
+    'team.description': '添加 Technician、发送邀请，并管理每个人可以查看报表的机器。',
     'account.profile': '资料',
     'account.email': '邮箱',
     'account.name': '姓名',

--- a/src/lib/seoRoutes.ts
+++ b/src/lib/seoRoutes.ts
@@ -485,6 +485,7 @@ export const privateRoutes: PrivateRouteSeo[] = [
     "/portal/time",
     "/portal/time/new",
     "/portal/account",
+    "/portal/team",
     "/portal/reports",
     "/portal/refunds",
     "/portal/training",

--- a/src/pages/admin/accessPersonConsole.tsx
+++ b/src/pages/admin/accessPersonConsole.tsx
@@ -1037,6 +1037,7 @@ function AccessLauncher({
   const [selectedPartnerId, setSelectedPartnerId] = useState(initialPartnerId ?? '');
   const [selectedAccountId, setSelectedAccountId] = useState(initialAccountId ?? '');
   const [selectedTechnicianMachineIds, setSelectedTechnicianMachineIds] = useState<Set<string>>(new Set());
+  const [trainingOnlyConfirmed, setTrainingOnlyConfirmed] = useState(false);
   const [grantReason, setGrantReason] = useState('');
   const [partnerForm, setPartnerForm] = useState(emptyPartnerForm);
   const [stagedPortalAccess, setStagedPortalAccess] = useState<Record<string, boolean>>({});
@@ -1056,6 +1057,7 @@ function AccessLauncher({
     setSelectedPartnerId(initialPartnerId ?? '');
     setSelectedAccountId(initialAccountId ?? '');
     setSelectedTechnicianMachineIds(new Set());
+    setTrainingOnlyConfirmed(false);
     setGrantReason('');
     setPartnerForm(emptyPartnerForm);
     setStagedPortalAccess({});
@@ -1254,6 +1256,8 @@ function AccessLauncher({
   }, [preset, selectedTechnicianMachineIds, selectedTechnicianMachines]);
 
   const selectedTechnicianMachineIdList = sortedSetValues(selectedTechnicianMachineIds);
+  const isTechnicianTrainingOnlyInvite =
+    preset === 'technician' && selectedTechnicianMachineIdList.length === 0;
   const selectedTechnicianMachineLabels = getSelectedTechnicianMachineLabels(
     selectedTechnicianMachines,
     selectedTechnicianMachineIdList
@@ -1265,9 +1269,19 @@ function AccessLauncher({
     !technicianContextError &&
     technicianContext.accounts.length === 0;
   const isExistingUserPreset = !presetMeta.inviteable;
-  const canSaveInvite = presetMeta.inviteable && Boolean(normalizedEmail) && Boolean(grantReason.trim());
+  const canSaveInvite =
+    presetMeta.inviteable &&
+    Boolean(normalizedEmail) &&
+    Boolean(grantReason.trim()) &&
+    (!isTechnicianTrainingOnlyInvite || trainingOnlyConfirmed);
   const existingPresetActionLabel =
     preset === 'plus_customer' ? 'Open Plus Customer workspace' : 'Open person workspace';
+
+  useEffect(() => {
+    if (preset !== 'technician' || selectedTechnicianMachineIdList.length > 0) {
+      setTrainingOnlyConfirmed(false);
+    }
+  }, [preset, selectedTechnicianMachineIdList.length]);
 
   const refreshLauncherQueries = async () => {
     await Promise.all([
@@ -1507,6 +1521,10 @@ function AccessLauncher({
           toast.error('Select a sponsor account.');
           return;
         }
+        if (selectedTechnicianMachineIdList.length === 0 && !trainingOnlyConfirmed) {
+          toast.error('Confirm training-only access before sending this Technician invite.');
+          return;
+        }
 
         const grant = await adminGrantTechnicianAccess({
           email: invitePreflight.targetEmail,
@@ -1573,10 +1591,11 @@ function AccessLauncher({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-5xl">
         <DialogHeader>
-          <DialogTitle>Add or invite access</DialogTitle>
+          <DialogTitle>{preset === 'technician' ? 'Add Technician' : 'Add or invite access'}</DialogTitle>
           <DialogDescription>
-            Start with a person or email, choose the intended outcome, then save the access source
-            with the right scope and audit reason.
+            {preset === 'technician'
+              ? 'Invite a Technician with training access and optional assigned-machine reporting.'
+              : 'Start with a person or email, choose the intended outcome, then save the access source with the right scope and audit reason.'}
           </DialogDescription>
         </DialogHeader>
 
@@ -2033,6 +2052,31 @@ function AccessLauncher({
                     }
                     disabled={!selectedTechnicianAccount}
                   />
+                  {isTechnicianTrainingOnlyInvite && (
+                    <label
+                      htmlFor="access-launcher-training-only-confirm"
+                      className={cn(
+                        'mt-3 flex min-h-11 cursor-pointer items-start gap-3 rounded-md border border-amber/40 bg-amber/10 p-3 text-sm',
+                        (!selectedTechnicianAccount || isSaving) && 'cursor-not-allowed opacity-70'
+                      )}
+                    >
+                      <Checkbox
+                        id="access-launcher-training-only-confirm"
+                        checked={trainingOnlyConfirmed}
+                        onCheckedChange={(checked) => setTrainingOnlyConfirmed(checked === true)}
+                        disabled={!selectedTechnicianAccount || isSaving}
+                      />
+                      <span className="min-w-0">
+                        <span className="block font-medium text-foreground">
+                          Send as training-only access
+                        </span>
+                        <span className="mt-1 block text-xs leading-5 text-muted-foreground">
+                          I understand this invite grants no machine reporting until machines are
+                          assigned later.
+                        </span>
+                      </span>
+                    </label>
+                  )}
                   {technicianContextError && (
                     <p className="mt-1 text-xs text-destructive">
                       {getErrorMessage(technicianContextError, 'Unable to load eligible Technician accounts.')}
@@ -2146,7 +2190,7 @@ function AccessLauncher({
               }
             >
               {isSaving ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Send className="mr-2 h-4 w-4" />}
-              Grant and send invite
+              {preset === 'technician' ? 'Save and send Technician invite' : 'Grant and send invite'}
             </Button>
           ) : (
             <Button type="button" onClick={openSelectedWorkspace} disabled={!selectedExistingAccount}>
@@ -3230,6 +3274,7 @@ function TechnicianAccessCard({
   const activeSourceGrants = sourceGrants.filter((grant) => grant.isActive);
   const [selectedAccountId, setSelectedAccountId] = useState('');
   const [selectedMachineIds, setSelectedMachineIds] = useState<Set<string>>(new Set());
+  const [trainingOnlyConfirmed, setTrainingOnlyConfirmed] = useState(false);
   const [grantReason, setGrantReason] = useState('');
   const [scopeDrafts, setScopeDrafts] = useState<Record<string, string[]>>({});
   const [scopeReasons, setScopeReasons] = useState<Record<string, string>>({});
@@ -3293,6 +3338,7 @@ function TechnicianAccessCard({
     const nextAccountId = firstActiveGrant?.accountId ?? accounts[0]?.accountId ?? '';
     setSelectedAccountId(nextAccountId);
     setSelectedMachineIds(new Set(firstActiveGrant ? getGrantMachineScopeIds(firstActiveGrant) : []));
+    setTrainingOnlyConfirmed(false);
     setGrantReason('');
     setScopeDrafts(
       Object.fromEntries(grants.map((grant) => [grant.grantId, getGrantMachineScopeIds(grant)]))
@@ -3313,6 +3359,12 @@ function TechnicianAccessCard({
     }
   }, [selectedAccountId, selectedAccountMachines, selectedMachineIds]);
 
+  useEffect(() => {
+    if (selectedMachineIdList.length > 0) {
+      setTrainingOnlyConfirmed(false);
+    }
+  }, [selectedMachineIdList.length]);
+
   const refreshTechnicianContext = async () => {
     await queryClient.invalidateQueries({ queryKey: ['admin-technician-access-context'] });
   };
@@ -3328,6 +3380,10 @@ function TechnicianAccessCard({
     }
     if (!grantReason.trim()) {
       toast.error('Reason is required.');
+      return;
+    }
+    if (selectedMachineIdList.length === 0 && !trainingOnlyConfirmed) {
+      toast.error('Confirm training-only access before sending this Technician invite.');
       return;
     }
     const invitePreflight = validateAccessInvitePreflight('technician', identity.email);
@@ -3382,6 +3438,7 @@ function TechnicianAccessCard({
         machine_count: selectedMachineIdList.length,
       });
       setGrantReason('');
+      setTrainingOnlyConfirmed(false);
       await refreshTechnicianContext();
       await queryClient.invalidateQueries({ queryKey: ['access-invite-deliveries'] });
       await onChanged();
@@ -3596,6 +3653,32 @@ function TechnicianAccessCard({
                   }
                   disabled={isFetching || !selectedAccountId}
                 />
+                {selectedMachineIdList.length === 0 && (
+                  <label
+                    htmlFor="admin-technician-training-only-confirm"
+                    className={cn(
+                      'mt-3 flex min-h-11 cursor-pointer items-start gap-3 rounded-md border border-amber/40 bg-amber/10 p-3 text-sm',
+                      (isFetching || isSavingGrant || !selectedAccountId) &&
+                        'cursor-not-allowed opacity-70'
+                    )}
+                  >
+                    <Checkbox
+                      id="admin-technician-training-only-confirm"
+                      checked={trainingOnlyConfirmed}
+                      onCheckedChange={(checked) => setTrainingOnlyConfirmed(checked === true)}
+                      disabled={isFetching || isSavingGrant || !selectedAccountId}
+                    />
+                    <span className="min-w-0">
+                      <span className="block font-medium text-foreground">
+                        Send as training-only access
+                      </span>
+                      <span className="mt-1 block text-xs leading-5 text-muted-foreground">
+                        I understand this Technician will not receive machine reporting from this
+                        source until machines are assigned later.
+                      </span>
+                    </span>
+                  </label>
+                )}
               </div>
               <div>
                 <Label htmlFor="admin-technician-reason">Grant or update reason</Label>
@@ -3619,7 +3702,13 @@ function TechnicianAccessCard({
             <Button
               className="mt-3"
               onClick={handleSaveGrant}
-              disabled={isSavingGrant || isFetching || !selectedAccountId || !identity.email}
+              disabled={
+                isSavingGrant ||
+                isFetching ||
+                !selectedAccountId ||
+                !identity.email ||
+                (selectedMachineIdList.length === 0 && !trainingOnlyConfirmed)
+              }
             >
               {isSavingGrant ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <CheckCircle2 className="mr-2 h-4 w-4" />}
               Save and send Technician invite

--- a/src/pages/admin/accessPersonConsole.tsx
+++ b/src/pages/admin/accessPersonConsole.tsx
@@ -34,6 +34,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { TechnicianMachineAssignmentPicker } from '@/components/technicians/TechnicianMachineAssignmentPicker';
 import { useAuth } from '@/contexts/auth-context';
 import {
   fetchAccessInviteDeliveries,
@@ -323,12 +324,6 @@ const uniqueValues = (items: string[]) => [...new Set(items)].sort((a, b) => a.l
 const sortedSetValues = (items: Set<string>) => [...items].sort((a, b) => a.localeCompare(b));
 const haveSameStringSetValues = (left: Set<string>, right: Set<string>) =>
   left.size === right.size && [...left].every((value) => right.has(value));
-const toggleStringSetValue = (items: Set<string>, value: string, checked: boolean) => {
-  const next = new Set(items);
-  if (checked) next.add(value);
-  else next.delete(value);
-  return next;
-};
 const getErrorMessage = (error: unknown, fallback: string) =>
   error instanceof Error && error.message.trim() ? error.message : fallback;
 const getCorporatePartnerMachineIds = (partnerships: CorporatePartnerPartnership[]) =>
@@ -647,6 +642,9 @@ function AdminPersonAccessConsoleInner({
   const [selectedPerson, setSelectedPerson] = useState<SelectedAccessPerson | null>(null);
   const [showActivity, setShowActivity] = useState(initialShowActivity);
   const [isAccessLauncherOpen, setIsAccessLauncherOpen] = useState(Boolean(initialLauncher?.open));
+  const [launcherPresetOverride, setLauncherPresetOverride] = useState<string | undefined>(
+    initialLauncher?.preset
+  );
   const normalizedSubmittedSearch = submittedSearch.trim();
   const submittedSearchIsEmail = hasEmailShape(normalizedSubmittedSearch);
 
@@ -756,6 +754,11 @@ function AdminPersonAccessConsoleInner({
     setSelectedPerson({ email: value, userId: null, label: value });
   };
 
+  const openAccessLauncher = (preset?: AccessLauncherPreset) => {
+    setLauncherPresetOverride(preset);
+    setIsAccessLauncherOpen(true);
+  };
+
   const searchFailed = Boolean(searchError);
   const canShowSearchResults = normalizedSubmittedSearch.length > 0 && !isSearching && !searchFailed;
   const searchErrorMessage = getErrorMessage(searchError, 'Unable to search people.');
@@ -769,7 +772,7 @@ function AdminPersonAccessConsoleInner({
       <AccessLauncher
         open={isAccessLauncherOpen}
         onOpenChange={setIsAccessLauncherOpen}
-        initialPreset={initialLauncher?.preset}
+        initialPreset={launcherPresetOverride}
         initialEmail={initialLauncher?.email}
         initialPartnerId={initialLauncher?.partnerId}
         initialAccountId={initialLauncher?.accountId}
@@ -805,7 +808,15 @@ function AdminPersonAccessConsoleInner({
                 {isSearching ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Search className="mr-2 h-4 w-4" />}
                 Search
               </Button>
-              <Button className="min-h-11" onClick={() => setIsAccessLauncherOpen(true)}>
+              <Button className="min-h-11" onClick={() => openAccessLauncher('technician')}>
+                <UserPlus className="mr-2 h-4 w-4" />
+                Add Technician
+              </Button>
+              <Button
+                variant="outline"
+                className="min-h-11"
+                onClick={() => openAccessLauncher()}
+              >
                 <UserPlus className="mr-2 h-4 w-4" />
                 Add or invite access
               </Button>
@@ -2013,32 +2024,15 @@ function AccessLauncher({
                   )}
                 </div>
                 <div>
-                  <div className="mb-2 flex items-center justify-between gap-2">
-                    <Label>Reporting machines</Label>
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="outline"
-                      onClick={() => setSelectedTechnicianMachineIds(new Set())}
-                      disabled={!selectedTechnicianAccount || selectedTechnicianMachineIds.size === 0}
-                    >
-                      Clear
-                    </Button>
-                  </div>
-                  <TechnicianMachineChecklist
+                  <TechnicianMachineAssignmentPicker
                     idPrefix="access-launcher-technician-machine"
                     machines={selectedTechnicianMachines}
-                    selectedMachineIds={selectedTechnicianMachineIds}
-                    toggleMachine={(machineId, checked) =>
-                      setSelectedTechnicianMachineIds((current) =>
-                        toggleStringSetValue(current, machineId, checked)
-                      )
+                    selectedMachineIds={selectedTechnicianMachineIdList}
+                    onSelectedMachineIdsChange={(machineIds) =>
+                      setSelectedTechnicianMachineIds(new Set(machineIds))
                     }
                     disabled={!selectedTechnicianAccount}
                   />
-                  <p className="mt-2 text-xs text-muted-foreground">
-                    Leave all machines unchecked for training-only access.
-                  </p>
                   {technicianContextError && (
                     <p className="mt-1 text-xs text-destructive">
                       {getErrorMessage(technicianContextError, 'Unable to load eligible Technician accounts.')}
@@ -3593,30 +3587,15 @@ function TechnicianAccessCard({
                 </select>
               </div>
               <div>
-                <div className="mb-2 flex items-center justify-between gap-2">
-                  <Label>Reporting machines</Label>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    onClick={() => setSelectedMachineIds(new Set())}
-                    disabled={isFetching || !selectedAccountId || selectedMachineIds.size === 0}
-                  >
-                    Clear
-                  </Button>
-                </div>
-                <TechnicianMachineChecklist
+                <TechnicianMachineAssignmentPicker
                   idPrefix="admin-technician-machine"
                   machines={selectedAccountMachines}
-                  selectedMachineIds={selectedMachineIds}
-                  toggleMachine={(machineId, checked) =>
-                    setSelectedMachineIds((current) => toggleStringSetValue(current, machineId, checked))
+                  selectedMachineIds={selectedMachineIdList}
+                  onSelectedMachineIdsChange={(machineIds) =>
+                    setSelectedMachineIds(new Set(machineIds))
                   }
                   disabled={isFetching || !selectedAccountId}
                 />
-                <p className="mt-2 text-xs text-muted-foreground">
-                  Leave all machines unchecked for training-only access.
-                </p>
               </div>
               <div>
                 <Label htmlFor="admin-technician-reason">Grant or update reason</Label>
@@ -3742,36 +3721,15 @@ function TechnicianAccessCard({
                         </PreviewBox>
                         <div className="grid gap-3 lg:grid-cols-[0.42fr_0.36fr_0.22fr]">
                           <div>
-                            <div className="mb-2 flex items-center justify-between gap-2">
-                              <Label>Scope after save</Label>
-                              <Button
-                                type="button"
-                                size="sm"
-                                variant="outline"
-                                onClick={() =>
-                                  setScopeDrafts((current) => ({ ...current, [grant.grantId]: [] }))
-                                }
-                                disabled={draftMachineIds.length === 0}
-                              >
-                                Clear
-                              </Button>
-                            </div>
-                            <TechnicianMachineChecklist
+                            <TechnicianMachineAssignmentPicker
                               idPrefix={`technician-scope-${grant.grantId}`}
                               machines={accountMachines}
-                              selectedMachineIds={new Set(draftMachineIds)}
-                              toggleMachine={(machineId, checked) =>
+                              selectedMachineIds={draftMachineIds}
+                              label="Scope after save"
+                              onSelectedMachineIdsChange={(machineIds) =>
                                 setScopeDrafts((current) => ({
                                   ...current,
-                                  [grant.grantId]: sortedSetValues(
-                                    toggleStringSetValue(
-                                      new Set(
-                                        current[grant.grantId] ?? getGrantMachineScopeIds(grant)
-                                      ),
-                                      machineId,
-                                      checked
-                                    )
-                                  ),
+                                  [grant.grantId]: machineIds,
                                 }))
                               }
                             />
@@ -4361,62 +4319,6 @@ function ScopedAdminAccessCard({
         </Button>
       </div>
     </SourceCard>
-  );
-}
-
-function TechnicianMachineChecklist({
-  idPrefix,
-  machines,
-  selectedMachineIds,
-  toggleMachine,
-  disabled = false,
-}: {
-  idPrefix: string;
-  machines: AdminTechnicianMachine[];
-  selectedMachineIds: Set<string>;
-  toggleMachine: (machineId: string, checked: boolean) => void;
-  disabled?: boolean;
-}) {
-  if (machines.length === 0) {
-    return (
-      <div className="rounded-md border border-border bg-muted/20 p-3 text-sm text-muted-foreground">
-        No active machines are available for this account.
-      </div>
-    );
-  }
-
-  return (
-    <div className="max-h-72 overflow-y-auto rounded-md border border-border">
-      {machines.map((machine) => {
-        const checkboxId = `${idPrefix}-${machine.machineId}`;
-
-        return (
-          <label
-            key={machine.machineId}
-            htmlFor={checkboxId}
-            className={cn(
-              'flex cursor-pointer items-start gap-3 border-b border-border/60 p-3 last:border-b-0',
-              disabled && 'cursor-not-allowed opacity-70'
-            )}
-          >
-            <Checkbox
-              id={checkboxId}
-              checked={selectedMachineIds.has(machine.machineId)}
-              onCheckedChange={(checked) => toggleMachine(machine.machineId, checked === true)}
-              disabled={disabled}
-            />
-            <span className="min-w-0 flex-1">
-              <span className="block break-words text-sm font-medium text-foreground">
-                {machine.machineLabel}
-              </span>
-              <span className="mt-1 block text-xs text-muted-foreground">
-                {machine.locationName ?? 'Unassigned location'} / {machine.machineType}
-              </span>
-            </span>
-          </label>
-        );
-      })}
-    </div>
   );
 }
 

--- a/src/pages/portal/Account.tsx
+++ b/src/pages/portal/Account.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import {
   User,
+  Users,
   MapPin,
   CreditCard,
   ExternalLink,
@@ -11,7 +12,6 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { PortalLayout } from '@/components/portal/PortalLayout';
 import { PortalPageIntro } from '@/components/portal/PortalPageIntro';
-import { TechnicianManagementPanel } from '@/components/portal/TechnicianManagementPanel';
 import { LanguagePreferenceControl } from '@/components/i18n/LanguagePreferenceControl';
 import { useAuth } from '@/contexts/auth-context';
 import { useLanguage } from '@/contexts/LanguageContext';
@@ -44,7 +44,7 @@ const formatMembershipStatus = (status: string) =>
     .join(' ');
 
 export default function AccountPage() {
-  const { user, isCorporatePartner } = useAuth();
+  const { user, canManageTechnicians, isCorporatePartner } = useAuth();
   const { t } = useLanguage();
   const location = useLocation();
   const navigate = useNavigate();
@@ -268,7 +268,29 @@ export default function AccountPage() {
             </div>
           )}
 
-          <TechnicianManagementPanel />
+          {canManageTechnicians && (
+            <div className="mt-6 card-elevated min-w-0 p-5 sm:p-6">
+              <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                <div className="flex min-w-0 items-start gap-3">
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+                    <Users className="h-5 w-5 text-primary" />
+                  </div>
+                  <div className="min-w-0">
+                    <h2 className="font-display text-lg font-semibold text-foreground">
+                      Team access
+                    </h2>
+                    <p className="mt-1 max-w-3xl text-sm leading-6 text-muted-foreground">
+                      Add Technicians, send invites, and manage assigned-machine reporting from
+                      the Team page.
+                    </p>
+                  </div>
+                </div>
+                <Button asChild className="min-h-11 w-full md:w-auto">
+                  <Link to="/portal/team">Manage Technicians</Link>
+                </Button>
+              </div>
+            </div>
+          )}
 
           <div className="mt-6 grid gap-6 lg:grid-cols-3 lg:gap-8">
             {/* Profile */}

--- a/src/pages/portal/Dashboard.tsx
+++ b/src/pages/portal/Dashboard.tsx
@@ -111,6 +111,7 @@ export default function PortalDashboard() {
     user,
     isMember,
     canAccessTraining,
+    canManageTechnicians,
     capabilities,
     hasReportingAccess,
     adminAccess,
@@ -128,7 +129,8 @@ export default function PortalDashboard() {
       access,
       hasReportingAccess,
       capabilities,
-      hasRefundOperationsAccess
+      hasRefundOperationsAccess,
+      canManageTechnicians
     );
   const onboardingProgress = getOnboardingProgress(user?.email);
   const { data: library = [] } = useTrainingLibrary(canAccessTraining);
@@ -450,6 +452,10 @@ export default function PortalDashboard() {
                 )
                 .filter((action) =>
                   action.access !== 'refunds' ||
+                  canAccessPortalAction(action.access)
+                )
+                .filter((action) =>
+                  action.access !== 'team' ||
                   canAccessPortalAction(action.access)
                 )
                 .filter((action) =>

--- a/src/pages/portal/Team.tsx
+++ b/src/pages/portal/Team.tsx
@@ -1,0 +1,41 @@
+import { Users } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { TechnicianManagementPanel } from '@/components/portal/TechnicianManagementPanel';
+import { PortalLayout } from '@/components/portal/PortalLayout';
+import { PortalPageIntro } from '@/components/portal/PortalPageIntro';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/contexts/auth-context';
+import { useLanguage } from '@/contexts/LanguageContext';
+
+export default function TeamPage() {
+  const { canManageTechnicians } = useAuth();
+  const { t } = useLanguage();
+
+  return (
+    <PortalLayout>
+      <section className="portal-section overflow-x-clip">
+        <div className="container-page">
+          <PortalPageIntro
+            title={t('team.title')}
+            description={t('team.description')}
+            badges={[{ label: t('portal.access.team'), tone: 'muted', icon: Users }]}
+            actions={
+              <Button asChild variant="outline" className="min-h-11">
+                <Link to="/portal/account">Account Settings</Link>
+              </Button>
+            }
+          />
+
+          {canManageTechnicians ? (
+            <TechnicianManagementPanel />
+          ) : (
+            <div className="mt-8 rounded-[24px] border border-border bg-background p-6 text-sm leading-6 text-muted-foreground shadow-[var(--shadow-sm)]">
+              Team management is available only to Plus account owners and eligible Corporate
+              Partner managers for the machines they control.
+            </div>
+          )}
+        </div>
+      </section>
+    </PortalLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `/portal/team` as the customer/partner Technician management surface and links eligible users from Account Settings.
- Shares the Technician machine-assignment picker across portal and Admin Access while preserving the existing UAT checkbox IDs.
- Makes Admin Access expose a direct Add Technician action, now opening a focused Technician launcher.
- Addresses Impeccable audit findings by requiring explicit training-only confirmation and moving Sonner toasts away from the mobile bottom action area.

Closes #528
Closes #529
Closes #530
Closes #531
Closes #533
Closes #534

Separate owner decision: #532 remains open. Scoped Admin Technician authority stays out of scope here; the recorded decision keeps Scoped Admins out of Technician grant authority unless that is explicitly changed later.

## Files changed
- Portal routing/navigation: `/portal/team`, Team nav access gating, locked Team route messaging, Account Settings Team handoff.
- Technician UI: shared machine assignment picker and portal/admin integrations, explicit training-only confirmation, top-right Sonner toast placement.
- Admin Access: direct Add Technician launcher entry, Technician-specific launcher title/copy, shared machine assignment controls, and explicit training-only confirmation in override paths.
- UAT/scripts/docs: partner/admin UAT route updates, role-boundary checks, decisions, roadmap, smoke checklist, UAT runbooks, and focused Add Technician launcher coverage.

## Verification commands + results
- `npm ci` - passed. npm audit reported existing dependency advisories; no dependency changes in this PR.
- `npm run build` - passed; Vite build and public/private route prerender completed.
- `npm test --if-present` - passed; no active test script output.
- `npm run lint --if-present` - passed with no warnings.
- `git diff --check` - passed.
- `npm run admin-access:validate-invite-uat -- --app-url http://127.0.0.1:8081 --artifact-dir $env:TEMP\bloomjoy-final-review` - passed, including direct Add Technician focused-launcher assertion.
- `npm run partner-technicians:validate-uat -- --app-url http://127.0.0.1:8081 --artifact-dir $env:TEMP\bloomjoy-final-review` - passed, including explicit training-only confirmation.

Final review screenshots were written locally under `$env:TEMP\bloomjoy-final-review`, including Admin Access desktop/mobile, partner Technician desktop/mobile, Technician reporting scope, and Technician Team-denied screenshots.

## How to test
1. From this branch, run `npm ci`.
2. Ensure local Vite env has `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` set. For mocked UAT, safe local dummy values are sufficient because the scripts intercept Supabase routes.
3. Run `npm run dev:uat` and open `http://127.0.0.1:8081`.
4. For a Plus Customer or Corporate Partner persona with `can_manage_technicians`, open `/portal/team` and confirm Technician Access is visible. Open `/portal/account` and confirm it links to Team instead of duplicating the full Technician workflow.
5. On `/portal/team`, confirm that selecting no machines requires checking “Send as training-only access” before Save and send invite is enabled.
6. For a Technician persona, open `/portal/team` and confirm the locked Team-management state; `/portal/training` and assigned-machine `/portal/reports` remain available when entitled.
7. For Super Admin, open `/admin/access` and confirm the direct Add Technician action opens the Technician-focused launcher. Confirm selected-person Technician controls also require explicit training-only confirmation when no machines are selected.
8. Run the mocked UAT scripts:
   - `npm run admin-access:validate-invite-uat -- --app-url http://127.0.0.1:8081`
   - `npm run partner-technicians:validate-uat -- --app-url http://127.0.0.1:8081`

Test credentials: the automated UAT scripts use mocked `example.test` users and do not send email or write Supabase data.