### PR TITLE
P0: Add operator employee provisioning

### DIFF
--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -28,6 +28,7 @@ GitHub Issues and the Bloomjoy Project board are the operational source of truth
 - Operator payouts foundation sprint: the foundation is on `main`; active follow-on PRs add timekeeping, revenue snapshots, calculation, review, and pay statement slices.
 - Manager review/finalization slice `#448` adds the admin review gate before operator pay statements are issued.
 - Operator pay statements slice `#449` publishes versioned operator-visible pay statements from finalized payout runs.
+- Operator employee provisioning `#505` gives `/admin/payouts` a dedicated setup lane for Auth-user provisioning, machine assignment, invite evidence, and deactivation before future time entry.
 - Frontend work should use existing app patterns plus `PRODUCT.md`, `DESIGN.md`, and `impeccable` when the visible experience matters.
 
 ## Safety

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -190,6 +190,13 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Operator Time edit/delete controls work for unlocked draft/submitted entries and are disabled or blocked for locked, payout-included, paid, or voided entries.
 - [ ] Operator Time empty state explains that an admin or machine manager must add an operator payout profile and assigned machines before time can be submitted.
 
+### Admin Operator Setup
+- [ ] Admin or scoped payout manager can open `/admin/payouts`, use Operator Setup to save a never-authenticated employee operator, create or reuse the Auth user server-side, assign only manageable active machines, and record an audit reason.
+- [ ] Saving Operator Setup automatically sends an `operator_payout` access invite, records `access_invite_deliveries` plus `admin_audit_log` evidence, and shows a saved-but-invite-failed state when delivery fails.
+- [ ] Operator Access shows active assignments, last invite status, resend invite, and copy login link actions without mixing those controls into payout run finalization.
+- [ ] Deactivating an operator revokes active machine assignments, keeps audit history, and prevents future `/portal/time` entry while preserving historical payout records.
+- [ ] DB/RLS smoke for operator setup proves a scoped payout manager can provision only in-scope machines; direct browser calls to service-role-only Auth/provisioning RPCs are blocked.
+
 ### Admin Operator Payout Review
 - [ ] Admin or scoped payout manager can open `/admin/payouts`; users without payout admin access see the existing admin access-required state.
 - [ ] Payout periods list shows account, period dates, status, operator count, total payout, warnings, and revision count without horizontal overflow on desktop or mobile.

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "operator-payouts:validate-revenue-snapshots": "node scripts/validate-operator-revenue-snapshots.mjs",
     "operator-payouts:validate-calculation": "node scripts/validate-operator-payout-calculation.mjs",
     "operator-payouts:validate-review": "node scripts/validate-operator-payout-review.mjs",
+    "operator-payouts:validate-employee-provisioning": "node scripts/validate-operator-employee-provisioning.mjs",
+    "operator-payouts:validate-employee-provisioning-uat": "node scripts/validate-operator-employee-provisioning-uat.mjs",
     "operator-payouts:validate-statements": "node scripts/validate-operator-pay-statements.mjs",
     "reporting:validate-partner-effective-windows": "node scripts/validate-partner-effective-windows.mjs",
     "reporting:validate-partner-scheduled-export": "node scripts/validate-partner-report-scheduled-export.mjs",

--- a/scripts/validate-operator-employee-provisioning-uat.mjs
+++ b/scripts/validate-operator-employee-provisioning-uat.mjs
@@ -1,0 +1,663 @@
+#!/usr/bin/env node
+
+import { chromium } from 'playwright';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const DEFAULT_APP_URL = 'http://127.0.0.1:8081';
+const DEFAULT_ARTIFACT_DIR = 'output/playwright';
+
+const parseArgs = (argv) => {
+  const args = {
+    appUrl: process.env.OPERATOR_EMPLOYEE_PROVISIONING_UAT_APP_URL || DEFAULT_APP_URL,
+    artifactDir:
+      process.env.OPERATOR_EMPLOYEE_PROVISIONING_UAT_ARTIFACT_DIR || DEFAULT_ARTIFACT_DIR,
+    headed: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--headed') {
+      args.headed = true;
+      continue;
+    }
+
+    if (arg === '--app-url') {
+      args.appUrl = argv[index + 1] || args.appUrl;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--app-url=')) {
+      args.appUrl = arg.slice('--app-url='.length) || args.appUrl;
+      continue;
+    }
+
+    if (arg === '--artifact-dir') {
+      args.artifactDir = argv[index + 1] || args.artifactDir;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--artifact-dir=')) {
+      args.artifactDir = arg.slice('--artifact-dir='.length) || args.artifactDir;
+    }
+  }
+
+  args.appUrl = args.appUrl.replace(/\/+$/, '');
+  args.artifactDir = path.resolve(process.cwd(), args.artifactDir);
+  return args;
+};
+
+const now = new Date();
+const isoHoursAgo = (hours) => new Date(now.getTime() - hours * 60 * 60 * 1000).toISOString();
+
+const adminUser = {
+  id: '77000000-0000-4000-8000-000000000001',
+  aud: 'authenticated',
+  role: 'authenticated',
+  email: 'operator-admin@example.test',
+  email_confirmed_at: isoHoursAgo(24),
+  confirmed_at: isoHoursAgo(24),
+  last_sign_in_at: now.toISOString(),
+  app_metadata: { provider: 'email', providers: ['email'] },
+  user_metadata: {},
+};
+
+const accountId = '77000000-0000-4000-8000-000000000010';
+const policyId = '77000000-0000-4000-8000-000000000011';
+const machineId = '77000000-0000-4000-8000-000000000012';
+const machineTwoId = '77000000-0000-4000-8000-000000000013';
+const locationId = '77000000-0000-4000-8000-000000000014';
+const profileId = '77000000-0000-4000-8000-000000000020';
+const operatorUserId = '77000000-0000-4000-8000-000000000021';
+const targetEmail = 'new-operator@example.test';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'apikey, authorization, content-type, x-client-info, x-supabase-auth-token',
+  'Access-Control-Allow-Methods': 'GET, POST, PATCH, DELETE, OPTIONS',
+};
+
+const jsonResponse = (body, status = 200) => ({
+  status,
+  contentType: 'application/json',
+  headers: corsHeaders,
+  body: JSON.stringify(body),
+});
+
+const buildSession = () => ({
+  access_token: `mock-access-token-${adminUser.id}`,
+  token_type: 'bearer',
+  expires_in: 3600,
+  expires_at: Math.floor(Date.now() / 1000) + 3600,
+  refresh_token: `mock-refresh-token-${adminUser.id}`,
+  user: adminUser,
+});
+
+const waitForCondition = async (predicate, label, timeoutMs = 10000) => {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return;
+    await delay(100);
+  }
+
+  throw new Error(`${label} timed out after ${timeoutMs}ms`);
+};
+
+const waitForServer = async (appUrl) => {
+  try {
+    const response = await fetch(appUrl);
+    if (!response.ok && response.status >= 500) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+  } catch (error) {
+    throw new Error(
+      `Unable to reach ${appUrl}. Start the app first, for example: npm run dev -- --host 127.0.0.1 --port 8081. ${error.message}`
+    );
+  }
+};
+
+const createRecorder = () => {
+  const results = [];
+
+  return {
+    pass(name, detail = '') {
+      results.push({ name, pass: true, detail });
+      console.log(`PASS ${name}${detail ? ` - ${detail}` : ''}`);
+    },
+    fail(name, detail = '') {
+      results.push({ name, pass: false, detail });
+      console.log(`FAIL ${name}${detail ? ` - ${detail}` : ''}`);
+    },
+    assert(name, condition, detail = '') {
+      if (condition) {
+        this.pass(name, detail);
+      } else {
+        this.fail(name, detail);
+      }
+    },
+    failed() {
+      return results.filter((result) => !result.pass);
+    },
+  };
+};
+
+const makeAssignment = (id, assignedMachineId, machineLabel, locationName) => ({
+  assignmentId: id,
+  machineId: assignedMachineId,
+  machineLabel,
+  locationId,
+  locationName,
+  effectiveStartDate: '2026-06-01',
+  effectiveEndDate: null,
+  canManage: true,
+});
+
+const buildSetupContext = (state) => ({
+  accounts: [
+    {
+      id: accountId,
+      name: 'Bloomjoy UAT Arcade',
+      canManageAccount: true,
+      machines: [
+        {
+          id: machineId,
+          label: 'Cotton Candy 01',
+          machineType: 'commercial',
+          locationId,
+          locationName: 'Mall Atrium',
+          status: 'active',
+          canManage: true,
+        },
+        {
+          id: machineTwoId,
+          label: 'Cotton Candy 02',
+          machineType: 'commercial',
+          locationId,
+          locationName: 'Food Court',
+          status: 'active',
+          canManage: true,
+        },
+      ],
+      policies: [
+        {
+          id: policyId,
+          name: 'Monthly operator payouts',
+          frequency: 'monthly',
+          roundingRule: 'round_up_60_minutes',
+          reviewModel: 'final_review_only',
+        },
+      ],
+    },
+  ],
+  operators: state.operator
+    ? [
+        {
+          ...state.operator,
+          latestInvite: state.inviteDeliveries.find(
+            (delivery) => delivery.source_id === state.operator.id
+          )
+            ? {
+                id: state.inviteDeliveries.find((delivery) => delivery.source_id === state.operator.id)
+                  .id,
+                sentAt: state.inviteDeliveries.find(
+                  (delivery) => delivery.source_id === state.operator.id
+                ).sent_at,
+                deliveryStatus: state.inviteDeliveries.find(
+                  (delivery) => delivery.source_id === state.operator.id
+                ).delivery_status,
+                errorMessage: state.inviteDeliveries.find(
+                  (delivery) => delivery.source_id === state.operator.id
+                ).error_message,
+              }
+            : null,
+        },
+      ]
+    : [],
+});
+
+const buildPayoutReviewContext = () => ({ periods: [] });
+
+const installMockRoutes = async (context, state) => {
+  await context.route('**/auth/v1/**', async (route) => {
+    const url = route.request().url();
+
+    if (url.includes('/token')) {
+      return route.fulfill(jsonResponse(buildSession()));
+    }
+
+    if (url.includes('/user')) {
+      return route.fulfill(jsonResponse(adminUser));
+    }
+
+    if (url.includes('/logout')) {
+      return route.fulfill({ status: 204, body: '' });
+    }
+
+    return route.fulfill(jsonResponse({}));
+  });
+
+  await context.route('**/rest/v1/customer_profiles**', async (route) => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill(jsonResponse([]));
+    }
+
+    return route.fulfill(jsonResponse({ user_id: adminUser.id, language_preference: 'en' }));
+  });
+
+  await context.route('**/rest/v1/customer_machine_inventory**', async (route) =>
+    route.fulfill(jsonResponse([]))
+  );
+
+  await context.route('**/rest/v1/access_invite_deliveries**', async (route) => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill(jsonResponse(state.inviteDeliveries));
+    }
+
+    return route.fulfill(jsonResponse({}));
+  });
+
+  await context.route('**/functions/v1/operator-payout-provision', async (route) => {
+    if (route.request().method() === 'OPTIONS') {
+      return route.fulfill({ status: 204, headers: corsHeaders, body: '' });
+    }
+
+    const body = route.request().postDataJSON();
+    state.provisionBodies.push(body);
+
+    if (body?.action === 'deactivate') {
+      if (state.operator) {
+        state.operator = {
+          ...state.operator,
+          status: 'inactive',
+          activeAssignments: [],
+        };
+      }
+
+      return route.fulfill(
+        jsonResponse({
+          ok: true,
+          operatorProfileId: body.operatorProfileId,
+          status: 'inactive',
+          activeAssignmentCount: 0,
+        })
+      );
+    }
+
+    const machineIds = Array.isArray(body?.machineIds) ? body.machineIds : [];
+    const assignments = machineIds.map((assignedMachineId, index) =>
+      assignedMachineId === machineId
+        ? makeAssignment(`assignment-${index + 1}`, machineId, 'Cotton Candy 01', 'Mall Atrium')
+        : makeAssignment(`assignment-${index + 1}`, machineTwoId, 'Cotton Candy 02', 'Food Court')
+    );
+
+    state.operator = {
+      id: profileId,
+      accountId,
+      accountName: 'Bloomjoy UAT Arcade',
+      userId: operatorUserId,
+      email: String(body?.userEmail ?? targetEmail).toLowerCase(),
+      displayName: String(body?.displayName ?? 'New Operator'),
+      workerType: body?.workerType ?? 'employee_w2',
+      status: 'active',
+      payoutPolicyId: body?.payoutPolicyId ?? policyId,
+      createdAt: now.toISOString(),
+      updatedAt: now.toISOString(),
+      canSendInvite: true,
+      activeAssignments: assignments,
+    };
+
+    return route.fulfill(
+      jsonResponse({
+        ok: true,
+        authUserCreated: true,
+        operatorProfile: {
+          id: profileId,
+          accountId,
+          accountName: 'Bloomjoy UAT Arcade',
+          userId: operatorUserId,
+          email: state.operator.email,
+          displayName: state.operator.displayName,
+          workerType: state.operator.workerType,
+          status: 'active',
+          payoutPolicyId: policyId,
+        },
+        assignments,
+        activeAssignmentCount: assignments.length,
+      })
+    );
+  });
+
+  await context.route('**/functions/v1/access-invite', async (route) => {
+    if (route.request().method() === 'OPTIONS') {
+      return route.fulfill({ status: 204, headers: corsHeaders, body: '' });
+    }
+
+    const body = route.request().postDataJSON();
+    state.accessInviteBodies.push(body);
+
+    const deliveryStatus = state.failNextInvite ? 'failed' : 'sent';
+    const delivery = {
+      id: `operator-invite-${state.accessInviteBodies.length}`,
+      invite_type: body?.inviteType ?? 'operator_payout',
+      source_type: 'operator_payout_profile',
+      source_id: body?.sourceId,
+      target_email: body?.targetEmail,
+      sent_by: adminUser.id,
+      sent_at: new Date().toISOString(),
+      delivery_status: deliveryStatus,
+      error_message: deliveryStatus === 'failed' ? 'Mock delivery provider failure' : null,
+    };
+    state.inviteDeliveries.unshift(delivery);
+
+    if (state.failNextInvite) {
+      state.failNextInvite = false;
+      return route.fulfill(jsonResponse({ error: 'Mock delivery provider failure' }, 500));
+    }
+
+    return route.fulfill(jsonResponse({ ok: true }));
+  });
+
+  await context.route('**/rest/v1/rpc/**', async (route) => {
+    if (route.request().method() === 'OPTIONS') {
+      return route.fulfill({ status: 204, headers: corsHeaders, body: '' });
+    }
+
+    const url = route.request().url();
+    const rpcName = new URL(url).pathname.split('/').pop() ?? '';
+    const body = route.request().postDataJSON();
+    state.rpcCalls.push({ rpcName, body });
+
+    if (rpcName === 'get_my_admin_access_context') {
+      return route.fulfill(
+        jsonResponse({
+          isSuperAdmin: true,
+          isScopedAdmin: false,
+          canAccessAdmin: true,
+          allowedSurfaces: ['all', 'payouts'],
+          scopedMachineIds: [],
+        })
+      );
+    }
+
+    if (rpcName === 'get_my_plus_access') {
+      return route.fulfill(
+        jsonResponse({
+          has_plus_access: true,
+          source: 'admin',
+          membership_status: 'active',
+          current_period_end: null,
+          cancel_at_period_end: false,
+          paid_subscription_active: false,
+          free_grant_id: null,
+          free_grant_starts_at: null,
+          free_grant_expires_at: null,
+          free_grant_active: false,
+        })
+      );
+    }
+
+    if (rpcName === 'get_my_portal_access_context') {
+      return route.fulfill(
+        jsonResponse({
+          access_tier: 'admin',
+          is_plus_member: true,
+          is_training_operator: false,
+          is_admin: true,
+          can_manage_operator_training: false,
+          is_corporate_partner: false,
+          has_supply_discount: true,
+          can_request_support: true,
+          can_manage_technicians: false,
+          capabilities: ['admin.global'],
+          effective_presets: ['super_admin'],
+        })
+      );
+    }
+
+    if (rpcName === 'get_my_reporting_access_context') {
+      return route.fulfill(
+        jsonResponse({
+          has_reporting_access: true,
+          accessible_machine_count: 2,
+          accessible_location_count: 1,
+          can_manage_reporting: true,
+          latest_sale_date: '2026-06-01',
+          latest_import_completed_at: isoHoursAgo(1),
+        })
+      );
+    }
+
+    if (rpcName === 'resolve_my_technician_entitlements') {
+      return route.fulfill(
+        jsonResponse({
+          technicianEmail: null,
+          resolvedGrantCount: 0,
+          resolvedOperatorTrainingGrantCount: 0,
+          upsertedReportingEntitlementCount: 0,
+          skippedGrantCount: 0,
+        })
+      );
+    }
+
+    if (rpcName === 'admin_get_account_summaries') {
+      return route.fulfill(jsonResponse([]));
+    }
+
+    if (rpcName === 'get_payout_review_context') {
+      return route.fulfill(jsonResponse(buildPayoutReviewContext()));
+    }
+
+    if (rpcName === 'get_operator_payout_setup_context') {
+      return route.fulfill(jsonResponse(buildSetupContext(state)));
+    }
+
+    return route.fulfill(jsonResponse({}));
+  });
+};
+
+const login = async (page) => {
+  await page.waitForURL('**/login', { timeout: 10000 }).catch(() => undefined);
+  if (new URL(page.url()).pathname !== '/login') return;
+
+  await page.waitForSelector('#email-password', { timeout: 10000 });
+  await page.fill('#email-password', adminUser.email);
+  await page.fill('#password', 'mock-password');
+  await page.getByRole('button', { name: /sign in/i }).click();
+};
+
+const unexpectedConsoleErrors = (errors) =>
+  errors.filter(
+    (error) =>
+      !error.includes('400 (Bad Request)') &&
+      !error.includes('500 (Internal Server Error)')
+  );
+
+const run = async () => {
+  const args = parseArgs(process.argv.slice(2));
+  const recorder = createRecorder();
+  const state = {
+    accessInviteBodies: [],
+    inviteDeliveries: [],
+    provisionBodies: [],
+    rpcCalls: [],
+    operator: null,
+    failNextInvite: true,
+  };
+
+  await mkdir(args.artifactDir, { recursive: true });
+  await waitForServer(args.appUrl);
+
+  const browser = await chromium.launch({ headless: !args.headed });
+  const context = await browser.newContext({ viewport: { width: 1440, height: 1000 } });
+  await context.grantPermissions(['clipboard-read', 'clipboard-write'], {
+    origin: args.appUrl,
+  });
+  await installMockRoutes(context, state);
+  const page = await context.newPage();
+  const consoleErrors = [];
+
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      consoleErrors.push(message.text());
+    }
+  });
+  page.on('pageerror', (error) => {
+    consoleErrors.push(error.message);
+  });
+
+  try {
+    await page.goto(`${args.appUrl}/admin/payouts`, { waitUntil: 'domcontentloaded' });
+    await login(page);
+    await page.goto(`${args.appUrl}/admin/payouts`, { waitUntil: 'domcontentloaded' });
+    await page
+      .getByRole('heading', { name: 'Operator Setup', exact: true })
+      .waitFor({ timeout: 15000 })
+      .catch(async (error) => {
+        console.log('Current URL:', page.url());
+        console.log('Body text:', (await page.locator('body').innerText()).slice(0, 4000));
+        console.log('RPC calls:', state.rpcCalls.map((call) => call.rpcName).join(', '));
+        console.log('Console/page errors:', unexpectedConsoleErrors(consoleErrors).join(' | '));
+        throw error;
+      });
+    await page.getByRole('heading', { name: 'Payout Review', exact: true }).waitFor({
+      timeout: 10000,
+    });
+
+    await page.screenshot({
+      path: path.join(args.artifactDir, 'operator-employee-provisioning-empty.png'),
+      fullPage: true,
+    });
+
+    await page.fill('#operator-setup-email', targetEmail);
+    await page.fill('#operator-setup-name', 'New Operator');
+    await page.selectOption('#operator-setup-worker-type', 'employee_w2');
+    await page.getByText('Cotton Candy 01 at Mall Atrium').click();
+    await page.fill('#operator-setup-reason', 'Agent UAT employee operator provisioning.');
+    await page.getByRole('button', { name: /Save Operator and Send Invite/i }).click();
+
+    await waitForCondition(() => state.provisionBodies.length === 1, 'operator provision request');
+    await waitForCondition(() => state.accessInviteBodies.length === 1, 'operator invite attempt');
+    await page.getByText(/Invite failed for new-operator@example\.test/i).waitFor({
+      timeout: 10000,
+    });
+
+    const provisionBody = state.provisionBodies[0];
+    recorder.assert(
+      'Provisioning function receives employee setup payload',
+      provisionBody?.action === 'provision' &&
+        provisionBody?.userEmail === targetEmail &&
+        provisionBody?.accountId === accountId &&
+        provisionBody?.workerType === 'employee_w2' &&
+        Array.isArray(provisionBody?.machineIds) &&
+        provisionBody.machineIds.length === 1 &&
+        provisionBody.machineIds[0] === machineId,
+      JSON.stringify(provisionBody)
+    );
+
+    const firstInviteBody = state.accessInviteBodies[0];
+    recorder.assert(
+      'Automatic invite uses operator_payout login intent and profile source',
+      firstInviteBody?.inviteType === 'operator_payout' &&
+        firstInviteBody?.sourceId === profileId &&
+        firstInviteBody?.targetEmail === targetEmail &&
+        String(firstInviteBody?.loginUrl ?? '').includes('intent=operator_payout'),
+      JSON.stringify(firstInviteBody)
+    );
+    recorder.assert(
+      'Saved-but-invite-failed delivery evidence remains visible',
+      state.inviteDeliveries[0]?.delivery_status === 'failed' &&
+        state.inviteDeliveries[0]?.source_type === 'operator_payout_profile',
+      JSON.stringify(state.inviteDeliveries[0])
+    );
+
+    await page.getByRole('button', { name: /Resend/i }).waitFor({ timeout: 10000 });
+    await page.getByRole('button', { name: /Resend/i }).click();
+    await waitForCondition(() => state.accessInviteBodies.length === 2, 'operator invite resend');
+
+    const resendInviteBody = state.accessInviteBodies[1];
+    recorder.assert(
+      'Resend invite recovers with the same operator profile source',
+      resendInviteBody?.inviteType === 'operator_payout' &&
+        resendInviteBody?.sourceId === profileId &&
+        String(resendInviteBody?.loginUrl ?? '').includes('email=new-operator%40example.test'),
+      JSON.stringify(resendInviteBody)
+    );
+    recorder.assert(
+      'Successful resend writes sent delivery evidence',
+      state.inviteDeliveries[0]?.delivery_status === 'sent' &&
+        state.inviteDeliveries[0]?.source_id === profileId,
+      JSON.stringify(state.inviteDeliveries[0])
+    );
+
+    await page.getByRole('button', { name: /Copy Link/i }).click();
+
+    await page.selectOption('#operator-deactivate-profile', profileId);
+    await page.fill('#operator-deactivate-reason', 'Agent UAT employment ended.');
+    await page.getByRole('button', { name: /Deactivate Operator/i }).click();
+    await waitForCondition(
+      () => state.provisionBodies.some((body) => body?.action === 'deactivate'),
+      'operator deactivation request'
+    );
+
+    const deactivateBody = state.provisionBodies.find((body) => body?.action === 'deactivate');
+    recorder.assert(
+      'Deactivate uses provisioning function with audit reason',
+      deactivateBody?.operatorProfileId === profileId &&
+        String(deactivateBody?.reason ?? '').includes('employment ended'),
+      JSON.stringify(deactivateBody)
+    );
+    await page.getByText('Inactive').waitFor({ timeout: 10000 });
+    recorder.assert(
+      'Deactivation clears future active assignments in setup context',
+      state.operator?.status === 'inactive' && state.operator?.activeAssignments.length === 0,
+      JSON.stringify(state.operator)
+    );
+
+    await page.locator('[data-sonner-toast]').first().waitFor({ state: 'detached', timeout: 7000 }).catch(() => undefined);
+    await page.evaluate(() => window.scrollTo(0, 0));
+
+    const overflow = await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth + 1);
+    recorder.assert('Operator setup desktop has no horizontal overflow', !overflow);
+
+    await page.screenshot({
+      path: path.join(args.artifactDir, 'operator-employee-provisioning-desktop.png'),
+      fullPage: true,
+    });
+
+    await page.setViewportSize({ width: 390, height: 900 });
+    await page.screenshot({
+      path: path.join(args.artifactDir, 'operator-employee-provisioning-mobile.png'),
+      fullPage: true,
+    });
+
+    const mobileOverflow = await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth + 1);
+    recorder.assert('Operator setup mobile has no horizontal overflow', !mobileOverflow);
+    recorder.assert(
+      'No browser console/page errors during operator employee provisioning UAT pass',
+      unexpectedConsoleErrors(consoleErrors).length === 0,
+      unexpectedConsoleErrors(consoleErrors).slice(0, 3).join(' | ')
+    );
+  } finally {
+    await context.close();
+    await browser.close();
+  }
+
+  const failed = recorder.failed();
+  if (failed.length > 0) {
+    console.error(`\n${failed.length} operator employee provisioning UAT assertion(s) failed.`);
+    process.exit(1);
+  }
+
+  console.log('\nOperator employee provisioning UAT passed.');
+  console.log(`Screenshots: ${args.artifactDir}`);
+};
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/validate-operator-employee-provisioning.mjs
+++ b/scripts/validate-operator-employee-provisioning.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+
+const files = {
+  migration: path.join(
+    repoRoot,
+    'supabase',
+    'migrations',
+    '20260626142851_operator_employee_provisioning.sql'
+  ),
+  provisionFunction: path.join(
+    repoRoot,
+    'supabase',
+    'functions',
+    'operator-payout-provision',
+    'index.ts'
+  ),
+  accessInviteFunction: path.join(repoRoot, 'supabase', 'functions', 'access-invite', 'index.ts'),
+  config: path.join(repoRoot, 'supabase', 'config.toml'),
+  helper: path.join(repoRoot, 'src', 'lib', 'operatorPayouts.ts'),
+  accessInvites: path.join(repoRoot, 'src', 'lib', 'accessInvites.ts'),
+  loginUrls: path.join(repoRoot, 'src', 'lib', 'accessInviteLoginUrls.ts'),
+  page: path.join(repoRoot, 'src', 'pages', 'admin', 'Payouts.tsx'),
+  rpcSurface: path.join(repoRoot, 'scripts', 'validate-rpc-execute-surface.mjs'),
+  packageJson: path.join(repoRoot, 'package.json'),
+  smoke: path.join(repoRoot, 'Docs', 'QA_SMOKE_TEST_CHECKLIST.md'),
+};
+
+const fail = (message) => {
+  throw new Error(message);
+};
+
+const readText = (filePath) => fs.readFileSync(filePath, 'utf8');
+
+const compact = (value) =>
+  value
+    .replace(/--.*$/gm, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+
+const expect = (source, snippet, label) => {
+  if (!compact(source).includes(compact(snippet))) {
+    fail(`${label}: missing ${snippet}`);
+  }
+};
+
+for (const [label, filePath] of Object.entries(files)) {
+  if (!fs.existsSync(filePath)) {
+    fail(`Missing ${label} file: ${path.relative(repoRoot, filePath)}`);
+  }
+}
+
+const migration = readText(files.migration);
+for (const snippet of [
+  "check (invite_type in ('corporate_partner', 'technician', 'machine_manager', 'operator_payout'))",
+  "'operator_payout_profile'",
+  'create or replace function public.admin_find_auth_user_by_email',
+  'create or replace function public.get_operator_payout_setup_context',
+  'create or replace function public.admin_provision_operator_payout_for_user',
+  'create or replace function public.admin_deactivate_operator_payout_profile_for_user',
+  'create or replace function public.can_send_operator_payout_invite_current_user',
+  'operator_employee_access.provisioned',
+  'operator_employee_access.deactivated',
+  'access_invite_deliveries_select_operator_payout_managers',
+  'grant execute on function public.get_operator_payout_setup_context() to authenticated',
+  'grant execute on function public.admin_find_auth_user_by_email(text) to service_role',
+  'grant execute on function public.admin_provision_operator_payout_for_user(uuid, uuid, text, uuid, text, text, uuid, uuid[], text) to service_role',
+  'grant execute on function public.admin_deactivate_operator_payout_profile_for_user(uuid, uuid, text) to service_role',
+  'tax_compliance_engine',
+  'payroll_provider_execution',
+]) {
+  expect(migration, snippet, 'operator provisioning migration');
+}
+
+for (const forbidden of [
+  'grant execute on function public.admin_find_auth_user_by_email(text) to authenticated',
+  'grant execute on function public.admin_provision_operator_payout_for_user(uuid, uuid, text, uuid, text, text, uuid, uuid[], text) to authenticated',
+  'grant execute on function public.admin_deactivate_operator_payout_profile_for_user(uuid, uuid, text) to authenticated',
+]) {
+  if (compact(migration).includes(compact(forbidden))) {
+    fail(`operator provisioning migration must not expose service-only helper: ${forbidden}`);
+  }
+}
+
+const provisionFunction = readText(files.provisionFunction);
+for (const snippet of [
+  'resolveSupabaseAccessToken',
+  'supabase.auth.getUser',
+  'supabase.auth.admin.createUser',
+  'email_confirm: true',
+  'admin_find_auth_user_by_email',
+  'admin_provision_operator_payout_for_user',
+  'admin_deactivate_operator_payout_profile_for_user',
+  'machineIds.length === 0',
+  'authUserCreated',
+]) {
+  if (!provisionFunction.includes(snippet)) {
+    fail(`operator-payout-provision function missing ${snippet}`);
+  }
+}
+
+const accessInviteFunction = readText(files.accessInviteFunction);
+for (const snippet of [
+  'operator_payout',
+  'operator_payout_profile',
+  'getOperatorPayoutSource',
+  'canSendOperatorPayoutInvite',
+  'admin_find_auth_user_by_email',
+  'Your Bloomjoy Operator invitation',
+]) {
+  if (!accessInviteFunction.includes(snippet)) {
+    fail(`access-invite function missing operator payout snippet: ${snippet}`);
+  }
+}
+
+const config = readText(files.config);
+expect(config, '[functions.operator-payout-provision]', 'Supabase config');
+expect(config, 'verify_jwt = false', 'Supabase config');
+
+const helper = readText(files.helper);
+for (const snippet of [
+  'OperatorPayoutSetupContext',
+  'fetchOperatorPayoutSetupContext',
+  'provisionOperatorPayoutAccessAdmin',
+  'deactivateOperatorPayoutProfileAdmin',
+  'operator-payout-provision',
+  'get_operator_payout_setup_context',
+]) {
+  if (!helper.includes(snippet)) {
+    fail(`operatorPayouts helper missing ${snippet}`);
+  }
+}
+
+const accessInvites = readText(files.accessInvites);
+for (const snippet of ["'operator_payout'", "'operator_payout_profile'"]) {
+  if (!accessInvites.includes(snippet)) {
+    fail(`accessInvites helper missing ${snippet}`);
+  }
+}
+
+const loginUrls = readText(files.loginUrls);
+if (!loginUrls.includes("'operator_payout'")) {
+  fail('accessInviteLoginUrls missing operator_payout login intent.');
+}
+
+const page = readText(files.page);
+for (const snippet of [
+  'Operator Setup',
+  'Save Operator and Send Invite',
+  'Operator Access',
+  'Deactivate Access',
+  'resendOperatorInvite',
+  'copyOperatorLoginUrl',
+  'deactivateOperator',
+  "sendAccessInvite({",
+  "inviteType: 'operator_payout'",
+]) {
+  if (!page.includes(snippet)) {
+    fail(`Admin payouts page missing operator setup snippet: ${snippet}`);
+  }
+}
+
+const rpcSurface = readText(files.rpcSurface);
+for (const snippet of [
+  'admin_find_auth_user_by_email',
+  'admin_provision_operator_payout_for_user',
+  'admin_deactivate_operator_payout_profile_for_user',
+]) {
+  if (!rpcSurface.includes(snippet)) {
+    fail(`RPC surface validator missing ${snippet}.`);
+  }
+}
+
+const packageJson = readText(files.packageJson);
+if (!packageJson.includes('operator-payouts:validate-employee-provisioning')) {
+  fail('package.json missing employee provisioning validator script.');
+}
+
+const smoke = readText(files.smoke);
+for (const snippet of [
+  'Admin Operator Setup',
+  'never-authenticated employee operator',
+  'operator_payout',
+  'saved-but-invite-failed',
+  'prevents future `/portal/time` entry',
+]) {
+  if (!smoke.includes(snippet)) {
+    fail(`Smoke checklist missing ${snippet}`);
+  }
+}
+
+console.log(
+  'Operator employee provisioning checks passed: service-role Auth provisioning, setup context, scoped machine assignment, operator invites, deactivation, UI, and smoke coverage are present.'
+);

--- a/scripts/validate-rpc-execute-surface.mjs
+++ b/scripts/validate-rpc-execute-surface.mjs
@@ -105,6 +105,32 @@ const serviceRoleOnlyFunctions = [
     name: 'operator_pay_statement_payload_for_item',
     migrationName: '202605200006_operator_pay_statements.sql',
   },
+  {
+    signature: 'public.operator_payout_can_manage_machine_set(uuid, uuid, uuid[])',
+    name: 'operator_payout_can_manage_machine_set',
+    migrationName: '20260626142851_operator_employee_provisioning.sql',
+  },
+  {
+    signature: 'public.can_send_operator_payout_invite(uuid, uuid)',
+    name: 'can_send_operator_payout_invite',
+    migrationName: '20260626142851_operator_employee_provisioning.sql',
+  },
+  {
+    signature: 'public.admin_find_auth_user_by_email(text)',
+    name: 'admin_find_auth_user_by_email',
+    migrationName: '20260626142851_operator_employee_provisioning.sql',
+  },
+  {
+    signature:
+      'public.admin_provision_operator_payout_for_user(uuid, uuid, text, uuid, text, text, uuid, uuid[], text)',
+    name: 'admin_provision_operator_payout_for_user',
+    migrationName: '20260626142851_operator_employee_provisioning.sql',
+  },
+  {
+    signature: 'public.admin_deactivate_operator_payout_profile_for_user(uuid, uuid, text)',
+    name: 'admin_deactivate_operator_payout_profile_for_user',
+    migrationName: '20260626142851_operator_employee_provisioning.sql',
+  },
 ];
 
 const protectedAuthenticatedFunctions = [

--- a/src/lib/accessInviteLoginUrls.ts
+++ b/src/lib/accessInviteLoginUrls.ts
@@ -4,7 +4,11 @@ import {
   validateAccessInvitePreflight as validateAccessInvitePreflightRuntime,
 } from './accessInviteLoginUrls.mjs';
 
-export type AccessInviteLoginIntent = 'corporate_partner' | 'technician' | 'machine_manager';
+export type AccessInviteLoginIntent =
+  | 'corporate_partner'
+  | 'technician'
+  | 'machine_manager'
+  | 'operator_payout';
 
 export type AccessInviteLocationLike = {
   origin: string;

--- a/src/lib/accessInvites.ts
+++ b/src/lib/accessInvites.ts
@@ -7,11 +7,12 @@ export {
   type AccessInvitePreflight,
 } from '@/lib/accessInviteLoginUrls';
 
-export type AccessInviteType = 'corporate_partner' | 'technician' | 'machine_manager';
+export type AccessInviteType = 'corporate_partner' | 'technician' | 'machine_manager' | 'operator_payout';
 export type AccessInviteSourceType =
   | 'corporate_partner_membership'
   | 'technician_grant'
-  | 'reporting_machine';
+  | 'reporting_machine'
+  | 'operator_payout_profile';
 
 export type AccessInviteDelivery = {
   id: string;

--- a/src/lib/operatorPayouts.ts
+++ b/src/lib/operatorPayouts.ts
@@ -1,3 +1,4 @@
+import { invokeEdgeFunction } from '@/lib/edgeFunctions';
 import { supabaseClient } from '@/lib/supabaseClient';
 
 export type OperatorWorkerType =
@@ -575,6 +576,116 @@ export type SetOperatorMachineAssignmentsResult = {
   assignments: unknown[];
 };
 
+export type OperatorPayoutSetupMachine = {
+  id: string;
+  label: string;
+  machineType: string | null;
+  locationId: string | null;
+  locationName: string | null;
+  status: 'active' | string;
+  canManage: boolean;
+};
+
+export type OperatorPayoutSetupPolicy = {
+  id: string;
+  name: string;
+  frequency: PayoutFrequency;
+  roundingRule: PayoutRoundingRule;
+  reviewModel: PayoutReviewModel;
+};
+
+export type OperatorPayoutSetupAccount = {
+  id: string;
+  name: string;
+  canManageAccount: boolean;
+  machines: OperatorPayoutSetupMachine[];
+  policies: OperatorPayoutSetupPolicy[];
+};
+
+export type OperatorPayoutSetupAssignment = {
+  assignmentId: string;
+  machineId: string;
+  machineLabel: string;
+  locationId: string | null;
+  locationName: string | null;
+  effectiveStartDate: string;
+  effectiveEndDate: string | null;
+  canManage?: boolean;
+};
+
+export type OperatorPayoutLatestInvite = {
+  id: string;
+  sentAt: string;
+  deliveryStatus: 'sent' | 'failed';
+  errorMessage: string | null;
+};
+
+export type OperatorPayoutSetupOperator = {
+  id: string;
+  accountId: string;
+  accountName: string;
+  userId: string;
+  email: string | null;
+  displayName: string;
+  workerType: OperatorWorkerType;
+  status: OperatorPayoutProfileStatus;
+  payoutPolicyId: string | null;
+  createdAt: string;
+  updatedAt: string;
+  canSendInvite: boolean;
+  activeAssignments: OperatorPayoutSetupAssignment[];
+  latestInvite: OperatorPayoutLatestInvite | null;
+};
+
+export type OperatorPayoutSetupContext = {
+  accounts: OperatorPayoutSetupAccount[];
+  operators: OperatorPayoutSetupOperator[];
+};
+
+export type ProvisionOperatorPayoutAccessInput = {
+  userEmail: string;
+  accountId: string;
+  displayName: string;
+  workerType?: OperatorWorkerType;
+  payoutPolicyId?: string | null;
+  machineIds: string[];
+  reason: string;
+};
+
+export type ProvisionedOperatorPayoutProfile = {
+  id: string;
+  accountId: string;
+  accountName: string;
+  userId: string;
+  email: string;
+  displayName: string;
+  workerType: OperatorWorkerType;
+  status: OperatorPayoutProfileStatus;
+  payoutPolicyId: string | null;
+};
+
+export type ProvisionOperatorPayoutAccessResult = {
+  ok?: true;
+  authUserCreated: boolean;
+  operatorProfile: ProvisionedOperatorPayoutProfile;
+  assignments: OperatorPayoutSetupAssignment[];
+  activeAssignmentCount: number;
+  error?: string;
+};
+
+export type DeactivateOperatorPayoutProfileInput = {
+  operatorProfileId: string;
+  reason: string;
+};
+
+export type DeactivateOperatorPayoutProfileResult = {
+  ok?: true;
+  operatorProfileId: string;
+  status: OperatorPayoutProfileStatus;
+  activeAssignmentCount: number;
+  error?: string;
+};
+
 export type SaveOperatorTimeEntryInput = {
   operatorProfileId: string;
   machineId: string;
@@ -739,6 +850,57 @@ export const fetchMyOperatorTimekeepingContext = async (
     ...((data as Partial<OperatorTimekeepingContext> | null) ?? {}),
   };
 };
+
+export const fetchOperatorPayoutSetupContext = async (): Promise<OperatorPayoutSetupContext> => {
+  const { data, error } = await supabaseClient.rpc('get_operator_payout_setup_context');
+
+  if (error) {
+    throw new Error(error.message || 'Unable to load operator payout setup.');
+  }
+
+  return {
+    accounts: [],
+    operators: [],
+    ...((data as Partial<OperatorPayoutSetupContext> | null) ?? {}),
+  };
+};
+
+export const provisionOperatorPayoutAccessAdmin = async (
+  input: ProvisionOperatorPayoutAccessInput
+): Promise<ProvisionOperatorPayoutAccessResult> =>
+  invokeEdgeFunction<ProvisionOperatorPayoutAccessResult>(
+    'operator-payout-provision',
+    {
+      action: 'provision',
+      userEmail: input.userEmail,
+      accountId: input.accountId,
+      displayName: input.displayName,
+      workerType: input.workerType ?? null,
+      payoutPolicyId: input.payoutPolicyId ?? null,
+      machineIds: input.machineIds,
+      reason: input.reason,
+    },
+    {
+      requireUserAuth: true,
+      authErrorMessage: 'Log in to provision operator payout access.',
+    }
+  );
+
+export const deactivateOperatorPayoutProfileAdmin = async (
+  input: DeactivateOperatorPayoutProfileInput
+): Promise<DeactivateOperatorPayoutProfileResult> =>
+  invokeEdgeFunction<DeactivateOperatorPayoutProfileResult>(
+    'operator-payout-provision',
+    {
+      action: 'deactivate',
+      operatorProfileId: input.operatorProfileId,
+      reason: input.reason,
+    },
+    {
+      requireUserAuth: true,
+      authErrorMessage: 'Log in to deactivate operator payout access.',
+    }
+  );
 
 export const submitOperatorTimeEntry = async (
   input: SaveOperatorTimeEntryInput

--- a/src/pages/admin/Payouts.tsx
+++ b/src/pages/admin/Payouts.tsx
@@ -4,12 +4,16 @@ import {
   Ban,
   CheckCircle2,
   Clock3,
+  Copy,
   FileText,
   Loader2,
+  Mail,
+  Power,
   RefreshCw,
   RotateCcw,
   Send,
   ShieldCheck,
+  UserPlus,
 } from 'lucide-react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
@@ -27,16 +31,22 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { getAccessInviteLoginUrl, sendAccessInvite } from '@/lib/accessInvites';
 import {
   addPayoutAdjustmentAdmin,
   calculatePayoutRunAdmin,
+  deactivateOperatorPayoutProfileAdmin,
+  fetchOperatorPayoutSetupContext,
   fetchPayoutReviewContext,
   finalizePayoutRunAdmin,
   issuePayStatementsAdmin,
   markPayoutRunReviewedAdmin,
   previewPayStatementsAdmin,
+  provisionOperatorPayoutAccessAdmin,
   reopenPayoutRunAdmin,
   voidPayoutRunAdmin,
+  type OperatorPayoutSetupOperator,
+  type OperatorWorkerType,
   type PayStatementPreviewResult,
   type PayoutCalculationWarning,
   type PayoutReviewPeriod,
@@ -46,6 +56,45 @@ import {
 import { cn } from '@/lib/utils';
 
 type ReviewAction = 'mark_reviewed' | 'finalize' | 'reopen' | 'void';
+
+type OperatorProvisionStatus = {
+  profileId: string;
+  email: string;
+  displayName: string;
+  authUserCreated: boolean;
+  inviteStatus: 'sent' | 'failed';
+  inviteError?: string;
+};
+
+type OperatorSetupForm = {
+  accountId: string;
+  email: string;
+  displayName: string;
+  workerType: OperatorWorkerType;
+  payoutPolicyId: string;
+  machineIds: string[];
+  reason: string;
+};
+
+const defaultOperatorSetupForm: OperatorSetupForm = {
+  accountId: '',
+  email: '',
+  displayName: '',
+  workerType: 'employee_w2',
+  payoutPolicyId: '',
+  machineIds: [],
+  reason: '',
+};
+
+const workerTypeOptions: Array<{ value: OperatorWorkerType; label: string }> = [
+  { value: 'employee_w2', label: 'Employee W-2' },
+  { value: 'part_time_employee', label: 'Part-time employee' },
+  { value: 'contractor_1099', label: 'Contractor 1099' },
+  { value: 'owner_operator', label: 'Owner/operator' },
+  { value: 'partner', label: 'Partner' },
+  { value: 'other', label: 'Other' },
+  { value: 'unspecified', label: 'Unspecified' },
+];
 
 const statusVariant = (status: string): 'default' | 'destructive' | 'outline' => {
   if (['finalized', 'issued', 'closed', 'reviewed'].includes(status)) return 'default';
@@ -68,6 +117,17 @@ const formatDate = (value: string | null | undefined) =>
       })
     : 'n/a';
 
+const formatDateTime = (value: string | null | undefined) =>
+  value
+    ? new Date(value).toLocaleString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      })
+    : 'n/a';
+
 const formatCurrency = (cents: number | null | undefined) =>
   new Intl.NumberFormat(undefined, {
     style: 'currency',
@@ -75,6 +135,11 @@ const formatCurrency = (cents: number | null | undefined) =>
   }).format((cents ?? 0) / 100);
 
 const formatHours = (minutes: number) => `${(minutes / 60).toFixed(2)}h`;
+
+const formatMachineLabel = (machine: { machineLabel?: string; label?: string; locationName?: string | null }) => {
+  const label = machine.machineLabel ?? machine.label ?? 'Bloomjoy machine';
+  return machine.locationName ? `${label} at ${machine.locationName}` : label;
+};
 
 const centsFromCurrency = (value: string) => {
   const normalized = value.replace(/[$,\s]/g, '');
@@ -268,6 +333,17 @@ export default function AdminPayoutsPage() {
   const [isIssuingStatements, setIsIssuingStatements] = useState(false);
   const [issueReason, setIssueReason] = useState('');
   const [issueRevisionReason, setIssueRevisionReason] = useState('');
+  const [operatorSetupForm, setOperatorSetupForm] =
+    useState<OperatorSetupForm>(defaultOperatorSetupForm);
+  const [isProvisioningOperator, setIsProvisioningOperator] = useState(false);
+  const [operatorProvisionStatus, setOperatorProvisionStatus] =
+    useState<OperatorProvisionStatus | null>(null);
+  const [resendingOperatorId, setResendingOperatorId] = useState<string | null>(null);
+  const [deactivationForm, setDeactivationForm] = useState({
+    operatorProfileId: '',
+    reason: '',
+  });
+  const [isDeactivatingOperator, setIsDeactivatingOperator] = useState(false);
 
   const {
     data: reviewContext,
@@ -280,7 +356,38 @@ export default function AdminPayoutsPage() {
     staleTime: 1000 * 20,
   });
 
+  const {
+    data: setupContext,
+    isLoading: isLoadingSetup,
+    isFetching: isFetchingSetup,
+    error: setupError,
+  } = useQuery({
+    queryKey: ['admin-operator-payout-setup-context'],
+    queryFn: fetchOperatorPayoutSetupContext,
+    staleTime: 1000 * 20,
+  });
+
   const periods = useMemo(() => reviewContext?.periods ?? [], [reviewContext?.periods]);
+  const setupAccounts = useMemo(() => setupContext?.accounts ?? [], [setupContext?.accounts]);
+  const setupOperators = useMemo(() => setupContext?.operators ?? [], [setupContext?.operators]);
+  const selectedSetupAccount = useMemo(
+    () =>
+      setupAccounts.find((account) => account.id === operatorSetupForm.accountId) ??
+      setupAccounts[0] ??
+      null,
+    [operatorSetupForm.accountId, setupAccounts]
+  );
+  const selectedAccountOperators = useMemo(
+    () =>
+      selectedSetupAccount
+        ? setupOperators.filter((operator) => operator.accountId === selectedSetupAccount.id)
+        : setupOperators,
+    [selectedSetupAccount, setupOperators]
+  );
+  const activeSetupOperators = useMemo(
+    () => selectedAccountOperators.filter((operator) => operator.status === 'active'),
+    [selectedAccountOperators]
+  );
   const selectedPeriod = useMemo(
     () => periods.find((period) => period.id === selectedPeriodId) ?? periods[0] ?? null,
     [periods, selectedPeriodId]
@@ -305,6 +412,30 @@ export default function AdminPayoutsPage() {
   }, [periods, selectedPeriodId]);
 
   useEffect(() => {
+    if (!selectedSetupAccount) return;
+
+    setOperatorSetupForm((current) => {
+      if (current.accountId === selectedSetupAccount.id) return current;
+
+      return {
+        ...current,
+        accountId: selectedSetupAccount.id,
+        payoutPolicyId: selectedSetupAccount.policies[0]?.id ?? '',
+        machineIds: [],
+      };
+    });
+  }, [selectedSetupAccount]);
+
+  useEffect(() => {
+    if (deactivationForm.operatorProfileId || !activeSetupOperators[0]) return;
+
+    setDeactivationForm((current) => ({
+      ...current,
+      operatorProfileId: activeSetupOperators[0].id,
+    }));
+  }, [activeSetupOperators, deactivationForm.operatorProfileId]);
+
+  useEffect(() => {
     const firstOperator = selectedRun?.items[0]?.operatorProfileId ?? '';
     setAdjustmentForm((current) => ({
       ...current,
@@ -320,6 +451,222 @@ export default function AdminPayoutsPage() {
 
   const refresh = () =>
     queryClient.invalidateQueries({ queryKey: ['admin-payout-review-context'] });
+
+  const refreshSetup = () =>
+    queryClient.invalidateQueries({ queryKey: ['admin-operator-payout-setup-context'] });
+
+  const refreshPayoutSurfaces = async () => {
+    await Promise.all([refresh(), refreshSetup()]);
+  };
+
+  const updateOperatorSetupForm = (updates: Partial<OperatorSetupForm>) => {
+    setOperatorSetupForm((current) => ({ ...current, ...updates }));
+  };
+
+  const setOperatorSetupAccount = (accountId: string) => {
+    const account = setupAccounts.find((item) => item.id === accountId);
+    setOperatorSetupForm((current) => ({
+      ...current,
+      accountId,
+      payoutPolicyId: account?.policies[0]?.id ?? '',
+      machineIds: [],
+    }));
+  };
+
+  const toggleOperatorMachine = (machineId: string) => {
+    setOperatorSetupForm((current) => ({
+      ...current,
+      machineIds: current.machineIds.includes(machineId)
+        ? current.machineIds.filter((id) => id !== machineId)
+        : [...current.machineIds, machineId],
+    }));
+  };
+
+  const requireOperatorLoginUrl = (email: string) => {
+    const loginUrlResult = getAccessInviteLoginUrl('operator_payout', email);
+
+    if (!loginUrlResult.ok) {
+      throw new Error(loginUrlResult.message);
+    }
+
+    return loginUrlResult.loginUrl;
+  };
+
+  const provisionOperator = async () => {
+    const email = operatorSetupForm.email.trim().toLowerCase();
+    const reason = operatorSetupForm.reason.trim();
+
+    if (!email) {
+      toast.error('Enter the operator email before saving access.');
+      return;
+    }
+
+    if (!operatorSetupForm.accountId) {
+      toast.error('Choose the account for this operator.');
+      return;
+    }
+
+    if (operatorSetupForm.machineIds.length === 0) {
+      toast.error('Assign at least one machine before saving operator access.');
+      return;
+    }
+
+    if (!reason) {
+      toast.error('Enter an audit reason before saving operator access.');
+      return;
+    }
+
+    setIsProvisioningOperator(true);
+    setOperatorProvisionStatus(null);
+
+    try {
+      const result = await provisionOperatorPayoutAccessAdmin({
+        userEmail: email,
+        accountId: operatorSetupForm.accountId,
+        displayName: operatorSetupForm.displayName.trim() || email,
+        workerType: operatorSetupForm.workerType,
+        payoutPolicyId: operatorSetupForm.payoutPolicyId || null,
+        machineIds: operatorSetupForm.machineIds,
+        reason,
+      });
+
+      try {
+        const loginUrl = requireOperatorLoginUrl(result.operatorProfile.email);
+        await sendAccessInvite({
+          inviteType: 'operator_payout',
+          sourceId: result.operatorProfile.id,
+          targetEmail: result.operatorProfile.email,
+          loginUrl,
+        });
+
+        setOperatorProvisionStatus({
+          profileId: result.operatorProfile.id,
+          email: result.operatorProfile.email,
+          displayName: result.operatorProfile.displayName,
+          authUserCreated: result.authUserCreated,
+          inviteStatus: 'sent',
+        });
+        toast.success(
+          result.authUserCreated
+            ? 'Operator Auth user, payout profile, assignments, and invite are saved.'
+            : 'Operator payout profile, assignments, and invite are saved.'
+        );
+      } catch (inviteError) {
+        const message =
+          inviteError instanceof Error ? inviteError.message : 'Unable to send operator invite.';
+        setOperatorProvisionStatus({
+          profileId: result.operatorProfile.id,
+          email: result.operatorProfile.email,
+          displayName: result.operatorProfile.displayName,
+          authUserCreated: result.authUserCreated,
+          inviteStatus: 'failed',
+          inviteError: message,
+        });
+        toast.error('Operator access was saved, but the invite email failed.');
+      }
+
+      setOperatorSetupForm((current) => ({
+        ...current,
+        email: '',
+        displayName: '',
+        reason: '',
+      }));
+      await refreshPayoutSurfaces();
+    } catch (provisionError) {
+      toast.error(
+        provisionError instanceof Error
+          ? provisionError.message
+          : 'Unable to save operator payout access.'
+      );
+    } finally {
+      setIsProvisioningOperator(false);
+    }
+  };
+
+  const resendOperatorInvite = async (operator: OperatorPayoutSetupOperator) => {
+    const email = operator.email?.trim().toLowerCase();
+
+    if (!email) {
+      toast.error('This operator profile does not have an email to invite.');
+      return;
+    }
+
+    setResendingOperatorId(operator.id);
+    try {
+      const loginUrl = requireOperatorLoginUrl(email);
+      await sendAccessInvite({
+        inviteType: 'operator_payout',
+        sourceId: operator.id,
+        targetEmail: email,
+        loginUrl,
+      });
+      setOperatorProvisionStatus((current) =>
+        current?.profileId === operator.id
+          ? {
+              ...current,
+              email,
+              inviteStatus: 'sent',
+              inviteError: undefined,
+            }
+          : current
+      );
+      toast.success('Operator invite resent.');
+      await refreshSetup();
+    } catch (inviteError) {
+      toast.error(inviteError instanceof Error ? inviteError.message : 'Unable to resend invite.');
+    } finally {
+      setResendingOperatorId(null);
+    }
+  };
+
+  const copyOperatorLoginUrl = async (email: string | null) => {
+    if (!email) {
+      toast.error('This operator profile does not have an email to copy.');
+      return;
+    }
+
+    try {
+      const loginUrl = requireOperatorLoginUrl(email);
+      await navigator.clipboard.writeText(loginUrl);
+      toast.success('Operator login link copied.');
+    } catch (copyError) {
+      toast.error(copyError instanceof Error ? copyError.message : 'Unable to copy login link.');
+    }
+  };
+
+  const deactivateOperator = async () => {
+    const reason = deactivationForm.reason.trim();
+
+    if (!deactivationForm.operatorProfileId) {
+      toast.error('Choose an operator to deactivate.');
+      return;
+    }
+
+    if (!reason) {
+      toast.error('Enter an audit reason before deactivating operator access.');
+      return;
+    }
+
+    setIsDeactivatingOperator(true);
+    try {
+      await deactivateOperatorPayoutProfileAdmin({
+        operatorProfileId: deactivationForm.operatorProfileId,
+        reason,
+      });
+      toast.success('Operator access deactivated.');
+      setOperatorProvisionStatus(null);
+      setDeactivationForm({ operatorProfileId: '', reason: '' });
+      await refreshPayoutSurfaces();
+    } catch (deactivateError) {
+      toast.error(
+        deactivateError instanceof Error
+          ? deactivateError.message
+          : 'Unable to deactivate operator access.'
+      );
+    } finally {
+      setIsDeactivatingOperator(false);
+    }
+  };
 
   const runCalculation = async () => {
     if (!selectedPeriod) return;
@@ -538,8 +885,12 @@ export default function AdminPayoutsPage() {
                 adjustments, and finalization history before pay statements are issued.
               </p>
             </div>
-            <Button variant="outline" onClick={() => void refresh()} disabled={isFetching}>
-              {isFetching ? (
+            <Button
+              variant="outline"
+              onClick={() => void refreshPayoutSurfaces()}
+              disabled={isFetching || isFetchingSetup}
+            >
+              {isFetching || isFetchingSetup ? (
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
               ) : (
                 <RefreshCw className="mr-2 h-4 w-4" />
@@ -551,7 +902,376 @@ export default function AdminPayoutsPage() {
       </section>
 
       <section className="section-padding">
-        <div className="container-page">
+        <div className="container-page space-y-6">
+          <div className="rounded-lg border border-border bg-background p-5">
+            <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+              <div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <UserPlus className="h-5 w-5 text-primary" />
+                  <h2 className="font-display text-2xl font-semibold text-foreground">
+                    Operator Setup
+                  </h2>
+                  <Badge variant="outline">{activeSetupOperators.length} active</Badge>
+                </div>
+                <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+                  Create employee operator access, assign machines, send the invite, and preserve
+                  setup evidence before the first time entry.
+                </p>
+              </div>
+              <Button
+                variant="outline"
+                onClick={() => void refreshSetup()}
+                disabled={isFetchingSetup}
+              >
+                {isFetchingSetup ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <RefreshCw className="mr-2 h-4 w-4" />
+                )}
+                Refresh Setup
+              </Button>
+            </div>
+
+            <div className="mt-5">
+              {isLoadingSetup ? (
+                <EmptyState title="Loading operator setup">
+                  Pulling manageable accounts, machines, payout policies, and invite evidence.
+                </EmptyState>
+              ) : setupError ? (
+                <EmptyState title="Unable to load operator setup">
+                  {setupError instanceof Error
+                    ? setupError.message
+                    : 'The operator setup context could not load.'}
+                </EmptyState>
+              ) : setupAccounts.length === 0 ? (
+                <EmptyState title="No operator setup access">
+                  Your account does not currently have payout setup access for any active machine.
+                </EmptyState>
+              ) : (
+                <>
+                  <div className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(320px,0.85fr)]">
+                    <div className="space-y-5">
+                      <div className="grid gap-4 md:grid-cols-2">
+                        <div>
+                          <Label htmlFor="operator-setup-account">Account</Label>
+                          <select
+                            id="operator-setup-account"
+                            value={operatorSetupForm.accountId}
+                            onChange={(event) => setOperatorSetupAccount(event.target.value)}
+                            className="mt-2 h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                          >
+                            {setupAccounts.map((account) => (
+                              <option key={account.id} value={account.id}>
+                                {account.name}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        <div>
+                          <Label htmlFor="operator-setup-policy">Payout policy</Label>
+                          <select
+                            id="operator-setup-policy"
+                            value={operatorSetupForm.payoutPolicyId}
+                            onChange={(event) =>
+                              updateOperatorSetupForm({ payoutPolicyId: event.target.value })
+                            }
+                            className="mt-2 h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                          >
+                            <option value="">Use account default</option>
+                            {(selectedSetupAccount?.policies ?? []).map((policy) => (
+                              <option key={policy.id} value={policy.id}>
+                                {policy.name} / {formatStatus(policy.frequency)}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        <div>
+                          <Label htmlFor="operator-setup-email">Operator email</Label>
+                          <Input
+                            id="operator-setup-email"
+                            type="email"
+                            value={operatorSetupForm.email}
+                            onChange={(event) =>
+                              updateOperatorSetupForm({ email: event.target.value })
+                            }
+                            placeholder="operator@example.com"
+                            className="mt-2"
+                          />
+                        </div>
+                        <div>
+                          <Label htmlFor="operator-setup-name">Display name</Label>
+                          <Input
+                            id="operator-setup-name"
+                            value={operatorSetupForm.displayName}
+                            onChange={(event) =>
+                              updateOperatorSetupForm({ displayName: event.target.value })
+                            }
+                            placeholder="Alex Operator"
+                            className="mt-2"
+                          />
+                        </div>
+                        <div>
+                          <Label htmlFor="operator-setup-worker-type">Worker type</Label>
+                          <select
+                            id="operator-setup-worker-type"
+                            value={operatorSetupForm.workerType}
+                            onChange={(event) =>
+                              updateOperatorSetupForm({
+                                workerType: event.target.value as OperatorWorkerType,
+                              })
+                            }
+                            className="mt-2 h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                          >
+                            {workerTypeOptions.map((option) => (
+                              <option key={option.value} value={option.value}>
+                                {option.label}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                      </div>
+
+                      <div>
+                        <div className="flex items-center justify-between gap-3">
+                          <Label>Assigned machines</Label>
+                          <Badge variant="outline">{operatorSetupForm.machineIds.length} selected</Badge>
+                        </div>
+                        {(selectedSetupAccount?.machines ?? []).length === 0 ? (
+                          <p className="mt-3 rounded-md border border-dashed border-border bg-muted/20 p-4 text-sm text-muted-foreground">
+                            No active manageable machines are available for this account.
+                          </p>
+                        ) : (
+                          <div className="mt-3 grid gap-2 md:grid-cols-2">
+                            {(selectedSetupAccount?.machines ?? []).map((machine) => (
+                              <label
+                                key={machine.id}
+                                className={cn(
+                                  'flex min-h-12 items-start gap-3 rounded-md border border-border bg-muted/10 p-3 text-sm',
+                                  !machine.canManage && 'opacity-60'
+                                )}
+                              >
+                                <input
+                                  type="checkbox"
+                                  className="mt-1"
+                                  checked={operatorSetupForm.machineIds.includes(machine.id)}
+                                  disabled={!machine.canManage}
+                                  onChange={() => toggleOperatorMachine(machine.id)}
+                                />
+                                <span>
+                                  <span className="block font-medium text-foreground">
+                                    {formatMachineLabel(machine)}
+                                  </span>
+                                  <span className="block text-xs text-muted-foreground">
+                                    {formatStatus(machine.machineType ?? 'machine')}
+                                  </span>
+                                </span>
+                              </label>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+
+                      <div>
+                        <Label htmlFor="operator-setup-reason">Audit reason</Label>
+                        <Textarea
+                          id="operator-setup-reason"
+                          value={operatorSetupForm.reason}
+                          onChange={(event) =>
+                            updateOperatorSetupForm({ reason: event.target.value })
+                          }
+                          placeholder="Hired for the June machine service schedule."
+                          className="mt-2"
+                        />
+                      </div>
+
+                      {operatorProvisionStatus && (
+                        <div
+                          className={cn(
+                            'rounded-md border p-4 text-sm',
+                            operatorProvisionStatus.inviteStatus === 'sent'
+                              ? 'border-sage/30 bg-sage-light'
+                              : 'border-amber/30 bg-amber/10'
+                          )}
+                        >
+                          <div className="flex items-start gap-3">
+                            {operatorProvisionStatus.inviteStatus === 'sent' ? (
+                              <CheckCircle2 className="mt-0.5 h-4 w-4 text-sage" />
+                            ) : (
+                              <AlertTriangle className="mt-0.5 h-4 w-4 text-amber" />
+                            )}
+                            <div>
+                              <p className="font-medium text-foreground">
+                                {operatorProvisionStatus.displayName} saved
+                              </p>
+                              <p className="mt-1 text-muted-foreground">
+                                {operatorProvisionStatus.inviteStatus === 'sent'
+                                  ? `Invite sent to ${operatorProvisionStatus.email}.`
+                                  : `Invite failed for ${operatorProvisionStatus.email}: ${
+                                      operatorProvisionStatus.inviteError ??
+                                      'retry from the operator list.'
+                                    }`}
+                              </p>
+                            </div>
+                          </div>
+                        </div>
+                      )}
+
+                      <Button
+                        onClick={() => void provisionOperator()}
+                        disabled={isProvisioningOperator}
+                      >
+                        {isProvisioningOperator ? (
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                        ) : (
+                          <UserPlus className="mr-2 h-4 w-4" />
+                        )}
+                        Save Operator and Send Invite
+                      </Button>
+                    </div>
+
+                    <div className="space-y-4">
+                      <div>
+                        <div className="flex items-center justify-between gap-3">
+                          <h3 className="font-semibold text-foreground">Operator Access</h3>
+                          <Badge variant="outline">{selectedAccountOperators.length}</Badge>
+                        </div>
+                        {selectedAccountOperators.length === 0 ? (
+                          <p className="mt-3 rounded-md border border-dashed border-border bg-muted/20 p-4 text-sm text-muted-foreground">
+                            No operators are set up for this account yet.
+                          </p>
+                        ) : (
+                          <div className="mt-3 divide-y divide-border rounded-md border border-border">
+                            {selectedAccountOperators.map((operator) => (
+                              <div key={operator.id} className="p-4">
+                                <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+                                  <div>
+                                    <div className="flex flex-wrap items-center gap-2">
+                                      <p className="font-medium text-foreground">
+                                        {operator.displayName}
+                                      </p>
+                                      <Badge variant={statusVariant(operator.status)}>
+                                        {formatStatus(operator.status)}
+                                      </Badge>
+                                    </div>
+                                    <p className="mt-1 text-sm text-muted-foreground">
+                                      {operator.email ?? 'No email on Auth user'}
+                                    </p>
+                                    <p className="mt-2 text-xs text-muted-foreground">
+                                      {operator.activeAssignments.length} active machines
+                                      {operator.latestInvite
+                                        ? ` / last invite ${formatStatus(
+                                            operator.latestInvite.deliveryStatus
+                                          )} ${formatDateTime(operator.latestInvite.sentAt)}`
+                                        : ' / no invite evidence yet'}
+                                    </p>
+                                  </div>
+                                  <div className="flex flex-wrap gap-2">
+                                    <Button
+                                      variant="outline"
+                                      className="h-9 px-3"
+                                      onClick={() => void copyOperatorLoginUrl(operator.email)}
+                                    >
+                                      <Copy className="mr-2 h-4 w-4" />
+                                      Copy Link
+                                    </Button>
+                                    <Button
+                                      variant="outline"
+                                      className="h-9 px-3"
+                                      onClick={() => void resendOperatorInvite(operator)}
+                                      disabled={
+                                        !operator.canSendInvite ||
+                                        resendingOperatorId === operator.id ||
+                                        operator.status !== 'active'
+                                      }
+                                    >
+                                      {resendingOperatorId === operator.id ? (
+                                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                      ) : (
+                                        <Mail className="mr-2 h-4 w-4" />
+                                      )}
+                                      Resend
+                                    </Button>
+                                  </div>
+                                </div>
+                                {operator.activeAssignments.length > 0 && (
+                                  <div className="mt-3 flex flex-wrap gap-2">
+                                    {operator.activeAssignments.map((assignment) => (
+                                      <Badge key={assignment.assignmentId} variant="outline">
+                                        {formatMachineLabel(assignment)}
+                                      </Badge>
+                                    ))}
+                                  </div>
+                                )}
+                              </div>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+
+                      <div className="rounded-md border border-border bg-muted/10 p-4">
+                        <div className="flex items-center gap-2">
+                          <Power className="h-4 w-4 text-destructive" />
+                          <h3 className="font-semibold text-foreground">Deactivate Access</h3>
+                        </div>
+                        <div className="mt-4 space-y-3">
+                          <div>
+                            <Label htmlFor="operator-deactivate-profile">Operator</Label>
+                            <select
+                              id="operator-deactivate-profile"
+                              value={deactivationForm.operatorProfileId}
+                              onChange={(event) =>
+                                setDeactivationForm((current) => ({
+                                  ...current,
+                                  operatorProfileId: event.target.value,
+                                }))
+                              }
+                              className="mt-2 h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+                            >
+                              <option value="">Choose an active operator</option>
+                              {activeSetupOperators.map((operator) => (
+                                <option key={operator.id} value={operator.id}>
+                                  {operator.displayName}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
+                          <div>
+                            <Label htmlFor="operator-deactivate-reason">Audit reason</Label>
+                            <Textarea
+                              id="operator-deactivate-reason"
+                              value={deactivationForm.reason}
+                              onChange={(event) =>
+                                setDeactivationForm((current) => ({
+                                  ...current,
+                                  reason: event.target.value,
+                                }))
+                              }
+                              placeholder="Employment ended; revoke future time entry access."
+                              className="mt-2"
+                            />
+                          </div>
+                          <Button
+                            variant="outline"
+                            className="border-destructive/30 text-destructive hover:bg-destructive/10"
+                            onClick={() => void deactivateOperator()}
+                            disabled={isDeactivatingOperator || activeSetupOperators.length === 0}
+                          >
+                            {isDeactivatingOperator ? (
+                              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            ) : (
+                              <Power className="mr-2 h-4 w-4" />
+                            )}
+                            Deactivate Operator
+                          </Button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+
           {isLoading ? (
             <EmptyState title="Loading payout review">
               Pulling the latest payout periods, review states, and scoped manager permissions.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -31,6 +31,9 @@ verify_jwt = false
 [functions.access-invite]
 verify_jwt = false
 
+[functions.operator-payout-provision]
+verify_jwt = false
+
 [functions.sales-report-export]
 verify_jwt = false
 

--- a/supabase/functions/access-invite/index.ts
+++ b/supabase/functions/access-invite/index.ts
@@ -26,8 +26,12 @@ const supabase = supabaseUrl && supabaseServiceRoleKey
     })
   : null;
 
-type InviteType = "corporate_partner" | "technician" | "machine_manager";
-type SourceType = "corporate_partner_membership" | "technician_grant" | "reporting_machine";
+type InviteType = "corporate_partner" | "technician" | "machine_manager" | "operator_payout";
+type SourceType =
+  | "corporate_partner_membership"
+  | "technician_grant"
+  | "reporting_machine"
+  | "operator_payout_profile";
 
 type InviteSource = {
   inviteType: InviteType;
@@ -61,6 +65,7 @@ const sourceTypeByInviteType: Record<InviteType, SourceType> = {
   corporate_partner: "corporate_partner_membership",
   technician: "technician_grant",
   machine_manager: "reporting_machine",
+  operator_payout: "operator_payout_profile",
 };
 const maxEvidenceMessageLength = 500;
 const sentEvidenceFailureMessage =
@@ -410,6 +415,116 @@ async function getMachineManagerSource(sourceId: string, targetEmail: string): P
   };
 }
 
+async function getOperatorPayoutSource(sourceId: string, targetEmail: string): Promise<InviteSource> {
+  if (!supabase) throw new Error("Access invite email is not configured.");
+
+  const { data: profile, error: profileError } = await supabase
+    .from("operator_payout_profiles")
+    .select("id, account_id, user_id, display_name, worker_type, status")
+    .eq("id", sourceId)
+    .maybeSingle();
+
+  if (profileError || !profile) {
+    throw new Error("Operator payout profile was not found.");
+  }
+
+  const profileRecord = profile as Record<string, unknown>;
+  if (getStringValue(profileRecord, "status") !== "active") {
+    throw new Error("Operator payout profile is not active.");
+  }
+
+  const { data: authUser, error: authUserError } = await supabase.rpc("admin_find_auth_user_by_email", {
+    p_email: targetEmail,
+  });
+
+  if (authUserError) {
+    throw new Error("Unable to verify operator invite email.");
+  }
+
+  const authUserRecord = (authUser as Record<string, unknown> | null) ?? {};
+  const targetUserId = getStringValue(authUserRecord, "id");
+  if (!targetUserId || targetUserId !== getStringValue(profileRecord, "user_id")) {
+    throw new Error("Invite email does not match the operator payout profile.");
+  }
+
+  const accountId = getStringValue(profileRecord, "account_id");
+  const { data: account } = await supabase
+    .from("customer_accounts")
+    .select("name")
+    .eq("id", accountId)
+    .maybeSingle();
+  const accountName = getStringValue((account as Record<string, unknown> | null) ?? {}, "name") || "a Bloomjoy account";
+
+  const { data: assignments } = await supabase
+    .from("operator_machine_assignments")
+    .select("reporting_machine_id, status, revoked_at")
+    .eq("operator_profile_id", sourceId)
+    .eq("status", "active")
+    .is("revoked_at", null);
+
+  const machineIds = [
+    ...new Set(
+      ((assignments as Record<string, unknown>[] | null) ?? [])
+        .map((assignment) => getStringValue(assignment, "reporting_machine_id"))
+        .filter(Boolean)
+    ),
+  ];
+
+  let machineLabels: string[] = [];
+  if (machineIds.length > 0) {
+    const { data: machines } = await supabase
+      .from("reporting_machines")
+      .select("id, machine_label, machine_type, location_id")
+      .in("id", machineIds);
+    const machineRows = (machines as Record<string, unknown>[] | null) ?? [];
+    const locationIds = [
+      ...new Set(machineRows.map((machine) => getStringValue(machine, "location_id")).filter(Boolean)),
+    ];
+    let locationNameById = new Map<string, string>();
+
+    if (locationIds.length > 0) {
+      const { data: locations } = await supabase
+        .from("reporting_locations")
+        .select("id, name")
+        .in("id", locationIds);
+
+      locationNameById = new Map(
+        ((locations as Record<string, unknown>[] | null) ?? [])
+          .map((location) => [getStringValue(location, "id"), getStringValue(location, "name")] as const)
+          .filter(([id]) => Boolean(id))
+      );
+    }
+
+    const machineLabelById = new Map(
+      machineRows.map((machine) => {
+        const id = getStringValue(machine, "id");
+        const label = getStringValue(machine, "machine_label") || "Bloomjoy machine";
+        const locationName = locationNameById.get(getStringValue(machine, "location_id"));
+        return [id, locationName ? `${label} at ${locationName}` : label] as const;
+      })
+    );
+
+    machineLabels = machineIds.map((machineId) => machineLabelById.get(machineId) ?? "Bloomjoy machine");
+  }
+
+  const machineSummary = machineLabels.length === 0
+    ? "This operator profile is active but has no assigned machines yet. Contact Bloomjoy before entering time."
+    : machineLabels.length === 1
+      ? `This access includes time entry for one assigned machine: ${machineLabels[0]}.`
+      : `This access includes time entry for ${machineLabels.length} assigned machines: ${machineLabels.join(", ")}.`;
+
+  return {
+    inviteType: "operator_payout",
+    sourceType: "operator_payout_profile",
+    sourceId,
+    targetEmail,
+    targetUserId,
+    title: "Your Bloomjoy Operator invitation",
+    body: `You have been invited as a Bloomjoy Operator for ${accountName}.`,
+    accessSummary: machineSummary,
+  };
+}
+
 async function recordInviteEvidence(
   attempt: InviteAttempt,
   actorUserId: string,
@@ -534,6 +649,26 @@ async function canSendTechnicianAccessInvite(actorUserId: string, sourceId: stri
   return data === true;
 }
 
+async function canSendOperatorPayoutInvite(actorUserId: string, sourceId: string) {
+  if (!supabase) return false;
+
+  const { data, error } = await supabase.rpc("can_send_operator_payout_invite", {
+    p_user_id: actorUserId,
+    p_operator_profile_id: sourceId,
+  });
+
+  if (error) {
+    console.error("access-invite authorization check failed", {
+      source_type: "operator_payout_profile",
+      source_id: sourceId,
+      error_message: sanitizeErrorEvidence(error, "Unable to validate invite permission."),
+    });
+    return false;
+  }
+
+  return data === true;
+}
+
 serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });
@@ -581,7 +716,7 @@ serve(async (req) => {
       allowConfiguredPreviewOrigins: true,
     });
 
-    if (!["corporate_partner", "technician", "machine_manager"].includes(inviteType)) {
+    if (!["corporate_partner", "technician", "machine_manager", "operator_payout"].includes(inviteType)) {
       return new Response(JSON.stringify({ error: "Unsupported invite type." }), {
         status: 400,
         headers: { ...corsHeaders, "Content-Type": "application/json" },
@@ -611,16 +746,24 @@ serve(async (req) => {
 
     const { data: isAdmin } = await supabase.rpc("is_super_admin", { uid: user.id });
     if (!isAdmin) {
-      if (inviteType !== "technician") {
+      if (inviteType === "technician") {
+        const canSendTechnicianInvite = await canSendTechnicianAccessInvite(user.id, sourceId);
+        if (!canSendTechnicianInvite) {
+          return new Response(JSON.stringify({ error: "Technician invite access denied." }), {
+            status: 403,
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+          });
+        }
+      } else if (inviteType === "operator_payout") {
+        const canSendOperatorInvite = await canSendOperatorPayoutInvite(user.id, sourceId);
+        if (!canSendOperatorInvite) {
+          return new Response(JSON.stringify({ error: "Operator payout invite access denied." }), {
+            status: 403,
+            headers: { ...corsHeaders, "Content-Type": "application/json" },
+          });
+        }
+      } else {
         return new Response(JSON.stringify({ error: "Super Admin access required." }), {
-          status: 403,
-          headers: { ...corsHeaders, "Content-Type": "application/json" },
-        });
-      }
-
-      const canSendTechnicianInvite = await canSendTechnicianAccessInvite(user.id, sourceId);
-      if (!canSendTechnicianInvite) {
-        return new Response(JSON.stringify({ error: "Technician invite access denied." }), {
           status: 403,
           headers: { ...corsHeaders, "Content-Type": "application/json" },
         });
@@ -649,7 +792,9 @@ serve(async (req) => {
         ? await getCorporatePartnerSource(sourceId, targetEmail)
         : inviteType === "technician"
           ? await getTechnicianSource(sourceId, targetEmail)
-          : await getMachineManagerSource(sourceId, targetEmail);
+          : inviteType === "machine_manager"
+            ? await getMachineManagerSource(sourceId, targetEmail)
+            : await getOperatorPayoutSource(sourceId, targetEmail);
     } catch (sourceError) {
       await recordFailureEvidence(
         inviteAttempt,

--- a/supabase/functions/operator-payout-provision/index.ts
+++ b/supabase/functions/operator-payout-provision/index.ts
@@ -1,0 +1,244 @@
+import { serve } from "https://deno.land/std@0.224.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2.48.1";
+import { resolveSupabaseAccessToken } from "../_shared/auth.ts";
+import { corsHeaders } from "../_shared/cors.ts";
+
+const supabaseUrl = Deno.env.get("SUPABASE_URL");
+const supabaseServiceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+const uuidPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{12}$/i;
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/i;
+
+if (!supabaseUrl) {
+  console.error("Missing SUPABASE_URL");
+}
+
+if (!supabaseServiceRoleKey) {
+  console.error("Missing SUPABASE_SERVICE_ROLE_KEY");
+}
+
+const supabase = supabaseUrl && supabaseServiceRoleKey
+  ? createClient(supabaseUrl, supabaseServiceRoleKey, {
+      auth: { persistSession: false },
+    })
+  : null;
+
+const sanitizeText = (value: unknown) => (typeof value === "string" ? value.trim() : "");
+const normalizeEmail = (value: unknown) => sanitizeText(value).toLowerCase();
+const isUuid = (value: unknown) => uuidPattern.test(sanitizeText(value));
+
+const sanitizeErrorMessage = (value: unknown, fallback = "Unable to provision operator access.") => {
+  const raw = value instanceof Error
+    ? value.message
+    : typeof value === "string"
+      ? value
+      : typeof value === "object" && value && "message" in value && typeof value.message === "string"
+        ? value.message
+        : fallback;
+
+  const message = (raw || fallback)
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, "[email]")
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [redacted]")
+    .replace(/(api[_-]?key["':=\s]+)[A-Za-z0-9._~+/=-]+/gi, "$1[redacted]")
+    .slice(0, 500);
+
+  return message || fallback;
+};
+
+const jsonResponse = (status: number, body: Record<string, unknown>) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+
+async function getActor(req: Request) {
+  if (!supabase) throw new Error("Operator payout provisioning is not configured.");
+
+  const accessToken = resolveSupabaseAccessToken(req);
+  if (!accessToken) return null;
+
+  const { data, error } = await supabase.auth.getUser(accessToken);
+  if (error || !data?.user) return null;
+
+  return data.user;
+}
+
+async function findAuthUserByEmail(email: string) {
+  if (!supabase) throw new Error("Operator payout provisioning is not configured.");
+
+  const { data, error } = await supabase.rpc("admin_find_auth_user_by_email", {
+    p_email: email,
+  });
+
+  if (error) {
+    throw new Error(error.message || "Unable to resolve operator Auth user.");
+  }
+
+  const record = data as Record<string, unknown> | null;
+  const id = sanitizeText(record?.id);
+  return id && uuidPattern.test(id) ? record : null;
+}
+
+async function ensureAuthUser(email: string, displayName: string) {
+  if (!supabase) throw new Error("Operator payout provisioning is not configured.");
+
+  const existingUser = await findAuthUserByEmail(email);
+  if (existingUser) {
+    return {
+      userId: existingUser.id as string,
+      authUserCreated: false,
+    };
+  }
+
+  const { data, error } = await supabase.auth.admin.createUser({
+    email,
+    email_confirm: true,
+    user_metadata: {
+      full_name: displayName || email,
+      provisioned_by: "operator-payout-provision",
+    },
+  });
+
+  if (error || !data?.user?.id) {
+    const retryUser = await findAuthUserByEmail(email);
+    if (retryUser) {
+      return {
+        userId: retryUser.id as string,
+        authUserCreated: false,
+      };
+    }
+
+    throw new Error(error?.message || "Unable to create operator Auth user.");
+  }
+
+  return {
+    userId: data.user.id,
+    authUserCreated: true,
+  };
+}
+
+async function provisionOperator(actorUserId: string, body: Record<string, unknown>) {
+  if (!supabase) throw new Error("Operator payout provisioning is not configured.");
+
+  const userEmail = normalizeEmail(body.userEmail ?? body.email);
+  const accountId = sanitizeText(body.accountId);
+  const displayName = sanitizeText(body.displayName);
+  const workerType = sanitizeText(body.workerType);
+  const payoutPolicyId = sanitizeText(body.payoutPolicyId);
+  const reason = sanitizeText(body.reason);
+  const machineIds = Array.isArray(body.machineIds)
+    ? [...new Set(body.machineIds.map((value) => sanitizeText(value)).filter(Boolean))]
+    : [];
+
+  if (!emailPattern.test(userEmail)) {
+    return jsonResponse(400, { error: "Operator email is invalid." });
+  }
+
+  if (!uuidPattern.test(accountId)) {
+    return jsonResponse(400, { error: "Operator account is required." });
+  }
+
+  if (payoutPolicyId && !uuidPattern.test(payoutPolicyId)) {
+    return jsonResponse(400, { error: "Payout policy is invalid." });
+  }
+
+  if (machineIds.length === 0 || machineIds.some((machineId) => !uuidPattern.test(machineId))) {
+    return jsonResponse(400, { error: "Select at least one valid assigned machine." });
+  }
+
+  if (!reason) {
+    return jsonResponse(400, { error: "Operator provisioning reason is required." });
+  }
+
+  const authUser = await ensureAuthUser(userEmail, displayName);
+  const { data, error } = await supabase.rpc("admin_provision_operator_payout_for_user", {
+    p_actor_user_id: actorUserId,
+    p_target_user_id: authUser.userId,
+    p_user_email: userEmail,
+    p_account_id: accountId,
+    p_display_name: displayName || userEmail,
+    p_worker_type: workerType || null,
+    p_payout_policy_id: payoutPolicyId || null,
+    p_machine_ids: machineIds,
+    p_reason: reason,
+  });
+
+  if (error || !data) {
+    throw new Error(error?.message || "Unable to save operator payout access.");
+  }
+
+  return jsonResponse(200, {
+    ok: true,
+    authUserCreated: authUser.authUserCreated,
+    ...(data as Record<string, unknown>),
+  });
+}
+
+async function deactivateOperator(actorUserId: string, body: Record<string, unknown>) {
+  if (!supabase) throw new Error("Operator payout provisioning is not configured.");
+
+  const operatorProfileId = sanitizeText(body.operatorProfileId);
+  const reason = sanitizeText(body.reason);
+
+  if (!uuidPattern.test(operatorProfileId)) {
+    return jsonResponse(400, { error: "Operator profile is required." });
+  }
+
+  if (!reason) {
+    return jsonResponse(400, { error: "Operator deactivation reason is required." });
+  }
+
+  const { data, error } = await supabase.rpc("admin_deactivate_operator_payout_profile_for_user", {
+    p_actor_user_id: actorUserId,
+    p_operator_profile_id: operatorProfileId,
+    p_reason: reason,
+  });
+
+  if (error || !data) {
+    throw new Error(error?.message || "Unable to deactivate operator payout access.");
+  }
+
+  return jsonResponse(200, {
+    ok: true,
+    ...(data as Record<string, unknown>),
+  });
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  try {
+    if (req.method !== "POST") {
+      return jsonResponse(405, { error: "Method not allowed." });
+    }
+
+    if (!supabase) {
+      return jsonResponse(500, { error: "Operator payout provisioning is not configured." });
+    }
+
+    const actor = await getActor(req);
+    if (!actor) {
+      return jsonResponse(401, { error: "Unauthorized." });
+    }
+
+    const body = await req.json() as Record<string, unknown>;
+    const action = sanitizeText(body.action || "provision");
+
+    if (action === "provision") {
+      return await provisionOperator(actor.id, body);
+    }
+
+    if (action === "deactivate") {
+      return await deactivateOperator(actor.id, body);
+    }
+
+    return jsonResponse(400, { error: "Unsupported operator provisioning action." });
+  } catch (error) {
+    const message = sanitizeErrorMessage(error);
+    console.error("operator-payout-provision error", message);
+
+    return jsonResponse(500, { error: message });
+  }
+});

--- a/supabase/migrations/20260626142851_operator_employee_provisioning.sql
+++ b/supabase/migrations/20260626142851_operator_employee_provisioning.sql
@@ -1,0 +1,907 @@
+-- Operator employee provisioning: service-role Auth-user handoff, guided
+-- machine assignment, invite evidence, and deactivation controls.
+
+alter table public.access_invite_deliveries
+  drop constraint if exists access_invite_deliveries_invite_type_check;
+
+alter table public.access_invite_deliveries
+  add constraint access_invite_deliveries_invite_type_check
+    check (invite_type in ('corporate_partner', 'technician', 'machine_manager', 'operator_payout'));
+
+alter table public.access_invite_deliveries
+  drop constraint if exists access_invite_deliveries_source_type_check;
+
+alter table public.access_invite_deliveries
+  add constraint access_invite_deliveries_source_type_check
+    check (source_type in (
+      'corporate_partner_membership',
+      'technician_grant',
+      'reporting_machine',
+      'operator_payout_profile'
+    ));
+
+create or replace function public.operator_payout_can_manage_machine_set(
+  p_actor_user_id uuid,
+  p_account_id uuid,
+  p_machine_ids uuid[]
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with requested as (
+    select distinct machine_id
+    from unnest(coalesce(p_machine_ids, '{}'::uuid[])) as machine_ids(machine_id)
+    where machine_id is not null
+  ),
+  counts as (
+    select
+      (select count(*) from requested)::integer as requested_count,
+      (
+        select count(*)::integer
+        from public.reporting_machines machine
+        join requested on requested.machine_id = machine.id
+        where machine.account_id = p_account_id
+          and machine.status = 'active'
+      ) as account_machine_count,
+      (
+        select count(*)::integer
+        from public.reporting_machines machine
+        join requested on requested.machine_id = machine.id
+        where machine.account_id = p_account_id
+          and machine.status = 'active'
+          and public.can_manage_operator_payout_machine(p_actor_user_id, machine.id)
+      ) as manageable_machine_count
+  )
+  select p_actor_user_id is not null
+    and p_account_id is not null
+    and exists (select 1 from requested)
+    and (
+      public.can_manage_operator_payout_account(p_actor_user_id, p_account_id)
+      or (
+        (select requested_count from counts) = (select account_machine_count from counts)
+        and (select requested_count from counts) = (select manageable_machine_count from counts)
+      )
+    );
+$$;
+
+create or replace function public.can_send_operator_payout_invite(
+  p_user_id uuid,
+  p_operator_profile_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select p_user_id is not null
+    and p_operator_profile_id is not null
+    and exists (
+      select 1
+      from public.operator_payout_profiles profile
+      where profile.id = p_operator_profile_id
+        and profile.status = 'active'
+        and (
+          public.can_manage_operator_payout_account(p_user_id, profile.account_id)
+          or (
+            exists (
+              select 1
+              from public.operator_machine_assignments assignment
+              where assignment.operator_profile_id = profile.id
+                and assignment.status = 'active'
+                and assignment.revoked_at is null
+                and public.can_manage_operator_payout_machine(
+                  p_user_id,
+                  assignment.reporting_machine_id
+                )
+            )
+            and not exists (
+              select 1
+              from public.operator_machine_assignments assignment
+              where assignment.operator_profile_id = profile.id
+                and assignment.status = 'active'
+                and assignment.revoked_at is null
+                and not public.can_manage_operator_payout_machine(
+                  p_user_id,
+                  assignment.reporting_machine_id
+                )
+            )
+          )
+        )
+    );
+$$;
+
+create or replace function public.can_send_operator_payout_invite_current_user(
+  p_operator_profile_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select public.can_send_operator_payout_invite((select auth.uid()), p_operator_profile_id);
+$$;
+
+create or replace function public.admin_find_auth_user_by_email(
+  p_email text
+)
+returns jsonb
+language sql
+stable
+security definer
+set search_path = public, auth
+as $$
+  select case when users.id is null then null::jsonb else jsonb_build_object(
+    'id', users.id,
+    'email', users.email,
+    'emailConfirmedAt', users.email_confirmed_at,
+    'createdAt', users.created_at
+  ) end
+  from (select lower(trim(coalesce(p_email, ''))) as normalized_email) input
+  left join auth.users users
+    on lower(users.email) = input.normalized_email
+  where input.normalized_email <> ''
+  order by users.created_at asc nulls last
+  limit 1;
+$$;
+
+create or replace function public.get_operator_payout_setup_context()
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path = public, auth
+as $$
+declare
+  actor_user_id uuid;
+  result jsonb;
+begin
+  actor_user_id := auth.uid();
+
+  if actor_user_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  select jsonb_build_object(
+    'accounts', coalesce((
+      select jsonb_agg(
+        jsonb_build_object(
+          'id', account_scope.account_id,
+          'name', account_scope.account_name,
+          'canManageAccount', public.can_manage_operator_payout_account(
+            actor_user_id,
+            account_scope.account_id
+          ),
+          'machines', coalesce((
+            select jsonb_agg(
+              jsonb_build_object(
+                'id', machine.id,
+                'label', machine.machine_label,
+                'machineType', machine.machine_type,
+                'locationId', machine.location_id,
+                'locationName', location.name,
+                'status', machine.status,
+                'canManage', public.can_manage_operator_payout_machine(actor_user_id, machine.id)
+              )
+              order by location.name, machine.machine_label, machine.id
+            )
+            from public.reporting_machines machine
+            join public.reporting_locations location
+              on location.id = machine.location_id
+            where machine.account_id = account_scope.account_id
+              and machine.status = 'active'
+              and (
+                public.can_manage_operator_payout_account(actor_user_id, account_scope.account_id)
+                or public.can_manage_operator_payout_machine(actor_user_id, machine.id)
+              )
+          ), '[]'::jsonb),
+          'policies', coalesce((
+            select jsonb_agg(
+              jsonb_build_object(
+                'id', policy.id,
+                'name', policy.name,
+                'frequency', policy.frequency,
+                'roundingRule', policy.rounding_rule,
+                'reviewModel', policy.review_model
+              )
+              order by policy.name, policy.id
+            )
+            from public.payout_policies policy
+            where policy.account_id = account_scope.account_id
+              and policy.active
+          ), '[]'::jsonb)
+        )
+        order by account_scope.account_name
+      )
+      from (
+        select distinct account.id as account_id, account.name as account_name
+        from public.customer_accounts account
+        where public.can_manage_operator_payout_account(actor_user_id, account.id)
+          or exists (
+            select 1
+            from public.reporting_machines machine
+            where machine.account_id = account.id
+              and machine.status = 'active'
+              and public.can_manage_operator_payout_machine(actor_user_id, machine.id)
+          )
+      ) account_scope
+    ), '[]'::jsonb),
+    'operators', coalesce((
+      select jsonb_agg(
+        jsonb_build_object(
+          'id', profile.id,
+          'accountId', profile.account_id,
+          'accountName', account.name,
+          'userId', profile.user_id,
+          'email', users.email,
+          'displayName', profile.display_name,
+          'workerType', profile.worker_type,
+          'status', profile.status,
+          'payoutPolicyId', profile.payout_policy_id,
+          'createdAt', profile.created_at,
+          'updatedAt', profile.updated_at,
+          'canSendInvite', public.can_send_operator_payout_invite(actor_user_id, profile.id),
+          'activeAssignments', coalesce((
+            select jsonb_agg(
+              jsonb_build_object(
+                'assignmentId', assignment.id,
+                'machineId', machine.id,
+                'machineLabel', machine.machine_label,
+                'locationId', machine.location_id,
+                'locationName', location.name,
+                'effectiveStartDate', assignment.effective_start_date,
+                'effectiveEndDate', assignment.effective_end_date,
+                'canManage', public.can_manage_operator_payout_machine(actor_user_id, machine.id)
+              )
+              order by location.name, machine.machine_label, assignment.id
+            )
+            from public.operator_machine_assignments assignment
+            join public.reporting_machines machine
+              on machine.id = assignment.reporting_machine_id
+            join public.reporting_locations location
+              on location.id = machine.location_id
+            where assignment.operator_profile_id = profile.id
+              and assignment.status = 'active'
+              and assignment.revoked_at is null
+          ), '[]'::jsonb),
+          'latestInvite', (
+            select case when delivery.id is null then null::jsonb else jsonb_build_object(
+              'id', delivery.id,
+              'sentAt', delivery.sent_at,
+              'deliveryStatus', delivery.delivery_status,
+              'errorMessage', delivery.error_message
+            ) end
+            from public.access_invite_deliveries delivery
+            where delivery.invite_type = 'operator_payout'
+              and delivery.source_type = 'operator_payout_profile'
+              and delivery.source_id = profile.id
+            order by delivery.sent_at desc
+            limit 1
+          )
+        )
+        order by account.name, profile.display_name, profile.id
+      )
+      from public.operator_payout_profiles profile
+      join public.customer_accounts account
+        on account.id = profile.account_id
+      left join auth.users users
+        on users.id = profile.user_id
+      where public.can_access_operator_payout_profile(actor_user_id, profile.id)
+        and (
+          public.can_manage_operator_payout_account(actor_user_id, profile.account_id)
+          or public.can_send_operator_payout_invite(actor_user_id, profile.id)
+        )
+    ), '[]'::jsonb)
+  )
+  into result;
+
+  return result;
+end;
+$$;
+
+create or replace function public.admin_provision_operator_payout_for_user(
+  p_actor_user_id uuid,
+  p_target_user_id uuid,
+  p_user_email text,
+  p_account_id uuid,
+  p_display_name text,
+  p_worker_type text,
+  p_payout_policy_id uuid,
+  p_machine_ids uuid[],
+  p_reason text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  normalized_email text;
+  normalized_display_name text;
+  normalized_worker_type text;
+  normalized_reason text;
+  normalized_machine_ids uuid[];
+  account_row public.customer_accounts;
+  target_user auth.users;
+  policy_row public.payout_policies;
+  before_profile public.operator_payout_profiles;
+  after_profile public.operator_payout_profiles;
+  before_assignments jsonb;
+  after_assignments jsonb;
+  requested_count integer;
+  account_machine_count integer;
+  manageable_count integer;
+begin
+  normalized_email := lower(trim(coalesce(p_user_email, '')));
+  normalized_display_name := trim(coalesce(p_display_name, ''));
+  normalized_reason := trim(coalesce(p_reason, ''));
+
+  if p_actor_user_id is null then
+    raise exception 'Actor user is required';
+  end if;
+
+  if p_target_user_id is null then
+    raise exception 'Target user is required';
+  end if;
+
+  if normalized_email = '' then
+    raise exception 'Operator email is required';
+  end if;
+
+  if normalized_display_name = '' then
+    normalized_display_name := normalized_email;
+  end if;
+
+  if normalized_reason = '' then
+    raise exception 'Operator provisioning reason is required';
+  end if;
+
+  select coalesce(array_agg(distinct machine_id), '{}'::uuid[])
+  into normalized_machine_ids
+  from unnest(coalesce(p_machine_ids, '{}'::uuid[])) as machine_ids(machine_id)
+  where machine_id is not null;
+
+  if cardinality(normalized_machine_ids) = 0 then
+    raise exception 'Assign at least one machine';
+  end if;
+
+  select *
+  into account_row
+  from public.customer_accounts account
+  where account.id = p_account_id
+  limit 1;
+
+  if account_row.id is null then
+    raise exception 'Account not found';
+  end if;
+
+  select *
+  into target_user
+  from auth.users users
+  where users.id = p_target_user_id
+  limit 1;
+
+  if target_user.id is null then
+    raise exception 'Target Auth user not found';
+  end if;
+
+  if lower(coalesce(target_user.email, '')) <> normalized_email then
+    raise exception 'Target Auth user email does not match operator email';
+  end if;
+
+  select count(*)
+  into requested_count
+  from unnest(normalized_machine_ids) as requested(machine_id);
+
+  select count(*)
+  into account_machine_count
+  from public.reporting_machines machine
+  where machine.id = any(normalized_machine_ids)
+    and machine.account_id = account_row.id
+    and machine.status = 'active';
+
+  if account_machine_count <> requested_count then
+    raise exception 'Every assigned machine must be active and belong to the selected account';
+  end if;
+
+  select count(*)
+  into manageable_count
+  from public.reporting_machines machine
+  where machine.id = any(normalized_machine_ids)
+    and public.can_manage_operator_payout_machine(p_actor_user_id, machine.id);
+
+  if not public.can_manage_operator_payout_account(p_actor_user_id, account_row.id)
+    and manageable_count <> requested_count then
+    raise exception 'Operator payout setup access is missing for one or more machines';
+  end if;
+
+  normalized_worker_type := lower(coalesce(nullif(trim(p_worker_type), ''), account_row.default_worker_type));
+
+  if normalized_worker_type not in (
+    'contractor_1099',
+    'employee_w2',
+    'part_time_employee',
+    'owner_operator',
+    'partner',
+    'other',
+    'unspecified'
+  ) then
+    raise exception 'Invalid worker type';
+  end if;
+
+  if p_payout_policy_id is not null then
+    select *
+    into policy_row
+    from public.payout_policies policy
+    where policy.id = p_payout_policy_id
+      and policy.account_id = account_row.id
+      and policy.active
+    limit 1;
+
+    if policy_row.id is null then
+      raise exception 'Payout policy not found for account';
+    end if;
+  else
+    select *
+    into policy_row
+    from public.payout_policies policy
+    where policy.id = account_row.default_payout_policy_id
+      and policy.account_id = account_row.id
+      and policy.active
+    limit 1;
+
+    if policy_row.id is null then
+      select *
+      into policy_row
+      from public.payout_policies policy
+      where policy.account_id = account_row.id
+        and policy.active
+      order by policy.created_at asc
+      limit 1;
+    end if;
+
+    if policy_row.id is null then
+      begin
+        insert into public.payout_policies (
+          account_id,
+          name,
+          frequency,
+          period_anchor_type,
+          monthly_period_type,
+          submission_due_offset_days,
+          grace_period_days,
+          lock_offset_days,
+          target_payout_offset_days,
+          rounding_rule,
+          review_model,
+          created_by,
+          updated_by
+        )
+        values (
+          account_row.id,
+          'Monthly operator payouts',
+          'monthly',
+          'calendar',
+          'calendar_month',
+          2,
+          0,
+          3,
+          5,
+          'round_up_60_minutes',
+          'final_review_only',
+          p_actor_user_id,
+          p_actor_user_id
+        )
+        returning * into policy_row;
+      exception
+        when unique_violation then
+          select *
+          into policy_row
+          from public.payout_policies policy
+          where policy.account_id = account_row.id
+            and lower(policy.name) = lower('Monthly operator payouts')
+            and policy.active
+          order by policy.created_at asc
+          limit 1;
+      end;
+    end if;
+
+    update public.customer_accounts
+    set default_payout_policy_id = policy_row.id
+    where id = account_row.id
+      and default_payout_policy_id is null;
+  end if;
+
+  select *
+  into before_profile
+  from public.operator_payout_profiles profile
+  where profile.account_id = account_row.id
+    and profile.user_id = p_target_user_id
+  limit 1;
+
+  if before_profile.id is not null then
+    select count(*)
+    into manageable_count
+    from public.operator_machine_assignments assignment
+    where assignment.operator_profile_id = before_profile.id
+      and assignment.status = 'active'
+      and assignment.revoked_at is null
+      and public.can_manage_operator_payout_machine(p_actor_user_id, assignment.reporting_machine_id);
+
+    select count(*)
+    into account_machine_count
+    from public.operator_machine_assignments assignment
+    where assignment.operator_profile_id = before_profile.id
+      and assignment.status = 'active'
+      and assignment.revoked_at is null;
+
+    if manageable_count <> account_machine_count
+      and not public.can_manage_operator_payout_account(p_actor_user_id, account_row.id) then
+      raise exception 'Existing out-of-scope assignments must be changed by a broader admin';
+    end if;
+  end if;
+
+  insert into public.operator_payout_profiles (
+    account_id,
+    user_id,
+    display_name,
+    worker_type,
+    status,
+    payout_policy_id,
+    created_by,
+    updated_by
+  )
+  values (
+    account_row.id,
+    p_target_user_id,
+    normalized_display_name,
+    normalized_worker_type,
+    'active',
+    policy_row.id,
+    p_actor_user_id,
+    p_actor_user_id
+  )
+  on conflict (account_id, user_id)
+  do update set
+    display_name = excluded.display_name,
+    worker_type = excluded.worker_type,
+    status = 'active',
+    payout_policy_id = excluded.payout_policy_id,
+    updated_by = p_actor_user_id
+  returning * into after_profile;
+
+  select coalesce(jsonb_agg(to_jsonb(assignment) order by assignment.created_at), '[]'::jsonb)
+  into before_assignments
+  from public.operator_machine_assignments assignment
+  where assignment.operator_profile_id = after_profile.id
+    and assignment.status = 'active'
+    and assignment.revoked_at is null;
+
+  update public.operator_machine_assignments assignment
+  set
+    status = 'revoked',
+    effective_end_date = current_date,
+    revoked_at = now(),
+    revoked_by = p_actor_user_id,
+    revoke_reason = normalized_reason
+  where assignment.operator_profile_id = after_profile.id
+    and assignment.status = 'active'
+    and assignment.revoked_at is null
+    and not (assignment.reporting_machine_id = any(normalized_machine_ids));
+
+  insert into public.operator_machine_assignments (
+    operator_profile_id,
+    account_id,
+    reporting_machine_id,
+    effective_start_date,
+    status,
+    grant_reason,
+    created_by
+  )
+  select
+    after_profile.id,
+    account_row.id,
+    machine_id,
+    current_date,
+    'active',
+    normalized_reason,
+    p_actor_user_id
+  from unnest(normalized_machine_ids) as requested(machine_id)
+  where not exists (
+    select 1
+    from public.operator_machine_assignments assignment
+    where assignment.operator_profile_id = after_profile.id
+      and assignment.reporting_machine_id = requested.machine_id
+      and assignment.status = 'active'
+      and assignment.revoked_at is null
+  );
+
+  select coalesce(
+    jsonb_agg(
+      jsonb_build_object(
+        'assignmentId', assignment.id,
+        'machineId', assignment.reporting_machine_id,
+        'machineLabel', machine.machine_label,
+        'locationId', machine.location_id,
+        'locationName', location.name,
+        'effectiveStartDate', assignment.effective_start_date,
+        'effectiveEndDate', assignment.effective_end_date
+      )
+      order by location.name, machine.machine_label, assignment.id
+    ),
+    '[]'::jsonb
+  )
+  into after_assignments
+  from public.operator_machine_assignments assignment
+  join public.reporting_machines machine
+    on machine.id = assignment.reporting_machine_id
+  join public.reporting_locations location
+    on location.id = machine.location_id
+  where assignment.operator_profile_id = after_profile.id
+    and assignment.status = 'active'
+    and assignment.revoked_at is null;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    target_user_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    p_actor_user_id,
+    'operator_employee_access.provisioned',
+    'operator_payout_profile',
+    after_profile.id::text,
+    p_target_user_id,
+    jsonb_build_object(
+      'profile', coalesce(to_jsonb(before_profile), '{}'::jsonb),
+      'assignments', before_assignments
+    ),
+    jsonb_build_object(
+      'profile', to_jsonb(after_profile),
+      'assignments', after_assignments
+    ),
+    jsonb_build_object(
+      'account_id', account_row.id,
+      'email', normalized_email,
+      'reason', normalized_reason,
+      'requested_machine_count', cardinality(normalized_machine_ids),
+      'tax_compliance_engine', false,
+      'payroll_provider_execution', false
+    )
+  );
+
+  return jsonb_build_object(
+    'operatorProfile', jsonb_build_object(
+      'id', after_profile.id,
+      'accountId', after_profile.account_id,
+      'accountName', account_row.name,
+      'userId', after_profile.user_id,
+      'email', normalized_email,
+      'displayName', after_profile.display_name,
+      'workerType', after_profile.worker_type,
+      'status', after_profile.status,
+      'payoutPolicyId', after_profile.payout_policy_id
+    ),
+    'assignments', after_assignments,
+    'activeAssignmentCount', jsonb_array_length(after_assignments)
+  );
+end;
+$$;
+
+create or replace function public.admin_deactivate_operator_payout_profile_for_user(
+  p_actor_user_id uuid,
+  p_operator_profile_id uuid,
+  p_reason text
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  normalized_reason text;
+  before_profile public.operator_payout_profiles;
+  after_profile public.operator_payout_profiles;
+  before_assignments jsonb;
+  after_assignments jsonb;
+  manageable_count integer;
+  assignment_count integer;
+begin
+  normalized_reason := trim(coalesce(p_reason, ''));
+
+  if p_actor_user_id is null then
+    raise exception 'Actor user is required';
+  end if;
+
+  if p_operator_profile_id is null then
+    raise exception 'Operator profile is required';
+  end if;
+
+  if normalized_reason = '' then
+    raise exception 'Operator deactivation reason is required';
+  end if;
+
+  select *
+  into before_profile
+  from public.operator_payout_profiles profile
+  where profile.id = p_operator_profile_id
+  limit 1;
+
+  if before_profile.id is null then
+    raise exception 'Operator payout profile not found';
+  end if;
+
+  select count(*)
+  into manageable_count
+  from public.operator_machine_assignments assignment
+  where assignment.operator_profile_id = before_profile.id
+    and assignment.status = 'active'
+    and assignment.revoked_at is null
+    and public.can_manage_operator_payout_machine(p_actor_user_id, assignment.reporting_machine_id);
+
+  select count(*)
+  into assignment_count
+  from public.operator_machine_assignments assignment
+  where assignment.operator_profile_id = before_profile.id
+    and assignment.status = 'active'
+    and assignment.revoked_at is null;
+
+  if not public.can_manage_operator_payout_account(p_actor_user_id, before_profile.account_id)
+    and manageable_count <> assignment_count then
+    raise exception 'Existing out-of-scope assignments must be changed by a broader admin';
+  end if;
+
+  if assignment_count = 0
+    and not public.can_manage_operator_payout_account(p_actor_user_id, before_profile.account_id) then
+    raise exception 'Operator payout setup access required';
+  end if;
+
+  select coalesce(jsonb_agg(to_jsonb(assignment) order by assignment.created_at), '[]'::jsonb)
+  into before_assignments
+  from public.operator_machine_assignments assignment
+  where assignment.operator_profile_id = before_profile.id
+    and assignment.status = 'active'
+    and assignment.revoked_at is null;
+
+  update public.operator_payout_profiles
+  set
+    status = 'inactive',
+    updated_by = p_actor_user_id
+  where id = before_profile.id
+  returning * into after_profile;
+
+  update public.operator_machine_assignments assignment
+  set
+    status = 'revoked',
+    effective_end_date = current_date,
+    revoked_at = now(),
+    revoked_by = p_actor_user_id,
+    revoke_reason = normalized_reason
+  where assignment.operator_profile_id = before_profile.id
+    and assignment.status = 'active'
+    and assignment.revoked_at is null;
+
+  select coalesce(jsonb_agg(to_jsonb(assignment) order by assignment.created_at), '[]'::jsonb)
+  into after_assignments
+  from public.operator_machine_assignments assignment
+  where assignment.operator_profile_id = before_profile.id
+    and assignment.status = 'active'
+    and assignment.revoked_at is null;
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    target_user_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    p_actor_user_id,
+    'operator_employee_access.deactivated',
+    'operator_payout_profile',
+    before_profile.id::text,
+    before_profile.user_id,
+    jsonb_build_object(
+      'profile', to_jsonb(before_profile),
+      'assignments', before_assignments
+    ),
+    jsonb_build_object(
+      'profile', to_jsonb(after_profile),
+      'assignments', after_assignments
+    ),
+    jsonb_build_object(
+      'account_id', before_profile.account_id,
+      'reason', normalized_reason
+    )
+  );
+
+  return jsonb_build_object(
+    'operatorProfileId', after_profile.id,
+    'status', after_profile.status,
+    'activeAssignmentCount', 0
+  );
+end;
+$$;
+
+drop policy if exists "access_invite_deliveries_select_operator_payout_managers"
+  on public.access_invite_deliveries;
+create policy "access_invite_deliveries_select_operator_payout_managers"
+on public.access_invite_deliveries
+for select
+to authenticated
+using (
+  invite_type = 'operator_payout'
+  and source_type = 'operator_payout_profile'
+  and public.can_send_operator_payout_invite_current_user(source_id)
+);
+
+comment on column public.access_invite_deliveries.invite_type is
+  'User-facing invite preset. Supports Corporate Partner, Technician, Machine Manager, and Operator Payout signup emails.';
+
+comment on column public.access_invite_deliveries.source_type is
+  'Source behind the invite: corporate_partner_membership, technician_grant, reporting_machine, or operator_payout_profile.';
+
+comment on function public.operator_payout_can_manage_machine_set(uuid, uuid, uuid[]) is
+  'Internal helper for validating operator provisioning machine scopes without exposing arbitrary user-id checks to browser callers.';
+
+comment on function public.can_send_operator_payout_invite(uuid, uuid) is
+  'Returns true when the actor may send or view invite evidence for an active operator payout profile they manage.';
+
+comment on function public.can_send_operator_payout_invite_current_user(uuid) is
+  'Current-user wrapper for operator payout invite evidence RLS.';
+
+comment on function public.admin_find_auth_user_by_email(text) is
+  'Service-role-only helper for operator provisioning Edge Functions to resolve an Auth user without exposing auth.users to browsers.';
+
+comment on function public.get_operator_payout_setup_context() is
+  'Admin/scoped-manager setup context for provisioning operator payout profiles and assigned machines.';
+
+comment on function public.admin_provision_operator_payout_for_user(uuid, uuid, text, uuid, text, text, uuid, uuid[], text) is
+  'Service-role-only helper that provisions an operator payout profile for an already resolved Auth user with audited machine assignments.';
+
+comment on function public.admin_deactivate_operator_payout_profile_for_user(uuid, uuid, text) is
+  'Service-role-only helper that deactivates an operator payout profile and revokes active assignments with audit history.';
+
+revoke execute on function public.operator_payout_can_manage_machine_set(uuid, uuid, uuid[])
+  from public, anon, authenticated;
+revoke execute on function public.can_send_operator_payout_invite(uuid, uuid)
+  from public, anon, authenticated;
+revoke execute on function public.can_send_operator_payout_invite_current_user(uuid)
+  from public, anon, authenticated;
+revoke execute on function public.admin_find_auth_user_by_email(text)
+  from public, anon, authenticated;
+revoke execute on function public.get_operator_payout_setup_context()
+  from public, anon;
+revoke execute on function public.admin_provision_operator_payout_for_user(uuid, uuid, text, uuid, text, text, uuid, uuid[], text)
+  from public, anon, authenticated;
+revoke execute on function public.admin_deactivate_operator_payout_profile_for_user(uuid, uuid, text)
+  from public, anon, authenticated;
+
+grant execute on function public.operator_payout_can_manage_machine_set(uuid, uuid, uuid[])
+  to service_role;
+grant execute on function public.can_send_operator_payout_invite(uuid, uuid)
+  to service_role;
+grant execute on function public.can_send_operator_payout_invite_current_user(uuid)
+  to authenticated;
+grant execute on function public.admin_find_auth_user_by_email(text)
+  to service_role;
+grant execute on function public.get_operator_payout_setup_context()
+  to authenticated;
+grant execute on function public.admin_provision_operator_payout_for_user(uuid, uuid, text, uuid, text, text, uuid, uuid[], text)
+  to service_role;
+grant execute on function public.admin_deactivate_operator_payout_profile_for_user(uuid, uuid, text)
+  to service_role;
+
+select pg_notify('pgrst', 'reload schema');


### PR DESCRIPTION
﻿## Summary
- Adds `/admin/payouts` Operator Setup for employee operator provisioning, machine assignment, invite resend/copy, and deactivation.
- Adds service-role-only Supabase provisioning RPCs plus a new `operator-payout-provision` Edge Function for Auth-user creation/reuse and audited profile/assignment writes.
- Extends `access-invite` to support `operator_payout` invite evidence and adds static/browser UAT validators.

## Files changed
- Supabase: new migration, new `operator-payout-provision` Edge Function, `access-invite` operator-payout support, function config.
- Frontend: payout helpers, access-invite types/login intent, `/admin/payouts` Operator Setup UI.
- Verification/docs: RPC surface validator, #505 static validator, Playwright UAT, smoke checklist, current status note.

## Verification commands + results
- `npm ci` - passed; npm reported existing dependency audit advisories: 3 moderate, 1 high.
- `npm run build` - passed; Vite build completed and prerendered 25 public routes plus SEO head tags for 26 private routes.
- `npm test --if-present` - passed.
- `npm run lint --if-present` - passed.
- `npx tsc --noEmit` - passed.
- `npm run operator-payouts:validate-employee-provisioning` - passed.
- `npm run operator-payouts:validate-employee-provisioning-uat -- --app-url http://127.0.0.1:8081 --artifact-dir output/playwright/operator-employee-provisioning` - passed; desktop/mobile screenshots captured.
- `npm run db:validate-rpc-surface` - passed.
- `npm run auth:preflight` with mock local `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` - passed with expected warnings for mock host and missing Google client ID.
- `git diff --check` - passed; only LF/CRLF warnings on this Windows worktree.
- `npm run db:validate-migrations` - not run to completion locally because Docker Desktop is not running: failed to connect to `dockerDesktopLinuxEngine`.

## How to test
1. Apply migrations and deploy Edge Functions in a non-production Supabase environment with `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` available to functions.
2. Start the app and sign in as a Super Admin or scoped payout manager with access to `/admin/payouts`.
3. Open `/admin/payouts`, fill Operator Setup with a never-authenticated employee email, select one or more manageable active machines, enter an audit reason, and save.
4. Confirm the operator profile appears in Operator Access, `operator_payout` invite evidence is written, and the login link includes `intent=operator_payout` with the invited email.
5. Use Resend and Copy Link from Operator Access.
6. Deactivate the operator with an audit reason; confirm active assignments are revoked and future `/portal/time` entry is blocked for that operator while history remains.

## UAT packet
- Local mocked browser UAT covers: never-authenticated employee provisioning payload, automatic invite attempt, saved-but-invite-failed state, resend recovery, delivery evidence, copy link, deactivation request, assignment clearing, and desktop/mobile overflow.
- Screenshot artifacts: `output/playwright/operator-employee-provisioning`.
- Remaining live UAT gate: owner/test-inbox confirmation that the real email provider accepts/delivers the operator invite and that the invited employee activates with the intended email.

## Risk / overlap
- Red-lane areas: DB migration, RLS, Auth admin user creation, service-role Edge Function, invite email evidence.
- This does not execute payroll provider payments and does not add tax-compliance automation.
- Owner approval required before merge/deploy.

## Rollback
- Revert this PR to remove the admin UI/helper changes and Edge Function/config changes.
- If already deployed, remove or supersede migration-created RPCs/policies/constraints with a rollback migration before disabling the function in production.

Refs #505
