### PR TITLE
Clean scoped admin access permissions UI

### DIFF
--- a/scripts/validate-scoped-admin-technician-uat.mjs
+++ b/scripts/validate-scoped-admin-technician-uat.mjs
@@ -884,6 +884,22 @@ const run = async () => {
             state.accessInviteBodies[0]?.sourceId === grantId,
           JSON.stringify(state.accessInviteBodies[0])
         );
+        recorder.assert(
+          'Scoped Admin Access hides legacy Corporate Partner preset panel',
+          !(await page.getByRole('heading', { name: 'Corporate Partner preset' }).isVisible().catch(() => false))
+        );
+        recorder.assert(
+          'Scoped Admin Access hides Corporate Partner grant CTA',
+          !(await page.getByRole('button', { name: /Grant Corporate Partner/i }).isVisible().catch(() => false))
+        );
+        recorder.assert(
+          'Scoped Admin Access hides legacy machine tax panel',
+          !(await page.getByRole('heading', { name: 'Machine tax rates' }).isVisible().catch(() => false))
+        );
+        recorder.assert(
+          'Scoped Admin Access hides legacy reporting matrix loader',
+          !(await page.getByLabel('Add existing user by email').isVisible().catch(() => false))
+        );
 
         const updateInScopeProbe = await directRpcProbe(page, 'admin_update_technician_machines', {
           p_grant_id: grantId,
@@ -934,11 +950,15 @@ const run = async () => {
         );
         recorder.assert(
           'Scoped Admin Account Settings hides billing tools',
-          !(await page.getByText('Billing').isVisible().catch(() => false))
+          !(await page.getByRole('heading', { name: /^Billing$/ }).isVisible().catch(() => false)) &&
+            !(await page.getByRole('button', { name: /Open Billing Portal|Manage Billing/i }).isVisible().catch(() => false)) &&
+            !(await page.getByRole('link', { name: /View Plus Membership/i }).isVisible().catch(() => false))
         );
 
         await page.goto(`${args.appUrl}/portal/team`, { waitUntil: 'domcontentloaded' });
-        await page.getByText(/Team requires Team access/i).waitFor({ timeout: 10000 });
+        await page
+          .getByText(/Team management is reserved for Plus account owners/i)
+          .waitFor({ timeout: 10000 });
         recorder.assert(
           'Scoped Admin direct Portal Team offers Admin Access exit',
           await page.getByRole('link', { name: 'Open Admin Access' }).isVisible()
@@ -980,7 +1000,9 @@ const run = async () => {
         });
 
         await page.goto(`${args.appUrl}/portal/team`, { waitUntil: 'domcontentloaded' });
-        await page.getByText(/Team requires Team access/i).waitFor({ timeout: 10000 });
+        await page
+          .getByText(/Team management is reserved for Plus account owners/i)
+          .waitFor({ timeout: 10000 });
         recorder.assert(
           'Capability drift direct Portal Team offers Admin Access exit',
           await page.getByRole('link', { name: 'Open Admin Access' }).isVisible()

--- a/src/pages/admin/Access.tsx
+++ b/src/pages/admin/Access.tsx
@@ -212,15 +212,12 @@ export default function AdminAccessPage() {
             )}
 
             {!isSuperAdmin && (
-              <div className="mt-6 space-y-6">
+              <div className="mt-6">
                 <div className="rounded-lg border border-border bg-muted/20 p-4 text-sm text-muted-foreground">
-                  Your scoped admin grant limits this workspace to assigned machines. Saving changes
-                  only affects Technician grants, Corporate Partner permissions, and manual
-                  reporting grants inside that scope.
+                  Your scoped admin grant limits this workspace to assigned machines. Use the
+                  person workspace above to manage Technician grants inside that assigned-machine
+                  scope.
                 </div>
-                <PresetsTab />
-                <ScopedMachineTaxRatesPanel />
-                <ReportingAccessTab />
               </div>
             )}
           </div>
@@ -231,7 +228,6 @@ export default function AdminAccessPage() {
 }
 
 function PresetsTab() {
-  const { isSuperAdmin } = useAuth();
   const queryClient = useQueryClient();
   const [personEmail, setPersonEmail] = useState('');
   const [effectiveAccess, setEffectiveAccess] = useState<EffectiveAccessContext | null>(null);
@@ -1413,7 +1409,6 @@ function UsersTab() {
 }
 
 function ReportingAccessTab() {
-  const { isScopedAdmin, isSuperAdmin } = useAuth();
   const queryClient = useQueryClient();
   const [peopleSearch, setPeopleSearch] = useState('');
   const [lookupEmail, setLookupEmail] = useState('');


### PR DESCRIPTION
Closes #567

## Summary
- Replaces the scoped-admin legacy panels below Admin Access with one concise assigned-machine scope notice.
- Keeps scoped admins in the person-first Access workspace for Technician grants instead of showing separate Corporate Partner, tax, and reporting matrix workflows.
- Expands the scoped-admin Technician UAT script to assert those legacy controls remain hidden and updates stale route-copy assertions.

## Files changed
- `src/pages/admin/Access.tsx`: scoped-admin Access hierarchy and copy.
- `scripts/validate-scoped-admin-technician-uat.mjs`: scoped-admin UAT assertions for hidden legacy controls and current locked-route copy.

## Verification commands + results
- `npm ci` - passed; npm audit still reports existing 4 vulnerabilities from project dependencies.
- `npm run build` - passed.
- `npm test --if-present` - passed; no test script is configured, so npm exited without output.
- `npm run lint --if-present` - passed.
- `npm run scoped-admin-technicians:validate-uat -- --app-url http://127.0.0.1:8082` - passed.

## How to test
1. Check out this branch.
2. Run `npm ci`.
3. Start local UAT server:
   `VITE_SUPABASE_URL=https://example.supabase.co VITE_SUPABASE_ANON_KEY=mock-anon-key npm exec -- vite --host 127.0.0.1 --port 8082 --strictPort`
4. Run `npm run scoped-admin-technicians:validate-uat -- --app-url http://127.0.0.1:8082`.
5. Key local URLs while the server is running:
   - `http://127.0.0.1:8082/admin/access?action=add-access&preset=technician`
   - `http://127.0.0.1:8082/portal/account`
   - `http://127.0.0.1:8082/portal/team`

## UAT notes
- This is a red-lane permissions UX change. Do not auto-merge before owner UAT.
- The scripted UAT uses mocked Supabase responses for `scoped-admin@example.test`, `super-admin@example.test`, and `capability-drift@example.test`.
- Expected scoped-admin result: the Access page shows the person workspace and assigned-machine scope notice, without the old Corporate Partner preset, machine tax rates, or reporting matrix panels.