### PR TITLE
Fix operator report rollup layout

### DIFF
--- a/scripts/validate-sales-report-pdf-polish.mjs
+++ b/scripts/validate-sales-report-pdf-polish.mjs
@@ -41,6 +41,13 @@ assert(
 );
 
 assert(
+  sharedBuilder.includes('const rollupCardHeight = 210') &&
+    sharedBuilder.includes('y -= rollupCardHeight + 42') &&
+    sharedBuilder.includes('if (additionalRollups > 0)'),
+  'Operator PDF machine rollup summary must reserve space for continuation notes.',
+);
+
+assert(
   exportFunction.includes('SALES_REPORT_PDF_GENERATOR_VERSION') &&
     exportFunction.includes('pdfGeneratorVersion: SALES_REPORT_PDF_GENERATOR_VERSION') &&
     exportFunction.includes('buildSalesReportPdf({'),

--- a/supabase/functions/_shared/sales-report-pdf.ts
+++ b/supabase/functions/_shared/sales-report-pdf.ts
@@ -768,24 +768,25 @@ const drawDashboardPage = (
     scopeWidth,
   );
 
-  y -= 220;
-  drawCard(page, { x: MARGIN, y, width: CONTENT_WIDTH, height: 178 });
+  const rollupCardHeight = 210;
+  y -= rollupCardHeight + 42;
+  drawCard(page, { x: MARGIN, y, width: CONTENT_WIDTH, height: rollupCardHeight });
   page.drawText("Machine rollup", {
     x: MARGIN + 18,
-    y: y + 150,
+    y: y + rollupCardHeight - 28,
     size: 14,
     font: fonts.bold,
     color: COLORS.ink,
   });
   page.drawText("Top machines by net sales for the selected period.", {
     x: MARGIN + 18,
-    y: y + 134,
+    y: y + rollupCardHeight - 44,
     size: 8.5,
     font: fonts.regular,
     color: COLORS.muted,
   });
 
-  const tableTop = y + 108;
+  const tableTop = y + rollupCardHeight - 70;
   const columns = [
     { label: "Machine", x: MARGIN + 18, width: 220, align: "left" as const },
     { label: "Gross", x: MARGIN + 260, width: 64, align: "right" as const },
@@ -899,13 +900,16 @@ const drawDashboardPage = (
     color: COLORS.muted,
     maxWidth: CONTENT_WIDTH - 28,
   });
-  drawText(page, fonts, `${formatInteger(Math.max(0, machineRollups.length - visibleRollups.length))} additional machine rollups continue in row-level detail when applicable.`, {
-    x: MARGIN + 18,
-    y: noteY,
-    size: 7,
-    color: COLORS.softText,
-    maxWidth: CONTENT_WIDTH - 36,
-  });
+  const additionalRollups = Math.max(0, machineRollups.length - visibleRollups.length);
+  if (additionalRollups > 0) {
+    drawText(page, fonts, `${formatInteger(additionalRollups)} additional machine rollups continue in row-level detail when applicable.`, {
+      x: MARGIN + 18,
+      y: noteY,
+      size: 7,
+      color: COLORS.softText,
+      maxWidth: CONTENT_WIDTH - 36,
+    });
+  }
 
   drawFooter(page, fonts, 1, context.reportReference);
 };


### PR DESCRIPTION
## Summary
- Fixes first-page operator report PDF rollup spacing so the continuation note no longer overlaps machine rows.
- Adds a regression assertion that the rollup card keeps reserved continuation-note space.

## Files changed
- `supabase/functions/_shared/sales-report-pdf.ts`: reserves additional vertical space for the machine rollup card and only renders the continuation note when needed.
- `scripts/validate-sales-report-pdf-polish.mjs`: extends PDF polish validation to cover the rollup continuation layout guard.

## Verification commands + results
- `npm ci` - passed; npm reported existing audit findings: 4 vulnerabilities (3 moderate, 1 high).
- `npm run build` - passed; Vite build and public-route prerender completed.
- `npm test --if-present` - passed; sales report PDF polish validation passed.
- `npm run lint --if-present` - passed.
- Local PDF render check - passed; generated a sample operator PDF with 7 machines, confirmed metadata `Subject: sales-report-pdf/polished-v1`, rendered both pages with Poppler, and visually confirmed page 1 has no machine rollup overlap.

## How to test
1. Run `npm ci`.
2. Run `npm run build`.
3. Run `npm test --if-present`.
4. Run `npm run lint --if-present`.
5. In production or localhost with Supabase env configured, sign in to the portal and open `/portal/reports`.
6. Select Operator view, choose machine scope, click Export polished PDF, and confirm the first-page Machine rollup section has clear spacing between rows, the continuation note, and the Warning state panel.