### PR TITLE
Fix portal Technician Team loop

### DIFF
--- a/scripts/validate-scoped-admin-technician-uat.mjs
+++ b/scripts/validate-scoped-admin-technician-uat.mjs
@@ -698,20 +698,36 @@ const runScenario = async ({ browser, args, recorder, state, name, test }) => {
   await installMockRoutes(context, state);
   const page = await context.newPage();
   const consoleErrors = [];
+  const pageErrors = [];
 
   page.on('console', (message) => {
     if (message.type() === 'error') {
       consoleErrors.push(message.text());
     }
   });
+  page.on('pageerror', (error) => {
+    pageErrors.push(error.stack || error.message);
+  });
 
   try {
     await test({ page, state, consoleErrors });
+    const unexpectedPageErrors = pageErrors.filter(Boolean);
     recorder.assert(
       `${name}: no unexpected browser console errors`,
-      unexpectedConsoleErrors(consoleErrors).length === 0,
-      unexpectedConsoleErrors(consoleErrors).slice(0, 3).join(' | ')
+      unexpectedConsoleErrors(consoleErrors).length === 0 && unexpectedPageErrors.length === 0,
+      [...unexpectedConsoleErrors(consoleErrors), ...unexpectedPageErrors].slice(0, 3).join(' | ')
     );
+  } catch (error) {
+    const unexpected = unexpectedConsoleErrors(consoleErrors);
+    if (unexpected.length > 0) {
+      console.error(`${name}: browser console errors before failure`);
+      console.error(unexpected.slice(0, 5).join('\n'));
+    }
+    if (pageErrors.length > 0) {
+      console.error(`${name}: page errors before failure`);
+      console.error(pageErrors.slice(0, 5).join('\n'));
+    }
+    throw error;
   } finally {
     await context.close();
   }
@@ -725,7 +741,19 @@ const openTechnicianLauncher = async (page, args, user) => {
   await page.goto(`${args.appUrl}/admin/access?action=add-access&preset=technician`, {
     waitUntil: 'domcontentloaded',
   });
-  await page.getByRole('heading', { name: 'Add Technician' }).waitFor({ timeout: 10000 });
+  await page
+    .getByRole('heading', { name: 'Add Technician' })
+    .waitFor({ timeout: 10000 })
+    .catch(async (error) => {
+      await page.screenshot({
+        path: path.join(args.artifactDir, 'admin-access-launcher-timeout.png'),
+        fullPage: true,
+      });
+      const bodyText = await page.locator('body').innerText().catch(() => '');
+      console.error(`Admin Access launcher did not open at ${page.url()}`);
+      console.error(bodyText.slice(0, 2000));
+      throw error;
+    });
   await page.getByLabel('Person or email').fill(targetEmail);
 };
 
@@ -912,6 +940,10 @@ const run = async () => {
         await page.goto(`${args.appUrl}/portal/team`, { waitUntil: 'domcontentloaded' });
         await page.getByText(/Team requires Team access/i).waitFor({ timeout: 10000 });
         recorder.assert(
+          'Scoped Admin direct Portal Team offers Admin Access exit',
+          await page.getByRole('link', { name: 'Open Admin Access' }).isVisible()
+        );
+        recorder.assert(
           'Scoped Admin direct Portal Team load is locked instead of looping',
           !(await page.getByRole('button', { name: /Save and send invite/i }).isVisible().catch(() => false))
         );
@@ -923,26 +955,40 @@ const run = async () => {
       args,
       recorder,
       name: 'Portal Team capability drift',
-      state: createState({ actor: 'scoped_admin', portalCapabilityDrift: true }),
+      state: createState({ actor: 'super_admin', portalCapabilityDrift: true }),
       test: async ({ page, state }) => {
-        await page.goto(`${args.appUrl}/portal/team`, { waitUntil: 'domcontentloaded' });
+        await page.goto(`${args.appUrl}/portal/account`, { waitUntil: 'domcontentloaded' });
         await login(page, state.user);
+        await page.goto(`${args.appUrl}/portal/account`, { waitUntil: 'domcontentloaded' });
+        await page.getByRole('heading', { name: 'Account Settings' }).waitFor({ timeout: 10000 });
+        await page.getByRole('link', { name: 'Open Admin Access' }).waitFor({ timeout: 10000 });
+        recorder.assert(
+          'Capability drift Account Settings points to Admin Access',
+          await page.getByRole('link', { name: 'Open Admin Access' }).isVisible()
+        );
+        recorder.assert(
+          'Capability drift Account Settings suppresses Portal Team Manage Technicians loop',
+          !(await page.getByRole('link', { name: 'Manage Technicians' }).isVisible().catch(() => false))
+        );
+        recorder.assert(
+          'Capability drift Portal nav hides dead Team destination',
+          !(await page.getByRole('link', { name: /^Team$/ }).isVisible().catch(() => false))
+        );
+        await page.screenshot({
+          path: path.join(args.artifactDir, 'portal-account-capability-drift.png'),
+          fullPage: true,
+        });
+
         await page.goto(`${args.appUrl}/portal/team`, { waitUntil: 'domcontentloaded' });
-        await page.waitForLoadState('networkidle').catch(() => undefined);
+        await page.getByText(/Team requires Team access/i).waitFor({ timeout: 10000 });
+        recorder.assert(
+          'Capability drift direct Portal Team offers Admin Access exit',
+          await page.getByRole('link', { name: 'Open Admin Access' }).isVisible()
+        );
         await page.screenshot({
           path: path.join(args.artifactDir, 'portal-team-capability-drift.png'),
           fullPage: true,
         });
-        const bodyText = await page.locator('body').innerText().catch(() => '');
-        const unavailableVisible = await page
-          .getByText('Technician management is not available')
-          .isVisible()
-          .catch(() => false);
-        recorder.assert(
-          'Portal Team capability drift renders explicit locked panel state',
-          unavailableVisible,
-          unavailableVisible ? '' : bodyText.slice(0, 1000)
-        );
         recorder.assert(
           'Portal Team capability drift does not expose add-Technician CTA',
           !(await page.getByRole('button', { name: /Save and send invite/i }).isVisible().catch(() => false))

--- a/src/components/auth/MemberRoute.tsx
+++ b/src/components/auth/MemberRoute.tsx
@@ -9,6 +9,7 @@ import {
   getPortalDestinationByPath,
 } from '@/components/portal/portalNavigation';
 import { Button } from '@/components/ui/button';
+import { usePortalTechnicianManagement } from '@/hooks/usePortalTechnicianManagement';
 
 export function MemberRoute() {
   const {
@@ -24,8 +25,13 @@ export function MemberRoute() {
   const accessLabel = getAccessLevelLabel(lockedDestination.access);
   const isReportingRoute = lockedDestination.access === 'reporting';
   const isTeamRoute = lockedDestination.access === 'team';
+  const { canUsePortalTeam, isResolvingPortalTeam } = usePortalTechnicianManagement();
+  const canUseAdminAccess =
+    adminAccess.canAccessAdmin ||
+    adminAccess.allowedSurfaces.includes('*') ||
+    adminAccess.allowedSurfaces.includes('access');
 
-  if (loading) {
+  if (loading || (isTeamRoute && isResolvingPortalTeam)) {
     return (
       <div className="flex min-h-screen items-center justify-center text-sm text-muted-foreground">
         Loading...
@@ -33,8 +39,9 @@ export function MemberRoute() {
     );
   }
 
-  if (
-    canAccessPortalLevel(
+  const canAccessRoute = isTeamRoute
+    ? canUsePortalTeam
+    : canAccessPortalLevel(
       portalAccessTier,
       lockedDestination.access,
       hasReportingAccess,
@@ -42,8 +49,9 @@ export function MemberRoute() {
       false,
       canManageTechnicians,
       adminAccess.isScopedAdmin
-    )
-  ) {
+    );
+
+  if (canAccessRoute) {
     return <Outlet />;
   }
 
@@ -82,6 +90,13 @@ export function MemberRoute() {
                   </div>
                 </div>
                 <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+                  {isTeamRoute && canUseAdminAccess && (
+                    <Button asChild className="min-h-11">
+                      <Link to="/admin/access?action=add-access&preset=technician">
+                        Open Admin Access
+                      </Link>
+                    </Button>
+                  )}
                   {lockedDestination.access !== 'baseline' && !isReportingRoute && !isTeamRoute && (
                     <Button asChild className="min-h-11">
                       <Link to="/plus">View Plus Membership</Link>

--- a/src/components/portal/PortalLayout.tsx
+++ b/src/components/portal/PortalLayout.tsx
@@ -21,6 +21,7 @@ import {
   getPortalDestinationByPath,
   portalDestinations,
 } from '@/components/portal/portalNavigation';
+import { usePortalTechnicianManagement } from '@/hooks/usePortalTechnicianManagement';
 
 interface PortalLayoutProps {
   children: ReactNode;
@@ -42,11 +43,16 @@ export function PortalLayout({ children }: PortalLayoutProps) {
   const allowedAdminSurfaces = new Set(adminAccess.allowedSurfaces);
   const hasRefundOperationsAccess =
     isSuperAdmin || allowedAdminSurfaces.has('*') || allowedAdminSurfaces.has('refunds');
+  const { canUsePortalTeam } = usePortalTechnicianManagement();
   const sortedDestinations = [...portalDestinations].sort(
     (left, right) => left.mobileOrder - right.mobileOrder
   );
-  const canAccessDestination = (access: (typeof portalDestinations)[number]['access']) =>
-    canAccessPortalLevel(
+  const canAccessDestination = (access: (typeof portalDestinations)[number]['access']) => {
+    if (access === 'team') {
+      return canUsePortalTeam;
+    }
+
+    return canAccessPortalLevel(
       portalAccessTier,
       access,
       hasReportingAccess,
@@ -55,6 +61,7 @@ export function PortalLayout({ children }: PortalLayoutProps) {
       canManageTechnicians,
       adminAccess.isScopedAdmin
     );
+  };
   const visibleDestinations = sortedDestinations
     .filter((destination) => destination.access !== 'reporting' || canAccessDestination(destination.access))
     .filter((destination) => destination.access !== 'refunds' || canAccessDestination(destination.access))

--- a/src/components/portal/TechnicianManagementPanel.tsx
+++ b/src/components/portal/TechnicianManagementPanel.tsx
@@ -636,7 +636,7 @@ export function TechnicianManagementPanel() {
               <AlertTitle>Technician management is not available</AlertTitle>
               <AlertDescription>
                 This portal session does not have an active customer or partner Technician
-                management scope. Scoped Admin Technician grants are handled from Admin Access.
+                management scope. Admin Technician grants are handled from Admin Access.
               </AlertDescription>
             </Alert>
           )}

--- a/src/hooks/usePortalTechnicianManagement.ts
+++ b/src/hooks/usePortalTechnicianManagement.ts
@@ -1,0 +1,32 @@
+import { useQuery } from '@tanstack/react-query';
+import { canUsePortalTeamManagement } from '@/components/portal/portalNavigation';
+import { useAuth } from '@/contexts/auth-context';
+import { fetchTechnicianManagementContext } from '@/lib/technicianEntitlements';
+
+export function usePortalTechnicianManagement() {
+  const { user, canManageTechnicians, capabilities } = useAuth();
+  const hasAdvertisedTeamCapability = canUsePortalTeamManagement({
+    canManageTechnicians,
+    capabilities,
+  });
+
+  const query = useQuery({
+    queryKey: ['technician-management-context', user?.id],
+    queryFn: fetchTechnicianManagementContext,
+    enabled: Boolean(user?.id && hasAdvertisedTeamCapability),
+    staleTime: 1000 * 30,
+  });
+
+  const hasActiveTeamManagementScope = Boolean(
+    query.data?.canManage && query.data.accounts.length > 0
+  );
+
+  return {
+    ...query,
+    hasAdvertisedTeamCapability,
+    hasActiveTeamManagementScope,
+    canUsePortalTeam: hasAdvertisedTeamCapability && hasActiveTeamManagementScope,
+    isResolvingPortalTeam:
+      hasAdvertisedTeamCapability && query.isLoading && !query.data && !query.error,
+  };
+}

--- a/src/pages/portal/Account.tsx
+++ b/src/pages/portal/Account.tsx
@@ -13,10 +13,10 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { PortalLayout } from '@/components/portal/PortalLayout';
 import { PortalPageIntro } from '@/components/portal/PortalPageIntro';
-import { canUsePortalTeamManagement } from '@/components/portal/portalNavigation';
 import { LanguagePreferenceControl } from '@/components/i18n/LanguagePreferenceControl';
 import { useAuth } from '@/contexts/auth-context';
 import { useLanguage } from '@/contexts/LanguageContext';
+import { usePortalTechnicianManagement } from '@/hooks/usePortalTechnicianManagement';
 import { openCustomerPortal } from '@/lib/stripeCheckout';
 import { hasPlusAccess } from '@/lib/membership';
 import {
@@ -46,8 +46,13 @@ const formatMembershipStatus = (status: string) =>
     .join(' ');
 
 export default function AccountPage() {
-  const { user, adminAccess, canManageTechnicians, capabilities, isCorporatePartner } = useAuth();
+  const { user, adminAccess, isCorporatePartner } = useAuth();
   const { t } = useLanguage();
+  const {
+    canUsePortalTeam,
+    hasAdvertisedTeamCapability,
+    isResolvingPortalTeam,
+  } = usePortalTechnicianManagement();
   const location = useLocation();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -197,11 +202,14 @@ export default function AccountPage() {
           day: 'numeric',
         })
       : null;
-  const canUseTeam = canUsePortalTeamManagement({ canManageTechnicians, capabilities });
   const canUseAdminAccess =
     Boolean(user?.isSuperAdmin) ||
     adminAccess.allowedSurfaces.includes('*') ||
     adminAccess.allowedSurfaces.includes('access');
+  const shouldShowAdminTechnicianCard =
+    canUseAdminAccess &&
+    (Boolean(user?.isScopedAdmin) ||
+      (hasAdvertisedTeamCapability && !isResolvingPortalTeam && !canUsePortalTeam));
 
   const handleManageBilling = async () => {
     if (!user?.email) {
@@ -288,7 +296,7 @@ export default function AccountPage() {
             </div>
           )}
 
-          {canUseTeam && (
+          {canUsePortalTeam && (
             <div className="mt-6 card-elevated min-w-0 p-5 sm:p-6">
               <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
                 <div className="flex min-w-0 items-start gap-3">
@@ -312,7 +320,7 @@ export default function AccountPage() {
             </div>
           )}
 
-          {!canUseTeam && user?.isScopedAdmin && canUseAdminAccess && (
+          {shouldShowAdminTechnicianCard && (
             <div className="mt-6 card-elevated min-w-0 p-5 sm:p-6">
               <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
                 <div className="flex min-w-0 items-start gap-3">
@@ -321,11 +329,12 @@ export default function AccountPage() {
                   </div>
                   <div className="min-w-0">
                     <h2 className="font-display text-lg font-semibold text-foreground">
-                      Scoped Admin access
+                      Technician administration
                     </h2>
                     <p className="mt-1 max-w-3xl text-sm leading-6 text-muted-foreground">
-                      Add Technicians for assigned machines from Admin Access. Portal Team remains
-                      reserved for Plus Customer owners and Corporate Partner managers.
+                      Use Admin Access to add Technicians for assigned or admin-controlled
+                      machines. Portal Team appears only when this account has an active customer
+                      or partner team management scope.
                     </p>
                   </div>
                 </div>

--- a/src/pages/portal/Dashboard.tsx
+++ b/src/pages/portal/Dashboard.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/components/portal/portalNavigation';
 import { useAuth } from '@/contexts/auth-context';
 import { useLanguage } from '@/contexts/LanguageContext';
+import { usePortalTechnicianManagement } from '@/hooks/usePortalTechnicianManagement';
 import { trackEvent } from '@/lib/analytics';
 import type { TranslationKey } from '@/lib/i18n';
 import { getOnboardingProgress } from '@/lib/onboardingChecklist';
@@ -123,8 +124,13 @@ export default function PortalDashboard() {
   const allowedAdminSurfaces = new Set(adminAccess.allowedSurfaces);
   const hasRefundOperationsAccess =
     isSuperAdmin || allowedAdminSurfaces.has('*') || allowedAdminSurfaces.has('refunds');
-  const canAccessPortalAction = (access: PortalAccessLevel) =>
-    canAccessPortalLevel(
+  const { canUsePortalTeam } = usePortalTechnicianManagement();
+  const canAccessPortalAction = (access: PortalAccessLevel) => {
+    if (access === 'team') {
+      return canUsePortalTeam;
+    }
+
+    return canAccessPortalLevel(
       portalAccessTier,
       access,
       hasReportingAccess,
@@ -133,6 +139,7 @@ export default function PortalDashboard() {
       canManageTechnicians,
       adminAccess.isScopedAdmin
     );
+  };
   const onboardingProgress = getOnboardingProgress(user?.email);
   const { data: library = [] } = useTrainingLibrary(canAccessTraining);
   const { data: trackDefinitions = [] } = useTrainingTracks(canAccessTraining);

--- a/src/pages/portal/Team.tsx
+++ b/src/pages/portal/Team.tsx
@@ -3,15 +3,13 @@ import { Link } from 'react-router-dom';
 import { TechnicianManagementPanel } from '@/components/portal/TechnicianManagementPanel';
 import { PortalLayout } from '@/components/portal/PortalLayout';
 import { PortalPageIntro } from '@/components/portal/PortalPageIntro';
-import { canUsePortalTeamManagement } from '@/components/portal/portalNavigation';
 import { Button } from '@/components/ui/button';
-import { useAuth } from '@/contexts/auth-context';
+import { usePortalTechnicianManagement } from '@/hooks/usePortalTechnicianManagement';
 import { useLanguage } from '@/contexts/LanguageContext';
 
 export default function TeamPage() {
-  const { canManageTechnicians, capabilities } = useAuth();
   const { t } = useLanguage();
-  const canUseTeam = canUsePortalTeamManagement({ canManageTechnicians, capabilities });
+  const { canUsePortalTeam } = usePortalTechnicianManagement();
 
   return (
     <PortalLayout>
@@ -28,7 +26,7 @@ export default function TeamPage() {
             }
           />
 
-          {canUseTeam ? (
+          {canUsePortalTeam ? (
             <TechnicianManagementPanel />
           ) : (
             <div className="mt-8 rounded-[24px] border border-border bg-background p-6 text-sm leading-6 text-muted-foreground shadow-[var(--shadow-sm)]">


### PR DESCRIPTION
## Summary
- Fixes the Account Settings -> Team Management recursive loop by requiring the live `get_my_technician_management_context` result before exposing `/portal/team` as usable.
- Sends admins/scoped admins without customer/partner Team scope to `/admin/access?action=add-access&preset=technician` instead of a dead Team page.
- Extends the scoped-admin Technician UAT harness to assert the no-scope drift case and capture screenshots for Account Settings and direct Team access.

## Root cause
Portal navigation and Account Settings were trusting the broad `technicians.manage` portal capability, while the Team panel correctly used the stricter management-context RPC. Users with an advertised Team capability but no active customer/partner Team scope were sent into `/portal/team`, where the page immediately said management was unavailable and pointed them back to Account Settings.

## Files changed
- Portal access gating: `MemberRoute`, `PortalLayout`, Dashboard, Account Settings, Team page.
- Shared hook: `usePortalTechnicianManagement`.
- Technician panel copy for no-scope admin cases.
- Scoped-admin Technician UAT coverage and screenshot capture.

## Risk And Overlap
- Risk: Yellow-to-red operational UI/access hotfix because it changes portal route gating for Technician team management and is attached to P0 live UAT issue #542.
- Mitigation: The change only tightens `/portal/team` visibility to the existing management-context RPC, while Admin Access and partner/self-service Technician UAT both passed.
- Overlap: Builds on PR #543 and does not add database migrations or touch Supabase production migration state. No unrelated worktree files are included.
- Remaining live risk: This does not send a real Technician invite or complete Madame Tussauds live UAT; it removes the current recursive UI blocker so the live invite flow can proceed.

## Merge Autonomy
- Lane: Red.
- Reason: Linked P0 issue #542 carries `uat-required`, `blocked-external`, and `risky-auth-payment` labels.
- Owner direction: Ethan explicitly instructed Codex in this thread to proceed with the next steps needed to get this live after reporting the recursive Account Settings/Team failure.
- Merge plan: Agent may merge this hotfix after green CI, merge gate re-run, and local UAT evidence because the owner direction is explicit for this live blocker.

## Verification
- `npm ci` - passed (`npm audit` reports existing 4 vulnerabilities: 1 high, 3 moderate).
- `npm run agent:preflight` - passed; warning only that PR linkage was pending before PR creation.
- `git diff --check` - passed.
- `npm run lint --if-present` - passed.
- `npm run build` - passed.
- `npm test --if-present` - passed; no package test script is configured.
- `npm run scoped-admin-technicians:validate-uat -- --app-url http://127.0.0.1:8081` - passed.
- `npm run partner-technicians:validate-uat -- --app-url http://127.0.0.1:8081` - passed.
- `npm run admin-access:validate-invite-uat -- --app-url http://127.0.0.1:8081` - passed.

## Screenshot evidence
- Account Settings no longer exposes Manage Technicians when Team scope is missing: `C:\Repos\wt-technician-loop-hotfix\output\playwright\portal-account-capability-drift.png`
- Direct `/portal/team` no-scope case shows Open Admin Access, not add-Technician controls: `C:\Repos\wt-technician-loop-hotfix\output\playwright\portal-team-capability-drift.png`

## How to test
1. From this branch, start local UAT with mock Supabase client env values:
   - PowerShell: `$env:VITE_SUPABASE_URL='https://example.supabase.co'; $env:VITE_SUPABASE_ANON_KEY='mock-anon-key'; npm run dev:uat`
2. Run `npm run scoped-admin-technicians:validate-uat -- --app-url http://127.0.0.1:8081`.
3. Open `/portal/account` as a no-scope admin-capability drift persona in the harness and confirm the card says `Technician administration` with `Open Admin Access`, and no `Manage Technicians` link.
4. Open `/portal/team` for the same persona and confirm it is locked with `Open Admin Access` and no add-Technician CTA.

Refs #542.