### PR TITLE
Add operator payout register export

### DIFF
--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -28,6 +28,7 @@ GitHub Issues and the Bloomjoy Project board are the operational source of truth
 - Operator payouts foundation sprint: the foundation is on `main`; active follow-on PRs add timekeeping, revenue snapshots, calculation, review, and pay statement slices.
 - Manager review/finalization slice `#448` adds the admin review gate before operator pay statements are issued.
 - Operator pay statements slice `#449` publishes versioned operator-visible pay statements from finalized payout runs.
+- Operator payout exports must remain an external payroll/payment handoff only; no tax filing, payroll-provider execution, direct-deposit, bank, or SSN handling belongs in Bloomjoy Hub.
 - Frontend work should use existing app patterns plus `PRODUCT.md`, `DESIGN.md`, and `impeccable` when the visible experience matters.
 
 ## Safety

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -208,6 +208,14 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Operators see only latest issued pay statements for their own operator profile on `/portal/time`; drafts, other operators' statements, and manager previews are not visible.
 - [ ] Operators can download the generated pay statement artifact and it includes entity branding fields, period, issue date, machines, hours, revenue basis, commission, adjustments, total payout, disclaimer, and revision status.
 - [ ] Direct artifact requests for drafts, missing statements, or another operator's statement fail with an access error.
+
+### Admin Operator Payout Register Export
+- [ ] `npm run operator-payouts:validate-register-export` passes.
+- [ ] With `npm run dev:uat` running, `npm run operator-payouts:validate-register-export-uat` passes and writes desktop/mobile screenshots to `output/playwright/`.
+- [ ] `/admin/payouts` shows `Export Register` only as a disabled or unavailable action until the selected payout run is finalized or issued.
+- [ ] For a finalized or issued payout run, `Export Register` downloads a CSV with period, account, operator, statement number/version when issued, assigned-machine hours, eligible revenue, commission basis, adjustments, total payout, status, and audit timestamps.
+- [ ] The CSV states it is for external payroll or payment execution and does not include SSNs, bank data, direct-deposit payloads, tax withholding, W-2, 1099, or payroll-provider execution fields.
+- [ ] Scoped payout managers cannot export out-of-scope operators or machines; direct RPC attempts against out-of-scope or non-finalized runs fail with an access or finalized/issued status error.
 - [ ] Desktop portal top bar shows one profile/session menu instead of separate Account and Sign Out buttons
 - [ ] Profile/session menu shows the signed-in email, an Account Settings link when the user can access `/portal/account`, and Sign Out
 - [ ] Portal section navigation labels `/portal/account` as Settings and does not show a separate Admin link for admin users

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "operator-payouts:validate-calculation": "node scripts/validate-operator-payout-calculation.mjs",
     "operator-payouts:validate-review": "node scripts/validate-operator-payout-review.mjs",
     "operator-payouts:validate-statements": "node scripts/validate-operator-pay-statements.mjs",
+    "operator-payouts:validate-register-export": "node scripts/validate-operator-payout-register-export.mjs",
+    "operator-payouts:validate-register-export-uat": "node scripts/validate-operator-payout-register-export-uat.mjs",
     "reporting:validate-partner-effective-windows": "node scripts/validate-partner-effective-windows.mjs",
     "reporting:validate-partner-scheduled-export": "node scripts/validate-partner-report-scheduled-export.mjs",
     "training:dedupe-catalog": "node scripts/dedupe-training-catalog.mjs",

--- a/scripts/validate-operator-payout-register-export-uat.mjs
+++ b/scripts/validate-operator-payout-register-export-uat.mjs
@@ -1,0 +1,667 @@
+#!/usr/bin/env node
+
+import { chromium } from 'playwright';
+import { mkdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const DEFAULT_APP_URL = 'http://127.0.0.1:8081';
+const DEFAULT_ARTIFACT_DIR = 'output/playwright';
+
+const parseArgs = (argv) => {
+  const args = {
+    appUrl: process.env.OPERATOR_PAYOUT_REGISTER_UAT_APP_URL || DEFAULT_APP_URL,
+    artifactDir:
+      process.env.OPERATOR_PAYOUT_REGISTER_UAT_ARTIFACT_DIR || DEFAULT_ARTIFACT_DIR,
+    headed: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--headed') {
+      args.headed = true;
+      continue;
+    }
+
+    if (arg === '--app-url') {
+      args.appUrl = argv[index + 1] || args.appUrl;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--app-url=')) {
+      args.appUrl = arg.slice('--app-url='.length) || args.appUrl;
+      continue;
+    }
+
+    if (arg === '--artifact-dir') {
+      args.artifactDir = argv[index + 1] || args.artifactDir;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--artifact-dir=')) {
+      args.artifactDir = arg.slice('--artifact-dir='.length) || args.artifactDir;
+    }
+  }
+
+  args.appUrl = args.appUrl.replace(/\/+$/, '');
+  args.artifactDir = path.resolve(process.cwd(), args.artifactDir);
+  return args;
+};
+
+const now = new Date();
+const isoHoursAgo = (hours) => new Date(now.getTime() - hours * 60 * 60 * 1000).toISOString();
+
+const adminUser = {
+  id: '77000000-0000-4000-8000-000000000001',
+  aud: 'authenticated',
+  role: 'authenticated',
+  email: 'payout-manager@example.test',
+  email_confirmed_at: isoHoursAgo(24),
+  confirmed_at: isoHoursAgo(24),
+  last_sign_in_at: now.toISOString(),
+  app_metadata: { provider: 'email', providers: ['email'] },
+  user_metadata: {},
+};
+
+const accountId = '77000000-0000-4000-8000-000000000010';
+const issuedPeriodId = '77000000-0000-4000-8000-000000000011';
+const draftPeriodId = '77000000-0000-4000-8000-000000000012';
+const issuedRunId = '77000000-0000-4000-8000-000000000013';
+const draftRunId = '77000000-0000-4000-8000-000000000014';
+const operatorProfileId = '77000000-0000-4000-8000-000000000015';
+const runItemId = '77000000-0000-4000-8000-000000000016';
+const machineItemId = '77000000-0000-4000-8000-000000000017';
+const machineId = '77000000-0000-4000-8000-000000000018';
+const locationId = '77000000-0000-4000-8000-000000000019';
+const adjustmentId = '77000000-0000-4000-8000-000000000020';
+const statementId = '77000000-0000-4000-8000-000000000021';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers':
+    'apikey, authorization, content-type, x-client-info, x-supabase-auth-token',
+  'Access-Control-Allow-Methods': 'GET, POST, PATCH, DELETE, OPTIONS',
+};
+
+const jsonResponse = (body, status = 200) => ({
+  status,
+  contentType: 'application/json',
+  headers: corsHeaders,
+  body: JSON.stringify(body),
+});
+
+const buildSession = () => ({
+  access_token: `mock-access-token-${adminUser.id}`,
+  token_type: 'bearer',
+  expires_in: 3600,
+  expires_at: Math.floor(Date.now() / 1000) + 3600,
+  refresh_token: `mock-refresh-token-${adminUser.id}`,
+  user: adminUser,
+});
+
+const buildMachineRow = () => ({
+  id: machineItemId,
+  machineId,
+  machineLabel: 'Cotton Candy 01',
+  locationId,
+  locationName: 'Mall Atrium',
+  netRevenueCents: 124500,
+  eligibleNetRevenueCents: 124500,
+  commissionBasisPoints: 500,
+  commissionPayCents: 6225,
+  shiftCount: 4,
+  rawMinutes: 455,
+  roundedPaidMinutes: 480,
+  includedInCommissionBasis: true,
+  inclusionReason: 'matched_assigned_machine',
+});
+
+const buildAdjustment = () => ({
+  id: adjustmentId,
+  amountCents: 1450,
+  adjustmentType: 'manual_bonus',
+  description: 'Weekend event bonus',
+  visibleToOperator: true,
+  createdAt: '2026-06-04T11:50:00.000Z',
+});
+
+const buildPayoutRunItem = (status = 'issued') => ({
+  id: runItemId,
+  operatorProfileId,
+  operatorDisplayName: 'Operator Export',
+  workerType: 'contractor_1099',
+  rawMinutes: 455,
+  roundedPaidMinutes: 480,
+  shiftCount: 4,
+  hourlyRateCents: 2500,
+  hourlyPayCents: 20000,
+  eligibleNetRevenueCents: 124500,
+  commissionBasisPoints: 500,
+  commissionPayCents: 6225,
+  adjustmentsTotalCents: 1450,
+  totalPayoutCents: 27675,
+  status,
+  warnings: [],
+  calculationNotes: {},
+  machines: [buildMachineRow()],
+  adjustments: [buildAdjustment()],
+});
+
+const buildRun = (status, payoutPeriodId, runId) => ({
+  id: runId,
+  accountId,
+  payoutPeriodId,
+  status,
+  totalRawMinutes: 455,
+  totalRoundedPaidMinutes: 480,
+  totalHourlyPayCents: 20000,
+  totalCommissionPayCents: 6225,
+  totalAdjustmentsCents: 1450,
+  totalPayoutCents: 27675,
+  warnings: [],
+  notes: null,
+  createdAt: '2026-06-04T10:00:00.000Z',
+  updatedAt: '2026-06-04T12:00:00.000Z',
+  items: [buildPayoutRunItem(status === 'issued' ? 'issued' : 'reviewed')],
+});
+
+const buildReviewContext = () => ({
+  accounts: [{ id: accountId, name: 'Bloomjoy UAT' }],
+  periods: [
+    {
+      id: issuedPeriodId,
+      accountId,
+      accountName: 'Bloomjoy UAT',
+      periodStartDate: '2026-05-01',
+      periodEndDate: '2026-05-31',
+      submissionDueDate: '2026-06-02',
+      lockDate: '2026-06-03',
+      targetPayoutDate: '2026-06-05',
+      status: 'issued',
+      payoutRun: buildRun('issued', issuedPeriodId, issuedRunId),
+      canReview: true,
+      canFinalize: true,
+      hasBlockers: false,
+      issuedStatementCount: 1,
+      revisionCount: 0,
+    },
+    {
+      id: draftPeriodId,
+      accountId,
+      accountName: 'Bloomjoy Draft',
+      periodStartDate: '2026-06-01',
+      periodEndDate: '2026-06-30',
+      submissionDueDate: '2026-07-02',
+      lockDate: '2026-07-03',
+      targetPayoutDate: '2026-07-05',
+      status: 'review',
+      payoutRun: buildRun('review', draftPeriodId, draftRunId),
+      canReview: true,
+      canFinalize: true,
+      hasBlockers: false,
+      issuedStatementCount: 0,
+      revisionCount: 0,
+    },
+  ],
+});
+
+const buildRegisterExport = () => ({
+  schemaVersion: 'operator-payout-register-v1',
+  exportType: 'approved_external_payout_register',
+  generatedAt: '2026-06-04T12:30:00.000Z',
+  payoutRun: {
+    id: issuedRunId,
+    accountId,
+    accountName: 'Bloomjoy UAT',
+    payoutPeriodId: issuedPeriodId,
+    periodStartDate: '2026-05-01',
+    periodEndDate: '2026-05-31',
+    targetPayoutDate: '2026-06-05',
+    status: 'issued',
+    finalizedAt: '2026-06-04T11:45:00.000Z',
+    issuedAt: '2026-06-04T12:00:00.000Z',
+    updatedAt: '2026-06-04T12:00:00.000Z',
+  },
+  totals: {
+    rawMinutes: 455,
+    roundedPaidMinutes: 480,
+    hourlyPayCents: 20000,
+    commissionPayCents: 6225,
+    adjustmentsTotalCents: 1450,
+    totalPayoutCents: 27675,
+  },
+  warnings: [],
+  rows: [
+    {
+      payoutRunItemId: runItemId,
+      operatorProfileId,
+      operatorDisplayName: 'Operator Export',
+      workerType: 'contractor_1099',
+      statement: {
+        id: statementId,
+        statementNumber: 'BJ-2026-05-0001',
+        statementLabel: 'May 2026 Pay Statement',
+        status: 'issued',
+        version: 1,
+        issuedAt: '2026-06-04T12:00:00.000Z',
+        revisionReason: null,
+      },
+      time: {
+        rawMinutes: 455,
+        roundedPaidMinutes: 480,
+        shiftCount: 4,
+      },
+      revenueBasis: {
+        eligibleNetRevenueCents: 124500,
+        commissionBasisPoints: 500,
+      },
+      totals: {
+        hourlyRateCents: 2500,
+        hourlyPayCents: 20000,
+        commissionPayCents: 6225,
+        adjustmentsTotalCents: 1450,
+        totalPayoutCents: 27675,
+      },
+      status: 'issued',
+      warnings: [],
+      machines: [
+        {
+          machineId,
+          machineLabel: 'Cotton Candy 01',
+          locationId,
+          locationName: 'Mall Atrium',
+          rawMinutes: 455,
+          roundedPaidMinutes: 480,
+          shiftCount: 4,
+          netRevenueCents: 124500,
+          eligibleNetRevenueCents: 124500,
+          commissionBasisPoints: 500,
+          commissionPayCents: 6225,
+          includedInCommissionBasis: true,
+          inclusionReason: 'matched_assigned_machine',
+        },
+      ],
+      adjustments: [buildAdjustment()],
+    },
+  ],
+  rowCount: 1,
+  disclaimer:
+    'Bloomjoy Hub records approved payout totals for external payroll or payment execution. It does not calculate tax withholding, file payroll forms, execute direct deposit, or store bank or SSN data.',
+  automation: {
+    taxComplianceEngine: false,
+    payrollProviderExecution: false,
+    directDepositExecution: false,
+    bankDataIncluded: false,
+    ssnIncluded: false,
+  },
+});
+
+const installMockRoutes = async (context, state) => {
+  await context.route('**/auth/v1/**', async (route) => {
+    const url = route.request().url();
+
+    if (route.request().method() === 'OPTIONS') {
+      return route.fulfill({ status: 204, headers: corsHeaders, body: '' });
+    }
+
+    if (url.includes('/token')) {
+      return route.fulfill(jsonResponse(buildSession()));
+    }
+
+    if (url.includes('/user')) {
+      return route.fulfill(jsonResponse(adminUser));
+    }
+
+    if (url.includes('/logout')) {
+      return route.fulfill({ status: 204, headers: corsHeaders, body: '' });
+    }
+
+    return route.fulfill(jsonResponse({}));
+  });
+
+  await context.route('**/rest/v1/customer_profiles**', async (route) => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill(jsonResponse([]));
+    }
+
+    return route.fulfill(jsonResponse({ user_id: adminUser.id, language_preference: 'en' }));
+  });
+
+  await context.route('**/rest/v1/rpc/**', async (route) => {
+    if (route.request().method() === 'OPTIONS') {
+      return route.fulfill({ status: 204, headers: corsHeaders, body: '' });
+    }
+
+    const url = route.request().url();
+    const rpcName = new URL(url).pathname.split('/').pop() ?? '';
+    const body = route.request().postDataJSON();
+    state.rpcCalls.push({ rpcName, body });
+
+    if (rpcName === 'get_my_admin_access_context') {
+      return route.fulfill(
+        jsonResponse({
+          isSuperAdmin: false,
+          isScopedAdmin: true,
+          canAccessAdmin: true,
+          allowedSurfaces: ['payouts'],
+          scopedMachineIds: [machineId],
+        })
+      );
+    }
+
+    if (rpcName === 'get_my_plus_access') {
+      return route.fulfill(
+        jsonResponse({
+          has_plus_access: false,
+          source: null,
+          membership_status: null,
+          current_period_end: null,
+          cancel_at_period_end: false,
+          paid_subscription_active: false,
+          free_grant_id: null,
+          free_grant_starts_at: null,
+          free_grant_expires_at: null,
+          free_grant_active: false,
+        })
+      );
+    }
+
+    if (rpcName === 'get_my_portal_access_context') {
+      return route.fulfill(
+        jsonResponse({
+          access_tier: 'baseline',
+          is_plus_member: false,
+          is_training_operator: false,
+          is_admin: true,
+          can_manage_operator_training: false,
+          is_corporate_partner: false,
+          has_supply_discount: false,
+          can_request_support: true,
+          can_manage_technicians: false,
+          capabilities: ['admin.payouts'],
+          effective_presets: ['scoped_admin'],
+        })
+      );
+    }
+
+    if (rpcName === 'get_my_reporting_access_context') {
+      return route.fulfill(
+        jsonResponse({
+          has_reporting_access: false,
+          accessible_machine_count: 0,
+          accessible_location_count: 0,
+          can_manage_reporting: false,
+          latest_sale_date: null,
+          latest_import_completed_at: null,
+        })
+      );
+    }
+
+    if (rpcName === 'resolve_my_technician_entitlements') {
+      return route.fulfill(
+        jsonResponse({
+          technicianEmail: adminUser.email,
+          resolvedGrantCount: 0,
+          resolvedOperatorTrainingGrantCount: 0,
+          upsertedReportingEntitlementCount: 0,
+          skippedGrantCount: 0,
+        })
+      );
+    }
+
+    if (rpcName === 'get_payout_review_context') {
+      return route.fulfill(jsonResponse(buildReviewContext()));
+    }
+
+    if (rpcName === 'admin_get_payout_register_export') {
+      if (body?.p_payout_run_id !== issuedRunId) {
+        return route.fulfill(
+          jsonResponse(
+            {
+              code: 'P0001',
+              message:
+                'Payout register export is available only for finalized or issued payout runs',
+            },
+            400
+          )
+        );
+      }
+
+      return route.fulfill(jsonResponse(buildRegisterExport()));
+    }
+
+    return route.fulfill(jsonResponse({}));
+  });
+};
+
+const waitForServer = async (appUrl) => {
+  try {
+    const response = await fetch(appUrl, { method: 'GET' });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+  } catch (error) {
+    throw new Error(
+      `Unable to reach ${appUrl}. Start the app first, for example: npm run dev:uat. ${error.message}`
+    );
+  }
+};
+
+const waitForCondition = async (predicate, label, timeoutMs = 10000) => {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return;
+    await delay(100);
+  }
+
+  throw new Error(`${label} timed out after ${timeoutMs}ms`);
+};
+
+const createRecorder = () => {
+  const results = [];
+
+  return {
+    pass(name, detail = '') {
+      results.push({ name, pass: true, detail });
+      console.log(`PASS ${name}${detail ? ` - ${detail}` : ''}`);
+    },
+    fail(name, detail = '') {
+      results.push({ name, pass: false, detail });
+      console.log(`FAIL ${name}${detail ? ` - ${detail}` : ''}`);
+    },
+    assert(name, condition, detail = '') {
+      if (condition) {
+        this.pass(name, detail);
+      } else {
+        this.fail(name, detail);
+      }
+    },
+    failed() {
+      return results.filter((result) => !result.pass);
+    },
+  };
+};
+
+const login = async (page) => {
+  await page.waitForURL('**/login', { timeout: 10000 }).catch(() => undefined);
+  if (new URL(page.url()).pathname !== '/login') return;
+
+  await page.waitForSelector('#email-password', { timeout: 10000 });
+  await page.fill('#email-password', adminUser.email);
+  await page.fill('#password', 'mock-password');
+  await page.getByRole('button', { name: /sign in/i }).click();
+};
+
+const hasCsvColumn = (header, columnName) => header.split(',').includes(columnName);
+
+const run = async () => {
+  const args = parseArgs(process.argv.slice(2));
+  const recorder = createRecorder();
+  const state = { rpcCalls: [] };
+
+  await mkdir(args.artifactDir, { recursive: true });
+  await waitForServer(args.appUrl);
+
+  const browser = await chromium.launch({ headless: !args.headed });
+  const context = await browser.newContext({
+    acceptDownloads: true,
+    viewport: { width: 1440, height: 1000 },
+  });
+  await installMockRoutes(context, state);
+  const page = await context.newPage();
+  const consoleErrors = [];
+
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      consoleErrors.push(message.text());
+    }
+  });
+  page.on('pageerror', (error) => {
+    consoleErrors.push(error.message);
+  });
+
+  try {
+    await page.goto(`${args.appUrl}/admin/payouts`, { waitUntil: 'domcontentloaded' });
+    await login(page);
+    await page.waitForURL('**/admin/payouts', { timeout: 20000 });
+    await page
+      .getByRole('heading', { name: 'Payout Review', exact: true })
+      .waitFor({ timeout: 10000 });
+    await page.getByRole('heading', { name: 'Payout Register' }).waitFor({ timeout: 10000 });
+    const getRegisterCard = () =>
+      page
+        .locator('div.rounded-lg', {
+          has: page.getByRole('heading', { name: 'Payout Register', exact: true }),
+        })
+        .first();
+
+    recorder.assert(
+      'Admin Payouts route loads for scoped payout manager',
+      new URL(page.url()).pathname === '/admin/payouts',
+      page.url()
+    );
+    recorder.assert(
+      'Payout Register card states external payroll boundary',
+      await getRegisterCard()
+        .getByText(/Bloomjoy Hub does not run payroll, taxes, direct deposit, or filings/i)
+        .isVisible()
+    );
+    recorder.assert(
+      'Issued run enables Export Register',
+      await page.getByRole('button', { name: /export register/i }).isEnabled()
+    );
+    recorder.assert(
+      'Register metrics show ready rows and external-only boundary',
+      (await getRegisterCard().getByText('Ready', { exact: true }).isVisible()) &&
+        (await getRegisterCard().getByText('External only', { exact: true }).isVisible()) &&
+        (await getRegisterCard().getByText('Rows', { exact: true }).isVisible())
+    );
+
+    await page.screenshot({
+      path: path.join(args.artifactDir, 'admin-payout-register-export-desktop.png'),
+      fullPage: true,
+    });
+
+    const downloadPromise = page.waitForEvent('download', { timeout: 10000 });
+    await page.getByRole('button', { name: /export register/i }).click();
+    const download = await downloadPromise;
+    await waitForCondition(
+      () => state.rpcCalls.some((call) => call.rpcName === 'admin_get_payout_register_export'),
+      'admin_get_payout_register_export RPC'
+    );
+    await page.getByText('Downloaded payout register for 1 operator.').last().waitFor({
+      timeout: 10000,
+    });
+
+    const downloadPath = await download.path();
+    const csv = downloadPath ? await readFile(downloadPath, 'utf8') : '';
+    const csvHeader = csv.split(/\r?\n/)[0] ?? '';
+
+    recorder.assert(
+      'Export Register calls approved register RPC for selected run',
+      state.rpcCalls.some(
+        (call) =>
+          call.rpcName === 'admin_get_payout_register_export' &&
+          call.body?.p_payout_run_id === issuedRunId
+      ),
+      JSON.stringify(state.rpcCalls.filter((call) => call.rpcName === 'admin_get_payout_register_export'))
+    );
+    recorder.assert(
+      'Downloaded CSV uses expected filename',
+      download.suggestedFilename() === 'payout-register-bloomjoy-uat-2026-05-01-2026-05-31.csv',
+      download.suggestedFilename()
+    );
+    recorder.assert(
+      'Downloaded CSV includes statement, machine, adjustment, and boundary columns',
+      hasCsvColumn(csvHeader, 'statement_number') &&
+        hasCsvColumn(csvHeader, 'machine_breakdown') &&
+        hasCsvColumn(csvHeader, 'adjustments') &&
+        hasCsvColumn(csvHeader, 'external_payroll_boundary')
+    );
+    recorder.assert(
+      'Downloaded CSV includes approved payout register values',
+      csv.includes('Operator Export') &&
+        csv.includes('BJ-2026-05-0001') &&
+        csv.includes('Cotton Candy 01 (Mall Atrium)') &&
+        csv.includes('Weekend event bonus') &&
+        csv.includes('$276.75')
+    );
+    recorder.assert(
+      'Downloaded CSV does not expose payment credentials or tax execution fields',
+      !/\b(ssn|bank_account|routing_number|direct_deposit_payload|tax_withholding_amount)\b/i.test(
+        csvHeader
+      )
+    );
+
+    await page.getByRole('button', { name: /Bloomjoy Draft/i }).click();
+    await page.getByRole('heading', { name: 'Payout Register' }).waitFor({ timeout: 10000 });
+    recorder.assert(
+      'Draft or review run disables Export Register until finalization',
+      (await page.getByRole('button', { name: /export register/i }).isDisabled()) &&
+        (await getRegisterCard().getByText('Finalize first', { exact: true }).isVisible())
+    );
+
+    await page.getByRole('button', { name: /Bloomjoy UAT/i }).click();
+    await page.getByRole('button', { name: /export register/i }).waitFor({ timeout: 10000 });
+    await page.setViewportSize({ width: 390, height: 900 });
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await page.waitForTimeout(500);
+
+    const mobileOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > window.innerWidth + 1
+    );
+    recorder.assert('Admin payout register mobile has no horizontal overflow', !mobileOverflow);
+
+    await page.screenshot({
+      path: path.join(args.artifactDir, 'admin-payout-register-export-mobile.png'),
+      fullPage: true,
+    });
+
+    recorder.assert(
+      'No browser console/page errors during payout register export UAT pass',
+      consoleErrors.length === 0,
+      consoleErrors.slice(0, 3).join(' | ')
+    );
+  } finally {
+    await context.close();
+    await browser.close();
+  }
+
+  const failed = recorder.failed();
+  if (failed.length > 0) {
+    console.error(`\nOperator payout register export UAT failed: ${failed.length} check(s).`);
+    process.exit(1);
+  }
+
+  console.log('\nOperator payout register export UAT passed.');
+  console.log(`Screenshots: ${args.artifactDir}`);
+};
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/validate-operator-payout-register-export.mjs
+++ b/scripts/validate-operator-payout-register-export.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+const files = {
+  migration: path.join(
+    repoRoot,
+    'supabase',
+    'migrations',
+    '20260626135851_operator_payout_register_export.sql'
+  ),
+  helper: path.join(repoRoot, 'src', 'lib', 'operatorPayouts.ts'),
+  adminPage: path.join(repoRoot, 'src', 'pages', 'admin', 'Payouts.tsx'),
+  uatScript: path.join(repoRoot, 'scripts', 'validate-operator-payout-register-export-uat.mjs'),
+  packageJson: path.join(repoRoot, 'package.json'),
+  smoke: path.join(repoRoot, 'Docs', 'QA_SMOKE_TEST_CHECKLIST.md'),
+};
+
+const fail = (message) => {
+  throw new Error(message);
+};
+
+const readText = (filePath) => fs.readFileSync(filePath, 'utf8');
+
+const compact = (value) =>
+  value
+    .replace(/--.*$/gm, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+
+const expect = (source, snippet, label) => {
+  if (!compact(source).includes(compact(snippet))) {
+    fail(`${label}: missing ${snippet}`);
+  }
+};
+
+for (const [label, filePath] of Object.entries(files)) {
+  if (!fs.existsSync(filePath)) {
+    fail(`Missing ${label} file: ${path.relative(repoRoot, filePath)}`);
+  }
+}
+
+const migration = readText(files.migration);
+for (const snippet of [
+  'create or replace function public.admin_get_payout_register_export',
+  "run_row.status not in ('finalized', 'issued', 'closed')",
+  'Payout register export is available only for finalized or issued payout runs',
+  'public.operator_can_finalize_payout_run(actor_user_id, run_row.id)',
+  'Payout register export access required',
+  'from public.pay_statements statement',
+  "statement.status in ('issued', 'revised')",
+  'operatorDisplayName',
+  'statementNumber',
+  'eligibleNetRevenueCents',
+  'commissionBasisPoints',
+  'adjustmentsTotalCents',
+  'totalPayoutCents',
+  'ssnIncluded',
+  'bankDataIncluded',
+  'payrollProviderExecution',
+  'directDepositExecution',
+  'revoke execute on function public.admin_get_payout_register_export(uuid) from public, anon',
+  'grant execute on function public.admin_get_payout_register_export(uuid) to authenticated',
+]) {
+  expect(migration, snippet, 'register export migration');
+}
+
+const helper = readText(files.helper);
+for (const snippet of [
+  'PayoutRegisterExport',
+  'PayoutRegisterExportRow',
+  'fetchPayoutRegisterExportAdmin',
+  'admin_get_payout_register_export',
+  'buildPayoutRegisterCsv',
+  'downloadPayoutRegisterCsv',
+  'getPayoutRegisterCsvFileName',
+  'external_payroll_boundary',
+]) {
+  if (!helper.includes(snippet)) {
+    fail(`operatorPayouts helper missing ${snippet}`);
+  }
+}
+
+const adminPage = readText(files.adminPage);
+for (const snippet of [
+  'Payout Register',
+  'Export Register',
+  'canExportPayoutRegister',
+  'fetchPayoutRegisterExportAdmin',
+  'downloadPayoutRegisterCsv',
+  'Bloomjoy Hub does not run payroll, taxes',
+  'direct deposit, or filings.',
+]) {
+  if (!adminPage.includes(snippet)) {
+    fail(`Admin payouts page missing ${snippet}`);
+  }
+}
+
+const packageJson = readText(files.packageJson);
+if (!packageJson.includes('operator-payouts:validate-register-export')) {
+  fail('package.json missing register export validator script.');
+}
+if (!packageJson.includes('operator-payouts:validate-register-export-uat')) {
+  fail('package.json missing register export UAT validator script.');
+}
+
+const uatScript = readText(files.uatScript);
+for (const snippet of [
+  'admin_get_payout_register_export',
+  'Export Register',
+  'payout-register-bloomjoy-uat-2026-05-01-2026-05-31.csv',
+  'admin-payout-register-export-desktop.png',
+  'admin-payout-register-export-mobile.png',
+]) {
+  if (!uatScript.includes(snippet)) {
+    fail(`Register export UAT script missing ${snippet}`);
+  }
+}
+
+const smoke = readText(files.smoke);
+for (const snippet of [
+  'Admin Operator Payout Register Export',
+  'Export Register',
+  'finalized or issued payout run',
+  'operator-payouts:validate-register-export-uat',
+  'external payroll or payment execution',
+]) {
+  if (!smoke.includes(snippet)) {
+    fail(`Smoke checklist missing ${snippet}`);
+  }
+}
+
+console.log(
+  'Operator payout register export checks passed: finalized or issued status guard, scoped manager access guard, CSV helper, admin UI action, payroll-boundary copy, and smoke coverage are present.'
+);

--- a/src/lib/operatorPayouts.ts
+++ b/src/lib/operatorPayouts.ts
@@ -233,6 +233,105 @@ export type IssuePayStatementsResult = {
   revision: boolean;
 };
 
+export type PayoutRegisterExportMachine = {
+  machineId: string;
+  machineLabel: string;
+  locationId: string;
+  locationName: string;
+  rawMinutes: number;
+  roundedPaidMinutes: number;
+  shiftCount: number;
+  netRevenueCents: number;
+  eligibleNetRevenueCents: number;
+  commissionBasisPoints: number | null;
+  commissionPayCents: number;
+  includedInCommissionBasis: boolean;
+  inclusionReason: string | null;
+};
+
+export type PayoutRegisterExportAdjustment = {
+  id: string;
+  amountCents: number;
+  adjustmentType: string;
+  description: string;
+  visibleToOperator: boolean;
+  createdAt: string;
+};
+
+export type PayoutRegisterExportRow = {
+  payoutRunItemId: string;
+  operatorProfileId: string;
+  operatorDisplayName: string;
+  workerType: OperatorWorkerType;
+  statement: {
+    id: string | null;
+    statementNumber: string | null;
+    statementLabel: string | null;
+    status: PayStatementStatus | null;
+    version: number | null;
+    issuedAt: string | null;
+    revisionReason: string | null;
+  };
+  time: {
+    rawMinutes: number;
+    roundedPaidMinutes: number;
+    shiftCount: number;
+  };
+  revenueBasis: {
+    eligibleNetRevenueCents: number;
+    commissionBasisPoints: number | null;
+  };
+  totals: {
+    hourlyRateCents: number | null;
+    hourlyPayCents: number;
+    commissionPayCents: number;
+    adjustmentsTotalCents: number;
+    totalPayoutCents: number;
+  };
+  status: PayoutRunItem['status'];
+  warnings: PayoutCalculationWarning[];
+  machines: PayoutRegisterExportMachine[];
+  adjustments: PayoutRegisterExportAdjustment[];
+};
+
+export type PayoutRegisterExport = {
+  schemaVersion: 'operator-payout-register-v1';
+  exportType: 'approved_external_payout_register';
+  generatedAt: string;
+  payoutRun: {
+    id: string;
+    accountId: string;
+    accountName: string;
+    payoutPeriodId: string;
+    periodStartDate: string;
+    periodEndDate: string;
+    targetPayoutDate: string;
+    status: Extract<PayoutRunStatus, 'finalized' | 'issued' | 'closed'>;
+    finalizedAt: string | null;
+    issuedAt: string | null;
+    updatedAt: string;
+  };
+  totals: {
+    rawMinutes: number;
+    roundedPaidMinutes: number;
+    hourlyPayCents: number;
+    commissionPayCents: number;
+    adjustmentsTotalCents: number;
+    totalPayoutCents: number;
+  };
+  warnings: PayoutCalculationWarning[];
+  rows: PayoutRegisterExportRow[];
+  rowCount: number;
+  disclaimer: string;
+  automation: {
+    taxComplianceEngine: false;
+    payrollProviderExecution: false;
+    directDepositExecution: false;
+    bankDataIncluded: false;
+    ssnIncluded: false;
+  };
+};
+
 export type OperatorPayoutPolicyContext = {
   id: string;
   name: string;
@@ -1050,6 +1149,20 @@ export const issuePayStatementsAdmin = async ({
   return data as IssuePayStatementsResult;
 };
 
+export const fetchPayoutRegisterExportAdmin = async (
+  payoutRunId: string
+): Promise<PayoutRegisterExport> => {
+  const { data, error } = await supabaseClient.rpc('admin_get_payout_register_export', {
+    p_payout_run_id: payoutRunId,
+  });
+
+  if (error || !data) {
+    throw new Error(error?.message || 'Unable to prepare payout register export.');
+  }
+
+  return data as PayoutRegisterExport;
+};
+
 export const markPayoutRunReviewedAdmin = async ({
   payoutRunId,
   reason,
@@ -1314,6 +1427,138 @@ export const downloadOperatorPayStatementHtml = (artifact: OperatorPayStatementA
   const anchor = document.createElement('a');
   anchor.href = url;
   anchor.download = artifact.artifact.downloadFileName || `${artifact.statement.statementNumber}.html`;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+};
+
+const csvEscape = (value: unknown) => {
+  const text = String(value ?? '');
+  if (/[",\r\n]/.test(text)) {
+    return `"${text.replace(/"/g, '""')}"`;
+  }
+
+  return text;
+};
+
+const fileSafeSegment = (value: string | null | undefined) =>
+  String(value ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48);
+
+const formatCsvHours = (minutes: number | null | undefined) =>
+  ((minutes ?? 0) / 60).toFixed(2);
+
+const formatCsvPercent = (basisPoints: number | null | undefined) =>
+  typeof basisPoints === 'number' ? (basisPoints / 100).toFixed(2) : '';
+
+const formatPayoutRegisterMachineBreakdown = (machines: PayoutRegisterExportMachine[]) =>
+  machines
+    .map((machine) =>
+      [
+        `${machine.machineLabel} (${machine.locationName})`,
+        `${formatCsvHours(machine.roundedPaidMinutes)}h`,
+        `${formatStatementMoney(machine.eligibleNetRevenueCents)} eligible revenue`,
+        machine.commissionBasisPoints === null
+          ? 'no commission rate'
+          : `${formatCsvPercent(machine.commissionBasisPoints)}% commission basis`,
+        `${formatStatementMoney(machine.commissionPayCents)} commission`,
+      ].join(' | ')
+    )
+    .join('; ');
+
+const formatPayoutRegisterAdjustments = (adjustments: PayoutRegisterExportAdjustment[]) =>
+  adjustments
+    .map((adjustment) =>
+      `${adjustment.adjustmentType.replaceAll('_', ' ')}: ${formatStatementMoney(
+        adjustment.amountCents
+      )} (${adjustment.description})`
+    )
+    .join('; ');
+
+const formatPayoutRegisterWarnings = (warnings: PayoutCalculationWarning[]) =>
+  warnings.map((warning) => `${warning.severity}: ${warning.message}`).join('; ');
+
+export const buildPayoutRegisterCsv = (register: PayoutRegisterExport) => {
+  const columns = [
+    'export_generated_at',
+    'payout_run_id',
+    'payout_run_status',
+    'account_name',
+    'period_start_date',
+    'period_end_date',
+    'target_payout_date',
+    'operator_name',
+    'worker_type',
+    'statement_number',
+    'statement_version',
+    'statement_status',
+    'statement_issued_at',
+    'paid_hours',
+    'shift_count',
+    'eligible_revenue',
+    'commission_rate_percent',
+    'hourly_pay',
+    'commission_pay',
+    'adjustments_total',
+    'total_payout',
+    'machine_breakdown',
+    'adjustments',
+    'warnings',
+    'finalized_at',
+    'issued_at',
+    'external_payroll_boundary',
+  ];
+
+  const rows = register.rows.map((row) => [
+    register.generatedAt,
+    register.payoutRun.id,
+    register.payoutRun.status,
+    register.payoutRun.accountName,
+    register.payoutRun.periodStartDate,
+    register.payoutRun.periodEndDate,
+    register.payoutRun.targetPayoutDate,
+    row.operatorDisplayName,
+    row.workerType,
+    row.statement.statementNumber ?? '',
+    row.statement.version ?? '',
+    row.statement.status ?? 'not_issued',
+    row.statement.issuedAt ?? '',
+    formatCsvHours(row.time.roundedPaidMinutes),
+    row.time.shiftCount,
+    formatStatementMoney(row.revenueBasis.eligibleNetRevenueCents),
+    formatCsvPercent(row.revenueBasis.commissionBasisPoints),
+    formatStatementMoney(row.totals.hourlyPayCents),
+    formatStatementMoney(row.totals.commissionPayCents),
+    formatStatementMoney(row.totals.adjustmentsTotalCents),
+    formatStatementMoney(row.totals.totalPayoutCents),
+    formatPayoutRegisterMachineBreakdown(row.machines),
+    formatPayoutRegisterAdjustments(row.adjustments),
+    formatPayoutRegisterWarnings(row.warnings),
+    register.payoutRun.finalizedAt ?? '',
+    register.payoutRun.issuedAt ?? '',
+    register.disclaimer,
+  ]);
+
+  return [columns, ...rows].map((row) => row.map(csvEscape).join(',')).join('\r\n');
+};
+
+export const getPayoutRegisterCsvFileName = (register: PayoutRegisterExport) => {
+  const account = fileSafeSegment(register.payoutRun.accountName) || 'account';
+  return `payout-register-${account}-${register.payoutRun.periodStartDate}-${register.payoutRun.periodEndDate}.csv`;
+};
+
+export const downloadPayoutRegisterCsv = (register: PayoutRegisterExport) => {
+  const csv = buildPayoutRegisterCsv(register);
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = getPayoutRegisterCsvFileName(register);
   document.body.appendChild(anchor);
   anchor.click();
   anchor.remove();

--- a/src/pages/admin/Payouts.tsx
+++ b/src/pages/admin/Payouts.tsx
@@ -4,6 +4,7 @@ import {
   Ban,
   CheckCircle2,
   Clock3,
+  Download,
   FileText,
   Loader2,
   RefreshCw,
@@ -30,6 +31,8 @@ import { Textarea } from '@/components/ui/textarea';
 import {
   addPayoutAdjustmentAdmin,
   calculatePayoutRunAdmin,
+  downloadPayoutRegisterCsv,
+  fetchPayoutRegisterExportAdmin,
   fetchPayoutReviewContext,
   finalizePayoutRunAdmin,
   issuePayStatementsAdmin,
@@ -266,6 +269,7 @@ export default function AdminPayoutsPage() {
   const [statementPreview, setStatementPreview] = useState<PayStatementPreviewResult | null>(null);
   const [isPreviewingStatements, setIsPreviewingStatements] = useState(false);
   const [isIssuingStatements, setIsIssuingStatements] = useState(false);
+  const [isExportingRegister, setIsExportingRegister] = useState(false);
   const [issueReason, setIssueReason] = useState('');
   const [issueRevisionReason, setIssueRevisionReason] = useState('');
 
@@ -296,6 +300,10 @@ export default function AdminPayoutsPage() {
     Boolean(selectedPeriod?.canFinalize) &&
     Boolean(selectedRun) &&
     ['finalized', 'issued'].includes(selectedRun?.status ?? '');
+  const canExportPayoutRegister =
+    Boolean(selectedPeriod?.canFinalize) &&
+    Boolean(selectedRun) &&
+    ['finalized', 'issued', 'closed'].includes(selectedRun?.status ?? '');
   const hasIssuedStatements = Boolean(selectedPeriod?.issuedStatementCount);
 
   useEffect(() => {
@@ -509,6 +517,23 @@ export default function AdminPayoutsPage() {
       toast.error(issueError instanceof Error ? issueError.message : 'Unable to issue pay statements.');
     } finally {
       setIsIssuingStatements(false);
+    }
+  };
+
+  const exportPayoutRegister = async () => {
+    if (!selectedRun) return;
+
+    setIsExportingRegister(true);
+    try {
+      const register = await fetchPayoutRegisterExportAdmin(selectedRun.id);
+      downloadPayoutRegisterCsv(register);
+      toast.success(`Downloaded payout register for ${register.rowCount} operator${register.rowCount === 1 ? '' : 's'}.`);
+    } catch (exportError) {
+      toast.error(
+        exportError instanceof Error ? exportError.message : 'Unable to download payout register.'
+      );
+    } finally {
+      setIsExportingRegister(false);
     }
   };
 
@@ -828,6 +853,43 @@ export default function AdminPayoutsPage() {
                         </div>
                       </div>
                     )}
+                  </div>
+                )}
+
+                {selectedRun && (
+                  <div className="rounded-lg border border-border bg-background p-5">
+                    <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                      <div>
+                        <h2 className="font-semibold text-foreground">Payout Register</h2>
+                        <p className="mt-1 text-sm text-muted-foreground">
+                          Download the approved CSV register for external payroll or payment
+                          execution after finalization. Bloomjoy Hub does not run payroll, taxes,
+                          direct deposit, or filings.
+                        </p>
+                      </div>
+                      <Button
+                        variant="outline"
+                        onClick={() => void exportPayoutRegister()}
+                        disabled={!canExportPayoutRegister || isExportingRegister}
+                      >
+                        {isExportingRegister ? (
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        ) : (
+                          <Download className="mr-2 h-4 w-4" />
+                        )}
+                        Export Register
+                      </Button>
+                    </div>
+
+                    <div className="mt-4 grid gap-3 sm:grid-cols-3">
+                      <Metric
+                        label="Register status"
+                        value={canExportPayoutRegister ? 'Ready' : 'Finalize first'}
+                        tone={canExportPayoutRegister ? 'good' : 'default'}
+                      />
+                      <Metric label="Rows" value={`${selectedRun.items.length}`} />
+                      <Metric label="Boundary" value="External only" />
+                    </div>
                   </div>
                 )}
 

--- a/supabase/migrations/20260626135851_operator_payout_register_export.sql
+++ b/supabase/migrations/20260626135851_operator_payout_register_export.sql
@@ -1,0 +1,195 @@
+create or replace function public.admin_get_payout_register_export(
+  p_payout_run_id uuid
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public, auth
+as $$
+declare
+  actor_user_id uuid;
+  run_row record;
+  register_rows jsonb;
+begin
+  actor_user_id := auth.uid();
+
+  if actor_user_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  select
+    run.*,
+    account.name as account_name,
+    period.period_start_date,
+    period.period_end_date,
+    period.target_payout_date
+  into run_row
+  from public.payout_runs run
+  join public.customer_accounts account
+    on account.id = run.account_id
+  join public.payout_periods period
+    on period.id = run.payout_period_id
+  where run.id = p_payout_run_id
+  limit 1;
+
+  if not found then
+    raise exception 'Payout run not found';
+  end if;
+
+  if run_row.status not in ('finalized', 'issued', 'closed') then
+    raise exception 'Payout register export is available only for finalized or issued payout runs';
+  end if;
+
+  if not public.operator_can_finalize_payout_run(actor_user_id, run_row.id) then
+    raise exception 'Payout register export access required';
+  end if;
+
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'payoutRunItemId', item.id,
+        'operatorProfileId', item.operator_profile_id,
+        'operatorDisplayName', profile.display_name,
+        'workerType', item.worker_type,
+        'statement', jsonb_build_object(
+          'id', latest_statement.id,
+          'statementNumber', latest_statement.statement_number,
+          'statementLabel', latest_statement.statement_label,
+          'status', latest_statement.status,
+          'version', latest_statement.version,
+          'issuedAt', latest_statement.issued_at,
+          'revisionReason', latest_statement.revision_reason
+        ),
+        'time', jsonb_build_object(
+          'rawMinutes', item.raw_minutes,
+          'roundedPaidMinutes', item.rounded_paid_minutes,
+          'shiftCount', item.shift_count
+        ),
+        'revenueBasis', jsonb_build_object(
+          'eligibleNetRevenueCents', item.eligible_net_revenue_cents,
+          'commissionBasisPoints', item.commission_basis_points
+        ),
+        'totals', jsonb_build_object(
+          'hourlyRateCents', item.hourly_rate_cents,
+          'hourlyPayCents', item.hourly_pay_cents,
+          'commissionPayCents', item.commission_pay_cents,
+          'adjustmentsTotalCents', item.adjustments_total_cents,
+          'totalPayoutCents', item.total_payout_cents
+        ),
+        'status', item.status,
+        'warnings', coalesce(item.warnings, '[]'::jsonb),
+        'machines', coalesce((
+          select jsonb_agg(
+            jsonb_build_object(
+              'machineId', item_machine.reporting_machine_id,
+              'machineLabel', machine.machine_label,
+              'locationId', item_machine.reporting_location_id,
+              'locationName', location.name,
+              'rawMinutes', item_machine.raw_minutes,
+              'roundedPaidMinutes', item_machine.rounded_paid_minutes,
+              'shiftCount', item_machine.shift_count,
+              'netRevenueCents', item_machine.net_revenue_cents,
+              'eligibleNetRevenueCents', item_machine.eligible_net_revenue_cents,
+              'commissionBasisPoints', item_machine.commission_basis_points,
+              'commissionPayCents', item_machine.commission_pay_cents,
+              'includedInCommissionBasis', item_machine.included_in_commission_basis,
+              'inclusionReason', item_machine.inclusion_reason
+            )
+            order by machine.machine_label, item_machine.id
+          )
+          from public.payout_run_item_machines item_machine
+          join public.reporting_machines machine
+            on machine.id = item_machine.reporting_machine_id
+          join public.reporting_locations location
+            on location.id = item_machine.reporting_location_id
+          where item_machine.payout_run_item_id = item.id
+        ), '[]'::jsonb),
+        'adjustments', coalesce((
+          select jsonb_agg(
+            jsonb_build_object(
+              'id', adjustment.id,
+              'amountCents', adjustment.amount_cents,
+              'adjustmentType', adjustment.adjustment_type,
+              'description', adjustment.description,
+              'visibleToOperator', adjustment.visible_to_operator,
+              'createdAt', adjustment.created_at
+            )
+            order by adjustment.created_at, adjustment.id
+          )
+          from public.payout_adjustments adjustment
+          where adjustment.payout_run_id = run_row.id
+            and adjustment.operator_profile_id = item.operator_profile_id
+        ), '[]'::jsonb)
+      )
+      order by profile.display_name, item.id
+    ),
+    '[]'::jsonb
+  )
+  into register_rows
+  from public.payout_run_items item
+  join public.operator_payout_profiles profile
+    on profile.id = item.operator_profile_id
+  left join lateral (
+    select statement.*
+    from public.pay_statements statement
+    where statement.payout_run_item_id = item.id
+      and statement.status in ('issued', 'revised')
+    order by statement.version desc, statement.issued_at desc nulls last, statement.created_at desc
+    limit 1
+  ) latest_statement on true
+  where item.payout_run_id = run_row.id
+    and item.status <> 'voided'
+    and public.can_access_payout_run_item(actor_user_id, item.id);
+
+  return jsonb_build_object(
+    'schemaVersion', 'operator-payout-register-v1',
+    'exportType', 'approved_external_payout_register',
+    'generatedAt', now(),
+    'payoutRun', jsonb_build_object(
+      'id', run_row.id,
+      'accountId', run_row.account_id,
+      'accountName', run_row.account_name,
+      'payoutPeriodId', run_row.payout_period_id,
+      'periodStartDate', run_row.period_start_date,
+      'periodEndDate', run_row.period_end_date,
+      'targetPayoutDate', run_row.target_payout_date,
+      'status', run_row.status,
+      'finalizedAt', run_row.finalized_at,
+      'issuedAt', run_row.issued_at,
+      'updatedAt', run_row.updated_at
+    ),
+    'totals', jsonb_build_object(
+      'rawMinutes', run_row.total_raw_minutes,
+      'roundedPaidMinutes', run_row.total_rounded_paid_minutes,
+      'hourlyPayCents', run_row.total_hourly_pay_cents,
+      'commissionPayCents', run_row.total_commission_pay_cents,
+      'adjustmentsTotalCents', run_row.total_adjustments_cents,
+      'totalPayoutCents', run_row.total_payout_cents
+    ),
+    'warnings', coalesce(run_row.warnings, '[]'::jsonb),
+    'rows', register_rows,
+    'rowCount', jsonb_array_length(register_rows),
+    'disclaimer',
+      'Bloomjoy Hub records approved payout totals for external payroll or payment execution. It does not calculate tax withholding, file payroll forms, execute direct deposit, or store bank or SSN data.',
+    'automation', jsonb_build_object(
+      'taxComplianceEngine', false,
+      'payrollProviderExecution', false,
+      'directDepositExecution', false,
+      'bankDataIncluded', false,
+      'ssnIncluded', false
+    )
+  );
+end;
+$$;
+
+comment on function public.admin_get_payout_register_export(uuid) is
+  'Returns an approved payout register for finalized or issued runs only, scoped to authorized payout managers, for external payroll/payment execution without tax, bank, SSN, or payroll-provider automation.';
+
+revoke execute on function public.admin_get_payout_register_export(uuid)
+  from public, anon;
+
+grant execute on function public.admin_get_payout_register_export(uuid)
+  to authenticated;
+
+select pg_notify('pgrst', 'reload schema');


### PR DESCRIPTION
﻿## Summary
- Adds a scoped admin RPC for approved operator payout register exports on finalized/issued/closed payout runs.
- Adds CSV download helpers and an `/admin/payouts` Payout Register card with explicit external payroll/payment boundary copy.
- Adds static and Playwright UAT validators plus smoke/status documentation for the payroll-boundary guardrails.

Closes #509

## Files changed
- `supabase/migrations/20260626135851_operator_payout_register_export.sql` adds `admin_get_payout_register_export(uuid)` with auth, status, and scoped payout-manager checks.
- `src/lib/operatorPayouts.ts` adds register export types, RPC fetcher, CSV builder, filename helper, and browser download helper.
- `src/pages/admin/Payouts.tsx` adds the Payout Register card/action to the admin payout review surface.
- `scripts/validate-operator-payout-register-export*.mjs`, `package.json`, and `Docs/*` add repeatable validation and smoke coverage.

## Verification
- `npm ci` passed. Existing audit output remains 1 high and 3 moderate vulnerabilities.
- `npm run build` passed.
- `npm test --if-present` passed.
- `npm run lint --if-present` passed.
- `npm run operator-payouts:validate-register-export` passed.
- `npm run operator-payouts:validate-register-export-uat` passed with `npm run dev:uat` running.
- `npm run db:validate-rpc-surface` passed.
- `npm run operator-payouts:validate-review` passed.
- `npm run operator-payouts:validate-statements` passed.
- `npm run agent:validate-workflow` passed.
- `git diff --check` passed.
- `npm run db:validate-migrations` could not run because Docker Desktop is not available in this environment: failed to connect to `npipe:////./pipe/dockerDesktopLinuxEngine`.

## UI / Design Evidence
- Used `impeccable` context before implementation for the visible admin payout change.
- Desktop screenshot: `C:\Repos\wt-payout-register-export\output\playwright\admin-payout-register-export-desktop.png`
- Mobile screenshot: `C:\Repos\wt-payout-register-export\output\playwright\admin-payout-register-export-mobile.png`
- Browser UAT verified: scoped payout manager can load `/admin/payouts`, issued run enables `Export Register`, review/draft run disables it, CSV downloads with expected statement/machine/adjustment/boundary fields, no credential/tax-execution columns are present, and mobile has no horizontal overflow.

## How to test
1. Check out this branch and install dependencies: `npm ci`.
2. Run the app for UAT: `$env:VITE_SUPABASE_URL='http://127.0.0.1:54321'; $env:VITE_SUPABASE_ANON_KEY='mock-anon-key'; npm run dev:uat`.
3. In another terminal, run `npm run operator-payouts:validate-register-export-uat`.
4. For manual QA with real data, sign in as a payout-scoped admin or super admin, open `http://127.0.0.1:8081/admin/payouts`, select a finalized or issued payout run, click `Export Register`, and confirm the CSV includes period/account/operator/statement/machine/adjustment/total fields while remaining an external payroll/payment handoff only.

## Risk and overlap
- Red lane: this touches payout/payment-adjacent admin workflow, scoped auth, a privileged `security definer` RPC, and visible UI.
- Overlap: PR #503 also changes `/admin/payouts` for guided payout review. Whichever lands second should reconcile card placement and rerun payout review/register validators.
- The RPC intentionally does not add payroll provider execution, tax filing, direct deposit, bank-data, or SSN handling.

## Merge Autonomy
- Lane: Red.
- Owner approval required before merge because this is P0, auth/payment-adjacent, DB migration-backed, and includes a visible admin UI change.

## Rollback
- Revert this PR to remove the admin UI action/helper scripts and drop the new RPC migration from future deployments. If already applied to Supabase, deploy a follow-up migration that revokes/drops `public.admin_get_payout_register_export(uuid)` and reloads PostgREST schema.
