### PR TITLE
Harden report export tab opening

### DIFF
--- a/scripts/validate-sales-report-pdf-polish.mjs
+++ b/scripts/validate-sales-report-pdf-polish.mjs
@@ -4,6 +4,9 @@ const files = {
   sharedBuilder: 'supabase/functions/_shared/sales-report-pdf.ts',
   exportFunction: 'supabase/functions/sales-report-export/index.ts',
   reportingClient: 'src/lib/reporting.ts',
+  signedExportWindow: 'src/lib/signedExportWindow.ts',
+  portalReports: 'src/pages/portal/Reports.tsx',
+  adminReporting: 'src/pages/admin/Reporting.tsx',
   smokeChecklist: 'Docs/QA_SMOKE_TEST_CHECKLIST.md',
 };
 
@@ -17,6 +20,9 @@ const assert = (condition, message) => {
 const sharedBuilder = read(files.sharedBuilder);
 const exportFunction = read(files.exportFunction);
 const reportingClient = read(files.reportingClient);
+const signedExportWindow = read(files.signedExportWindow);
+const portalReports = read(files.portalReports);
+const adminReporting = read(files.adminReporting);
 const smokeChecklist = read(files.smokeChecklist);
 
 assert(
@@ -59,6 +65,27 @@ assert(
     reportingClient.includes('response.pdfGeneratorVersion !== expectedSalesReportPdfGeneratorVersion') &&
     reportingClient.includes('outdated PDF generator'),
   'Portal report exports must block stale sales-report-export responses instead of opening them.',
+);
+
+assert(
+  signedExportWindow.includes("window.open('about:blank', '_blank')") &&
+    signedExportWindow.includes('target.location.href = signedUrl') &&
+    signedExportWindow.includes('window.location.assign(signedUrl)'),
+  'Report exports must reserve a browser window before async signed URL work.',
+);
+
+assert(
+  portalReports.includes('reserveSignedExportWindow()') &&
+    portalReports.includes('openSignedExportUrl(exportResult.signedUrl, exportWindow)') &&
+    portalReports.includes('closeReservedSignedExportWindow(exportWindow)'),
+  'Portal report exports must use the reserved signed export window helper.',
+);
+
+assert(
+  adminReporting.includes('reserveSignedExportWindow()') &&
+    adminReporting.includes('openSignedExportUrl(signedUrl, exportWindow)') &&
+    adminReporting.includes('closeReservedSignedExportWindow(exportWindow)'),
+  'Admin report artifact exports must use the reserved signed export window helper.',
 );
 
 assert(

--- a/src/lib/signedExportWindow.ts
+++ b/src/lib/signedExportWindow.ts
@@ -1,0 +1,39 @@
+export type ReservedSignedExportWindow = Window | null;
+
+export const reserveSignedExportWindow = (): ReservedSignedExportWindow => {
+  if (typeof window === 'undefined') return null;
+
+  const target = window.open('about:blank', '_blank');
+  if (target) {
+    target.opener = null;
+  }
+
+  return target;
+};
+
+export const closeReservedSignedExportWindow = (
+  target: ReservedSignedExportWindow
+) => {
+  if (!target || target.closed) return;
+
+  try {
+    target.close();
+  } catch {
+    // The browser may deny closing tabs it did not associate with this script.
+  }
+};
+
+export const openSignedExportUrl = (
+  signedUrl: string,
+  target: ReservedSignedExportWindow
+) => {
+  if (target && !target.closed) {
+    target.location.href = signedUrl;
+    return;
+  }
+
+  const fallback = window.open(signedUrl, '_blank', 'noopener,noreferrer');
+  if (!fallback) {
+    window.location.assign(signedUrl);
+  }
+};

--- a/src/pages/admin/Reporting.tsx
+++ b/src/pages/admin/Reporting.tsx
@@ -48,6 +48,11 @@ import {
   type ReportingMachineType,
 } from '@/lib/reporting';
 import { trackEvent } from '@/lib/analytics';
+import {
+  closeReservedSignedExportWindow,
+  openSignedExportUrl,
+  reserveSignedExportWindow,
+} from '@/lib/signedExportWindow';
 import { formatLabel, machineTypes } from '@/pages/admin/reportingSetupUi';
 
 const sunzeStaleHours = 30;
@@ -1332,12 +1337,14 @@ function ExportsTab({ snapshots }: { snapshots: AdminReportViewSnapshot[] }) {
     artifact: AdminReportExportArtifact
   ) => {
     const artifactKey = `${snapshot.id}:${artifact.storagePath}`;
+    const exportWindow = reserveSignedExportWindow();
     setOpeningArtifactKey(artifactKey);
 
     try {
       const signedUrl = await createReportExportSignedUrl(artifact.storagePath);
-      window.open(signedUrl, '_blank', 'noopener,noreferrer');
+      openSignedExportUrl(signedUrl, exportWindow);
     } catch (error) {
+      closeReservedSignedExportWindow(exportWindow);
       toast.error(error instanceof Error ? error.message : 'Unable to open report export.');
     } finally {
       setOpeningArtifactKey(null);

--- a/src/pages/portal/Reports.tsx
+++ b/src/pages/portal/Reports.tsx
@@ -88,6 +88,11 @@ import {
   type PartnerDashboardTotals,
 } from '@/lib/partnerDashboardReporting';
 import type { TranslationKey } from '@/lib/i18n';
+import {
+  closeReservedSignedExportWindow,
+  openSignedExportUrl,
+  reserveSignedExportWindow,
+} from '@/lib/signedExportWindow';
 import { cn } from '@/lib/utils';
 
 type ReportingView = 'operator' | 'partner';
@@ -773,6 +778,7 @@ function OperatorReportingView({ accessContext }: { accessContext: ReportingAcce
   };
 
   const exportPdf = async () => {
+    const exportWindow = reserveSignedExportWindow();
     setIsExporting(true);
     try {
       const exportResult = await exportSalesReportPdf({
@@ -780,8 +786,9 @@ function OperatorReportingView({ accessContext }: { accessContext: ReportingAcce
         title: 'Bloomjoy Operator Sales Report',
       });
       toast.success('Polished operator report PDF is ready.');
-      window.open(exportResult.signedUrl, '_blank', 'noopener,noreferrer');
+      openSignedExportUrl(exportResult.signedUrl, exportWindow);
     } catch (exportError) {
+      closeReservedSignedExportWindow(exportWindow);
       toast.error(exportError instanceof Error ? exportError.message : 'Unable to export report.');
     } finally {
       setIsExporting(false);
@@ -1477,6 +1484,7 @@ function PartnerDashboardView() {
       return;
     }
 
+    const exportWindow = reserveSignedExportWindow();
     setExportingPartnerFormat(format);
     try {
       const exportPeriodLabel = currentPeriod
@@ -1492,7 +1500,7 @@ function PartnerDashboardView() {
         format,
         machineIds: scopedMachineIds,
       });
-      window.open(exportResult.signedUrl, '_blank', 'noopener,noreferrer');
+      openSignedExportUrl(exportResult.signedUrl, exportWindow);
       const exportFormatLabel =
         format === 'pdf' ? 'PDF' : format === 'xlsx' ? 'Excel workbook' : 'CSV';
       const machineScopeLabel = selectedMachineLabel ? ` for ${selectedMachineLabel}` : '';
@@ -1500,6 +1508,7 @@ function PartnerDashboardView() {
         `${trendLabel} partner ${exportFormatLabel} generated${machineScopeLabel} for ${exportPeriodLabel}.`
       );
     } catch (error) {
+      closeReservedSignedExportWindow(exportWindow);
       toast.error(error instanceof Error ? error.message : 'Unable to export partner report.');
     } finally {
       setExportingPartnerFormat(null);


### PR DESCRIPTION
## Summary
- Reserves a browser tab synchronously before async report signed-URL generation, then navigates that tab when the export is ready.
- Applies the helper to portal operator exports, portal partner exports, and admin report artifact opens.
- Extends the report PDF regression script to guard the reserved-window export path.

## Files changed
- `src/lib/signedExportWindow.ts`: shared helper for reserving, navigating, and closing export tabs.
- `src/pages/portal/Reports.tsx`: uses the helper for operator and partner reporting exports.
- `src/pages/admin/Reporting.tsx`: uses the helper for report snapshot artifact opens.
- `scripts/validate-sales-report-pdf-polish.mjs`: validates the reserved-window export wiring.

## Verification commands + results
- `npm ci` - passed; npm reported existing audit findings: 4 vulnerabilities (3 moderate, 1 high).
- `npm run build` - passed; Vite build and public-route prerender completed.
- `npm test --if-present` - passed; sales report PDF polish validation passed.
- `npm run lint --if-present` - passed.

## How to test
1. Run `npm ci`.
2. Run `npm run build`.
3. Run `npm test --if-present`.
4. Run `npm run lint --if-present`.
5. In production or localhost with Supabase env configured, sign in to `/portal/reports`.
6. Click Operator view > Export polished PDF and confirm a new tab is reserved immediately, then navigates to the generated PDF when ready.
7. In Admin Reporting > Exports, open an existing report artifact and confirm it opens in the reserved tab instead of silently failing when signed URL generation is async.