### PR TITLE
Tighten agent worktree hygiene and merge autonomy

### DIFF
--- a/.agents/skills/bloomjoy-agent-workflow/SKILL.md
+++ b/.agents/skills/bloomjoy-agent-workflow/SKILL.md
@@ -39,8 +39,9 @@ description: Use for Bloomjoy Hub GitHub issue or PR work, agent workflow upgrad
 
 - Use the verification profile from `npm run agent:context -- --issue <number>`.
 - For board hygiene, run `npm run agent:github-hygiene` and summarize the report in the issue or PR comment.
+- For local cleanup, run `npm run agent:worktree-hygiene` and use it to identify stale, duplicate, detached, dirty, merged, or closed PR worktrees before removing anything.
 - For workflow/template changes, also run `npm run agent:validate-workflow`.
 - Every repo change gets a PR into `main` with linked issue, summary, files changed, verification results, risk/overlap, and how-to-test steps.
 - Before an agent-initiated merge, run `npm run agent:merge-gate -- --pr <number>` and record the result in the PR.
-- Agents may merge Green and Yellow lane PRs after required evidence is complete. Red lane PRs require explicit owner direction.
+- Agents should proactively test, review, merge, and clean up Green and Yellow lane PRs after required evidence is complete. Red lane means an executive decision or unresolved blocker exists and requires explicit owner direction or blocker resolution.
 - Put task chronology and closeout evidence in the issue or PR, not static markdown docs.

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -62,13 +62,13 @@ body:
     validations:
       required: true
   - type: checkboxes
-    id: owner_approval_triggers
+    id: executive_decision_triggers
     attributes:
-      label: Owner approval triggers
-      description: Apply matching labels after creating the issue. Any selected trigger makes the PR red lane until owner direction is recorded.
+      label: Executive decision and risk triggers
+      description: Apply matching labels after creating the issue. Executive decision triggers require owner direction; technical-risk triggers require stronger agent evidence.
       options:
         - label: Needs owner decision (`needs-owner-decision`)
-        - label: Owner UAT or go/no-go required (`uat-required`)
+        - label: Agent UAT evidence required (`uat-required`)
         - label: Blocked by external account, vendor, credentials, or owner-controlled setup (`blocked-external`)
         - label: Touches database schema, migrations, RLS, or production data paths (`risky-db-change`)
         - label: Touches auth, permissions, Stripe, payments, or server-side secrets (`risky-auth-payment`)
@@ -89,6 +89,7 @@ body:
         - npm ci
         - npm run agent:context -- --issue <number>
         - npm run agent:preflight -- --issue <number>
+        - npm run agent:worktree-hygiene when workflow/worktree cleanup is in scope
         - npm run agent:validate-workflow when workflow/templates/config/skills changed
         - npm run build
         - npm test --if-present

--- a/.github/ISSUE_TEMPLATE/feature_task.yml
+++ b/.github/ISSUE_TEMPLATE/feature_task.yml
@@ -61,13 +61,13 @@ body:
     validations:
       required: true
   - type: checkboxes
-    id: owner_approval_triggers
+    id: executive_decision_triggers
     attributes:
-      label: Owner approval triggers
-      description: Apply matching labels after creating the issue. Any selected trigger makes the PR red lane until owner direction is recorded.
+      label: Executive decision and risk triggers
+      description: Apply matching labels after creating the issue. Executive decision triggers require owner direction; technical-risk triggers require stronger agent evidence.
       options:
         - label: Needs owner decision (`needs-owner-decision`)
-        - label: Owner UAT or go/no-go required (`uat-required`)
+        - label: Agent UAT evidence required (`uat-required`)
         - label: Blocked by external account, vendor, credentials, or owner-controlled setup (`blocked-external`)
         - label: Touches database schema, migrations, RLS, or production data paths (`risky-db-change`)
         - label: Touches auth, permissions, Stripe, payments, or server-side secrets (`risky-auth-payment`)
@@ -88,6 +88,7 @@ body:
         - npm ci
         - npm run agent:context -- --issue <number>
         - npm run agent:preflight -- --issue <number>
+        - npm run agent:worktree-hygiene when workflow/worktree cleanup is in scope
         - npm run agent:validate-workflow when workflow/templates/config/skills changed
         - npm run build
         - npm test --if-present

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,7 @@
 ## Verification
 - [ ] `npm ci` -
 - [ ] `npm run agent:preflight` -
+- [ ] `npm run agent:worktree-hygiene` if this changes workflow or cleans stale worktrees -
 - [ ] `npm run agent:merge-gate -- --pr <number>` before agent merge -
 - [ ] `npm run agent:validate-workflow` if workflow/templates/config/skills changed -
 - [ ] `npm run build` -
@@ -29,8 +30,12 @@
 
 ## Merge Autonomy
 - Lane: Green / Yellow / Red
-- Owner approval: Not required / Required because ___
+- Executive decision: Not required / Required because ___
 - Gate evidence: checks green, issue linked, risk labels reviewed, merge gate result recorded
+- Proactive closeout: agent may merge after gate passes / blocked because ___
+
+## Independent Review / QA Evidence
+- Subagent or separate review notes, if high-risk/stale/UAT-required:
 
 ## UI / Design Evidence
 - Screenshots or browser notes:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ If docs and the GitHub board disagree on active task state, the board wins. If d
 - Run `npm run agent:preflight` before edits and again before PR closeout.
 - Run `npm run agent:context -- --issue <number>` at kickoff when an issue number is available.
 - Run `npm run agent:github-hygiene` for weekly or as-requested issue board hygiene sweeps.
+- Run `npm run agent:worktree-hygiene` before broad cleanup or when worktree state looks confusing.
 - Run `npm run agent:merge-gate -- --pr <number>` before agent-merging a PR.
 - Run `npm run agent:validate-workflow` when changing agent docs, templates, Codex config, skills, or workflow scripts.
 - Keep PRs small and focused: one feature, fix, workflow upgrade, or vertical slice per PR.
@@ -61,7 +62,7 @@ If docs and the GitHub board disagree on active task state, the board wins. If d
 - `.codex/config.toml` defines conservative project subagent limits.
 - `.codex/agents/*.toml` defines read-only helper agents for repo mapping, QA challenge, design review, docs research, and security/risk review.
 - `.agents/skills/bloomjoy-agent-workflow/SKILL.md` holds the repo-local workflow skill so detailed workflow guidance loads only when relevant.
-- Use subagents only when they reduce real risk or parallelize meaningful lanes: repo mapping, QA challenge, design review, docs research, or security/risk review.
+- Use subagents only when they reduce real risk or parallelize meaningful lanes: repo mapping, QA challenge, design review, docs research, security/risk review, or independent PR closeout review.
 - Keep small single-lane fixes local to the primary agent to reduce overhead and context confusion.
 - Subagents are advisory. The primary agent remains responsible for final code, verification, and PR quality.
 - Prefer repo skills and plugin guidance when the task clearly matches them.
@@ -78,15 +79,15 @@ A task is done when:
 
 ## Merge Autonomy
 
-Agents should not make Ethan the default merge bottleneck. Use the PR labels, issue labels, PR evidence, and `npm run agent:merge-gate -- --pr <number>` to classify the merge lane.
+Agents should not make Ethan the default merge bottleneck. When a PR already exists, agents are expected to proactively test it, request or run independent subagent review when risk warrants it, update evidence, merge it when eligible, and clean up the worktree afterward. Use the PR labels, issue labels, PR evidence, and `npm run agent:merge-gate -- --pr <number>` to classify the merge lane.
 
 ### Green Lane - Agent May Merge
 
 Agent merge is allowed when all of these are true:
 
 - PR targets `main`, is not draft, has no merge conflicts, and all required checks are green.
-- PR links a GitHub issue and includes verification, risk/overlap, rollback, and board closeout notes.
-- No red-lane labels are present on the PR or linked issue.
+- PR links a GitHub issue, except routine Dependabot PRs, and includes verification, risk/overlap, rollback, and board closeout notes.
+- No executive decision or unresolved-blocker labels are present on the PR or linked issue.
 - The change is low-risk: docs, workflow tooling, lint/build cleanup, safe dependency updates, small tests, or narrow non-sensitive code cleanup.
 
 ### Yellow Lane - Agent May Merge With Extra Evidence
@@ -96,20 +97,18 @@ Agent merge is allowed after extra evidence is recorded in the PR:
 - Visible UI changes: include browser evidence at relevant desktop/mobile widths and `impeccable` or design-review notes when design quality matters.
 - Shared code or workflow changes: call out open-PR overlap and rollback.
 - Performance/build changes: include before/after evidence.
-- P0/P1 priority without red-lane labels: confirm the work is not launch-critical, owner-blocked, or externally dependent.
+- P0/P1 priority: confirm the work is not executive-blocked or externally dependent.
+- `uat-required`: include agent-run UAT, localhost/preview evidence, or exact proof that the required UAT path passed.
+- `risky-db-change` or `risky-auth-payment`: include independent AI/subagent review evidence and rollback notes.
 
-### Red Lane - Owner Approval Required
+### Red Lane - Executive Decision Required
 
-Agents must not merge without explicit owner direction when the PR or linked issue has any of these labels:
+Agents must not merge without explicit owner direction when the PR or linked issue has an unresolved executive decision label:
 
 - `needs-owner-decision`
-- `uat-required`
-- `blocked`
 - `blocked-external`
-- `risky-db-change`
-- `risky-auth-payment`
 
-Also treat production deploys, secrets, auth/permission changes, payments, refunds, RLS, migrations, destructive data changes, vendor/account setup, legal/terms changes, and brand commitments as red lane unless the issue explicitly scopes them as safe and non-production.
+The `blocked` label blocks merge until resolved, but it is not owner approval by itself. Technical-risk labels such as `uat-required`, `risky-db-change`, and `risky-auth-payment` require stronger evidence and independent review, not Ethan approval, unless the PR also needs an executive decision. Treat production deploys, secrets, destructive data changes, vendor/account setup, legal/terms changes, and brand commitments as executive-decision work unless the issue explicitly scopes them as safe and non-production.
 
 ## Version Control Protocol
 
@@ -131,6 +130,7 @@ Also treat production deploys, secrets, auth/permission changes, payments, refun
 - Worktree directory: `..\wt-<short-task-slug>`.
 - Branch: `agent/<short-task-slug>`.
 - One worktree equals one checked-out branch.
+- Run `npm run agent:worktree-hygiene` before cleanup sweeps and after confusing multi-agent sessions.
 - If you must run without worktrees, run only one agent at a time.
 
 ## Operational Safeguards

--- a/Docs/AGENT_SPRINT_WORKFLOW.md
+++ b/Docs/AGENT_SPRINT_WORKFLOW.md
@@ -36,9 +36,11 @@ Repeatable PM/PO orchestration for Bloomjoy Hub agent sprints.
 - If a shared foundation PR merges, sync dependent branches from `main` and rerun verification before marking them ready.
 - Before any agent-initiated merge, run `npm run agent:merge-gate -- --pr <number>` and record the result in the PR.
 - Merge in dependency order: foundations first, then feature slices, then QA/docs closeout.
+- When a PR already exists, proactively test, review, merge, and clean it up when the gate passes. Do not wait for Ethan approval unless an executive decision is genuinely needed.
 
 ## 5. Blockers
 - Treat external-account work, production credentials, owner product decisions, missing secrets, and ambiguous go/no-go calls as blockers.
+- Use `needs-owner-decision` only for true executive decision blockers, not routine review confidence or merge readiness.
 - Record blockers in the issue or PR. Update `Docs/CURRENT_STATUS.md` only for compact launch-level blockers or cross-cutting context that should outlive one issue.
 - Park stale or blocked branches as issues instead of leaving broad draft PRs open.
 - Do not invent new platforms, CMS, commerce providers, or workflow infrastructure without a `Docs/DECISIONS.md` entry.
@@ -58,12 +60,15 @@ PR body must include:
 - Verification commands and exact results: `npm ci`, `npm run agent:preflight -- --issue <number>`, `npm run build`, `npm test --if-present`, `npm run lint --if-present`, and `git diff --check`; include `npm run agent:validate-workflow` for workflow/template/config/skill changes and route-specific checks when relevant.
 - How to test: localhost steps, key URLs, and any non-secret test credentials or persona notes.
 - Risk/overlap notes: open PRs, shared files, blockers, rollback if high risk.
-- Merge autonomy: Green, Yellow, or Red lane; owner approval status; merge-gate result before agent merge.
+- Merge autonomy: Green, Yellow, or Red lane; executive decision status; merge-gate result before agent merge.
+- Independent review / QA evidence for high-risk technical, UAT-required, or stale PR closeout work.
 - UI/design evidence for visible UI changes.
 
 ## 8. Sprint Closeout
 - Confirm all implementation, QA challenge, and docs closeout PRs are merged or intentionally parked.
 - Update issues and project board status.
+- Run `npm run agent:github-hygiene` and `npm run agent:worktree-hygiene` for broad closeout sweeps.
+- Remove clean merged/closed worktrees and prune local branches after confirming no uncommitted work remains.
 - Close superseded PRs only when the replacement evidence is clear.
 - Update `Docs/CURRENT_STATUS.md` only for compact launch-level changes or blockers that should survive beyond one issue.
 - Update `Docs/QA_SMOKE_TEST_CHECKLIST.md` when a new user-facing flow exists.

--- a/Docs/AI_WORKFLOW.md
+++ b/Docs/AI_WORKFLOW.md
@@ -8,7 +8,7 @@ This repo is operated primarily through AI coding agents. The owner is not expec
 - Use `npm run agent:context -- --issue <number>` to gather compact issue, board, PR, docs, and verification context.
 - Convert vague ideas, parked work, or exploratory branches into issues instead of leaving long-lived draft PRs.
 - Use the GitHub issue and PR templates as the source of truth for active scope, risk, verification, UAT steps, screenshots, rollback, and closeout evidence.
-- Ask the owner only for product judgment, external-account actions, final high-risk UAT, or ambiguous go/no-go decisions.
+- Ask the owner only for executive decision work: product judgment, external-account actions, legal/brand/account commitments, secrets, production go/no-go, or genuinely ambiguous acceptance.
 - For repeatable PM/PO sprint orchestration with subagent execution and QA challenge lanes, use `Docs/AGENT_SPRINT_WORKFLOW.md`.
 
 ## Risk levels
@@ -28,24 +28,26 @@ This repo is operated primarily through AI coding agents. The owner is not expec
 - For high-risk changes, include an explicit rollback plan and independent AI review evidence.
 
 Use an independent AI reviewer or delegated subagent for high-risk review when the current agent environment allows it. If not available, perform a separate review pass and record what was checked.
+When a PR already exists, proactively drive it through testing, review, merge, and cleanup instead of waiting for Ethan approval. Owner approval is reserved for executive decision blockers, not routine code review or technical confidence.
 
 ## Owner involvement
 - Green lane: no owner involvement unless wording or product direction is unclear.
-- Yellow lane: owner UAT is optional; agents provide the extra preview, browser, overlap, or performance evidence that matches the change.
-- Red lane: owner UAT, explicit owner direction, or go/no-go confirmation is required before merge or production rollout.
+- Yellow lane: owner UAT is optional; agents provide the extra preview, browser, overlap, independent-review, or performance evidence that matches the change.
+- Red lane: only executive decision labels or unresolved external blockers require owner direction before merge or production rollout.
 
 The owner should not need to inspect code diffs to make routine decisions. PRs should present enough evidence for a product-level go/no-go.
 
 See `Docs/UAT_PERSONA_PLAYBOOK.md` for the persona-based checklist agents should use before asking the owner for UAT.
 
-Before any agent-initiated merge, run `npm run agent:merge-gate -- --pr <number>`. The gate blocks red-lane labels and unready PRs; it is evidence for merge readiness, not a replacement for required owner direction.
+Before any agent-initiated merge, run `npm run agent:merge-gate -- --pr <number>`. The gate blocks executive-decision labels, unresolved blockers, and unready PRs; it is evidence for merge readiness, not a replacement for required owner direction when a true executive decision exists.
 
 ## Weekly hygiene
 Agents should periodically:
 - run `npm run agent:github-hygiene` and use the report as the starting point;
-- list stale PRs and recommend close, merge, park, or rebuild;
-- close/supersede stale PRs after owner approval when needed;
-- prune branches and worktrees only after confirming no uncommitted work remains;
+- run `npm run agent:worktree-hygiene` before local cleanup sweeps;
+- list stale PRs and proactively close, merge, park, or rebuild according to merge-gate evidence;
+- close/supersede stale PRs without owner approval when replacement evidence is clear and no executive decision is needed;
+- prune branches and worktrees after confirming no uncommitted work remains;
 - ensure GitHub issues, labels, and the project board reflect the actual work queue;
 - keep `Docs/CURRENT_STATUS.md` limited to compact launch-level snapshots and cross-cutting blockers.
 

--- a/Docs/LOCAL_DEV.md
+++ b/Docs/LOCAL_DEV.md
@@ -302,12 +302,13 @@ Privacy guardrails:
 - Start from a GitHub issue and Bloomjoy Project board item. Those are the source of truth for active status, priority, blockers, and acceptance.
 - Generate compact kickoff context with `npm run agent:context -- --issue <number>`.
 - Run `npm run agent:github-hygiene` for weekly or as-requested GitHub issue/board hygiene reports.
+- Run `npm run agent:worktree-hygiene` before broad local cleanup or when many `wt-*` directories make ownership unclear.
 - Use `/goal` for multi-step, multi-PR, high-risk, or ambiguous work. Use `/plan` first if acceptance is unclear.
 - Each agent uses its own worktree and its own `.env` file.
 - Do not copy another person's `.env`; create your own from `.env.example`.
 - Never commit or paste secret keys, raw customer data, payment IDs, vendor exports, or free-text complaint content in PRs, issues, docs, or chat.
 - Keep PRs small and focused; one change set per PR.
-- Use green/yellow/red merge autonomy: agents may merge green/yellow PRs after evidence is complete, but red-lane PRs require owner direction.
+- Use green/yellow/red merge autonomy: agents proactively test, review, merge, and clean up green/yellow PRs after evidence is complete; only executive decision blockers require owner direction.
 - Run `npm run agent:merge-gate -- --pr <number>` before any agent-initiated merge.
 - Enable repo git hooks once per clone: `git config core.hooksPath .githooks`
 - Fetch before checking recent merges or status: `git fetch origin`
@@ -325,16 +326,17 @@ Privacy guardrails:
 5) Run `npm run agent:context -- --issue <number>` when the task has a GitHub issue.
 6) Run `git status -sb` and make sure the output is reviewable.
 7) Run `npm run agent:validate-workflow` when changing workflow docs, GitHub templates, Codex config, skills, or agent scripts.
-8) Run `npm run agent:merge-gate -- --pr <number>` before agent-merging a PR.
-9) Run `npm run auth:preflight` when working on auth/OAuth launch tasks.
-10) Run `npm run commerce:preflight` when working on Stripe/order/notification changes.
-11) Run `npm run db:validate-migrations` when working on Supabase migrations.
-12) If you are in `C:\Repos\Bloomjoy_hub`, stop and switch to a worktree.
+8) Run `npm run agent:worktree-hygiene` before cleanup sweeps or when local worktree state is confusing.
+9) Run `npm run agent:merge-gate -- --pr <number>` before agent-merging a PR.
+10) Run `npm run auth:preflight` when working on auth/OAuth launch tasks.
+11) Run `npm run commerce:preflight` when working on Stripe/order/notification changes.
+12) Run `npm run db:validate-migrations` when working on Supabase migrations.
+13) If you are in `C:\Repos\Bloomjoy_hub`, stop and switch to a worktree.
 
 ## Merge autonomy lanes
 - Green: low-risk docs, workflow tooling, lint/build cleanup, safe dependency updates, tests, or narrow non-sensitive cleanup. Agents may merge when checks are green and the PR evidence is complete.
-- Yellow: UI changes, shared code/workflow changes, performance/build changes, or P0/P1 work without risk labels. Agents may merge after the PR includes the extra browser/design/overlap/performance evidence that matches the change.
-- Red: `needs-owner-decision`, `uat-required`, `blocked`, `blocked-external`, `risky-db-change`, or `risky-auth-payment`. Agents do not merge red-lane PRs without explicit owner direction.
+- Yellow: UI changes, shared code/workflow changes, performance/build changes, P0/P1 work, `uat-required`, `risky-db-change`, or `risky-auth-payment`. Agents may merge after the PR includes the extra browser/design/overlap/UAT/independent-review/performance evidence that matches the change.
+- Red: `needs-owner-decision` or `blocked-external`. The `blocked` label also blocks merge until resolved. Agents do not ask for routine merge approval; they ask only when an executive decision is genuinely needed.
 
 ## Post-merge hygiene (2 minutes)
 Use this after a PR is merged or intentionally closed. Do not remove a worktree that still has uncommitted work.
@@ -345,13 +347,15 @@ Use this after a PR is merged or intentionally closed. Do not remove a worktree 
    - `git status -sb`
 3) Refresh local remote-tracking refs:
    - `git fetch --prune origin`
-4) Remove the task worktree:
+4) For cleanup sweeps or confusing state, generate the read-only local report:
+   - `npm run agent:worktree-hygiene`
+5) Remove the task worktree:
    - `git worktree remove C:\Repos\wt-<task>`
-5) Delete the local task branch with the safe form:
+6) Delete the local task branch with the safe form:
    - `git branch -d agent/<task>`
-6) Prune stale worktree metadata:
+7) Prune stale worktree metadata:
    - `git worktree prune`
-7) Verify cleanup:
+8) Verify cleanup:
    - `git worktree list`
    - `git branch --all --list "*<task>*"`
 
@@ -362,7 +366,8 @@ Use this after a PR is merged or intentionally closed. Do not remove a worktree 
 - Keep repo docs light: `Docs/CURRENT_STATUS.md` is a short, plain-language snapshot and `Docs/BACKLOG.md` is only a historical pointer.
 - Capture task status, handoffs, and test evidence in issue/PR comments instead of static markdown.
 - Use `npm run agent:context -- --issue <number>` to summarize issue, project, linked PR, docs, and verification context before asking agents to implement.
-- Use `npm run agent:github-hygiene` to surface missing board items, stale active work, stale P0/P1 status comments, red-lane PRs, and open PRs needing cleanup.
+- Use `npm run agent:github-hygiene` to surface missing board items, stale active work, stale P0/P1 status comments, executive-decision PRs, and open PRs needing cleanup.
+- Use `npm run agent:worktree-hygiene` to surface stale/duplicate/detached/dirty local worktrees and local branches with no open PR or issue evidence.
 - If you keep personal notes, store them locally and do not commit them.
 
 

--- a/Docs/TASK_TEMPLATE.md
+++ b/Docs/TASK_TEMPLATE.md
@@ -41,6 +41,7 @@ Context to read:
 Verification:
 - npm ci
 - npm run agent:preflight -- --issue ___
+- npm run agent:worktree-hygiene when cleaning stale PR/worktree state
 - npm run agent:merge-gate -- --pr ___ before agent merge
 - npm run agent:validate-workflow when agent workflow docs/templates/config/scripts/skills changed
 - npm run build
@@ -57,13 +58,16 @@ PR requirements:
 - Include localhost how-to-test steps
 - Call out risk, overlap, and rollback notes
 - Classify merge autonomy as Green, Yellow, or Red
-- Record owner approval status and merge-gate result before agent merge
+- Record executive decision status and merge-gate result before agent merge
+- Include independent review / QA evidence when the PR is high-risk, stale, or UAT-required
 - Include UI/design evidence when applicable
 
 Board closeout:
 - Move/update the project-board item
 - Add closeout evidence to the issue or PR
 - Run `npm run agent:github-hygiene` when the task is board, stale PR, or issue hygiene work
+- Run `npm run agent:worktree-hygiene` when the task is stale worktree or branch cleanup
+- Proactively merge eligible PRs after testing/review; ask the owner only for a true executive decision
 - Note remaining follow-ups as GitHub issues, not static backlog entries
 ```
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "agent:preflight": "node scripts/agent-preflight.mjs",
     "agent:context": "node scripts/agent-context.mjs",
     "agent:github-hygiene": "node scripts/agent-github-hygiene.mjs",
+    "agent:worktree-hygiene": "node scripts/agent-worktree-hygiene.mjs",
     "agent:merge-gate": "node scripts/agent-merge-gate.mjs",
     "agent:validate-workflow": "node scripts/validate-agent-workflow.mjs",
     "auth:validate-admin-boundaries": "node scripts/validate-admin-permission-boundaries.mjs",

--- a/scripts/agent-github-hygiene.mjs
+++ b/scripts/agent-github-hygiene.mjs
@@ -15,14 +15,9 @@ const failOnFindings = Boolean(args["fail-on-findings"]);
 const now = new Date();
 
 const priorityLabels = ["P0", "P1", "P2", "P3"];
-const redLabels = new Set([
-  "blocked",
-  "blocked-external",
-  "needs-owner-decision",
-  "risky-auth-payment",
-  "risky-db-change",
-  "uat-required",
-]);
+const executiveDecisionLabels = new Set(["blocked-external", "needs-owner-decision"]);
+const unresolvedBlockerLabels = new Set(["blocked"]);
+const technicalRiskLabels = new Set(["risky-auth-payment", "risky-db-change", "uat-required"]);
 const blockerLabels = new Set(["blocked", "blocked-external", "needs-owner-decision", "parked"]);
 
 function parseArgs(argv) {
@@ -157,14 +152,18 @@ function prAttentionReasons(pr, issuesByNumber) {
   const reasons = [];
   const linkedIssues = linkedIssueNumbers(pr.body);
   const labels = collectPrLabels(pr, issuesByNumber);
-  const red = labels.filter((label) => redLabels.has(label));
+  const executive = labels.filter((label) => executiveDecisionLabels.has(label));
+  const unresolved = labels.filter((label) => unresolvedBlockerLabels.has(label));
+  const technicalRisk = labels.filter((label) => technicalRiskLabels.has(label));
   const age = daysSince(pr.updatedAt);
 
   if (!linkedIssues.length) reasons.push("no linked issue in PR body");
   if (pr.isDraft) reasons.push("draft");
   if (pr.baseRefName !== "main") reasons.push(`targets ${pr.baseRefName}, not main`);
   if (!["CLEAN", "HAS_HOOKS"].includes(pr.mergeStateStatus)) reasons.push(`merge state ${pr.mergeStateStatus}`);
-  if (red.length) reasons.push(`red-lane labels: ${red.join(", ")}`);
+  if (executive.length) reasons.push(`executive decision labels: ${executive.join(", ")}`);
+  if (unresolved.length) reasons.push(`unresolved blocker labels: ${unresolved.join(", ")}`);
+  if (technicalRisk.length) reasons.push(`technical-risk labels need review evidence: ${technicalRisk.join(", ")}`);
   if (age >= prDays) reasons.push(`${age}d since PR update`);
 
   return {
@@ -285,7 +284,7 @@ const priorityCounts = Object.fromEntries(
   priorityLabels.map((label) => [label, issues.filter((issue) => hasLabel(issue, label)).length]),
 );
 const riskCounts = Object.fromEntries(
-  [...redLabels, "parked", "ui-change", "docs-only"].map((label) => [
+  [...executiveDecisionLabels, ...unresolvedBlockerLabels, ...technicalRiskLabels, "parked", "ui-change", "docs-only"].map((label) => [
     label,
     issues.filter((issue) => hasLabel(issue, label)).length,
   ]),
@@ -424,7 +423,7 @@ if (outputJson) {
   lines.push("1. Add missing open issues to the Bloomjoy Project board.");
   lines.push("2. Move blocked or parked work out of active In Progress unless an agent is actively unblocking it.");
   lines.push("3. Add short status comments to stale P0/P1 issues, especially owner/blocker items.");
-  lines.push("4. Close, park, or rebuild stale PRs after merge-gate and owner-approval rules are applied.");
+  lines.push("4. Close, park, rebuild, or agent-merge stale PRs after merge-gate and executive-decision rules are applied.");
   lines.push("5. Keep task chronology in issue/PR comments; update repo docs only for durable decisions or compact launch snapshots.");
   lines.push("");
 

--- a/scripts/agent-merge-gate.mjs
+++ b/scripts/agent-merge-gate.mjs
@@ -5,19 +5,17 @@ const args = parseArgs(process.argv.slice(2));
 const prNumber = args.pr || process.env.AGENT_PR || "";
 const repo = args.repo || process.env.AGENT_REPO || "ethtri/bloomjoy-hub";
 
-const redLabels = new Set([
-  "blocked",
-  "blocked-external",
-  "needs-owner-decision",
-  "risky-auth-payment",
-  "risky-db-change",
-  "uat-required",
-]);
+const executiveDecisionLabels = new Set(["blocked-external", "needs-owner-decision"]);
+const unresolvedBlockerLabels = new Set(["blocked"]);
+const highRiskTechnicalLabels = new Set(["risky-auth-payment", "risky-db-change"]);
+const uatEvidenceLabels = new Set(["uat-required"]);
 
 const yellowLabels = new Set([
   "P0",
   "P1",
   "ui-change",
+  ...highRiskTechnicalLabels,
+  ...uatEvidenceLabels,
 ]);
 
 const passingConclusions = new Set(["SUCCESS", "NEUTRAL", "SKIPPED"]);
@@ -146,15 +144,19 @@ function claimedLane(body) {
   return match?.[1]?.toLowerCase() ?? "";
 }
 
-function ownerApprovalRequired(body) {
+function executiveDecisionRequired(body) {
   const autonomy = sectionText(body, "Merge Autonomy");
-  return /owner approval\s*:\s*required/i.test(autonomy);
+  return /(?:owner approval|executive decision)\s*:\s*required/i.test(autonomy);
 }
 
 function laneFromLabels(labels) {
-  if (labels.some((label) => redLabels.has(label))) return "red";
+  if (labels.some((label) => executiveDecisionLabels.has(label) || unresolvedBlockerLabels.has(label))) return "red";
   if (labels.some((label) => yellowLabels.has(label))) return "yellow";
   return "green";
+}
+
+function labelsIn(labels, labelSet) {
+  return labels.filter((label) => labelSet.has(label));
 }
 
 function summarize(labels, lane) {
@@ -190,7 +192,17 @@ const linkedIssues = linkedIssueNumbers(pr.body);
 const verification = sectionText(pr.body, "Verification");
 const risk = sectionText(pr.body, "Risk And Overlap") || sectionText(pr.body, "Risk and overlap");
 const designEvidence = sectionText(pr.body, "UI / Design Evidence");
+const reviewEvidence =
+  sectionText(pr.body, "Independent Review / QA Evidence") ||
+  sectionText(pr.body, "Independent Review") ||
+  sectionText(pr.body, "Review / QA Evidence");
+const howToTest = sectionText(pr.body, "How To Test Locally") || sectionText(pr.body, "How To Test");
 const autonomy = sectionText(pr.body, "Merge Autonomy");
+const executiveLabels = labelsIn(labels, executiveDecisionLabels);
+const unresolvedBlockerLabelHits = labelsIn(labels, unresolvedBlockerLabels);
+const highRiskTechnicalLabelHits = labelsIn(labels, highRiskTechnicalLabels);
+const uatEvidenceLabelHits = labelsIn(labels, uatEvidenceLabels);
+const isDependabot = pr.headRefName?.startsWith("dependabot/");
 
 summarize(labels, inferredLane);
 
@@ -205,13 +217,17 @@ if (!["CLEAN", "HAS_HOOKS"].includes(pr.mergeStateStatus)) {
 
 checkStatusRollup(pr.statusCheckRollup);
 
-if (!linkedIssues.length) failures.push("PR body does not link a GitHub issue.");
+if (!linkedIssues.length && !isDependabot) failures.push("PR body does not link a GitHub issue.");
 if (!isSubstantive(verification)) failures.push("PR body needs substantive verification results.");
 if (!isSubstantive(risk)) failures.push("PR body needs a substantive Risk And Overlap section.");
 if (!isSubstantive(autonomy)) failures.push("PR body needs a substantive Merge Autonomy section.");
 
-if (inferredLane === "red") {
-  failures.push("Red-lane labels are present. Owner approval is required; do not agent-merge.");
+if (executiveLabels.length) {
+  failures.push(`Executive decision label(s) present: ${executiveLabels.join(", ")}. Owner direction is required; do not agent-merge.`);
+}
+
+if (unresolvedBlockerLabelHits.length) {
+  failures.push(`Unresolved blocker label(s) present: ${unresolvedBlockerLabelHits.join(", ")}. Remove the blocker or document resolution before merge.`);
 }
 
 if (!laneClaim) {
@@ -219,19 +235,33 @@ if (!laneClaim) {
 } else if (inferredLane === "yellow" && laneClaim === "green") {
   failures.push("PR claims Green lane, but labels require Yellow lane evidence.");
 } else if (laneClaim === "red") {
-  failures.push("PR claims Red lane. Owner approval is required; do not agent-merge.");
+  failures.push("PR claims Red lane. Reclassify only after executive/blocker status is resolved, or wait for owner direction.");
 }
 
-if (ownerApprovalRequired(pr.body) && inferredLane !== "red") {
-  failures.push("PR says owner approval is required. Do not agent-merge until it is reclassified or owner merges.");
+if (executiveDecisionRequired(pr.body) && !executiveLabels.length) {
+  failures.push("PR says an executive decision is required without an executive decision label. Reclassify or document the executive blocker before merge.");
 }
 
 if (labels.includes("ui-change") && !isSubstantive(designEvidence)) {
   failures.push("ui-change PRs need substantive UI / Design Evidence.");
 }
 
+if (highRiskTechnicalLabelHits.length && !isSubstantive(reviewEvidence)) {
+  failures.push(
+    `${highRiskTechnicalLabelHits.join(", ")} PRs need substantive Independent Review / QA Evidence before agent merge.`,
+  );
+}
+
+if (uatEvidenceLabelHits.length && !isSubstantive(howToTest)) {
+  failures.push(`${uatEvidenceLabelHits.join(", ")} PRs need substantive UAT or How To Test evidence before agent merge.`);
+}
+
 if (labels.includes("P0") || labels.includes("P1")) {
-  warnings.push("P0/P1 priority detected. Confirm this is not launch-critical or owner-blocking before merge.");
+  warnings.push("P0/P1 priority detected. Confirm the PR evidence proves it is not executive-blocked before merge.");
+}
+
+if (isDependabot) {
+  warnings.push("Dependabot branch detected. A linked issue is optional, but local verification and merge-autonomy evidence are still required.");
 }
 
 if (warnings.length) {

--- a/scripts/agent-worktree-hygiene.mjs
+++ b/scripts/agent-worktree-hygiene.mjs
@@ -1,0 +1,475 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+
+const args = parseArgs(process.argv.slice(2));
+const repo = args.repo || process.env.AGENT_REPO || "ethtri/bloomjoy-hub";
+const staleDays = Number(args["stale-days"] || 14);
+const maxItems = Number(args["max-items"] || 25);
+const outputJson = hasFlag(args, "json");
+const failOnFindings = hasFlag(args, "fail-on-findings");
+const now = new Date();
+const warnings = [];
+
+function parseArgs(argv) {
+  const parsed = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith("--")) continue;
+
+    const [rawKey, rawValue] = arg.slice(2).split("=");
+    if (rawValue !== undefined) {
+      parsed[rawKey] = rawValue;
+      continue;
+    }
+
+    const next = argv[index + 1];
+    if (next && !next.startsWith("--")) {
+      parsed[rawKey] = next;
+      index += 1;
+    } else {
+      parsed[rawKey] = "true";
+    }
+  }
+  return parsed;
+}
+
+function hasFlag(parsed, key) {
+  return parsed[key] === "true" || parsed[key] === true;
+}
+
+function run(command, commandArgs, options = {}) {
+  return execFileSync(command, commandArgs, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    ...options,
+  }).trim();
+}
+
+function runOrNull(command, commandArgs, options = {}) {
+  try {
+    return run(command, commandArgs, options);
+  } catch (error) {
+    warnings.push(`${command} ${commandArgs.join(" ")} failed: ${error.stderr?.toString().trim() || error.message}`);
+    return null;
+  }
+}
+
+function runJsonOrEmpty(command, commandArgs) {
+  const stdout = runOrNull(command, commandArgs);
+  if (!stdout) return [];
+  try {
+    return JSON.parse(stdout);
+  } catch (error) {
+    warnings.push(`Could not parse JSON from ${command} ${commandArgs.join(" ")}: ${error.message}`);
+    return [];
+  }
+}
+
+function parseWorktrees(source) {
+  const records = [];
+  let current = null;
+
+  for (const line of source.split(/\r?\n/)) {
+    if (!line.trim()) {
+      if (current) records.push(current);
+      current = null;
+      continue;
+    }
+
+    const [key, ...rest] = line.split(" ");
+    const value = rest.join(" ");
+
+    if (key === "worktree") {
+      if (current) records.push(current);
+      current = {
+        path: value,
+        head: "",
+        branch: "",
+        detached: false,
+        bare: false,
+        prunable: "",
+      };
+      continue;
+    }
+
+    if (!current) continue;
+    if (key === "HEAD") current.head = value;
+    if (key === "branch") current.branch = value.replace(/^refs\/heads\//, "");
+    if (key === "detached") current.detached = true;
+    if (key === "bare") current.bare = true;
+    if (key === "prunable") current.prunable = value || "yes";
+  }
+
+  if (current) records.push(current);
+  return records;
+}
+
+function parseBranches(source) {
+  if (!source) return [];
+  return source
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => {
+      const [name, committedAt, upstream, worktreePath, head] = line.split("\t");
+      return { name, committedAt, upstream, worktreePath, head };
+    });
+}
+
+function statusFor(worktreePath) {
+  if (!existsSync(worktreePath)) {
+    return {
+      exists: false,
+      dirty: false,
+      trackedCount: 0,
+      untrackedCount: 0,
+      untrackedExamples: [],
+      error: "path does not exist",
+    };
+  }
+
+  const stdout = runOrNull("git", ["-C", worktreePath, "status", "--porcelain=v1"]);
+  if (stdout === null) {
+    return {
+      exists: true,
+      dirty: true,
+      trackedCount: 0,
+      untrackedCount: 0,
+      untrackedExamples: [],
+      error: "git status failed",
+    };
+  }
+
+  const lines = stdout.split(/\r?\n/).filter(Boolean);
+  const untracked = lines.filter((line) => line.startsWith("?? "));
+  const tracked = lines.filter((line) => !line.startsWith("?? "));
+
+  return {
+    exists: true,
+    dirty: lines.length > 0,
+    trackedCount: tracked.length,
+    untrackedCount: untracked.length,
+    untrackedExamples: untracked.slice(0, 8).map((line) => line.slice(3)),
+    error: "",
+  };
+}
+
+function daysSince(dateValue) {
+  if (!dateValue) return Number.POSITIVE_INFINITY;
+  const date = new Date(dateValue);
+  if (Number.isNaN(date.valueOf())) return Number.POSITIVE_INFINITY;
+  return Math.max(0, Math.floor((now.valueOf() - date.valueOf()) / 86_400_000));
+}
+
+function issueMentionsBranch(issue, branchName) {
+  const slug = branchName.replace(/^agent\//, "");
+  const source = `${issue.title || ""}\n${issue.body || ""}`.toLowerCase();
+  return source.includes(branchName.toLowerCase()) || source.includes(slug.toLowerCase());
+}
+
+function groupBy(items, keyFor) {
+  const groups = new Map();
+  for (const item of items) {
+    const key = keyFor(item);
+    if (!key) continue;
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(item);
+  }
+  return [...groups.entries()]
+    .filter(([, group]) => group.length > 1)
+    .map(([key, group]) => ({ key, group }));
+}
+
+function compactPr(pr) {
+  if (!pr) return null;
+  return {
+    number: pr.number,
+    title: pr.title,
+    state: pr.state,
+    isDraft: pr.isDraft,
+    url: pr.url,
+    updatedAt: pr.updatedAt,
+    mergedAt: pr.mergedAt,
+    closedAt: pr.closedAt,
+  };
+}
+
+function compactWorktree(worktree) {
+  return {
+    path: worktree.path,
+    branch: worktree.branch || "(detached)",
+    head: worktree.head,
+    upstream: worktree.upstream || "",
+    dirty: worktree.status.dirty,
+    trackedCount: worktree.status.trackedCount,
+    untrackedCount: worktree.status.untrackedCount,
+    untrackedExamples: worktree.status.untrackedExamples,
+    pr: compactPr(worktree.pr),
+    reasons: worktree.reasons,
+  };
+}
+
+function renderList(title, items, formatter) {
+  const lines = [`### ${title}`, ""];
+  if (!items.length) {
+    lines.push("- None");
+    lines.push("");
+    return lines;
+  }
+
+  for (const item of items.slice(0, maxItems)) lines.push(formatter(item));
+  if (items.length > maxItems) lines.push(`- ...and ${items.length - maxItems} more`);
+  lines.push("");
+  return lines;
+}
+
+function formatWorktree(item) {
+  const dirty = item.status.dirty
+    ? `dirty: ${item.status.trackedCount} tracked, ${item.status.untrackedCount} untracked`
+    : "clean";
+  const pr = item.pr ? `PR #${item.pr.number} ${item.pr.state}` : "no PR";
+  const reasons = item.reasons.length ? ` - ${item.reasons.join("; ")}` : "";
+  return `- \`${item.path}\` on \`${item.branch || "(detached)"}\` (${dirty}, ${pr})${reasons}`;
+}
+
+const worktrees = parseWorktrees(run("git", ["worktree", "list", "--porcelain"]));
+const branches = parseBranches(
+  run("git", [
+    "for-each-ref",
+    "refs/heads",
+    "--format=%(refname:short)%09%(committerdate:iso8601)%09%(upstream:short)%09%(worktreepath)%09%(objectname)",
+  ]),
+);
+const prs = runJsonOrEmpty("gh", [
+  "pr",
+  "list",
+  "--repo",
+  repo,
+  "--state",
+  "all",
+  "--limit",
+  "1000",
+  "--json",
+  "number,title,url,state,isDraft,headRefName,baseRefName,updatedAt,closedAt,mergedAt",
+]);
+const openIssues = runJsonOrEmpty("gh", [
+  "issue",
+  "list",
+  "--repo",
+  repo,
+  "--state",
+  "open",
+  "--limit",
+  "1000",
+  "--json",
+  "number,title,url,body,labels,updatedAt",
+]);
+
+const branchByName = new Map(branches.map((branch) => [branch.name, branch]));
+const prsByHead = new Map();
+for (const pr of prs) {
+  if (!prsByHead.has(pr.headRefName)) prsByHead.set(pr.headRefName, []);
+  prsByHead.get(pr.headRefName).push(pr);
+}
+
+for (const group of prsByHead.values()) {
+  group.sort((a, b) => {
+    const aOpen = a.state === "OPEN" ? 0 : 1;
+    const bOpen = b.state === "OPEN" ? 0 : 1;
+    if (aOpen !== bOpen) return aOpen - bOpen;
+    return Number(b.number) - Number(a.number);
+  });
+}
+
+const enrichedWorktrees = worktrees.map((worktree) => {
+  const branch = branchByName.get(worktree.branch);
+  const branchPrs = prsByHead.get(worktree.branch) || [];
+  const pr = branchPrs[0] || null;
+  const openPr = branchPrs.find((candidate) => candidate.state === "OPEN") || null;
+  const status = statusFor(worktree.path);
+  const issueEvidence = worktree.branch ? openIssues.filter((issue) => issueMentionsBranch(issue, worktree.branch)) : [];
+  const branchAge = daysSince(branch?.committedAt);
+  const reasons = [];
+
+  if (worktree.detached || !worktree.branch) reasons.push("detached");
+  if (worktree.prunable) reasons.push(`prunable: ${worktree.prunable}`);
+  if (status.dirty) reasons.push(`${status.trackedCount} tracked and ${status.untrackedCount} untracked local changes`);
+  if (pr && pr.state !== "OPEN") reasons.push(`PR #${pr.number} is ${pr.state.toLowerCase()}`);
+  if (openPr) reasons.push(`open PR #${openPr.number}`);
+  if (!openPr && issueEvidence.length) reasons.push(`open issue evidence: ${issueEvidence.map((issue) => `#${issue.number}`).join(", ")}`);
+  if (!openPr && !issueEvidence.length && worktree.branch?.startsWith("agent/") && branchAge >= staleDays) {
+    reasons.push(`${branchAge}d old with no open PR or issue evidence`);
+  }
+
+  return {
+    ...worktree,
+    upstream: branch?.upstream || "",
+    branchCommittedAt: branch?.committedAt || "",
+    branchAge,
+    status,
+    pr,
+    openPr,
+    issueEvidence,
+    reasons,
+  };
+});
+
+const agentBranches = branches.filter((branch) => branch.name.startsWith("agent/"));
+const localBranchesWithoutOpenPrOrIssue = agentBranches
+  .map((branch) => {
+    const openPr = (prsByHead.get(branch.name) || []).find((pr) => pr.state === "OPEN") || null;
+    const issueEvidence = openIssues.filter((issue) => issueMentionsBranch(issue, branch.name));
+    return {
+      ...branch,
+      age: daysSince(branch.committedAt),
+      openPr,
+      issueEvidence,
+    };
+  })
+  .filter((branch) => !branch.openPr && !branch.issueEvidence.length)
+  .sort((a, b) => b.age - a.age);
+
+const mergedOrClosedPrWorktrees = enrichedWorktrees
+  .filter((worktree) => worktree.pr && worktree.pr.state !== "OPEN")
+  .sort((a, b) => daysSince(b.pr.updatedAt) - daysSince(a.pr.updatedAt));
+const safeRemoveCandidates = mergedOrClosedPrWorktrees.filter((worktree) => !worktree.status.dirty);
+const archiveBeforeRemoveCandidates = mergedOrClosedPrWorktrees.filter((worktree) => worktree.status.dirty);
+const detachedWorktrees = enrichedWorktrees.filter((worktree) => worktree.detached || !worktree.branch);
+const dirtyWorktrees = enrichedWorktrees.filter((worktree) => worktree.status.dirty);
+const staleNoEvidenceWorktrees = enrichedWorktrees
+  .filter(
+    (worktree) =>
+      worktree.branch?.startsWith("agent/") &&
+      !worktree.openPr &&
+      !worktree.issueEvidence.length &&
+      worktree.branchAge >= staleDays,
+  )
+  .sort((a, b) => b.branchAge - a.branchAge);
+const duplicateBranches = groupBy(enrichedWorktrees, (worktree) => worktree.branch);
+const duplicateHeads = groupBy(enrichedWorktrees, (worktree) => worktree.head);
+const duplicateUpstreams = groupBy(enrichedWorktrees, (worktree) => worktree.upstream);
+
+const findingCount =
+  safeRemoveCandidates.length +
+  archiveBeforeRemoveCandidates.length +
+  detachedWorktrees.length +
+  dirtyWorktrees.length +
+  staleNoEvidenceWorktrees.length +
+  duplicateBranches.length +
+  duplicateHeads.length +
+  duplicateUpstreams.length +
+  localBranchesWithoutOpenPrOrIssue.length;
+
+const report = {
+  generatedAt: now.toISOString(),
+  repo,
+  thresholds: {
+    staleDays,
+  },
+  summary: {
+    worktrees: enrichedWorktrees.length,
+    localBranches: branches.length,
+    localAgentBranches: agentBranches.length,
+    openPrs: prs.filter((pr) => pr.state === "OPEN").length,
+    safeRemoveCandidates: safeRemoveCandidates.length,
+    archiveBeforeRemoveCandidates: archiveBeforeRemoveCandidates.length,
+    dirtyWorktrees: dirtyWorktrees.length,
+    detachedWorktrees: detachedWorktrees.length,
+    staleNoEvidenceWorktrees: staleNoEvidenceWorktrees.length,
+    localAgentBranchesWithoutOpenPrOrIssue: localBranchesWithoutOpenPrOrIssue.length,
+    findingCount,
+  },
+  findings: {
+    safeRemoveCandidates: safeRemoveCandidates.map(compactWorktree),
+    archiveBeforeRemoveCandidates: archiveBeforeRemoveCandidates.map(compactWorktree),
+    dirtyWorktrees: dirtyWorktrees.map(compactWorktree),
+    detachedWorktrees: detachedWorktrees.map(compactWorktree),
+    staleNoEvidenceWorktrees: staleNoEvidenceWorktrees.map(compactWorktree),
+    duplicateBranches: duplicateBranches.map(({ key, group }) => ({ key, worktrees: group.map(compactWorktree) })),
+    duplicateHeads: duplicateHeads.map(({ key, group }) => ({ key, worktrees: group.map(compactWorktree) })),
+    duplicateUpstreams: duplicateUpstreams.map(({ key, group }) => ({ key, worktrees: group.map(compactWorktree) })),
+    localBranchesWithoutOpenPrOrIssue: localBranchesWithoutOpenPrOrIssue.map((branch) => ({
+      name: branch.name,
+      committedAt: branch.committedAt,
+      age: branch.age,
+      upstream: branch.upstream,
+      worktreePath: branch.worktreePath,
+      head: branch.head,
+    })),
+  },
+  warnings,
+};
+
+if (outputJson) {
+  console.log(JSON.stringify(report, null, 2));
+} else {
+  const lines = [];
+  lines.push("# Worktree Hygiene Report");
+  lines.push("");
+  lines.push(`Generated: ${report.generatedAt}`);
+  lines.push(`Repo: ${repo}`);
+  lines.push(`Stale threshold: ${staleDays} days`);
+  lines.push("");
+  lines.push("## Summary");
+  lines.push("");
+  lines.push(`- Worktrees: ${report.summary.worktrees}`);
+  lines.push(`- Local branches: ${report.summary.localBranches}`);
+  lines.push(`- Local agent branches: ${report.summary.localAgentBranches}`);
+  lines.push(`- Open PRs: ${report.summary.openPrs}`);
+  lines.push(`- Clean merged/closed PR worktrees ready to remove: ${report.summary.safeRemoveCandidates}`);
+  lines.push(`- Dirty merged/closed PR worktrees to archive before removal: ${report.summary.archiveBeforeRemoveCandidates}`);
+  lines.push(`- Dirty worktrees: ${report.summary.dirtyWorktrees}`);
+  lines.push(`- Detached worktrees: ${report.summary.detachedWorktrees}`);
+  lines.push(`- Stale agent worktrees with no open PR or issue evidence: ${report.summary.staleNoEvidenceWorktrees}`);
+  lines.push(`- Local agent branches with no open PR or issue evidence: ${report.summary.localAgentBranchesWithoutOpenPrOrIssue}`);
+  lines.push(`- Findings: ${findingCount}`);
+  lines.push("");
+  lines.push("## Findings");
+  lines.push("");
+  lines.push(...renderList("Clean Merged Or Closed PR Worktrees Ready To Remove", safeRemoveCandidates, formatWorktree));
+  lines.push(...renderList("Dirty Merged Or Closed PR Worktrees To Archive Before Removal", archiveBeforeRemoveCandidates, formatWorktree));
+  lines.push(...renderList("Dirty Worktrees", dirtyWorktrees, formatWorktree));
+  lines.push(...renderList("Detached Worktrees", detachedWorktrees, formatWorktree));
+  lines.push(...renderList("Stale Agent Worktrees With No Open PR Or Issue Evidence", staleNoEvidenceWorktrees, formatWorktree));
+  lines.push(
+    ...renderList("Duplicate HEAD Worktree Groups", duplicateHeads, ({ key, group }) => {
+      const paths = group.map((worktree) => `\`${worktree.path}\``).join(", ");
+      return `- \`${key}\`: ${paths}`;
+    }),
+  );
+  lines.push(
+    ...renderList("Duplicate Upstream Worktree Groups", duplicateUpstreams, ({ key, group }) => {
+      const paths = group.map((worktree) => `\`${worktree.path}\` on \`${worktree.branch}\``).join(", ");
+      return `- \`${key}\`: ${paths}`;
+    }),
+  );
+  lines.push(
+    ...renderList("Local Agent Branches With No Open PR Or Issue Evidence", localBranchesWithoutOpenPrOrIssue, (branch) => {
+      const where = branch.worktreePath ? ` checked out at \`${branch.worktreePath}\`` : " not checked out";
+      const upstream = branch.upstream ? `, upstream \`${branch.upstream}\`` : ", no upstream";
+      return `- \`${branch.name}\` (${branch.age}d old${upstream}${where})`;
+    }),
+  );
+
+  lines.push("## Recommended Sweep Actions");
+  lines.push("");
+  lines.push("1. Remove clean merged/closed PR worktrees with `git worktree remove <path>`.");
+  lines.push("2. For dirty merged/closed worktrees, inspect `git status -sb`; archive generated artifacts outside the repo before removal.");
+  lines.push("3. For duplicate HEAD/upstream groups, keep only the active PR or assigned QA worktree.");
+  lines.push("4. For stale branches with no open PR or issue evidence, create an issue, close/supersede the work, or delete the local branch after confirming it is not needed.");
+  lines.push("5. Run `git fetch --prune origin` and `git worktree prune` after cleanup.");
+  lines.push("");
+
+  if (warnings.length) {
+    lines.push("## Warnings");
+    lines.push("");
+    for (const warning of warnings) lines.push(`- ${warning}`);
+    lines.push("");
+  }
+
+  console.log(lines.join("\n"));
+}
+
+if (failOnFindings && findingCount > 0) {
+  process.exitCode = 1;
+}

--- a/scripts/validate-agent-workflow.mjs
+++ b/scripts/validate-agent-workflow.mjs
@@ -46,6 +46,7 @@ const requiredFiles = [
   "scripts/agent-preflight.mjs",
   "scripts/agent-context.mjs",
   "scripts/agent-github-hygiene.mjs",
+  "scripts/agent-worktree-hygiene.mjs",
   "scripts/agent-merge-gate.mjs",
   "scripts/validate-agent-workflow.mjs",
 ];
@@ -94,6 +95,7 @@ if (exists("package.json")) {
   assert(pkg.scripts?.["agent:preflight"], "package.json must include agent:preflight.");
   assert(pkg.scripts?.["agent:context"], "package.json must include agent:context.");
   assert(pkg.scripts?.["agent:github-hygiene"], "package.json must include agent:github-hygiene.");
+  assert(pkg.scripts?.["agent:worktree-hygiene"], "package.json must include agent:worktree-hygiene.");
   assert(pkg.scripts?.["agent:merge-gate"], "package.json must include agent:merge-gate.");
   assert(pkg.scripts?.["agent:validate-workflow"], "package.json must include agent:validate-workflow.");
 }
@@ -108,7 +110,7 @@ for (const file of [".github/ISSUE_TEMPLATE/feature_task.yml", ".github/ISSUE_TE
   const source = read(file);
   assert(/^name:/m.test(source), `${file} must define name.`);
   assert(/^body:/m.test(source), `${file} must define body.`);
-  assert(/Owner approval triggers/.test(source), `${file} must include owner approval triggers.`);
+  assert(/Executive decision and risk triggers/.test(source), `${file} must include executive decision and risk triggers.`);
   assert(/Sensitive data warning/.test(source), `${file} must include sensitive data warning.`);
   assert(/Expected verification/.test(source), `${file} must include expected verification.`);
 }
@@ -123,6 +125,7 @@ const hygieneDocs = [
   "AGENTS.md",
   "Docs/LOCAL_DEV.md",
   "Docs/AI_WORKFLOW.md",
+  "Docs/AGENT_SPRINT_WORKFLOW.md",
   ".agents/skills/bloomjoy-agent-workflow/SKILL.md",
 ];
 
@@ -130,6 +133,23 @@ for (const file of hygieneDocs) {
   if (!exists(file)) continue;
   const source = read(file);
   assert(/agent:github-hygiene/.test(source), `${file} must mention npm run agent:github-hygiene.`);
+  assert(/agent:worktree-hygiene/.test(source), `${file} must mention npm run agent:worktree-hygiene.`);
+}
+
+const mergeAutonomyDocs = [
+  "AGENTS.md",
+  "Docs/AI_WORKFLOW.md",
+  "Docs/LOCAL_DEV.md",
+  "Docs/AGENT_SPRINT_WORKFLOW.md",
+  ".agents/skills/bloomjoy-agent-workflow/SKILL.md",
+  ".github/PULL_REQUEST_TEMPLATE.md",
+];
+
+for (const file of mergeAutonomyDocs) {
+  if (!exists(file)) continue;
+  const source = read(file);
+  assert(/executive decision/i.test(source), `${file} must reserve owner approval for executive decisions.`);
+  assert(/proactive/i.test(source), `${file} must describe proactive PR closeout or merge responsibility.`);
 }
 
 const workflowDocs = [


### PR DESCRIPTION
## Linked Issue
- Closes #583

## Summary
- Adds `npm run agent:worktree-hygiene`, a read-only local report for stale, duplicate, detached, dirty, merged, or closed PR worktrees and local agent branches with no open PR/issue evidence.
- Updates merge-gate and GitHub hygiene behavior so technical-risk PRs require stronger agent evidence instead of defaulting to Ethan approval.
- Updates durable workflow docs, issue templates, PR template, task template, and repo workflow skill to make proactive PR testing/review/merge/cleanup the expected agent behavior.

## Files Changed
- Agent scripts: new worktree hygiene reporter, merge-gate lane logic, GitHub hygiene wording, workflow validator coverage.
- Workflow docs/templates: `AGENTS.md`, `Docs/AI_WORKFLOW.md`, `Docs/LOCAL_DEV.md`, `Docs/AGENT_SPRINT_WORKFLOW.md`, `Docs/TASK_TEMPLATE.md`, issue templates, PR template, repo workflow skill.
- `package.json`: adds the `agent:worktree-hygiene` npm command.

## Verification
- [x] `npm ci` - passed after rebase; 409 packages installed/audited, existing audit output reports 4 vulnerabilities (3 moderate, 1 high).
- [x] `node --check scripts/agent-worktree-hygiene.mjs` - passed.
- [x] `node --check scripts/agent-merge-gate.mjs` - passed.
- [x] `node --check scripts/agent-github-hygiene.mjs` - passed.
- [x] `node --check scripts/validate-agent-workflow.mjs` - passed.
- [x] `npm run agent:preflight -- --issue 583` - passed.
- [x] `npm run agent:github-hygiene -- --max-items 5` - passed; live report found 102 hygiene findings.
- [x] `npm run agent:worktree-hygiene -- --max-items 5` - passed; live report found 163 worktrees, 97 clean merged/closed PR worktrees ready to remove, 6 detached worktrees, and dirty worktrees requiring inspection.
- [x] `node scripts/agent-worktree-hygiene.mjs --json` parsed from temp file - passed; parsed summary: worktrees=163, findings=518, cleanMergedClosed=97.
- [x] `npm run agent:validate-workflow` - passed.
- [x] `npm run build` - passed; Vite build and prerender completed.
- [x] `npm test --if-present` - passed; sales report PDF polish validation passed.
- [x] `npm run lint --if-present` - passed.
- [x] `git diff --check` - passed.
- [x] GitHub checks - passed: CI `verify`, Supabase Migrations `validate`, Vercel, and Vercel Preview Comments.
- [x] `npm run agent:merge-gate -- --pr 586` - passed as Yellow lane with expected P1 warning.

## How To Test Locally
1. Run `npm ci`.
2. Run `npm run agent:worktree-hygiene -- --max-items 10` and confirm it prints a Markdown report without mutating worktrees.
3. Run `node scripts/agent-worktree-hygiene.mjs --json` and confirm it emits parseable JSON.
4. Run `npm run agent:validate-workflow` to confirm docs/templates/scripts retain the workflow contract.
5. For PR closeout behavior, run `npm run agent:merge-gate -- --pr <open-pr-number>` against a PR with the updated template sections.

## Risk And Overlap
- Priority/risk: P1 workflow/tooling and docs change. No product runtime behavior changes.
- Shared files or open PR overlap: workflow docs/templates/scripts only; no overlap found with the latest `origin/main` report PDF fix before rebase.
- Rollback: revert this PR to remove the worktree hygiene command and restore the prior merge-gate/template wording.

## Merge Autonomy
- Lane: Yellow
- Executive decision: Not required. This is owner-requested workflow/tooling cleanup with no production deploy, secrets, external account setup, or product go/no-go.
- Gate evidence: GitHub checks green; issue #583 linked; risk labels reviewed; `npm run agent:merge-gate -- --pr 586` passed.
- Proactive closeout: agent may merge after checks, independent review, and merge gate pass.

## Independent Review / QA Evidence
- Subagent `Hooke` reviewed PR #586 read-only and found no blocking issues.
- Review confirmed the new worktree hygiene command is read-only, merge-gate separates executive labels from technical-risk labels, docs/templates/skill include proactive closeout guidance, and validator coverage includes the new contract.
- Subagent verification passed: `npm run agent:validate-workflow`, `node --check` for worktree hygiene and merge gate scripts, `npm run agent:worktree-hygiene -- --max-items 1`, `npm run agent:merge-gate -- --pr 586`, and `git diff --check fab3330...HEAD`.
- Residual risk: behavior is covered by script execution and workflow validation, not fixture-based unit tests for every duplicate-branch or ambiguous issue-text edge case.

## UI / Design Evidence
- Not applicable; no visible product UI changes.

## Board Closeout
- Project-board status: issue #583 is on the Bloomjoy Hub Priorities board.
- Remaining follow-ups: actual broad worktree deletion should be a separate sweep using the new read-only report; this PR only adds tooling and policy.