### PR TITLE
P0 Permissions UX 02: Build scoped partnerships UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "admin-access:validate-invite-uat": "node scripts/validate-admin-access-invite-uat.mjs",
     "partner-technicians:validate-uat": "node scripts/validate-partner-technician-access-uat.mjs",
     "scoped-admin-technicians:validate-uat": "node scripts/validate-scoped-admin-technician-uat.mjs",
+    "scoped-partnerships:validate-uat": "node scripts/validate-scoped-partnerships-uat.mjs",
     "refunds:pilot-readiness": "node scripts/refunds/pilot-readiness.mjs",
     "refunds:pilot-cohort-config": "node scripts/refunds/pilot-cohort-config.mjs",
     "operator-payouts:validate-foundation": "node scripts/validate-operator-payout-foundation.mjs",

--- a/scripts/validate-scoped-partnerships-uat.mjs
+++ b/scripts/validate-scoped-partnerships-uat.mjs
@@ -1,0 +1,660 @@
+import { chromium } from 'playwright';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+
+const DEFAULT_APP_URL = 'http://127.0.0.1:8081';
+const DEFAULT_ARTIFACT_DIR = 'output/playwright';
+const MOCK_SUPABASE_URL = 'https://example.supabase.co';
+const MOCK_SUPABASE_AUTH_STORAGE_KEY = 'sb-example-auth-token';
+
+const parseArgs = (argv) => {
+  const args = {
+    appUrl: process.env.SCOPED_PARTNERSHIPS_UAT_APP_URL || DEFAULT_APP_URL,
+    artifactDir: process.env.SCOPED_PARTNERSHIPS_UAT_ARTIFACT_DIR || DEFAULT_ARTIFACT_DIR,
+    headed: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--headed') {
+      args.headed = true;
+      continue;
+    }
+
+    if (arg === '--app-url') {
+      args.appUrl = argv[index + 1] || args.appUrl;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--app-url=')) {
+      args.appUrl = arg.slice('--app-url='.length) || args.appUrl;
+      continue;
+    }
+
+    if (arg === '--artifact-dir') {
+      args.artifactDir = argv[index + 1] || args.artifactDir;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--artifact-dir=')) {
+      args.artifactDir = arg.slice('--artifact-dir='.length) || args.artifactDir;
+    }
+  }
+
+  args.appUrl = args.appUrl.replace(/\/+$/, '');
+  args.artifactDir = path.resolve(process.cwd(), args.artifactDir);
+  return args;
+};
+
+const now = new Date();
+const isoHoursAgo = (hours) => new Date(now.getTime() - hours * 60 * 60 * 1000).toISOString();
+
+const scopedAdminUser = {
+  id: '22222222-2222-4222-8222-222222222222',
+  aud: 'authenticated',
+  role: 'authenticated',
+  email: 'adam.scoped-admin@example.test',
+  email_confirmed_at: isoHoursAgo(24),
+  confirmed_at: isoHoursAgo(24),
+  last_sign_in_at: now.toISOString(),
+  app_metadata: { provider: 'email', providers: ['email'] },
+  user_metadata: {},
+};
+
+const inScopeMachineId = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const outsideMachineId = 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee';
+const existingPartnershipId = '11111111-aaaa-4111-8111-aaaaaaaaaaaa';
+const newPartnershipId = '22222222-bbbb-4222-8222-bbbbbbbbbbbb';
+const existingAssignmentId = '33333333-cccc-4333-8333-cccccccccccc';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers':
+    'apikey, authorization, content-type, x-client-info, x-supabase-auth-token',
+  'Access-Control-Allow-Methods': 'GET, POST, PATCH, DELETE, OPTIONS',
+};
+
+const jsonResponse = (body, status = 200) => ({
+  status,
+  contentType: 'application/json',
+  headers: corsHeaders,
+  body: JSON.stringify(body),
+});
+
+const buildSession = (user) => ({
+  access_token: `mock-access-token-${user.id}`,
+  token_type: 'bearer',
+  expires_in: 3600,
+  expires_at: Math.floor(Date.now() / 1000) + 3600,
+  refresh_token: `mock-refresh-token-${user.id}`,
+  user,
+});
+
+const createRecorder = () => {
+  const results = [];
+
+  return {
+    pass(name, detail = '') {
+      results.push({ name, pass: true, detail });
+      console.log(`PASS ${name}${detail ? ` - ${detail}` : ''}`);
+    },
+    fail(name, detail = '') {
+      results.push({ name, pass: false, detail });
+      console.log(`FAIL ${name}${detail ? ` - ${detail}` : ''}`);
+    },
+    assert(name, condition, detail = '') {
+      if (condition) {
+        this.pass(name, detail);
+      } else {
+        this.fail(name, detail);
+      }
+    },
+    failed() {
+      return results.filter((result) => !result.pass);
+    },
+  };
+};
+
+const waitForCondition = async (predicate, label, timeoutMs = 10000) => {
+  const startedAt = Date.now();
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return;
+    await delay(100);
+  }
+
+  throw new Error(`${label} timed out after ${timeoutMs}ms`);
+};
+
+const buildScopedMachine = () => ({
+  id: inScopeMachineId,
+  machine_label: 'MTLV Kiosk 01',
+  machine_type: 'commercial',
+  sunze_machine_id: 'mtlv-001',
+  status: 'active',
+  account_name: 'Madame Tussauds Las Vegas',
+  location_name: 'Las Vegas Strip',
+  latest_sale_date: '2026-06-01',
+});
+
+const buildOutsideMachine = () => ({
+  id: outsideMachineId,
+  machine_label: 'MTLV Kiosk 02',
+  machine_type: 'commercial',
+  sunze_machine_id: 'mtlv-002',
+  status: 'active',
+  account_name: 'Madame Tussauds Las Vegas',
+  location_name: 'Back of House',
+  latest_sale_date: '2026-06-01',
+});
+
+const buildExistingPartnership = () => ({
+  id: existingPartnershipId,
+  name: 'MTLV Venue Share',
+  partnership_type: 'revenue_share',
+  reporting_week_end_day: 0,
+  timezone: 'America/Los_Angeles',
+  reporting_frequency: 'weekly_and_monthly',
+  monthly_report_due_days: 10,
+  invoice_payment_due_days: null,
+  payment_method: null,
+  machine_ownership_model: 'unknown',
+  consumer_pricing_authority: 'unknown',
+  contract_reference: null,
+  effective_start_date: '2026-06-01',
+  effective_end_date: null,
+  status: 'active',
+  notes: 'Existing scoped partnership',
+  created_at: '2026-06-01T00:00:00.000Z',
+  updated_at: '2026-06-01T00:00:00.000Z',
+});
+
+const createState = () => ({
+  user: scopedAdminUser,
+  rpcCalls: [],
+  outsideMachine: buildOutsideMachine(),
+  setup: {
+    partners: [],
+    partnerships: [buildExistingPartnership()],
+    machines: [buildScopedMachine()],
+    assignments: [
+      {
+        id: existingAssignmentId,
+        machine_id: inScopeMachineId,
+        machine_label: 'MTLV Kiosk 01',
+        partnership_id: existingPartnershipId,
+        partnership_name: 'MTLV Venue Share',
+        assignment_role: 'primary_reporting',
+        effective_start_date: '2026-06-01',
+        effective_end_date: null,
+        status: 'active',
+        notes: null,
+      },
+    ],
+    parties: [],
+    taxRates: [],
+    financialRules: [],
+    warnings: [],
+  },
+});
+
+const installMockRoutes = async (context, state) => {
+  await context.route('**/auth/v1/**', async (route) => {
+    const url = route.request().url();
+
+    if (url.includes('/token')) {
+      return route.fulfill(jsonResponse(buildSession(state.user)));
+    }
+
+    if (url.includes('/user')) {
+      return route.fulfill(jsonResponse(state.user));
+    }
+
+    if (url.includes('/logout')) {
+      return route.fulfill({ status: 204, body: '' });
+    }
+
+    return route.fulfill(jsonResponse({}));
+  });
+
+  await context.route('**/rest/v1/customer_profiles**', async (route) => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill(jsonResponse([]));
+    }
+
+    return route.fulfill(
+      jsonResponse({
+        user_id: state.user.id,
+        language_preference: 'en',
+        created_at: now.toISOString(),
+        updated_at: now.toISOString(),
+      })
+    );
+  });
+
+  await context.route('**/rest/v1/customer_machine_inventory**', async (route) =>
+    route.fulfill(jsonResponse([]))
+  );
+
+  await context.route('**/rest/v1/access_invite_deliveries**', async (route) =>
+    route.fulfill(jsonResponse([]))
+  );
+
+  await context.route('**/rest/v1/rpc/**', async (route) => {
+    const url = route.request().url();
+    const rpcName = new URL(url).pathname.split('/').pop() ?? '';
+    const body = route.request().postDataJSON();
+    state.rpcCalls.push({ rpcName, body });
+
+    if (route.request().method() === 'OPTIONS') {
+      return route.fulfill({ status: 204, headers: corsHeaders, body: '' });
+    }
+
+    if (rpcName === 'get_my_admin_access_context') {
+      return route.fulfill(
+        jsonResponse({
+          isSuperAdmin: false,
+          isScopedAdmin: true,
+          canAccessAdmin: true,
+          allowedSurfaces: ['access', 'reporting_access', 'partnerships'],
+          scopedMachineIds: [inScopeMachineId],
+        })
+      );
+    }
+
+    if (rpcName === 'get_my_plus_access') {
+      return route.fulfill(
+        jsonResponse({
+          has_plus_access: false,
+          source: 'none',
+          membership_status: 'none',
+          current_period_end: null,
+          cancel_at_period_end: false,
+          paid_subscription_active: false,
+          free_grant_id: null,
+          free_grant_starts_at: null,
+          free_grant_expires_at: null,
+          free_grant_active: false,
+        })
+      );
+    }
+
+    if (rpcName === 'get_my_portal_access_context') {
+      return route.fulfill(
+        jsonResponse({
+          access_tier: 'training',
+          is_plus_member: false,
+          is_training_operator: true,
+          is_admin: true,
+          can_manage_operator_training: false,
+          is_corporate_partner: false,
+          has_supply_discount: false,
+          can_request_support: false,
+          can_manage_technicians: false,
+          capabilities: [],
+          effective_presets: ['scoped_admin'],
+        })
+      );
+    }
+
+    if (rpcName === 'get_my_reporting_access_context') {
+      return route.fulfill(
+        jsonResponse({
+          has_reporting_access: true,
+          accessible_machine_count: 1,
+          accessible_location_count: 1,
+          can_manage_reporting: true,
+          latest_sale_date: '2026-06-01',
+          latest_import_completed_at: isoHoursAgo(1),
+        })
+      );
+    }
+
+    if (rpcName === 'resolve_my_technician_entitlements') {
+      return route.fulfill(
+        jsonResponse({
+          technicianEmail: null,
+          resolvedGrantCount: 0,
+          resolvedOperatorTrainingGrantCount: 0,
+          upsertedReportingEntitlementCount: 0,
+          skippedGrantCount: 0,
+        })
+      );
+    }
+
+    if (rpcName === 'admin_get_partnership_reporting_setup') {
+      return route.fulfill(jsonResponse(state.setup));
+    }
+
+    if (rpcName === 'admin_upsert_reporting_partnership') {
+      const partnershipId = body?.p_partnership_id || newPartnershipId;
+      const partnership = {
+        ...buildExistingPartnership(),
+        id: partnershipId,
+        name: String(body?.p_name ?? 'Untitled partnership'),
+        partnership_type: String(body?.p_partnership_type ?? 'revenue_share'),
+        reporting_week_end_day: Number(body?.p_reporting_week_end_day ?? 0),
+        timezone: String(body?.p_timezone ?? 'America/Los_Angeles'),
+        reporting_frequency: String(body?.p_reporting_frequency ?? 'weekly_and_monthly'),
+        monthly_report_due_days: body?.p_monthly_report_due_days ?? null,
+        invoice_payment_due_days: body?.p_invoice_payment_due_days ?? null,
+        payment_method: body?.p_payment_method ?? null,
+        machine_ownership_model: String(body?.p_machine_ownership_model ?? 'unknown'),
+        consumer_pricing_authority: String(body?.p_consumer_pricing_authority ?? 'unknown'),
+        contract_reference: body?.p_contract_reference ?? null,
+        effective_start_date: String(body?.p_effective_start_date ?? '2026-06-01'),
+        effective_end_date: body?.p_effective_end_date ?? null,
+        status: String(body?.p_status ?? 'active'),
+        notes: body?.p_notes ?? null,
+        updated_at: now.toISOString(),
+      };
+      state.setup.partnerships = [
+        partnership,
+        ...state.setup.partnerships.filter((candidate) => candidate.id !== partnershipId),
+      ];
+      return route.fulfill(jsonResponse(partnership));
+    }
+
+    if (rpcName === 'admin_upsert_reporting_machine_assignment') {
+      if (body?.p_machine_id !== inScopeMachineId) {
+        return route.fulfill(
+          jsonResponse({ message: 'Scoped Admin can manage only assigned partnership machines' }, 403)
+        );
+      }
+
+      const partnership = state.setup.partnerships.find(
+        (candidate) => candidate.id === body?.p_partnership_id
+      );
+      const assignment = {
+        id: body?.p_assignment_id || '44444444-dddd-4444-8444-dddddddddddd',
+        machine_id: inScopeMachineId,
+        machine_label: 'MTLV Kiosk 01',
+        partnership_id: String(body?.p_partnership_id ?? newPartnershipId),
+        partnership_name: partnership?.name ?? 'Scoped Event Partnership',
+        assignment_role: String(body?.p_assignment_role ?? 'primary_reporting'),
+        effective_start_date: String(body?.p_effective_start_date ?? '2026-06-01'),
+        effective_end_date: body?.p_effective_end_date ?? null,
+        status: String(body?.p_status ?? 'active'),
+        notes: body?.p_notes ?? null,
+      };
+      state.setup.assignments = [
+        assignment,
+        ...state.setup.assignments.filter((candidate) => candidate.id !== assignment.id),
+      ];
+      return route.fulfill(jsonResponse(assignment));
+    }
+
+    if (rpcName === 'admin_archive_reporting_partnership') {
+      state.setup.partnerships = state.setup.partnerships.map((partnership) =>
+        partnership.id === body?.p_partnership_id
+          ? { ...partnership, status: 'archived', effective_end_date: '2026-06-29' }
+          : partnership
+      );
+      return route.fulfill(
+        jsonResponse({
+          targetType: 'reporting_partnership',
+          targetId: body?.p_partnership_id,
+          status: 'archived',
+          alreadyArchived: false,
+          archivedAssignments: 1,
+          archivedFinancialRules: 0,
+          archivedSchedules: 0,
+        })
+      );
+    }
+
+    return route.fulfill(jsonResponse({}));
+  });
+};
+
+const waitForServer = async (appUrl) => {
+  try {
+    const response = await fetch(appUrl, { method: 'GET' });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+  } catch (error) {
+    throw new Error(
+      `Unable to reach ${appUrl}. Start the app first, for example: npm run dev:uat. ${error.message}`
+    );
+  }
+};
+
+const login = async (page, user) => {
+  await page.waitForURL('**/login', { timeout: 10000 }).catch(() => undefined);
+  if (new URL(page.url()).pathname !== '/login') return;
+
+  await page.waitForSelector('#email-password', { timeout: 10000 });
+  await page.fill('#email-password', user.email);
+  await page.fill('#password', 'mock-password');
+  await page.getByRole('button', { name: /sign in/i }).click();
+};
+
+const directRpcProbe = async (page, rpcName, payload) =>
+  page.evaluate(
+    async ({ rpcName: evaluatedRpcName, payload: evaluatedPayload, supabaseUrl }) => {
+      const response = await fetch(`${supabaseUrl}/rest/v1/rpc/${evaluatedRpcName}`, {
+        method: 'POST',
+        headers: {
+          apikey: 'mock-anon-key',
+          authorization: 'Bearer mock-access-token',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(evaluatedPayload),
+      });
+
+      return {
+        ok: response.ok,
+        status: response.status,
+        body: await response.text(),
+      };
+    },
+    { rpcName, payload, supabaseUrl: MOCK_SUPABASE_URL }
+  );
+
+const openScopedPartnerships = async (page, args, user) => {
+  await page.goto(`${args.appUrl}/admin/partnerships`, { waitUntil: 'domcontentloaded' });
+  await login(page, user);
+  await page.goto(`${args.appUrl}/admin/partnerships`, { waitUntil: 'domcontentloaded' });
+  await page.getByRole('heading', { name: 'Partnerships', level: 1 }).waitFor({ timeout: 10000 });
+};
+
+const unexpectedConsoleErrors = (errors) =>
+  errors.filter(
+    (error) => !error.includes('Failed to load resource') && !error.includes('403 (Forbidden)')
+  );
+
+const runViewportScenario = async ({ browser, args, recorder, viewport, screenshotName, performSave }) => {
+  const state = createState();
+  const context = await browser.newContext({ viewport });
+  await context.addInitScript(
+    ({ storageKey, session }) => {
+      window.localStorage.setItem(storageKey, JSON.stringify(session));
+    },
+    { storageKey: MOCK_SUPABASE_AUTH_STORAGE_KEY, session: buildSession(state.user) }
+  );
+  await installMockRoutes(context, state);
+  const page = await context.newPage();
+  const consoleErrors = [];
+  const pageErrors = [];
+
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      consoleErrors.push(message.text());
+    }
+  });
+  page.on('pageerror', (error) => {
+    pageErrors.push(error.stack || error.message);
+  });
+
+  try {
+    await openScopedPartnerships(page, args, state.user);
+    await page.getByText('Assigned-machine scope is active').waitFor({ timeout: 10000 });
+
+    recorder.assert(
+      `${screenshotName}: scoped machine is visible`,
+      await page.getByText('MTLV Kiosk 01').isVisible()
+    );
+    recorder.assert(
+      `${screenshotName}: out-of-scope machine is hidden`,
+      !(await page.getByText('MTLV Kiosk 02').isVisible().catch(() => false))
+    );
+    recorder.assert(
+      `${screenshotName}: Partner Records link is hidden`,
+      !(await page.getByRole('link', { name: /Partner Records/i }).isVisible().catch(() => false))
+    );
+    recorder.assert(
+      `${screenshotName}: Machines admin link is hidden`,
+      !(await page.getByRole('link', { name: /^Machines$/i }).isVisible().catch(() => false))
+    );
+    recorder.assert(
+      `${screenshotName}: Reporting admin link is hidden`,
+      !(await page.getByRole('link', { name: /^Reporting$/i }).isVisible().catch(() => false))
+    );
+
+    if (performSave) {
+      await page.fill('#scoped-partnership-name', 'Scoped Event Partnership');
+      await page.fill('#scoped-partnership-reason', 'Create partnership for assigned MTLV machine');
+      recorder.assert(
+        'Scoped partnership save stays disabled until a machine is selected',
+        await page.getByRole('button', { name: 'Create partnership' }).isDisabled()
+      );
+
+      await page.locator('label').filter({ hasText: 'MTLV Kiosk 01' }).click();
+      await page.getByRole('button', { name: 'Create partnership' }).click();
+      await waitForCondition(
+        () =>
+          state.rpcCalls.some((call) => call.rpcName === 'admin_upsert_reporting_partnership') &&
+          state.rpcCalls.some((call) => call.rpcName === 'admin_upsert_reporting_machine_assignment'),
+        'scoped partnership save RPCs'
+      );
+
+      const partnershipCall = [...state.rpcCalls]
+        .reverse()
+        .find((call) => call.rpcName === 'admin_upsert_reporting_partnership');
+      const assignmentCall = [...state.rpcCalls]
+        .reverse()
+        .find((call) => call.rpcName === 'admin_upsert_reporting_machine_assignment');
+
+      recorder.assert(
+        'Scoped partnership save sends entered partnership name and reason',
+        partnershipCall?.body?.p_name === 'Scoped Event Partnership' &&
+          partnershipCall?.body?.p_reason === 'Create partnership for assigned MTLV machine',
+        JSON.stringify(partnershipCall?.body)
+      );
+      recorder.assert(
+        'Scoped partnership save sends only the in-scope machine',
+        assignmentCall?.body?.p_machine_id === inScopeMachineId &&
+          assignmentCall?.body?.p_machine_id !== outsideMachineId,
+        JSON.stringify(assignmentCall?.body)
+      );
+
+      const outsideMachineProbe = await directRpcProbe(page, 'admin_upsert_reporting_machine_assignment', {
+        p_assignment_id: null,
+        p_machine_id: outsideMachineId,
+        p_partnership_id: newPartnershipId,
+        p_assignment_role: 'primary_reporting',
+        p_effective_start_date: '2026-06-28',
+        p_effective_end_date: null,
+        p_status: 'active',
+        p_notes: null,
+        p_reason: 'Scoped Admin out-of-scope machine probe',
+      });
+      recorder.assert(
+        'Scoped partnership direct out-of-scope assignment fails closed',
+        outsideMachineProbe.status === 403,
+        outsideMachineProbe.body
+      );
+    }
+
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await delay(250);
+    await page.screenshot({
+      path: path.join(args.artifactDir, `${screenshotName}.png`),
+      fullPage: true,
+    });
+
+    if (performSave) {
+      const archiveCallCount = state.rpcCalls.filter(
+        (call) => call.rpcName === 'admin_archive_reporting_partnership'
+      ).length;
+      await page.getByRole('button', { name: /^Archive$/ }).click();
+      await page.getByRole('button', { name: 'Archive Partnership' }).click();
+      await delay(250);
+      recorder.assert(
+        'Scoped partnership archive requires a reason',
+        state.rpcCalls.filter((call) => call.rpcName === 'admin_archive_reporting_partnership').length ===
+          archiveCallCount
+      );
+      await page.fill('#partnership-archive-reason', 'Archive scoped partnership UAT cleanup');
+      await page.getByRole('button', { name: 'Archive Partnership' }).click();
+      await waitForCondition(
+        () =>
+          state.rpcCalls.some(
+            (call) =>
+              call.rpcName === 'admin_archive_reporting_partnership' &&
+              call.body?.p_reason === 'Archive scoped partnership UAT cleanup'
+          ),
+        'scoped partnership archive RPC'
+      );
+      recorder.pass('Scoped partnership archive sends required reason');
+    }
+
+    const unexpectedPageErrors = pageErrors.filter(Boolean);
+    recorder.assert(
+      `${screenshotName}: no unexpected browser errors`,
+      unexpectedConsoleErrors(consoleErrors).length === 0 && unexpectedPageErrors.length === 0,
+      [...unexpectedConsoleErrors(consoleErrors), ...unexpectedPageErrors].slice(0, 3).join(' | ')
+    );
+  } finally {
+    await context.close();
+  }
+};
+
+const run = async () => {
+  const args = parseArgs(process.argv.slice(2));
+  await mkdir(args.artifactDir, { recursive: true });
+  await waitForServer(args.appUrl);
+
+  const recorder = createRecorder();
+  const browser = await chromium.launch({ headless: !args.headed });
+
+  try {
+    await runViewportScenario({
+      browser,
+      args,
+      recorder,
+      viewport: { width: 1440, height: 1000 },
+      screenshotName: 'scoped-partnerships-desktop',
+      performSave: true,
+    });
+    await runViewportScenario({
+      browser,
+      args,
+      recorder,
+      viewport: { width: 390, height: 844 },
+      screenshotName: 'scoped-partnerships-mobile',
+      performSave: false,
+    });
+  } finally {
+    await browser.close();
+  }
+
+  const failed = recorder.failed();
+  if (failed.length > 0) {
+    console.error(`\n${failed.length} scoped partnership UAT assertion(s) failed.`);
+    process.exit(1);
+  }
+
+  console.log('\nScoped partnership UAT passed.');
+  console.log(`Screenshots: ${args.artifactDir}`);
+};
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/components/auth/AdminRoute.tsx
+++ b/src/components/auth/AdminRoute.tsx
@@ -12,6 +12,9 @@ export function AdminRoute() {
     isSuperAdmin || allowedSurfaces.has('*') || allowedSurfaces.has(surface);
   const isAdminAccessPath =
     location.pathname === '/admin/access' || location.pathname.startsWith('/admin/access/');
+  const isAdminPartnershipsPath =
+    location.pathname === '/admin/partnerships' ||
+    location.pathname.startsWith('/admin/partnerships/');
 
   if (loading) {
     return (
@@ -39,11 +42,17 @@ export function AdminRoute() {
       ? '/admin/payouts'
       : canAccessSurface('refunds')
       ? '/portal/refunds'
+      : canAccessSurface('partnerships')
+      ? '/admin/partnerships'
       : '/admin/access?tab=reporting-access';
     return <Navigate to={redirectTarget} replace />;
   }
 
   if (isScopedAdmin && canAccessSurface('access') && isAdminAccessPath) {
+    return <Outlet />;
+  }
+
+  if (isScopedAdmin && canAccessSurface('partnerships') && isAdminPartnershipsPath) {
     return <Outlet />;
   }
 

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -66,7 +66,7 @@ type AdminDestination = {
   descriptionKey: TranslationKey;
   icon: LucideIcon;
   requiresSuperAdmin?: boolean;
-  surface?: 'access' | 'payouts';
+  surface?: 'access' | 'partnerships' | 'payouts';
 };
 
 const adminDestinations: AdminDestination[] = [
@@ -145,7 +145,7 @@ const adminDestinations: AdminDestination[] = [
     description: 'Guided agreement setup, participants, assigned machines, split terms, and preview.',
     descriptionKey: 'admin.partnershipsDescription',
     icon: Handshake,
-    requiresSuperAdmin: true,
+    surface: 'partnerships',
   },
   {
     href: '/admin/reporting',

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -29,6 +29,7 @@ export function Navbar() {
     (isSuperAdmin ||
       allowedAdminSurfaces.has('*') ||
       (isScopedAdmin && allowedAdminSurfaces.has('access')) ||
+      allowedAdminSurfaces.has('partnerships') ||
       allowedAdminSurfaces.has('payouts'));
   const currentLocation = typeof window === 'undefined' ? undefined : window.location;
   const operatorAppUrl = getCanonicalUrlForSurface('app', '/portal', '', '', currentLocation);

--- a/src/pages/admin/Partnerships.tsx
+++ b/src/pages/admin/Partnerships.tsx
@@ -46,6 +46,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { Textarea } from '@/components/ui/textarea';
+import { useAuth } from '@/contexts/auth-context';
 import {
   archiveReportingPartnershipAdmin,
   fetchPartnershipReportingSetup,
@@ -470,6 +471,7 @@ const applyPayoutModelPreset = (
 };
 
 export default function AdminPartnershipsPage() {
+  const { adminAccess, isScopedAdmin, isSuperAdmin } = useAuth();
   const queryClient = useQueryClient();
   const [searchParams, setSearchParams] = useSearchParams();
   const selectedPartnershipId = searchParams.get('partnershipId') ?? '';
@@ -581,6 +583,23 @@ export default function AdminPartnershipsPage() {
     nextParams.delete('externalMachineName');
     setSearchParams(nextParams, { replace: true });
   };
+
+  if (
+    isScopedAdmin &&
+    !isSuperAdmin &&
+    (adminAccess.allowedSurfaces.includes('partnerships') ||
+      adminAccess.allowedSurfaces.includes('*'))
+  ) {
+    return (
+      <ScopedPartnershipsWorkspace
+        setup={setup}
+        isLoading={isLoading}
+        isFetching={isFetching}
+        hasLoadError={Boolean(error)}
+        onRefresh={refresh}
+      />
+    );
+  }
 
   return (
     <AppLayout>
@@ -729,6 +748,574 @@ export default function AdminPartnershipsPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+    </AppLayout>
+  );
+}
+
+function ScopedPartnershipsWorkspace({
+  setup,
+  isLoading,
+  isFetching,
+  hasLoadError,
+  onRefresh,
+}: {
+  setup: PartnershipReportingSetup;
+  isLoading: boolean;
+  isFetching: boolean;
+  hasLoadError: boolean;
+  onRefresh: () => Promise<unknown>;
+}) {
+  const [selectedPartnershipId, setSelectedPartnershipId] = useState('');
+  const [form, setForm] = useState({ ...emptyPartnershipForm, reason: '' });
+  const [selectedMachineIds, setSelectedMachineIds] = useState<Set<string>>(() => new Set());
+  const [machineSearch, setMachineSearch] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [isArchiveDialogOpen, setIsArchiveDialogOpen] = useState(false);
+
+  const visiblePartnerships = useMemo(
+    () => setup.partnerships.filter((partnership) => partnership.status !== 'archived'),
+    [setup.partnerships]
+  );
+  const selectedPartnership = useMemo(
+    () =>
+      visiblePartnerships.find((partnership) => partnership.id === selectedPartnershipId) ?? null,
+    [selectedPartnershipId, visiblePartnerships]
+  );
+  const currentDate = today();
+  const activeAssignments = useMemo(
+    () =>
+      selectedPartnership
+        ? setup.assignments.filter(
+            (assignment) =>
+              assignment.partnership_id === selectedPartnership.id &&
+              assignment.status === 'active' &&
+              assignment.effective_start_date <= currentDate &&
+              (!assignment.effective_end_date || assignment.effective_end_date >= currentDate)
+          )
+        : [],
+    [currentDate, selectedPartnership, setup.assignments]
+  );
+  const originalMachineIds = useMemo(
+    () => new Set(activeAssignments.map((assignment) => assignment.machine_id)),
+    [activeAssignments]
+  );
+  const machineById = useMemo(
+    () => new Map(setup.machines.map((machine) => [machine.id, machine])),
+    [setup.machines]
+  );
+  const selectedMachines = useMemo(
+    () =>
+      [...selectedMachineIds]
+        .map((machineId) => machineById.get(machineId))
+        .filter((machine): machine is PartnershipReportingSetup['machines'][number] =>
+          Boolean(machine)
+        ),
+    [machineById, selectedMachineIds]
+  );
+  const filteredMachines = useMemo(() => {
+    const normalizedSearch = machineSearch.trim().toLowerCase();
+    if (!normalizedSearch) return setup.machines;
+
+    return setup.machines.filter((machine) =>
+      [
+        machine.machine_label,
+        machine.account_name,
+        machine.location_name,
+        machine.sunze_machine_id ?? '',
+      ]
+        .join(' ')
+        .toLowerCase()
+        .includes(normalizedSearch)
+    );
+  }, [machineSearch, setup.machines]);
+  const addedMachineIds = [...selectedMachineIds].filter((machineId) => !originalMachineIds.has(machineId));
+  const removedMachineIds = [...originalMachineIds].filter((machineId) => !selectedMachineIds.has(machineId));
+  const hasMachineChanges = addedMachineIds.length > 0 || removedMachineIds.length > 0;
+  const hasPartnershipChanges =
+    !selectedPartnership ||
+    form.name !== selectedPartnership.name ||
+    form.effectiveStartDate !== selectedPartnership.effective_start_date ||
+    form.status !== selectedPartnership.status ||
+    form.notes !== (selectedPartnership.notes ?? '');
+  const canSave =
+    !isSaving &&
+    form.name.trim().length > 0 &&
+    form.effectiveStartDate.length > 0 &&
+    form.reason.trim().length > 0 &&
+    selectedMachineIds.size > 0 &&
+    (hasPartnershipChanges || hasMachineChanges);
+
+  useEffect(() => {
+    if (selectedPartnershipId && !selectedPartnership) {
+      setSelectedPartnershipId('');
+    }
+  }, [selectedPartnership, selectedPartnershipId]);
+
+  useEffect(() => {
+    if (!selectedPartnership) {
+      setForm({ ...emptyPartnershipForm, reason: '' });
+      setSelectedMachineIds(new Set());
+      return;
+    }
+
+    setForm({
+      ...emptyPartnershipForm,
+      partnershipId: selectedPartnership.id,
+      name: selectedPartnership.name,
+      partnershipType: selectedPartnership.partnership_type,
+      reportingWeekEndDay: String(selectedPartnership.reporting_week_end_day),
+      timezone: selectedPartnership.timezone,
+      reportingFrequency: selectedPartnership.reporting_frequency ?? 'weekly_and_monthly',
+      monthlyReportDueDays:
+        selectedPartnership.monthly_report_due_days === null ||
+        selectedPartnership.monthly_report_due_days === undefined
+          ? ''
+          : String(selectedPartnership.monthly_report_due_days),
+      invoicePaymentDueDays:
+        selectedPartnership.invoice_payment_due_days === null ||
+        selectedPartnership.invoice_payment_due_days === undefined
+          ? ''
+          : String(selectedPartnership.invoice_payment_due_days),
+      paymentMethod: selectedPartnership.payment_method ?? '',
+      machineOwnershipModel: selectedPartnership.machine_ownership_model ?? 'unknown',
+      consumerPricingAuthority: selectedPartnership.consumer_pricing_authority ?? 'unknown',
+      contractReference: selectedPartnership.contract_reference ?? '',
+      effectiveStartDate: selectedPartnership.effective_start_date,
+      effectiveEndDate: selectedPartnership.effective_end_date ?? '',
+      status: selectedPartnership.status === 'draft' ? 'draft' : 'active',
+      notes: selectedPartnership.notes ?? '',
+      reason: '',
+    });
+    setSelectedMachineIds(new Set(originalMachineIds));
+  }, [originalMachineIds, selectedPartnership]);
+
+  const startNewPartnership = () => {
+    setSelectedPartnershipId('');
+    setForm({ ...emptyPartnershipForm, reason: '' });
+    setSelectedMachineIds(new Set());
+    setMachineSearch('');
+  };
+
+  const toggleMachine = (machineId: string, checked: boolean) => {
+    setSelectedMachineIds((current) => {
+      const next = new Set(current);
+      if (checked) {
+        next.add(machineId);
+      } else {
+        next.delete(machineId);
+      }
+      return next;
+    });
+  };
+
+  const saveScopedPartnership = async () => {
+    const reason = form.reason.trim();
+    if (!form.name.trim() || !form.effectiveStartDate) {
+      toast.error('Partnership name and effective start date are required.');
+      return;
+    }
+    if (!reason) {
+      toast.error('Enter a reason before saving this partnership.');
+      return;
+    }
+    if (selectedMachineIds.size === 0) {
+      toast.error('Select at least one assigned machine before saving.');
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      const savedPartnership = await upsertReportingPartnershipAdmin({
+        ...form,
+        partnershipId: form.partnershipId,
+        name: form.name.trim(),
+        reportingWeekEndDay: Number(form.reportingWeekEndDay),
+        monthlyReportDueDays: optionalIntegerFromInput(form.monthlyReportDueDays),
+        invoicePaymentDueDays: optionalIntegerFromInput(form.invoicePaymentDueDays),
+        paymentMethod: form.paymentMethod.trim() || null,
+        contractReference: form.contractReference.trim() || null,
+        effectiveEndDate: form.effectiveEndDate || null,
+        notes: form.notes.trim() || null,
+        reason,
+      });
+
+      for (const machineId of addedMachineIds) {
+        await upsertReportingMachineAssignmentAdmin({
+          assignmentId: null,
+          machineId,
+          partnershipId: savedPartnership.id,
+          assignmentRole: 'primary_reporting',
+          effectiveStartDate: savedPartnership.effective_start_date,
+          effectiveEndDate: '',
+          status: 'active',
+          notes: null,
+          reason,
+        });
+      }
+
+      const assignmentsToArchive = activeAssignments.filter((assignment) =>
+        removedMachineIds.includes(assignment.machine_id)
+      );
+
+      for (const assignment of assignmentsToArchive) {
+        await upsertReportingMachineAssignmentAdmin({
+          assignmentId: assignment.id,
+          machineId: assignment.machine_id,
+          partnershipId: savedPartnership.id,
+          assignmentRole: assignment.assignment_role,
+          effectiveStartDate: assignment.effective_start_date,
+          effectiveEndDate: getSafeArchiveEndDate(assignment.effective_start_date),
+          status: 'archived',
+          notes: assignment.notes ?? null,
+          reason,
+        });
+      }
+
+      await onRefresh();
+      toast.success(form.partnershipId ? 'Partnership updated.' : 'Partnership created.');
+      setSelectedPartnershipId(savedPartnership.id);
+      setForm((current) => ({ ...current, partnershipId: savedPartnership.id, reason: '' }));
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Unable to save partnership.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <AppLayout>
+      <section className="section-padding admin-touch-targets">
+        <div className="container-page">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
+                Scoped Admin
+              </p>
+              <h1 className="mt-2 font-display text-3xl font-bold text-foreground">
+                Partnerships
+              </h1>
+              <p className="mt-2 max-w-3xl text-sm text-muted-foreground">
+                Create and update partnerships only for machines in your assigned admin scope.
+              </p>
+            </div>
+            <Button variant="outline" className="min-h-11" onClick={onRefresh} disabled={isFetching}>
+              {isFetching ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-2 h-4 w-4" />}
+              Refresh
+            </Button>
+          </div>
+
+          {hasLoadError && (
+            <div className="mt-4 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+              Unable to load your scoped partnership setup.
+            </div>
+          )}
+
+          {isLoading ? (
+            <div className="mt-6 rounded-lg border border-border bg-card p-6 text-sm text-muted-foreground">
+              Loading scoped partnership setup...
+            </div>
+          ) : setup.machines.length === 0 ? (
+            <div className="mt-6 rounded-lg border border-border bg-card p-6">
+              <div className="flex items-start gap-3">
+                <Info className="mt-0.5 h-5 w-5 text-muted-foreground" />
+                <div>
+                  <h2 className="font-semibold text-foreground">No assigned machines</h2>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    A Super Admin needs to assign machines before scoped partnership management can
+                    be used.
+                  </p>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="mt-6 grid gap-6 xl:grid-cols-[320px_minmax(0,1fr)]">
+              <aside className="space-y-4">
+                <div className="rounded-lg border border-border bg-card p-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <div>
+                      <h2 className="font-semibold text-foreground">Partnerships</h2>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Only scoped partnerships are listed.
+                      </p>
+                    </div>
+                    <Button variant="outline" size="sm" className="min-h-11" onClick={startNewPartnership}>
+                      <Plus className="mr-2 h-4 w-4" />
+                      New
+                    </Button>
+                  </div>
+                  <div className="mt-4 space-y-2">
+                    {visiblePartnerships.length === 0 ? (
+                      <EmptyState text="No partnerships are linked to your machines yet." />
+                    ) : (
+                      visiblePartnerships.map((partnership) => {
+                        const isSelected = selectedPartnershipId === partnership.id;
+                        return (
+                          <button
+                            key={partnership.id}
+                            type="button"
+                            onClick={() => setSelectedPartnershipId(partnership.id)}
+                            className={`w-full rounded-md border px-3 py-3 text-left text-sm transition-colors ${
+                              isSelected
+                                ? 'border-primary/40 bg-primary/10 text-primary'
+                                : 'border-border bg-background text-foreground hover:bg-muted/40'
+                            }`}
+                          >
+                            <div className="font-medium">{partnership.name}</div>
+                            <div className="mt-1 flex flex-wrap gap-2 text-xs text-muted-foreground">
+                              <span>{formatLabel(partnership.status)}</span>
+                              <span>{formatDate(partnership.effective_start_date)}</span>
+                            </div>
+                          </button>
+                        );
+                      })
+                    )}
+                  </div>
+                </div>
+
+                <div className="grid gap-3 sm:grid-cols-3 xl:grid-cols-1">
+                  <Metric label="Scoped machines" value={String(setup.machines.length)} />
+                  <Metric label="Visible partnerships" value={String(visiblePartnerships.length)} />
+                  <Metric label="Selected machines" value={String(selectedMachineIds.size)} />
+                </div>
+              </aside>
+
+              <main className="min-w-0 space-y-4">
+                <div className="rounded-lg border border-emerald-300 bg-emerald-50 p-4 text-sm text-emerald-950">
+                  <div className="flex items-start gap-3">
+                    <Info className="mt-0.5 h-5 w-5 shrink-0" />
+                    <div>
+                      <div className="font-semibold">Assigned-machine scope is active</div>
+                      <div className="mt-1">
+                        The machine list below is the full set available to this admin. Out-of-scope
+                        machines and global reporting tools are intentionally hidden.
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                {setup.warnings.length > 0 && <WarningList warnings={setup.warnings} />}
+
+                <section className="rounded-lg border border-border bg-card p-5">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <h2 className="font-semibold text-foreground">
+                        {selectedPartnership ? 'Manage partnership' : 'Create partnership'}
+                      </h2>
+                      <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+                        Name the partnership, select its assigned machines, and enter the reason for
+                        the audit log.
+                      </p>
+                    </div>
+                    {selectedPartnership && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="min-h-11 border-destructive/40 text-destructive hover:border-destructive hover:text-destructive"
+                        onClick={() => setIsArchiveDialogOpen(true)}
+                      >
+                        <Archive className="mr-2 h-4 w-4" />
+                        Archive
+                      </Button>
+                    )}
+                  </div>
+
+                  <div className="mt-5 grid gap-4 lg:grid-cols-2">
+                    <div>
+                      <Label htmlFor="scoped-partnership-name">Partnership name</Label>
+                      <Input
+                        id="scoped-partnership-name"
+                        value={form.name}
+                        onChange={(event) => setForm({ ...form, name: event.target.value })}
+                        placeholder="Venue or event partnership"
+                        className="h-11"
+                      />
+                    </div>
+                    <div>
+                      <Label htmlFor="scoped-partnership-status">Status</Label>
+                      <select
+                        id="scoped-partnership-status"
+                        value={form.status}
+                        onChange={(event) => setForm({ ...form, status: event.target.value })}
+                        className="h-11 w-full rounded-md border border-input bg-background px-3 text-sm"
+                      >
+                        <option value="active">active</option>
+                        <option value="draft">draft</option>
+                      </select>
+                    </div>
+                    <div>
+                      <Label htmlFor="scoped-partnership-start">Effective start</Label>
+                      <Input
+                        id="scoped-partnership-start"
+                        type="date"
+                        value={form.effectiveStartDate}
+                        onChange={(event) =>
+                          setForm({ ...form, effectiveStartDate: event.target.value })
+                        }
+                        className="h-11"
+                      />
+                    </div>
+                    <div>
+                      <Label htmlFor="scoped-partnership-notes">Notes</Label>
+                      <Input
+                        id="scoped-partnership-notes"
+                        value={form.notes}
+                        onChange={(event) => setForm({ ...form, notes: event.target.value })}
+                        placeholder="Optional internal note"
+                        className="h-11"
+                      />
+                    </div>
+                    <div className="lg:col-span-2">
+                      <Label htmlFor="scoped-partnership-reason">Reason for change</Label>
+                      <Textarea
+                        id="scoped-partnership-reason"
+                        value={form.reason}
+                        onChange={(event) => setForm({ ...form, reason: event.target.value })}
+                        placeholder="Example: Adam added MTLV Kiosk 01 to the venue partnership"
+                      />
+                    </div>
+                  </div>
+                </section>
+
+                <section className="rounded-lg border border-border bg-card p-5">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+                    <div className="min-w-0 flex-1">
+                      <h2 className="font-semibold text-foreground">Assigned machines</h2>
+                      <p className="mt-1 text-sm text-muted-foreground">
+                        Select from the machines this admin is allowed to manage.
+                      </p>
+                    </div>
+                    <div className="min-w-0 sm:w-80">
+                      <Label htmlFor="scoped-machine-search">Find machines</Label>
+                      <div className="relative">
+                        <Search className="pointer-events-none absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+                        <Input
+                          id="scoped-machine-search"
+                          value={machineSearch}
+                          onChange={(event) => setMachineSearch(event.target.value)}
+                          className="h-11 pl-9"
+                          placeholder="Machine, account, location"
+                        />
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="mt-4 rounded-lg border border-border">
+                    <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border bg-muted/30 px-4 py-3 text-sm">
+                      <div>
+                        <span className="font-medium text-foreground">{selectedMachineIds.size}</span>{' '}
+                        <span className="text-muted-foreground">selected</span>
+                      </div>
+                      {hasMachineChanges && (
+                        <Badge variant="secondary">
+                          +{addedMachineIds.length} / -{removedMachineIds.length}
+                        </Badge>
+                      )}
+                    </div>
+                    <div className="max-h-[520px] divide-y divide-border overflow-y-auto">
+                      {filteredMachines.length === 0 ? (
+                        <EmptyRow text="No assigned machines match this search." />
+                      ) : (
+                        filteredMachines.map((machine) => {
+                          const checked = selectedMachineIds.has(machine.id);
+                          const isOriginal = originalMachineIds.has(machine.id);
+
+                          return (
+                            <label
+                              key={machine.id}
+                              className="flex cursor-pointer items-start gap-3 px-4 py-4 transition-colors hover:bg-muted/30"
+                            >
+                              <Checkbox
+                                checked={checked}
+                                onCheckedChange={(value) => toggleMachine(machine.id, Boolean(value))}
+                                className="mt-1"
+                              />
+                              <span className="min-w-0 flex-1">
+                                <span className="block font-medium text-foreground">
+                                  {machine.machine_label}
+                                </span>
+                                <span className="mt-1 block text-sm text-muted-foreground">
+                                  {machine.account_name} / {machine.location_name}
+                                </span>
+                                <span className="mt-2 inline-flex rounded-full border border-border bg-muted/30 px-2 py-1 text-xs text-muted-foreground">
+                                  Visible through assigned admin machine scope
+                                </span>
+                              </span>
+                              {checked ? (
+                                <Badge variant={isOriginal ? 'secondary' : 'outline'}>
+                                  {isOriginal ? 'Current' : 'Added'}
+                                </Badge>
+                              ) : isOriginal ? (
+                                <Badge variant="destructive">Removing</Badge>
+                              ) : null}
+                            </label>
+                          );
+                        })
+                      )}
+                    </div>
+                  </div>
+                </section>
+
+                <section className="rounded-lg border border-border bg-card p-5">
+                  <div className="grid gap-4 lg:grid-cols-2">
+                    <div>
+                      <h2 className="font-semibold text-foreground">Before</h2>
+                      <div className="mt-3 rounded-md border border-border bg-muted/20 p-3 text-sm text-muted-foreground">
+                        {activeAssignments.length === 0 ? (
+                          'No current machine assignments.'
+                        ) : (
+                          <ul className="space-y-1">
+                            {activeAssignments.map((assignment) => (
+                              <li key={assignment.id}>{assignment.machine_label}</li>
+                            ))}
+                          </ul>
+                        )}
+                      </div>
+                    </div>
+                    <div>
+                      <h2 className="font-semibold text-foreground">After save</h2>
+                      <div className="mt-3 rounded-md border border-border bg-muted/20 p-3 text-sm text-muted-foreground">
+                        {selectedMachines.length === 0 ? (
+                          'No machines selected.'
+                        ) : (
+                          <ul className="space-y-1">
+                            {selectedMachines.map((machine) => (
+                              <li key={machine.id}>{machine.machine_label}</li>
+                            ))}
+                          </ul>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                  <div className="mt-5 flex flex-wrap items-center gap-3">
+                    <Button className="min-h-11" onClick={saveScopedPartnership} disabled={!canSave}>
+                      {isSaving ? (
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      ) : (
+                        <CheckCircle2 className="mr-2 h-4 w-4" />
+                      )}
+                      {form.partnershipId ? 'Save partnership' : 'Create partnership'}
+                    </Button>
+                    {!canSave && (
+                      <p className="text-sm text-muted-foreground">
+                        Name, date, reason, and at least one assigned machine are required.
+                      </p>
+                    )}
+                  </div>
+                </section>
+              </main>
+            </div>
+          )}
+        </div>
+      </section>
+      <ArchivePartnershipDialog
+        partnership={selectedPartnership}
+        open={isArchiveDialogOpen}
+        onOpenChange={setIsArchiveDialogOpen}
+        onArchived={async () => {
+          setSelectedPartnershipId('');
+          await onRefresh();
+        }}
+      />
     </AppLayout>
   );
 }


### PR DESCRIPTION
Closes #566
Depends on #575

## Summary
- Adds the `partnerships` scoped admin surface to admin route/menu access while preserving the Super Admin global Partnerships wizard.
- Adds a focused scoped Partnerships workspace for assigned-machine admins: create/update/archive partnership details, select only in-scope machines, see before/after machine assignment preview, and require audit reasons.
- Adds a mocked Playwright UAT script for Adam-style scoped partnership management across desktop and mobile.

## Files changed
- `src/components/auth/AdminRoute.tsx`, `src/components/layout/AppLayout.tsx`, `src/components/layout/Navbar.tsx`: route and navigation access for the `partnerships` surface.
- `src/pages/admin/Partnerships.tsx`: scoped-admin mode before the existing Super Admin wizard.
- `scripts/validate-scoped-partnerships-uat.mjs`, `package.json`: new scoped partnerships UAT command.

## Verification commands + results
- `npm ci` - passed; existing audit output reports 4 vulnerabilities on the project baseline.
- `npm run build` - passed.
- `npm test --if-present` - passed.
- `npm run lint --if-present` - passed.
- `VITE_SUPABASE_URL=https://example.supabase.co VITE_SUPABASE_ANON_KEY=mock-anon-key npm run auth:preflight` - passed with expected placeholder-env warnings.
- `git diff --check` - passed; Git emitted Windows LF-to-CRLF working-copy warnings only.
- `npm run scoped-partnerships:validate-uat -- --app-url http://127.0.0.1:8084` - passed.

## UAT screenshots
Generated locally by the UAT script:
- `C:\Repos\wt-scoped-partnership-ui\output\playwright\scoped-partnerships-desktop.png`
- `C:\Repos\wt-scoped-partnership-ui\output\playwright\scoped-partnerships-mobile.png`

## How to test
1. Check out this branch and run `npm ci`.
2. Start the app with mock Supabase env: `VITE_SUPABASE_URL=https://example.supabase.co VITE_SUPABASE_ANON_KEY=mock-anon-key npm run dev -- --host 127.0.0.1 --port 8084`.
3. Run `npm run scoped-partnerships:validate-uat -- --app-url http://127.0.0.1:8084`.
4. For manual integrated UAT after #575 is applied, log in as a scoped admin with `allowedSurfaces` including `partnerships` and an active machine scope. Confirm `/admin/partnerships` shows only scoped partnerships/machines, requires reasons for create/update/archive, and does not expose Partner Records, Machines, Reporting, exports, or out-of-scope machine choices.

## Merge note
This is a red-lane permissions/UI change. Keep `uat-required` and do not merge until owner UAT passes against an environment with #575 deployed.