### PR TITLE
P0 Permissions UX 04: Clarify partner permission grants

### DIFF
--- a/scripts/validate-admin-access-invite-uat.mjs
+++ b/scripts/validate-admin-access-invite-uat.mjs
@@ -66,8 +66,11 @@ const adminUser = {
 
 const targetEmail = 'new-partner-manager@example.test';
 const partnerId = '22222222-2222-4222-8222-222222222222';
+const noPortalPartnerId = '22222222-2222-4222-8222-333333333333';
 const partyId = '33333333-3333-4333-8333-333333333333';
+const noPortalPartyId = '33333333-3333-4333-8333-444444444444';
 const partnershipId = '44444444-4444-4444-8444-444444444444';
+const noPortalPartnershipId = '44444444-4444-4444-8444-555555555555';
 const machineId = '55555555-5555-4555-8555-555555555555';
 const machineTwoId = '55555555-5555-4555-8555-555555555556';
 const accountId = '66666666-6666-4666-8666-666666666666';
@@ -160,6 +163,34 @@ const buildCorporateOptions = (state) => ({
         },
       ],
     },
+    {
+      partnerId: noPortalPartnerId,
+      partnerName: 'Portal Setup Missing Partner',
+      partnerType: 'revenue_share_partner',
+      status: 'active',
+      memberships: [],
+      portalPartnerships: [
+        {
+          partyId: noPortalPartyId,
+          partnershipId: noPortalPartnershipId,
+          partnershipName: 'Portal Setup Missing Revenue Share',
+          partnershipStatus: 'active',
+          portalAccessEnabled: false,
+          machineCount: 1,
+          machines: [
+            {
+              machineId,
+              machineLabel: 'Bubble Planet Kiosk 01',
+              accountId,
+              accountName: 'Bubble Planet Pier 39',
+              locationId: '77777777-7777-4777-8777-777777777777',
+              locationName: 'Pier 39',
+              status: 'active',
+            },
+          ],
+        },
+      ],
+    },
   ],
 });
 
@@ -234,14 +265,23 @@ const installMockRoutes = async (context, state) => {
     const url = route.request().url();
 
     if (url.includes('/token')) {
+      state.isLoggedIn = true;
       return route.fulfill(jsonResponse(buildSession()));
     }
 
+    if (url.includes('/otp')) {
+      return route.fulfill(jsonResponse({}));
+    }
+
     if (url.includes('/user')) {
+      if (!state.isLoggedIn) {
+        return route.fulfill(jsonResponse({ message: 'No active mock session' }, 401));
+      }
       return route.fulfill(jsonResponse(adminUser));
     }
 
     if (url.includes('/logout')) {
+      state.isLoggedIn = false;
       return route.fulfill({ status: 204, body: '' });
     }
 
@@ -562,6 +602,7 @@ const run = async () => {
     memberships: [],
     technicianGrants: [],
     rpcCalls: [],
+    isLoggedIn: false,
   };
 
   await mkdir(args.artifactDir, { recursive: true });
@@ -673,6 +714,30 @@ const run = async () => {
         return details ? !details.open : false;
       })
     );
+    recorder.assert(
+      'Corporate Partner person workspace shows prerequisite checklist',
+      await page.getByText('Grant this person partner access').first().isVisible() &&
+        await page.getByText('Person email').first().isVisible() &&
+        await page.getByText('Partner portal access').first().isVisible()
+    );
+    recorder.assert(
+      'Corporate Partner checklist shows missing grant reason before save',
+      await page.getByText('5 of 6 requirements ready').isVisible()
+    );
+
+    await page.selectOption('#person-corporate-partner', noPortalPartnerId);
+    await page.getByText('Partner portal setup is required before invite.').waitFor({ timeout: 10000 });
+    await page.fill('#person-corporate-reason', 'Missing prerequisite UAT check');
+    recorder.assert(
+      'Corporate Partner save stays disabled when portal access prerequisite is missing',
+      await page.getByRole('button', { name: 'Grant and send invite' }).isDisabled()
+    );
+    recorder.assert(
+      'Corporate Partner missing prerequisite checklist names portal access',
+      await page.getByText('Enable partner portal access below before inviting this person.').isVisible()
+    );
+
+    await page.selectOption('#person-corporate-partner', partnerId);
 
     await page.fill('#person-corporate-reason', 'Agent UAT Corporate Partner grant');
     await page.getByRole('button', { name: 'Grant and send invite' }).click();
@@ -725,12 +790,16 @@ const run = async () => {
     const overflow = await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth + 1);
     recorder.assert('Admin Access desktop has no horizontal overflow', !overflow);
 
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await delay(250);
     await page.screenshot({
       path: path.join(args.artifactDir, 'admin-access-corporate-partner-invite-desktop.png'),
       fullPage: true,
     });
 
     await page.setViewportSize({ width: 390, height: 900 });
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await delay(250);
     await page.screenshot({
       path: path.join(args.artifactDir, 'admin-access-corporate-partner-invite-mobile.png'),
       fullPage: true,

--- a/scripts/validate-admin-access-invite-uat.mjs
+++ b/scripts/validate-admin-access-invite-uat.mjs
@@ -682,6 +682,12 @@ const run = async () => {
     await page.getByRole('button', { name: 'Open email workspace' }).click();
     await page.getByRole('heading', { name: targetEmail }).waitFor({ timeout: 10000 });
     await page.getByText('Portal-ready partnerships').waitFor({ timeout: 10000 });
+    recorder.assert(
+      'Selected-person workspace separates common grant work from admin authority',
+      await page.getByText('Common access work', { exact: true }).isVisible() &&
+        await page.getByText('Customer, partner, and Technician access', { exact: true }).isVisible() &&
+        await page.getByText('Admin authority', { exact: true }).isVisible()
+    );
     await page.screenshot({
       path: path.join(args.artifactDir, 'admin-access-corporate-partner-before-save.png'),
       fullPage: true,
@@ -785,6 +791,25 @@ const run = async () => {
         state.accessInviteBodies[1]?.targetEmail === targetEmail &&
         String(state.accessInviteBodies[1]?.loginUrl ?? '').includes('intent=technician'),
       JSON.stringify(state.accessInviteBodies[1])
+    );
+
+    await page.getByTestId('machine-scope-source-map').getByText('Why machines are visible').waitFor({
+      timeout: 10000,
+    });
+    const sourceMapText = await page.getByTestId('machine-scope-source-map').innerText();
+    recorder.assert(
+      'Machine source map explains Corporate Partner visibility',
+      sourceMapText.includes('Corporate Partner') &&
+        sourceMapText.includes('Bubble Planet') &&
+        sourceMapText.includes(machineId),
+      sourceMapText
+    );
+    recorder.assert(
+      'Machine source map explains Technician visibility',
+      sourceMapText.includes('Technician') &&
+        sourceMapText.includes('Bubble Planet Pier 39') &&
+        sourceMapText.includes(machineTwoId),
+      sourceMapText
     );
 
     const overflow = await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth + 1);

--- a/src/pages/admin/accessPersonConsole.tsx
+++ b/src/pages/admin/accessPersonConsole.tsx
@@ -198,6 +198,12 @@ type CorporatePartnerSaveConfirmation = {
   inviteMessage: string;
 };
 
+type PrerequisiteChecklistItem = {
+  label: string;
+  ready: boolean;
+  detail: string;
+};
+
 const machineTypeMeta: Array<{ key: MachineType; label: string }> = [
   { key: 'commercial', label: 'Commercial' },
   { key: 'mini', label: 'Mini' },
@@ -1303,6 +1309,48 @@ function AccessLauncher({
           : 'Save will grant this person Corporate Partner access and send the invite.',
     };
   })();
+  const corporatePartnerPrerequisites: PrerequisiteChecklistItem[] = [
+    {
+      label: 'Person invite email',
+      ready: Boolean(normalizedEmail),
+      detail: normalizedEmail || 'Enter a valid email for the person receiving partner access.',
+    },
+    {
+      label: 'Partner record',
+      ready: Boolean(selectedPartner),
+      detail: selectedPartner
+        ? `${selectedPartner.partnerName} is selected.`
+        : 'Select or create the partner record first.',
+    },
+    {
+      label: 'Active partnership',
+      ready: hasActiveLinkedPartnership,
+      detail: hasActiveLinkedPartnership
+        ? `${selectedPartner?.portalPartnerships.length ?? 0} linked active partnership${(selectedPartner?.portalPartnerships.length ?? 0) === 1 ? '' : 's'} found.`
+        : 'Create or link an active reporting partnership before inviting a partner member.',
+    },
+    {
+      label: 'Active machines',
+      ready: hasActiveMachines,
+      detail: hasActiveMachines
+        ? `${allLinkedMachineIds.size} active reporting machine${allLinkedMachineIds.size === 1 ? '' : 's'} linked.`
+        : 'The partnership needs at least one active reporting machine.',
+    },
+    {
+      label: 'Partner portal access',
+      ready: corporatePartnerWillHavePortalScope,
+      detail: corporatePartnerWillHavePortalScope
+        ? `${effectivePortalEnabledPartnerships.length} partnership${effectivePortalEnabledPartnerships.length === 1 ? '' : 's'} will be portal-enabled.`
+        : 'Enable portal access for a machine-backed partnership before sending the invite.',
+    },
+    {
+      label: 'Audit reason',
+      ready: Boolean(grantReason.trim()),
+      detail: grantReason.trim()
+        ? 'Reason will be saved on the person grant and staged portal access change.'
+        : 'Enter why this person should receive Corporate Partner access.',
+    },
+  ];
   const selectedTechnicianAccount =
     technicianContext.accounts.find((account) => account.accountId === selectedAccountId) ??
     technicianContext.accounts[0] ??
@@ -1975,6 +2023,10 @@ function AccessLauncher({
                     </Badge>
                   </div>
                 </div>
+                <PrerequisiteChecklist
+                  title="Corporate Partner grant checklist"
+                  items={corporatePartnerPrerequisites}
+                />
                 <PreviewBox>
                   This will grant Corporate Partner access for{' '}
                   {selectedPartner?.partnerName ?? 'the selected partner'} and send an invite to{' '}
@@ -2552,6 +2604,47 @@ function PreviewBox({ children, tone = 'neutral' }: { children: React.ReactNode;
   );
 }
 
+function PrerequisiteChecklist({
+  title,
+  items,
+}: {
+  title: string;
+  items: PrerequisiteChecklistItem[];
+}) {
+  const readyCount = items.filter((item) => item.ready).length;
+
+  return (
+    <div className="rounded-md border border-border bg-muted/20 p-3">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <p className="text-sm font-semibold text-foreground">{title}</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {readyCount} of {items.length} requirements ready
+          </p>
+        </div>
+        <Badge className="w-fit" variant={readyCount === items.length ? 'default' : 'outline'}>
+          {readyCount === items.length ? 'Ready' : 'Needs setup'}
+        </Badge>
+      </div>
+      <div className="mt-3 grid gap-2">
+        {items.map((item) => (
+          <div key={item.label} className="flex items-start gap-2 rounded-md border border-border bg-background p-2">
+            {item.ready ? (
+              <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+            ) : (
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber" />
+            )}
+            <div className="min-w-0">
+              <p className="text-sm font-medium text-foreground">{item.label}</p>
+              <p className="mt-0.5 text-xs text-muted-foreground">{item.detail}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 function PlusCustomerAccessCard({
   identity,
   account,
@@ -2811,6 +2904,51 @@ function CorporatePartnerAccessCard({
   const selectedPartnerHasPortalScope =
     portalEnabledPartnerships.length > 0 && derivedMachineIds.size > 0;
   const activePartnerPartnershipCount = selectedPartner?.portalPartnerships.length ?? 0;
+  const corporatePartnerPrerequisites: PrerequisiteChecklistItem[] = [
+    {
+      label: 'Person email',
+      ready: Boolean(identity.email),
+      detail: identity.email ?? 'Select a person with an email before granting partner access.',
+    },
+    {
+      label: 'Partner record',
+      ready: Boolean(selectedPartner),
+      detail: selectedPartner
+        ? `${selectedPartner.partnerName} is selected.`
+        : 'Select the partner record connected to this person.',
+    },
+    {
+      label: 'Active partnership',
+      ready: activePartnerPartnershipCount > 0,
+      detail:
+        activePartnerPartnershipCount > 0
+          ? `${activePartnerPartnershipCount} linked active partnership${activePartnerPartnershipCount === 1 ? '' : 's'} found.`
+          : 'This partner needs an active reporting partnership before invite.',
+    },
+    {
+      label: 'Partner portal access',
+      ready: portalEnabledPartnerships.length > 0,
+      detail:
+        portalEnabledPartnerships.length > 0
+          ? `${portalEnabledPartnerships.length} partnership${portalEnabledPartnerships.length === 1 ? '' : 's'} portal-enabled.`
+          : 'Enable partner portal access below before inviting this person.',
+    },
+    {
+      label: 'Active machines',
+      ready: derivedMachineIds.size > 0,
+      detail:
+        derivedMachineIds.size > 0
+          ? `${derivedMachineIds.size} reporting machine${derivedMachineIds.size === 1 ? '' : 's'} will be visible.`
+          : 'Portal-enabled partnership scope needs at least one active reporting machine.',
+    },
+    {
+      label: 'Grant reason',
+      ready: Boolean(grantReason.trim()),
+      detail: grantReason.trim()
+        ? 'Reason is ready for the audit log.'
+        : 'Enter why this person should receive Corporate Partner access.',
+    },
+  ];
 
   const refreshOptions = async () => {
     await queryClient.invalidateQueries({ queryKey: ['admin-corporate-partner-access-options'] });
@@ -3115,7 +3253,7 @@ function CorporatePartnerAccessCard({
                       />
                       <Button
                         variant="outline"
-                        disabled={revokingMembershipId === membership.id}
+                        disabled={revokingMembershipId === membership.id || !(revokeReasons[membership.id] ?? '').trim()}
                         onClick={() => void revokeCorporatePartner(membership.id)}
                       >
                         {revokingMembershipId === membership.id ? (
@@ -3147,6 +3285,11 @@ function CorporatePartnerAccessCard({
             value={pluralize(derivedMachineIds.size, 'machine')}
           />
         </div>
+
+        <PrerequisiteChecklist
+          title="Grant this person partner access"
+          items={corporatePartnerPrerequisites}
+        />
 
         {!selectedPartnerHasPortalScope && selectedPartner && (
           <div className="rounded-md border border-amber/40 bg-amber/10 p-3 text-sm text-foreground">

--- a/src/pages/admin/accessPersonConsole.tsx
+++ b/src/pages/admin/accessPersonConsole.tsx
@@ -149,6 +149,17 @@ type TechnicianSourceRecord = {
   machineIds: string[];
 };
 
+type MachineScopeSource = 'Corporate Partner' | 'Technician' | 'Scoped Admin' | 'Manual Reporting' | 'Super Admin';
+
+type MachineScopeSourceRow = {
+  id: string;
+  machineId: string | null;
+  machineLabel: string;
+  source: MachineScopeSource;
+  detail: string;
+  accessKind: 'derived' | 'manual' | 'admin';
+};
+
 type AccessWorkspaceIdentity = {
   email: string | null;
   userId: string | null;
@@ -604,6 +615,122 @@ const getManualReportingMachineIds = (context: EffectiveAccessContext | null) =>
   return (context.scopes.machineIds ?? []).filter((machineId) => !derivedMachineIds.has(machineId));
 };
 
+const machineScopeSourceOrder: Record<MachineScopeSource, number> = {
+  'Super Admin': 0,
+  'Corporate Partner': 1,
+  Technician: 2,
+  'Scoped Admin': 3,
+  'Manual Reporting': 4,
+};
+
+const buildMachineScopeSourceRows = (context: EffectiveAccessContext | null): MachineScopeSourceRow[] => {
+  if (!context) return [];
+
+  const rows: MachineScopeSourceRow[] = [];
+  const rowKeys = new Set<string>();
+  const addRow = (row: MachineScopeSourceRow) => {
+    const rowKey = `${row.source}:${row.machineId ?? 'global'}`;
+    if (rowKeys.has(rowKey)) return;
+    rowKeys.add(rowKey);
+    rows.push(row);
+  };
+
+  if (context.presets.includes('Super Admin')) {
+    addRow({
+      id: 'super-admin:global',
+      machineId: null,
+      machineLabel: 'All machines and admin surfaces',
+      source: 'Super Admin',
+      detail: 'Global admin authority is not limited to a machine, partner, or account scope.',
+      accessKind: 'admin',
+    });
+  }
+
+  const corporatePartnerNames = uniqueValues(
+    getCorporateSources(context)
+      .filter((source) => source.isActive)
+      .map((source) => source.partnerName)
+      .filter(Boolean)
+  );
+  const corporateDetail =
+    corporatePartnerNames.length > 0
+      ? `Active Corporate Partner membership through ${corporatePartnerNames.join(', ')}. Machines come from portal-enabled partnerships attached to that partner.`
+      : 'Active Corporate Partner scope. Machines come from portal-enabled partnerships attached to that partner.';
+
+  (context.scopes.corporatePartnerMachineIds ?? []).forEach((machineId) => {
+    addRow({
+      id: `corporate:${machineId}`,
+      machineId,
+      machineLabel: machineId,
+      source: 'Corporate Partner',
+      detail: corporateDetail,
+      accessKind: 'derived',
+    });
+  });
+
+  getTechnicianSources(context)
+    .filter((source) => source.isActive)
+    .forEach((source) => {
+      source.machineIds.forEach((machineId) => {
+        addRow({
+          id: `technician:${source.id}:${machineId}`,
+          machineId,
+          machineLabel: machineId,
+          source: 'Technician',
+          detail: `Active Technician grant for ${source.accountName}. ${source.grantReason}`,
+          accessKind: 'derived',
+        });
+      });
+    });
+
+  (context.scopes.technicianMachineIds ?? []).forEach((machineId) => {
+    addRow({
+      id: `technician:${machineId}`,
+      machineId,
+      machineLabel: machineId,
+      source: 'Technician',
+      detail: 'Active Technician machine assignment from the reporting entitlement scope.',
+      accessKind: 'derived',
+    });
+  });
+
+  (context.scopes.scopedAdminMachineIds ?? []).forEach((machineId) => {
+    addRow({
+      id: `scoped-admin:${machineId}`,
+      machineId,
+      machineLabel: machineId,
+      source: 'Scoped Admin',
+      detail: 'Assigned Scoped Admin boundary for internal admin work on this machine.',
+      accessKind: 'admin',
+    });
+  });
+
+  getManualReportingMachineIds(context).forEach((machineId) => {
+    addRow({
+      id: `manual:${machineId}`,
+      machineId,
+      machineLabel: machineId,
+      source: 'Manual Reporting',
+      detail: 'Explicit reporting grant added outside partner, Technician, or Scoped Admin sources.',
+      accessKind: 'manual',
+    });
+  });
+
+  return rows.sort((a, b) => {
+    if (a.source === 'Super Admin' && b.source !== 'Super Admin') return -1;
+    if (b.source === 'Super Admin' && a.source !== 'Super Admin') return 1;
+    const machineCompare = a.machineLabel.localeCompare(b.machineLabel);
+    if (machineCompare !== 0) return machineCompare;
+    return machineScopeSourceOrder[a.source] - machineScopeSourceOrder[b.source];
+  });
+};
+
+const formatMachineScopeAccessKind = (accessKind: MachineScopeSourceRow['accessKind']) => {
+  if (accessKind === 'manual') return 'Manual grant';
+  if (accessKind === 'admin') return 'Admin authority';
+  return 'Derived';
+};
+
 const getSoonestFutureDate = (values: Array<string | null | undefined>) => {
   const now = Date.now();
   const futureDates = values
@@ -1013,6 +1140,15 @@ function AdminPersonAccessConsoleInner({
 
           <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_minmax(320px,0.44fr)]">
             <div className="space-y-5">
+              <WorkspaceSectionHeader
+                eyebrow="Common access work"
+                title={isSuperAdmin ? 'Customer, partner, and Technician access' : 'Scoped Technician access'}
+                description={
+                  isSuperAdmin
+                    ? 'Start here for the access changes used most often: Plus, Corporate Partner, Technician, and manual reporting scope.'
+                    : 'Grant or adjust Technician access inside the machine boundary already assigned to you.'
+                }
+              />
               {isSuperAdmin && (
                 <>
                   <PlusCustomerAccessCard
@@ -1036,6 +1172,11 @@ function AdminPersonAccessConsoleInner({
               <ManualReportingAccessCard identity={identity} onChanged={refreshWorkspace} />
               {isSuperAdmin && (
                 <>
+                  <WorkspaceSectionHeader
+                    eyebrow="Admin authority"
+                    title="Internal admin roles"
+                    description="Use these only when the person needs operational admin authority, not customer or partner access."
+                  />
                   <ScopedAdminAccessCard identity={identity} onChanged={refreshWorkspace} />
                   <SuperAdminAccessCard identity={identity} onChanged={refreshWorkspace} />
                 </>
@@ -2548,6 +2689,24 @@ function SummaryMetric({ label, value }: { label: string; value: string }) {
     <div className="rounded-md border border-border bg-muted/20 p-3">
       <p className="text-xs font-medium text-muted-foreground">{label}</p>
       <p className="mt-1 text-sm font-semibold text-foreground">{value}</p>
+    </div>
+  );
+}
+
+function WorkspaceSectionHeader({
+  eyebrow,
+  title,
+  description,
+}: {
+  eyebrow: string;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="pt-1">
+      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{eyebrow}</p>
+      <h3 className="mt-1 text-base font-semibold text-foreground">{title}</h3>
+      <p className="mt-1 max-w-2xl text-sm text-muted-foreground">{description}</p>
     </div>
   );
 }
@@ -5101,6 +5260,9 @@ function ScopeBreakdownCard({
     ...corporateSources.map((source) => source.expiresAt),
     ...technicianSources.map((source) => source.expiresAt),
   ]);
+  const sourceRows = buildMachineScopeSourceRows(effectiveAccess);
+  const visibleSourceRows = sourceRows.slice(0, 10);
+  const hiddenSourceRowCount = Math.max(sourceRows.length - visibleSourceRows.length, 0);
 
   return (
     <div className="rounded-lg border border-border bg-card p-4 sm:p-5">
@@ -5142,6 +5304,46 @@ function ScopeBreakdownCard({
           label="Next source expiry"
           value={nextExpiry ? formatDate(nextExpiry) : 'No expiry recorded'}
         />
+      </div>
+      <div className="mt-4" data-testid="machine-scope-source-map">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Why machines are visible
+          </p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Source-by-source explanation of the machine scope shown in reporting and grant workflows.
+          </p>
+        </div>
+        {visibleSourceRows.length === 0 ? (
+          <div className="mt-3 rounded-md border border-dashed border-border bg-muted/20 p-3 text-sm text-muted-foreground">
+            No machine-scoped source is currently active for this person.
+          </div>
+        ) : (
+          <div className="mt-3 divide-y divide-border rounded-md border border-border">
+            {visibleSourceRows.map((row) => (
+              <div key={row.id} className="p-3">
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="min-w-0">
+                    <p className="break-all text-sm font-semibold text-foreground">{row.machineLabel}</p>
+                    {row.machineId && row.machineId !== row.machineLabel ? (
+                      <p className="mt-0.5 break-all text-xs text-muted-foreground">{row.machineId}</p>
+                    ) : null}
+                    <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{row.detail}</p>
+                  </div>
+                  <div className="flex shrink-0 flex-wrap gap-1">
+                    <Badge variant="secondary">{row.source}</Badge>
+                    <Badge variant="outline">{formatMachineScopeAccessKind(row.accessKind)}</Badge>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+        {hiddenSourceRowCount > 0 ? (
+          <p className="mt-2 text-xs text-muted-foreground">
+            Showing 10 of {sourceRows.length} active machine-source rows.
+          </p>
+        ) : null}
       </div>
       <p className="mt-4 text-xs text-muted-foreground">
         Manual reporting access is shown in its own access section because it can be changed independently


### PR DESCRIPTION
Closes #568
Closes #570
Closes #572
Related dependency: #573 covers the broader scoped-admin legacy panel cleanup so scoped admins do not see unsupported Corporate Partner legacy controls.

## Summary
- Adds a plain-English Corporate Partner prerequisite checklist to both the Add/invite launcher and selected-person workspace.
- Separates common access work from high-risk internal admin authority in the selected-person workspace.
- Adds a "Why machines are visible" source map so admins can see whether machine scope comes from Corporate Partner, Technician, Scoped Admin, manual reporting, or Super Admin access.
- Disables Corporate Partner revoke until a revoke reason is present and expands UAT for missing portal-access prerequisites plus machine-source explanations.

## Files changed
- `src/pages/admin/accessPersonConsole.tsx`: Corporate Partner checklist UI, workspace section hierarchy, machine-scope source rows, and revoke disabled-state tightening.
- `scripts/validate-admin-access-invite-uat.mjs`: stateful auth mock, missing-prerequisite partner scenario, hierarchy/source-map assertions, and screenshot stabilization.

## Verification commands + results
- `npm ci` - passed; existing audit output reports 4 vulnerabilities on the project baseline.
- `npm run build` - passed.
- `npm test --if-present` - passed.
- `npm run lint --if-present` - passed.
- `npm run auth:preflight` - passed with local env loaded into the process.
- `npm run auth:validate-admin-boundaries` - passed; live RPC checks intentionally skipped by default.
- `git diff --check` - passed; Git emitted Windows LF-to-CRLF working-copy warnings only.
- `npm run admin-access:validate-invite-uat -- --app-url http://127.0.0.1:8085` - passed.

## UAT screenshots
Generated locally by the UAT script:
- `C:\Repos\wt-permissions-ux-partner-grants\output\playwright\admin-access-corporate-partner-before-save.png`
- `C:\Repos\wt-permissions-ux-partner-grants\output\playwright\admin-access-corporate-partner-invite-desktop.png`
- `C:\Repos\wt-permissions-ux-partner-grants\output\playwright\admin-access-corporate-partner-invite-mobile.png`

## How to test
1. Check out this branch and run `npm ci`.
2. Start the app with Supabase env available, for example: `VITE_SUPABASE_URL=https://example.supabase.co VITE_SUPABASE_ANON_KEY=mock-anon-key npm run dev -- --host 127.0.0.1 --port 8085`.
3. Run `npm run admin-access:validate-invite-uat -- --app-url http://127.0.0.1:8085`.
4. Manual UAT: in `/admin/access`, search a person, open the person workspace, and verify Corporate Partner access clearly distinguishes person membership from partner portal setup. Confirm the grant button stays disabled until email, partner, active partnership, portal access/machines, and reason are ready.
5. Manual UAT: after granting Corporate Partner and Technician access in the mocked flow or a safe test environment, verify the "Why machines are visible" panel explains the Corporate Partner and Technician sources for each machine.

## Merge note
This is a red-lane permissions/UI change. Keep `uat-required` and do not merge until owner UAT passes.