### PR TITLE
Fix scoped admin Access landing routes

### DIFF
--- a/scripts/validate-scoped-admin-technician-uat.mjs
+++ b/scripts/validate-scoped-admin-technician-uat.mjs
@@ -663,6 +663,76 @@ const login = async (page, user) => {
   await page.getByRole('button', { name: /sign in/i }).click();
 };
 
+const openPathAsUser = async (page, args, user, pathName) => {
+  await page.goto(`${args.appUrl}${pathName}`, { waitUntil: 'domcontentloaded' });
+  await login(page, user);
+  await page.goto(`${args.appUrl}${pathName}`, { waitUntil: 'domcontentloaded' });
+};
+
+const assertScopedAdminAccessRoute = async ({
+  page,
+  args,
+  recorder,
+  user,
+  pathName,
+  label,
+  expectLauncher = false,
+  expectActivity = false,
+}) => {
+  await openPathAsUser(page, args, user, pathName);
+  const primaryLocator = expectLauncher
+    ? page.getByRole('heading', { name: 'Add Technician' })
+    : page.getByRole('heading', { name: 'Access' });
+
+  await primaryLocator
+    .waitFor({ timeout: 10000 })
+    .catch(async (error) => {
+      await page.screenshot({
+        path: path.join(args.artifactDir, `${label.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-route-timeout.png`),
+        fullPage: true,
+      });
+      const bodyText = await page.locator('body').innerText().catch(() => '');
+      console.error(`${label} did not reach Admin Access at ${page.url()}`);
+      console.error(bodyText.slice(0, 2000));
+      throw error;
+    });
+
+  const url = new URL(page.url());
+  recorder.assert(
+    `${label} lands on Admin Access`,
+    url.pathname === '/admin/access',
+    page.url()
+  );
+
+  if (expectLauncher) {
+    const launcherUrl = new URL(page.url());
+    recorder.assert(
+      `${label} normalizes to Technician launcher`,
+      launcherUrl.searchParams.get('action') === 'add-access' &&
+        launcherUrl.searchParams.get('preset') === 'technician',
+      page.url()
+    );
+    recorder.assert(
+      `${label} opens Add Technician launcher`,
+      await page.getByRole('heading', { name: 'Add Technician' }).isVisible()
+    );
+  } else {
+    recorder.assert(
+      `${label} exposes Add Technician primary action`,
+      await page.getByRole('button', { name: 'Add Technician' }).isVisible()
+    );
+  }
+
+  if (expectActivity) {
+    await page.getByRole('heading', { name: 'Global activity' }).waitFor({ timeout: 10000 });
+    recorder.assert(
+      `${label} preserves audit activity focus`,
+      url.searchParams.get('tab') === 'audit',
+      page.url()
+    );
+  }
+};
+
 const directRpcProbe = async (page, rpcName, payload) =>
   page.evaluate(
     async ({ rpcName: evaluatedRpcName, payload: evaluatedPayload, supabaseUrl }) => {
@@ -815,6 +885,51 @@ const run = async () => {
       name: 'Scoped Admin Technician grant',
       state: createState({ actor: 'scoped_admin' }),
       test: async ({ page, state }) => {
+        await assertScopedAdminAccessRoute({
+          page,
+          args,
+          recorder,
+          user: state.user,
+          pathName: '/admin',
+          label: 'Scoped Admin /admin landing',
+          expectLauncher: true,
+        });
+        await assertScopedAdminAccessRoute({
+          page,
+          args,
+          recorder,
+          user: state.user,
+          pathName: '/admin/access',
+          label: 'Scoped Admin /admin/access landing',
+        });
+        await assertScopedAdminAccessRoute({
+          page,
+          args,
+          recorder,
+          user: state.user,
+          pathName: '/admin/access?tab=reporting-access',
+          label: 'Scoped Admin legacy reporting-access tab',
+          expectLauncher: true,
+        });
+        await assertScopedAdminAccessRoute({
+          page,
+          args,
+          recorder,
+          user: state.user,
+          pathName: '/admin/access?action=add-access&preset=technician',
+          label: 'Scoped Admin explicit Technician launcher',
+          expectLauncher: true,
+        });
+        await assertScopedAdminAccessRoute({
+          page,
+          args,
+          recorder,
+          user: state.user,
+          pathName: '/admin/audit',
+          label: 'Scoped Admin audit shortcut',
+          expectActivity: true,
+        });
+
         await openTechnicianLauncher(page, args, state.user);
         await page.locator('p').filter({ hasText: /^Scoped Admin machine scope$/ }).waitFor({ timeout: 10000 });
 
@@ -934,11 +1049,15 @@ const run = async () => {
         );
         recorder.assert(
           'Scoped Admin Account Settings hides billing tools',
-          !(await page.getByText('Billing').isVisible().catch(() => false))
+          !(await page.getByRole('heading', { name: /^Billing$/ }).isVisible().catch(() => false)) &&
+            !(await page.getByRole('button', { name: /Open Billing Portal|Manage Billing/i }).isVisible().catch(() => false)) &&
+            !(await page.getByRole('link', { name: /View Plus Membership/i }).isVisible().catch(() => false))
         );
 
         await page.goto(`${args.appUrl}/portal/team`, { waitUntil: 'domcontentloaded' });
-        await page.getByText(/Team requires Team access/i).waitFor({ timeout: 10000 });
+        await page
+          .getByText(/Team management is reserved for Plus account owners/i)
+          .waitFor({ timeout: 10000 });
         recorder.assert(
           'Scoped Admin direct Portal Team offers Admin Access exit',
           await page.getByRole('link', { name: 'Open Admin Access' }).isVisible()
@@ -980,7 +1099,9 @@ const run = async () => {
         });
 
         await page.goto(`${args.appUrl}/portal/team`, { waitUntil: 'domcontentloaded' });
-        await page.getByText(/Team requires Team access/i).waitFor({ timeout: 10000 });
+        await page
+          .getByText(/Team management is reserved for Plus account owners/i)
+          .waitFor({ timeout: 10000 });
         recorder.assert(
           'Capability drift direct Portal Team offers Admin Access exit',
           await page.getByRole('link', { name: 'Open Admin Access' }).isVisible()

--- a/src/components/auth/AdminRoute.tsx
+++ b/src/components/auth/AdminRoute.tsx
@@ -4,6 +4,8 @@ import { Button } from '@/components/ui/button';
 import { PortalLayout } from '@/components/portal/PortalLayout';
 import { useAuth } from '@/contexts/auth-context';
 
+const scopedAdminAccessLanding = '/admin/access?action=add-access&preset=technician';
+
 export function AdminRoute() {
   const { adminAccess, loading, isAdmin, isScopedAdmin, isSuperAdmin } = useAuth();
   const location = useLocation();
@@ -12,6 +14,7 @@ export function AdminRoute() {
     isSuperAdmin || allowedSurfaces.has('*') || allowedSurfaces.has(surface);
   const isAdminAccessPath =
     location.pathname === '/admin/access' || location.pathname.startsWith('/admin/access/');
+  const isAdminAuditShortcutPath = location.pathname === '/admin/audit';
 
   if (loading) {
     return (
@@ -34,16 +37,16 @@ export function AdminRoute() {
     return <Navigate to="/portal/refunds" replace />;
   }
 
-  if (!isSuperAdmin && isAdmin && location.pathname === '/admin') {
+  if (!isSuperAdmin && (isAdmin || isScopedAdmin) && location.pathname === '/admin') {
     const redirectTarget = canAccessSurface('payouts')
       ? '/admin/payouts'
       : canAccessSurface('refunds')
       ? '/portal/refunds'
-      : '/admin/access?tab=reporting-access';
+      : scopedAdminAccessLanding;
     return <Navigate to={redirectTarget} replace />;
   }
 
-  if (isScopedAdmin && canAccessSurface('access') && isAdminAccessPath) {
+  if (isScopedAdmin && canAccessSurface('access') && (isAdminAccessPath || isAdminAuditShortcutPath)) {
     return <Outlet />;
   }
 

--- a/src/pages/admin/Access.tsx
+++ b/src/pages/admin/Access.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
   AlertTriangle,
   CheckCircle2,
@@ -165,6 +165,7 @@ const roleSort = (a: AdminRoleRecord, b: AdminRoleRecord) => {
 
 export default function AdminAccessPage() {
   const { isScopedAdmin, isSuperAdmin } = useAuth();
+  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const initialShowActivity = searchParams.get('tab') === 'audit';
   const initialLauncher = useMemo(
@@ -177,6 +178,26 @@ export default function AdminAccessPage() {
     }),
     [searchParams]
   );
+
+  useEffect(() => {
+    if (!isScopedAdmin || isSuperAdmin) return;
+
+    const legacyTab = searchParams.get('tab');
+    if (!legacyTab || legacyTab === 'audit') return;
+
+    const normalizedParams = new URLSearchParams(searchParams);
+    normalizedParams.delete('tab');
+    normalizedParams.set('action', 'add-access');
+    normalizedParams.set('preset', 'technician');
+
+    navigate(
+      {
+        pathname: '/admin/access',
+        search: `?${normalizedParams.toString()}`,
+      },
+      { replace: true }
+    );
+  }, [isScopedAdmin, isSuperAdmin, navigate, searchParams]);
 
   return (
     <AppLayout>


### PR DESCRIPTION
Closes #569

## Summary
- Redirects scoped admins from `/admin` to the supported Add Technician launcher instead of the stale `tab=reporting-access` state.
- Normalizes legacy scoped-admin `/admin/access?tab=<old-value>` URLs to `action=add-access&preset=technician`, while preserving `tab=audit` for the activity view.
- Expands scoped-admin Technician UAT coverage for `/admin`, `/admin/access`, `/admin/access?tab=reporting-access`, `/admin/access?action=add-access&preset=technician`, and `/admin/audit`.

## Files changed
- `src/components/auth/AdminRoute.tsx`: scoped-admin `/admin` and `/admin/audit` routing.
- `src/pages/admin/Access.tsx`: scoped-admin legacy tab normalization.
- `scripts/validate-scoped-admin-technician-uat.mjs`: route assertions and stale copy assertion repair.

## Verification commands + results
- `npm ci` - passed; npm audit still reports existing 4 vulnerabilities from project dependencies.
- `npm run build` - passed.
- `npm test --if-present` - passed; no test script is configured, so npm exited without output.
- `npm run lint --if-present` - passed.
- `git diff --check` - passed.
- `VITE_SUPABASE_URL=https://example.supabase.co VITE_SUPABASE_ANON_KEY=mock-anon-key npm run auth:preflight` - passed with expected placeholder URL/key warnings.
- `npm run scoped-admin-technicians:validate-uat -- --app-url http://127.0.0.1:8083` - passed.

## Not run / blocked
- `npm run db:validate-migrations` - blocked locally because Docker Desktop / Docker Linux engine is not available.

## How to test
1. Check out this branch.
2. Run `npm ci`.
3. Start local UAT server:
   `VITE_SUPABASE_URL=https://example.supabase.co VITE_SUPABASE_ANON_KEY=mock-anon-key npm exec -- vite --host 127.0.0.1 --port 8083 --strictPort`
4. Run `npm run scoped-admin-technicians:validate-uat -- --app-url http://127.0.0.1:8083`.
5. Key local URLs while the server is running:
   - `http://127.0.0.1:8083/admin`
   - `http://127.0.0.1:8083/admin/access`
   - `http://127.0.0.1:8083/admin/access?tab=reporting-access`
   - `http://127.0.0.1:8083/admin/access?action=add-access&preset=technician`
   - `http://127.0.0.1:8083/admin/audit`

## UAT notes
- Red-lane UI permissions change: owner UAT required before merge.
- The scripted UAT uses mocked Supabase responses for `scoped-admin@example.test`, `super-admin@example.test`, and `capability-drift@example.test`.
- Merge-order note: this PR touches the same scoped-admin UAT stale-copy assertions as #573. If #573 merges first, resolve the small script overlap by keeping the stricter route assertions from this PR and the hidden-legacy-panel assertions from #573.