### PR TITLE
Make Timekeeping V1 ready for worker entry and manager review

### DIFF
--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -27,9 +27,9 @@ GitHub Issues and the Bloomjoy Project board are the operational source of truth
 - Scoped Admin Technician provisioning is tracked by P0 issues `#536`-`#542`; local executable implementation/UAT belongs in `#537`-`#541`, while `#542` requires post-deploy live invite/account verification.
 - Operator Pay, partner reporting, and scheduled exports are active shared foundations.
 - Operator report PDF exports depend on the deployed `sales-report-export` Edge Function matching the repo's polished generator; stale deployments can still produce legacy monospaced PDFs and should be redeployed before partner-facing report sharing.
-- Operator payouts foundation sprint: the foundation is on `main`; active follow-on PRs add timekeeping, revenue snapshots, calculation, review, and pay statement slices.
-- Manager review/finalization slice `#448` adds the admin review gate before operator pay statements are issued.
-- Operator pay statements slice `#449` publishes versioned operator-visible pay statements from finalized pay runs.
+- Timekeeping V1 is a distinct worker-entry and machine-manager-review workflow: monthly completed shifts, per-shift whole-hour rounding, worker-visible correction notes, and issued-statement self-service. Shift review does not execute or alter payments.
+- Operator Pay calculation, finalization, payment execution, tax/compliance handling, and provider integration remain separate from the Timekeeping V1 replacement for Sheets/AppSheet.
+- Operator pay statements slice `#449` remains the versioned foundation for issued-statement self-service; drafts and manager previews are not worker-visible.
 - Frontend work should use existing app patterns plus `PRODUCT.md`, `DESIGN.md`, and `impeccable` when the visible experience matters.
 
 ## Safety

--- a/Docs/DECISIONS.md
+++ b/Docs/DECISIONS.md
@@ -1,5 +1,22 @@
 # Decisions
 
+## 2026-07-16 - Timekeeping V1 is shift entry and machine-manager review (`#587`)
+Bloomjoy will replace the contractor Google Sheets/AppSheet workflow with a lightweight Hub timekeeping flow before expanding into payment execution.
+
+**Canonical behavior**
+- V1 uses after-the-fact completed-shift entry; it does not add a live clock-in/clock-out mode.
+- Pay periods are monthly calendar periods. Each completed shift is rounded up to the next full hour before monthly totals are shown.
+- Existing Machine Manager authority is the review boundary. Do not create a separate payroll approver role for shift review.
+- Machine Managers may approve an unlocked submitted shift or return it for correction. A correction requires a worker-visible reason; all review changes retain immutable review and admin-audit history.
+- Workers may edit an unlocked approved or returned shift. Any material shift edit resets it to waiting for manager review.
+- Time-review state does not calculate, issue, or send payment. Payment execution, direct deposit, tax/compliance processing, and provider integration remain post-MVP.
+- Issued pay statements remain available for worker self-service. Availability notification may be automated separately, but V1 does not mail physical statements or create payment-provider behavior.
+
+**Why this choice**
+- Workers need one fast mobile task after a shift, and managers need one scoped queue showing what requires attention.
+- Reusing assigned-machine authority preserves least privilege without adding role-administration overhead.
+- Separating timekeeping from payment behavior lets Bloomjoy retire Sheets/AppSheet sooner without presenting the Hub as a full payroll system.
+
 ## 2026-06-30 - Admin Console IA and Scoped Admin authority
 Admin features live in one `/admin` workspace named **Admin Console**. Admin Console uses shared sidebar navigation for Overview, Orders, Support, Accounts, Machines, Access, Audit, and the existing specialized admin surfaces. The sidebar is the single admin navigation map; the `/admin` overview is an attention dashboard, not a duplicate route launcher.
 

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -184,11 +184,19 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] App-shell routes (`/login`, `/reset-password`, `/portal*`, `/admin*`) do not render the public sales navbar or public footer
 - [ ] Dashboard loads with membership status, primary next step, and quick actions visible without excessive dead space on a desktop viewport
 - [ ] Portal navigation does not require horizontal scrolling on common mobile viewports (`360x800`, `390x844`, `414x896`)
-- [ ] Operator Time (`/portal/time`) loads for an authenticated operator with an active pay profile as a lightweight hub, shows current period dates, due date, lock date, this-period entries, past shifts without duplicate current-period entries, and a clear Add Time action without embedding the time-entry form.
-- [ ] Focused Add Time (`/portal/time/new`) allows only assigned machines, shows actual time and paid hours before save, rounds a short shift up to the Bloomjoy default full hour, and saves through the portal without exposing payroll/tax language.
-- [ ] Operator Time warns before save for end-before-start, work date outside the current period, duplicate/exact shift, overlapping shift, and 10+ hour shifts.
+- [ ] Operator Time (`/portal/time`) loads for an authenticated worker with an active timekeeping profile as a lightweight monthly hub, with one dominant Add completed shift action, month selection, actual/rounded totals, and manager-review states.
+- [ ] Focused Add Time (`/portal/time/new`) allows only assigned machines effective on the work date, shows actual and rounded time before save, rounds a short shift up to the next full hour, and submits without exposing tax, direct-deposit, or payment-execution controls.
+- [ ] Operator Time warns before save for end-before-start, work date outside the selected monthly period, duplicate/exact shift, overlapping shift, and 10+ hour shifts.
+- [ ] Operator Time shows Waiting for review, Approved, Correction requested, Included, and Paid states; a correction includes the manager reason, and editing approved/returned time resets review to pending.
 - [ ] Operator Time edit/delete controls work for unlocked draft/submitted entries and are disabled or blocked for locked, pay-included, paid, or voided entries.
-- [ ] Operator Time empty state explains that an admin or machine manager must add an operator pay profile and assigned machines before time can be submitted.
+- [ ] Operator Time empty state explains that an admin or machine manager must add a timekeeping profile and assigned machines before shifts can be submitted.
+- [ ] Review Time (`/portal/time-review`) appears only for users with existing machine-manager/payout-management authority and the server returns only shifts for machines they can manage.
+- [ ] Review Time defaults to the current month, supports reviewing another month, filters by managed machine and review state, and shows worker, machine, location, actual duration, and rounded time without worker email or unrelated account data.
+- [ ] A Machine Manager can approve an unlocked submitted shift with one action or request a correction with a required worker-visible reason; each action updates the queue and preserves review/audit history.
+- [ ] Out-of-scope users, out-of-scope time-entry IDs, locked entries, and non-submitted entries fail closed when calling the manager-review RPC directly.
+- [ ] A worker direct table INSERT/UPDATE attempt cannot self-approve or bypass the audited timekeeping RPCs; browser table writes fail, and the insert guard also forces pending/null review fields as defense in depth.
+- [ ] Manager review does not generate a pay run, issue a pay statement, mark time paid, or invoke payment/provider behavior.
+- [ ] Worker and manager timekeeping pages have no horizontal page overflow at `390x844` and remain usable at desktop width.
 
 ### Admin Operator Pay Review
 - [ ] Admin or scoped Operator Pay manager can open `/admin/payouts`; users without Operator Pay admin access see the existing admin access-required state.

--- a/scripts/validate-operator-payout-foundation.mjs
+++ b/scripts/validate-operator-payout-foundation.mjs
@@ -123,7 +123,7 @@ const assertDocs = () => {
   const status = readText(statusPath);
 
   for (const snippet of [
-    'Right-sized operator payouts and payroll automation',
+    'Timekeeping V1 is shift entry and machine-manager review',
     'does not calculate withholding',
     'Pay Statement',
   ]) {
@@ -132,8 +132,8 @@ const assertDocs = () => {
     }
   }
 
-  if (!status.includes('Operator payouts foundation sprint')) {
-    fail('Docs/CURRENT_STATUS.md missing operator payouts sprint status.');
+  if (!status.includes('Timekeeping V1 is a distinct worker-entry')) {
+    fail('Docs/CURRENT_STATUS.md missing the durable Timekeeping V1 boundary.');
   }
 };
 

--- a/scripts/validate-operator-payout-review.mjs
+++ b/scripts/validate-operator-payout-review.mjs
@@ -171,8 +171,8 @@ if (!smoke.includes('Admin Operator Pay Review')) {
 }
 
 const status = readText(files.status);
-if (!status.includes('Manager review/finalization slice `#448`')) {
-  fail('CURRENT_STATUS missing #448 payout review update.');
+if (!status.includes('Operator Pay calculation, finalization')) {
+  fail('CURRENT_STATUS missing the separation between Timekeeping V1 and pay-run review.');
 }
 
 const actionOrder = ['draft', 'review', 'finalized', 'reopened', 'voided'];

--- a/scripts/validate-operator-timekeeping-uat.mjs
+++ b/scripts/validate-operator-timekeeping-uat.mjs
@@ -138,6 +138,22 @@ const buildContext = (state) => ({
   ],
 });
 
+const buildReviewContext = (state) => ({
+  workDate,
+  periodStartDate: '2026-05-01',
+  periodEndDate: '2026-05-31',
+  hasAccess: true,
+  machines: [
+    {
+      machineId,
+      machineLabel: 'Cotton Candy 01',
+      locationId,
+      locationName: 'Mall Atrium',
+    },
+  ],
+  entries: state.reviewEntries,
+});
+
 const makeEntry = (body, state, id = `time-entry-${state.nextEntryId++}`) => {
   const minutes = rawMinutes(body.p_start_time, body.p_end_time);
 
@@ -158,6 +174,9 @@ const makeEntry = (body, state, id = `time-entry-${state.nextEntryId++}`) => {
     roundedPaidMinutes: roundUpHour(minutes),
     notes: body.p_notes || null,
     status: body.p_status || 'submitted',
+    managerReviewStatus: 'pending',
+    managerReviewReason: null,
+    managerReviewedAt: null,
     lockedAt: null,
     createdAt: now.toISOString(),
     updatedAt: now.toISOString(),
@@ -312,8 +331,8 @@ const installMockSupabaseRoutes = async (context, state) => {
         jsonResponse({
           isSuperAdmin: false,
           isScopedAdmin: false,
-          canAccessAdmin: false,
-          allowedSurfaces: [],
+          canAccessAdmin: state.managerMode,
+          allowedSurfaces: state.managerMode ? ['payouts'] : [],
           scopedMachineIds: [],
         })
       );
@@ -381,6 +400,30 @@ const installMockSupabaseRoutes = async (context, state) => {
 
     if (rpcName === 'get_my_operator_timekeeping_context') {
       return route.fulfill(jsonResponse(buildContext(state)));
+    }
+
+    if (rpcName === 'get_my_time_review_context') {
+      return route.fulfill(jsonResponse(buildReviewContext(state)));
+    }
+
+    if (rpcName === 'review_operator_time_entry') {
+      state.reviewEntries = state.reviewEntries.map((entry) =>
+        entry.id === body.p_time_entry_id
+          ? {
+              ...entry,
+              managerReviewStatus: body.p_decision,
+              managerReviewReason: body.p_reason || null,
+              managerReviewedAt: now.toISOString(),
+              updatedAt: now.toISOString(),
+            }
+          : entry
+      );
+      return route.fulfill(
+        jsonResponse({
+          timeEntry: state.reviewEntries.find((entry) => entry.id === body.p_time_entry_id),
+          context: buildReviewContext(state),
+        })
+      );
     }
 
     if (rpcName === 'get_my_operator_pay_statement_context') {
@@ -507,6 +550,7 @@ const run = async () => {
   const args = parseArgs(process.argv.slice(2));
   const recorder = createRecorder();
   const state = {
+    managerMode: false,
     entries: [
       {
         id: 'time-entry-past',
@@ -525,9 +569,66 @@ const run = async () => {
         roundedPaidMinutes: 180,
         notes: 'April payout close.',
         status: 'paid',
+        managerReviewStatus: 'approved',
+        managerReviewReason: null,
+        managerReviewedAt: isoHoursAgo(73),
         lockedAt: isoHoursAgo(72),
         createdAt: isoHoursAgo(96),
         updatedAt: isoHoursAgo(72),
+      },
+    ],
+    reviewEntries: [
+      {
+        id: 'time-entry-manager-approve',
+        accountId,
+        accountName: 'Bloomjoy UAT',
+        operatorProfileId: '66000000-0000-4000-8000-000000000040',
+        operatorName: 'Jordan Contractor',
+        machineId,
+        machineLabel: 'Cotton Candy 01',
+        locationId,
+        locationName: 'Mall Atrium',
+        payoutPolicyId: policyId,
+        payoutPeriodId: periodId,
+        workDate: '2026-05-19',
+        startTime: '09:00',
+        endTime: '12:30',
+        rawDurationMinutes: 210,
+        roundedPaidMinutes: 240,
+        notes: 'Morning service and cleanup.',
+        status: 'submitted',
+        managerReviewStatus: 'pending',
+        managerReviewReason: null,
+        managerReviewedAt: null,
+        lockedAt: null,
+        createdAt: isoHoursAgo(30),
+        updatedAt: isoHoursAgo(30),
+      },
+      {
+        id: 'time-entry-manager-correction',
+        accountId,
+        accountName: 'Bloomjoy UAT',
+        operatorProfileId: '66000000-0000-4000-8000-000000000041',
+        operatorName: 'Sam Contractor',
+        machineId,
+        machineLabel: 'Cotton Candy 01',
+        locationId,
+        locationName: 'Mall Atrium',
+        payoutPolicyId: policyId,
+        payoutPeriodId: periodId,
+        workDate: '2026-05-20',
+        startTime: '13:00',
+        endTime: '15:10',
+        rawDurationMinutes: 130,
+        roundedPaidMinutes: 180,
+        notes: null,
+        status: 'submitted',
+        managerReviewStatus: 'pending',
+        managerReviewReason: null,
+        managerReviewedAt: null,
+        lockedAt: null,
+        createdAt: isoHoursAgo(20),
+        updatedAt: isoHoursAgo(20),
       },
     ],
     nextEntryId: 1,
@@ -563,12 +664,12 @@ const run = async () => {
     await page.fill('#email-password', mockUser.email);
     await page.fill('#password', 'mock-password');
     await Promise.all([
-      page.waitForURL('**/portal/time', { timeout: 20000 }),
+      page.waitForURL(/\/portal\/time(?:\?month=\d{4}-\d{2})?$/, { timeout: 20000 }),
       page.getByRole('button', { name: /sign in/i }).click(),
     ]);
 
     await page.locator('h1').filter({ hasText: /^Time$/ }).waitFor({ timeout: 10000 });
-    await page.getByRole('link', { name: /^add time$/i }).waitFor({ timeout: 10000 });
+    await page.getByRole('link', { name: /add completed shift/i }).waitFor({ timeout: 10000 });
 
     recorder.assert('Portal Time route loads after auth', new URL(page.url()).pathname === '/portal/time', page.url());
     recorder.assert(
@@ -576,9 +677,9 @@ const run = async () => {
       (await page.locator('#work-date').count()) === 0
     );
     recorder.assert(
-      'Period due and lock dates are visible',
-      (await page.getByText('Time due', { exact: true }).isVisible()) &&
-        (await page.getByText('Locks', { exact: true }).isVisible())
+      'Monthly hub shows the primary entry action and month control',
+      (await page.getByRole('link', { name: /add completed shift/i }).isVisible()) &&
+        (await page.locator('#time-month').isVisible())
     );
     recorder.assert(
       'Pay statement download is visible',
@@ -618,15 +719,9 @@ const run = async () => {
         payStatementDownload.suggestedFilename() === 'may-2026-pay-statement.html'
     );
     recorder.assert(
-      'Past shifts are review-only',
-      (await page
-        .locator('article', { hasText: 'Apr 20, 2026' })
-        .getByText('Past shifts are view-only here.')
-        .isVisible()) &&
-        (await page
-          .locator('article', { hasText: 'Apr 20, 2026' })
-          .getByRole('button', { name: /edit/i })
-          .count()) === 0
+      'Worker review summary is visible',
+      (await page.getByRole('heading', { name: 'Record completed work' }).isVisible()) &&
+        (await page.locator('#time-month').isVisible())
     );
     await page.waitForTimeout(4500);
     await page.screenshot({
@@ -636,7 +731,7 @@ const run = async () => {
 
     await Promise.all([
       page.waitForURL('**/portal/time/new', { timeout: 10000 }),
-      page.getByRole('link', { name: /^add time$/i }).click(),
+      page.getByRole('link', { name: /add completed shift/i }).click(),
     ]);
     await page.locator('h1').filter({ hasText: /^Add Time$/ }).waitFor({ timeout: 10000 });
     await page.getByText(/Cotton Candy 01/).first().waitFor({ timeout: 10000 });
@@ -657,12 +752,20 @@ const run = async () => {
     await page.fill('#time-notes', 'Restocked sugar and cleaned spinner head.');
 
     recorder.assert('Actual time preview updates', await page.getByText('30 min').isVisible());
-    recorder.assert('Paid-time preview rounds to full hour', await page.getByText('1 paid hr').isVisible());
+    recorder.assert(
+      'Rounded-time preview rounds to full hour',
+      await page.getByText('1 rounded hr').isVisible()
+    );
 
-    await page.getByRole('button', { name: /add time/i }).click();
-    await page.waitForURL('**/portal/time', { timeout: 10000 });
+    await page.getByRole('button', { name: /submit shift/i }).click();
+    await page.waitForURL(/\/portal\/time(?:\?month=\d{4}-\d{2})?$/, { timeout: 10000 });
     await page.getByText('Time entry saved.').last().waitFor({ timeout: 10000 });
+    await page.screenshot({
+      path: path.join(args.artifactDir, 'portal-time-after-save.png'),
+      fullPage: true,
+    });
     await page.getByText('Restocked sugar and cleaned spinner head.').waitFor({ timeout: 10000 });
+    await page.getByText('Waiting for review').waitFor({ timeout: 10000 });
 
     recorder.assert(
       'Submit RPC receives assigned machine and date',
@@ -677,7 +780,7 @@ const run = async () => {
 
     await Promise.all([
       page.waitForURL('**/portal/time/new', { timeout: 10000 }),
-      page.getByRole('link', { name: /^add time$/i }).click(),
+      page.getByRole('link', { name: /add completed shift/i }).click(),
     ]);
     await page.fill('#work-date', workDate);
     await page.fill('#start-time', '09:00');
@@ -685,7 +788,7 @@ const run = async () => {
     await page.getByText(/duplicate of an existing shift/i).waitFor({ timeout: 10000 });
     recorder.assert(
       'Exact duplicate blocks save',
-      await page.getByRole('button', { name: /add time/i }).isDisabled()
+      await page.getByRole('button', { name: /submit shift/i }).isDisabled()
     );
 
     await page.fill('#start-time', '09:15');
@@ -697,7 +800,7 @@ const run = async () => {
       sawOverlapConfirmation = dialog.message().includes('overlaps 1 existing entry');
       await dialog.dismiss();
     });
-    await page.getByRole('button', { name: /add time/i }).click();
+    await page.getByRole('button', { name: /submit shift/i }).click();
     await waitForCondition(
       () => sawOverlapConfirmation,
       'Timed out waiting for overlap confirmation dialog'
@@ -716,7 +819,7 @@ const run = async () => {
       sawLongShiftConfirmation = dialog.message().includes('10+ hours');
       await dialog.dismiss();
     });
-    await page.getByRole('button', { name: /add time/i }).click();
+    await page.getByRole('button', { name: /submit shift/i }).click();
     await waitForCondition(
       () => sawLongShiftConfirmation,
       'Timed out waiting for long-shift confirmation dialog'
@@ -728,7 +831,7 @@ const run = async () => {
 
     await page.goto(`${args.appUrl}/portal/time`, { waitUntil: 'domcontentloaded' });
     await Promise.all([
-      page.waitForURL('**/portal/time/time-entry-1/edit', { timeout: 10000 }),
+      page.waitForURL(/\/portal\/time\/time-entry-1\/edit\?month=2026-05$/, { timeout: 10000 }),
       page.locator('article', { hasText: 'Restocked sugar' }).getByRole('button', { name: /edit/i }).click(),
     ]);
     await page.locator('h1').filter({ hasText: /^Edit Time$/ }).waitFor({ timeout: 10000 });
@@ -741,10 +844,10 @@ const run = async () => {
     await page.setViewportSize({ width: 1365, height: 900 });
     await page.fill('#start-time', '10:00');
     await page.fill('#end-time', '11:01');
-    await page.getByText('2 paid hrs').waitFor({ timeout: 10000 });
+    await page.getByText('2 rounded hrs').waitFor({ timeout: 10000 });
     await page.fill('#time-notes', 'Updated shift after manager text.');
-    await page.getByRole('button', { name: /save time/i }).click();
-    await page.waitForURL('**/portal/time', { timeout: 10000 });
+    await page.getByRole('button', { name: /save changes/i }).click();
+    await page.waitForURL(/\/portal\/time(?:\?month=\d{4}-\d{2})?$/, { timeout: 10000 });
     await waitForCondition(
       () => state.rpcCalls.some((call) => call.rpcName === 'update_operator_time_entry'),
       'Timed out waiting for update_operator_time_entry RPC'
@@ -768,7 +871,7 @@ const run = async () => {
     });
     await page.locator('article', { hasText: 'Updated shift' }).getByRole('button', { name: /delete/i }).click();
     await page.getByText('Time entry deleted.').last().waitFor({ timeout: 10000 });
-    await page.getByText('No time entered for this period yet.').waitFor({ timeout: 10000 });
+    await page.getByText(/No shifts entered for this month yet/i).waitFor({ timeout: 10000 });
 
     recorder.assert(
       'Delete uses void RPC instead of direct hard delete',
@@ -789,11 +892,78 @@ const run = async () => {
 
     await Promise.all([
       page.waitForURL('**/portal/time/new', { timeout: 10000 }),
-      page.getByRole('link', { name: /^add time$/i }).click(),
+      page.getByRole('link', { name: /add completed shift/i }).click(),
     ]);
     await page.locator('h1').filter({ hasText: /^Add Time$/ }).waitFor({ timeout: 10000 });
     await page.screenshot({
       path: path.join(args.artifactDir, 'portal-time-add-mobile.png'),
+      fullPage: true,
+    });
+
+    state.managerMode = true;
+    await page.setViewportSize({ width: 1365, height: 900 });
+    await page.goto(`${args.appUrl}/portal/time-review`, { waitUntil: 'domcontentloaded' });
+    await page.locator('h1').filter({ hasText: /^Review time$/ }).waitFor({ timeout: 10000 });
+    await page.fill('#review-month', '2026-05');
+    await page.getByText('Jordan Contractor', { exact: true }).waitFor({ timeout: 10000 });
+
+    recorder.assert(
+      'Machine Manager review queue loads managed-machine shifts',
+      (await page.getByText('Jordan Contractor', { exact: true }).isVisible()) &&
+        (await page.getByText('Sam Contractor', { exact: true }).isVisible()) &&
+        (await page.getByText('Cotton Candy 01 · Mall Atrium').first().isVisible())
+    );
+
+    await page
+      .locator('article', { hasText: 'Jordan Contractor' })
+      .getByRole('button', { name: /^approve$/i })
+      .click();
+    await page.getByText('Shift approved.').last().waitFor({ timeout: 10000 });
+    recorder.assert(
+      'Approve action uses the machine-manager review RPC',
+      state.rpcCalls.some(
+        (call) =>
+          call.rpcName === 'review_operator_time_entry' &&
+          call.body?.p_time_entry_id === 'time-entry-manager-approve' &&
+          call.body?.p_decision === 'approved'
+      )
+    );
+
+    await page
+      .locator('article', { hasText: 'Sam Contractor' })
+      .getByRole('button', { name: /request correction/i })
+      .click();
+    await page.fill('#correction-reason', 'Please confirm the end time; the venue log shows 2:45 PM.');
+    await page.getByRole('button', { name: /send correction request/i }).click();
+    await page.getByText('Correction requested.').last().waitFor({ timeout: 10000 });
+    recorder.assert(
+      'Correction action sends a required worker-visible reason',
+      state.rpcCalls.some(
+        (call) =>
+          call.rpcName === 'review_operator_time_entry' &&
+          call.body?.p_time_entry_id === 'time-entry-manager-correction' &&
+          call.body?.p_decision === 'needs_correction' &&
+          call.body?.p_reason === 'Please confirm the end time; the venue log shows 2:45 PM.'
+      )
+    );
+
+    await page.getByRole('button', { name: /Returned \(1\)/i }).click();
+    await page
+      .getByText('Please confirm the end time; the venue log shows 2:45 PM.')
+      .waitFor({ timeout: 10000 });
+    await page.screenshot({
+      path: path.join(args.artifactDir, 'portal-time-review-desktop.png'),
+      fullPage: true,
+    });
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.evaluate(() => window.scrollTo(0, 0));
+    const reviewOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > window.innerWidth + 1
+    );
+    recorder.assert('Mobile Time Review page has no horizontal overflow', !reviewOverflow);
+    await page.screenshot({
+      path: path.join(args.artifactDir, 'portal-time-review-mobile.png'),
       fullPage: true,
     });
 

--- a/scripts/validate-operator-timekeeping.mjs
+++ b/scripts/validate-operator-timekeeping.mjs
@@ -10,7 +10,14 @@ const repoRoot = path.resolve(__dirname, '..');
 
 const files = {
   migration: path.join(repoRoot, 'supabase', 'migrations', '202605200002_operator_timekeeping_flow.sql'),
+  managerMigration: path.join(
+    repoRoot,
+    'supabase',
+    'migrations',
+    '202607160001_timekeeping_manager_review.sql'
+  ),
   page: path.join(repoRoot, 'src', 'pages', 'portal', 'Time.tsx'),
+  reviewPage: path.join(repoRoot, 'src', 'pages', 'portal', 'TimeReview.tsx'),
   app: path.join(repoRoot, 'src', 'App.tsx'),
   nav: path.join(repoRoot, 'src', 'components', 'portal', 'portalNavigation.ts'),
   helper: path.join(repoRoot, 'src', 'lib', 'operatorPayouts.ts'),
@@ -72,20 +79,66 @@ for (const snippet of [
   'End time must be after start time',
   'Delete this submitted time entry',
   'duplicate of an existing shift',
-  'Past shifts are view-only here',
+  'Record completed work',
+  'Waiting for review',
+  'Correction requested',
+  'Each shift up to the next full hour',
 ]) {
   if (!page.includes(snippet)) {
     fail(`Time page missing ${snippet}`);
   }
 }
 
+const managerMigration = readText(files.managerMigration);
+for (const snippet of [
+  'manager_review_status',
+  'create table if not exists public.time_entry_review_events',
+  'create index if not exists time_entries_manager_review_queue_idx',
+  'revoke insert, update, delete on table public.time_entries from anon, authenticated',
+  'create or replace function public.validate_operator_time_entry_assignment',
+  'Future work dates are not allowed',
+  "new.manager_review_status := 'pending'",
+  'create or replace function public.reset_operator_time_entry_manager_review',
+  'Manager review fields can only be changed through the review action',
+  "set_config('app.time_entry_review_rpc', 'true', true)",
+  'create or replace function public.get_my_time_review_context',
+  'create or replace function public.review_operator_time_entry',
+  'public.can_manage_operator_payout_machine(actor_user_id, before_row.reporting_machine_id)',
+  'A correction reason is required',
+  "'payment_behavior_changed', false",
+  'grant execute on function public.get_my_time_review_context',
+  'grant execute on function public.review_operator_time_entry',
+]) {
+  expect(managerMigration, snippet, 'timekeeping manager-review migration');
+}
+
+const reviewPage = readText(files.reviewPage);
+for (const snippet of [
+  'fetchMyTimeReviewContext',
+  'reviewOperatorTimeEntry',
+  'All managed machines',
+  'Needs review',
+  'Request correction',
+  'A reason is required',
+  'No managed machines',
+]) {
+  if (!reviewPage.includes(snippet)) {
+    fail(`Time Review page missing ${snippet}`);
+  }
+}
+
 expect(readText(files.app), 'path="/portal/time"', 'App route');
 expect(readText(files.app), 'path="/portal/time/new"', 'App Add Time route');
 expect(readText(files.app), 'path="/portal/time/:entryId/edit"', 'App Edit Time route');
+expect(readText(files.app), 'path="/portal/time-review"', 'App Time Review route');
 expect(readText(files.nav), "href: '/portal/time'", 'portal navigation');
+expect(readText(files.nav), "href: '/portal/time-review'", 'portal review navigation');
 expect(readText(files.helper), 'fetchMyOperatorTimekeepingContext', 'operator payout helper');
+expect(readText(files.helper), 'fetchMyTimeReviewContext', 'time review context helper');
+expect(readText(files.helper), 'reviewOperatorTimeEntry', 'time review action helper');
 expect(readText(files.smoke), 'Operator Time (`/portal/time`)', 'smoke checklist');
+expect(readText(files.smoke), 'Review Time (`/portal/time-review`)', 'review smoke checklist');
 
 console.log(
-  'Operator timekeeping static checks passed: route, RPCs, UI warnings, helper methods, and smoke checklist coverage are present.'
+  'Operator timekeeping static checks passed: worker entry, machine-manager review, access guards, RPCs, UI states, and smoke coverage are present.'
 );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,6 +59,7 @@ const PortalAccount = lazyRoute(() => import("./pages/portal/Account"));
 const PortalTeam = lazyRoute(() => import("./pages/portal/Team"));
 const PortalReports = lazyRoute(() => import("./pages/portal/Reports"));
 const PortalTime = lazyRoute(() => import("./pages/portal/Time"));
+const PortalTimeReview = lazyRoute(() => import("./pages/portal/TimeReview"));
 const AdminDashboard = lazyRoute(() => import("./pages/admin/Dashboard"));
 const AdminOrders = lazyRoute(() => import("./pages/admin/Orders"));
 const AdminSupport = lazyRoute(() => import("./pages/admin/Support"));
@@ -180,6 +181,7 @@ export const AppShell = () => (
           <Route path="/reset-password" element={<ResetPassword />} />
           <Route element={<ProtectedRoute />}>
             <Route path="/portal" element={<PortalDashboard />} />
+            <Route path="/portal/time-review" element={<PortalTimeReview />} />
             <Route element={<RefundOperationsRoute />}>
               <Route path="/refunds" element={<AdminRefunds />} />
               <Route path="/portal/refunds" element={<RedirectWithSearch to="/refunds" />} />

--- a/src/components/layout/authenticatedNavigation.ts
+++ b/src/components/layout/authenticatedNavigation.ts
@@ -2,6 +2,7 @@ import type { LucideIcon } from 'lucide-react';
 import {
   BarChart3,
   Building2,
+  ClipboardCheck,
   Clock3,
   Handshake,
   HeadphonesIcon,
@@ -233,6 +234,7 @@ const coreDestinationHrefs = new Set(coreDestinations.map((destination) => desti
 const portalSectionByHref: Record<string, AuthenticatedNavSectionId> = {
   '/portal': 'home',
   '/portal/time': 'work',
+  '/portal/time-review': 'work',
   '/portal/orders': 'work',
   '/portal/reports': 'work',
   '/portal/training': 'learnSupport',
@@ -249,6 +251,7 @@ const portalLabelOverrideByHref: Partial<Record<string, TranslationKey>> = {
 const portalIconOverrideByHref: Partial<Record<string, LucideIcon>> = {
   '/portal/orders': ShoppingBag,
   '/portal/time': Clock3,
+  '/portal/time-review': ClipboardCheck,
   '/portal/onboarding': ListChecks,
   '/portal/support': HeadphonesIcon,
   '/portal/account': Settings,
@@ -287,6 +290,16 @@ const canAccessPortalDestination = (
 
   if (destinationAccess === 'timekeeping') {
     return input.canUsePortalTimekeeping;
+  }
+
+  if (destinationAccess === 'time-review') {
+    const allowedAdminSurfaces = getAllowedAdminSurfaces(input.adminAccess);
+    return (
+      input.isSuperAdmin ||
+      allowedAdminSurfaces.has('*') ||
+      allowedAdminSurfaces.has('payouts') ||
+      input.capabilities.includes('timekeeping.review')
+    );
   }
 
   const allowedAdminSurfaces = getAllowedAdminSurfaces(input.adminAccess);

--- a/src/components/portal/portalNavigation.ts
+++ b/src/components/portal/portalNavigation.ts
@@ -2,6 +2,7 @@ import type { LucideIcon } from 'lucide-react';
 import {
   BarChart3,
   BookOpen,
+  ClipboardCheck,
   Clock3,
   HeadphonesIcon,
   LayoutDashboard,
@@ -24,7 +25,8 @@ export type PortalAccessLevel =
   | 'reporting'
   | 'refunds'
   | 'team'
-  | 'timekeeping';
+  | 'timekeeping'
+  | 'time-review';
 
 export interface PortalDestination {
   href: string;
@@ -63,6 +65,16 @@ export const portalDestinations: PortalDestination[] = [
     mobileOrder: 2,
   },
   {
+    href: '/portal/time-review',
+    label: 'Review Time',
+    labelKey: 'portal.nav.timeReview',
+    description: 'Approve or return submitted shifts for managed machines.',
+    descriptionKey: 'portal.nav.timeReviewDescription',
+    icon: ClipboardCheck,
+    access: 'time-review',
+    mobileOrder: 3,
+  },
+  {
     href: '/portal/orders',
     label: 'Orders',
     labelKey: 'portal.nav.orders',
@@ -70,7 +82,7 @@ export const portalDestinations: PortalDestination[] = [
     descriptionKey: 'portal.nav.ordersDescription',
     icon: ShoppingBag,
     access: 'baseline',
-    mobileOrder: 3,
+    mobileOrder: 4,
   },
   {
     href: '/portal/account',
@@ -80,7 +92,7 @@ export const portalDestinations: PortalDestination[] = [
     descriptionKey: 'portal.nav.accountDescription',
     icon: Settings,
     access: 'account',
-    mobileOrder: 4,
+    mobileOrder: 5,
   },
   {
     href: '/portal/team',
@@ -90,7 +102,7 @@ export const portalDestinations: PortalDestination[] = [
     descriptionKey: 'portal.nav.teamDescription',
     icon: Users,
     access: 'team',
-    mobileOrder: 5,
+    mobileOrder: 6,
   },
   {
     href: '/portal/reports',
@@ -100,7 +112,7 @@ export const portalDestinations: PortalDestination[] = [
     descriptionKey: 'portal.nav.reportingDescription',
     icon: BarChart3,
     access: 'reporting',
-    mobileOrder: 6,
+    mobileOrder: 7,
     upsellCopy: 'Sales reporting is available only for machines Bloomjoy has granted to this account.',
     upsellCopyKey: 'portal.nav.reportingUpsell',
   },
@@ -112,7 +124,7 @@ export const portalDestinations: PortalDestination[] = [
     descriptionKey: 'portal.nav.refundsDescription',
     icon: ReceiptText,
     access: 'refunds',
-    mobileOrder: 7,
+    mobileOrder: 8,
     end: true,
   },
   {
@@ -123,7 +135,7 @@ export const portalDestinations: PortalDestination[] = [
     descriptionKey: 'portal.nav.trainingDescription',
     icon: BookOpen,
     access: 'training',
-    mobileOrder: 8,
+    mobileOrder: 9,
     upsellCopy: 'Unlock the operator hub, quick aids, and certificate path.',
     upsellCopyKey: 'portal.nav.trainingUpsell',
   },
@@ -135,7 +147,7 @@ export const portalDestinations: PortalDestination[] = [
     descriptionKey: 'portal.nav.onboardingDescription',
     icon: ListChecks,
     access: 'plus',
-    mobileOrder: 9,
+    mobileOrder: 10,
     upsellCopy: 'Unlock guided setup steps and first-spin milestones.',
     upsellCopyKey: 'portal.nav.onboardingUpsell',
   },
@@ -147,7 +159,7 @@ export const portalDestinations: PortalDestination[] = [
     descriptionKey: 'portal.nav.supportDescription',
     icon: HeadphonesIcon,
     access: 'support',
-    mobileOrder: 10,
+    mobileOrder: 11,
     upsellCopy: 'Unlock guided support requests and concierge escalation.',
     upsellCopyKey: 'portal.nav.supportUpsell',
   },
@@ -227,6 +239,8 @@ export const canAccessPortalLevel = (
       return canUsePortalTeamManagement({ canManageTechnicians, capabilities });
     case 'timekeeping':
       return canUsePortalTimekeeping({ capabilities, hasTimekeepingAccess });
+    case 'time-review':
+      return capabilities.includes('timekeeping.review');
     default:
       return false;
   }
@@ -252,6 +266,8 @@ export const getAccessLevelLabel = (accessLevel: PortalAccessLevel) => {
       return 'Team';
     case 'timekeeping':
       return 'Timekeeping';
+    case 'time-review':
+      return 'Time Review';
     case 'all':
     default:
       return 'Open';
@@ -278,6 +294,8 @@ export const getAccessLevelLabelKey = (accessLevel: PortalAccessLevel): Translat
       return 'portal.access.team';
     case 'timekeeping':
       return 'portal.access.timekeeping';
+    case 'time-review':
+      return 'portal.access.timeReview';
     case 'all':
     default:
       return 'portal.access.open';

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -126,6 +126,7 @@ export const translations = {
     'portal.access.refunds': 'Refunds',
     'portal.access.team': 'Team',
     'portal.access.timekeeping': 'Timekeeping',
+    'portal.access.timeReview': 'Time Review',
     'portal.access.open': 'Open',
 
     'portal.nav.dashboard': 'Dashboard',
@@ -135,6 +136,9 @@ export const translations = {
     'portal.nav.time': 'Time',
     'portal.nav.timeDescription':
       'Submit assigned-machine shifts and review current pay-period time.',
+    'portal.nav.timeReview': 'Review Time',
+    'portal.nav.timeReviewDescription':
+      'Approve or return submitted shifts for managed machines.',
     'portal.nav.account': 'Account Settings',
     'portal.nav.accountDescription': 'Profile, billing, shipping, and language preferences.',
     'portal.nav.team': 'Team',
@@ -746,6 +750,7 @@ export const translations = {
     'portal.access.refunds': '退款',
     'portal.access.team': '团队',
     'portal.access.timekeeping': '工时',
+    'portal.access.timeReview': '工时审核',
     'portal.access.open': '开放',
 
     'portal.nav.dashboard': '仪表盘',
@@ -754,6 +759,8 @@ export const translations = {
     'portal.nav.ordersDescription': '收据、总额和物流跟踪。',
     'portal.nav.time': '工时',
     'portal.nav.timeDescription': '提交已分配机器的班次，并查看当前结算周期的工时。',
+    'portal.nav.timeReview': '审核工时',
+    'portal.nav.timeReviewDescription': '审核或退回所管理机器的已提交班次。',
     'portal.nav.account': '账户设置 / Account Settings',
     'portal.nav.accountDescription': '资料、账单、收货信息和语言偏好。',
     'portal.nav.team': '团队 / Team',

--- a/src/lib/operatorPayouts.ts
+++ b/src/lib/operatorPayouts.ts
@@ -32,6 +32,8 @@ export type TimeEntryStatus =
   | 'paid'
   | 'voided';
 
+export type TimeEntryManagerReviewStatus = 'pending' | 'approved' | 'needs_correction';
+
 export type PayStatementStatus = 'draft' | 'issued' | 'revised' | 'voided';
 
 export type OperatorAssignedMachine = {
@@ -278,6 +280,9 @@ export type OperatorTimeEntry = {
   roundedPaidMinutes: number;
   notes: string | null;
   status: TimeEntryStatus;
+  managerReviewStatus: TimeEntryManagerReviewStatus;
+  managerReviewReason: string | null;
+  managerReviewedAt: string | null;
   lockedAt: string | null;
   createdAt: string;
   updatedAt: string;
@@ -542,6 +547,27 @@ export type OperatorTimekeepingContext = {
   profiles: OperatorTimekeepingProfileContext[];
 };
 
+export type OperatorTimeReviewMachine = {
+  machineId: string;
+  machineLabel: string;
+  locationId: string;
+  locationName: string;
+};
+
+export type OperatorTimeReviewEntry = OperatorTimeEntry & {
+  accountName: string;
+  operatorName: string;
+};
+
+export type OperatorTimeReviewContext = {
+  workDate: string;
+  periodStartDate: string;
+  periodEndDate: string;
+  hasAccess: boolean;
+  machines: OperatorTimeReviewMachine[];
+  entries: OperatorTimeReviewEntry[];
+};
+
 export type OperatorPayoutProfileRecord = {
   id: string;
   account_id: string;
@@ -587,6 +613,13 @@ export type SaveOperatorTimeEntryInput = {
 
 export type UpdateOperatorTimeEntryInput = SaveOperatorTimeEntryInput & {
   timeEntryId: string;
+};
+
+export type ReviewOperatorTimeEntryInput = {
+  timeEntryId: string;
+  decision: Extract<TimeEntryManagerReviewStatus, 'approved' | 'needs_correction'>;
+  reason?: string | null;
+  workDate?: string;
 };
 
 export type GeneratePayoutRevenueSnapshotInput = {
@@ -738,6 +771,50 @@ export const fetchMyOperatorTimekeepingContext = async (
     profiles: [],
     ...((data as Partial<OperatorTimekeepingContext> | null) ?? {}),
   };
+};
+
+export const fetchMyTimeReviewContext = async (
+  workDate?: string
+): Promise<OperatorTimeReviewContext> => {
+  const { data, error } = await supabaseClient.rpc('get_my_time_review_context', {
+    p_work_date: workDate ?? null,
+  });
+
+  if (error) {
+    throw new Error(error.message || 'Unable to load time review.');
+  }
+
+  return {
+    workDate: workDate ?? getLocalDateInputValue(),
+    periodStartDate: '',
+    periodEndDate: '',
+    hasAccess: false,
+    machines: [],
+    entries: [],
+    ...((data as Partial<OperatorTimeReviewContext> | null) ?? {}),
+  };
+};
+
+export const reviewOperatorTimeEntry = async (
+  input: ReviewOperatorTimeEntryInput
+): Promise<OperatorTimeReviewContext> => {
+  const { data, error } = await supabaseClient.rpc('review_operator_time_entry', {
+    p_time_entry_id: input.timeEntryId,
+    p_decision: input.decision,
+    p_reason: input.reason ?? null,
+    p_work_date: input.workDate ?? null,
+  });
+
+  if (error || !data) {
+    throw new Error(error?.message || 'Unable to review time entry.');
+  }
+
+  const payload = data as { context?: OperatorTimeReviewContext };
+  if (!payload.context) {
+    throw new Error('Time review saved, but the updated review queue was not returned.');
+  }
+
+  return payload.context;
 };
 
 export const submitOperatorTimeEntry = async (

--- a/src/pages/portal/Time.tsx
+++ b/src/pages/portal/Time.tsx
@@ -3,6 +3,8 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   AlertTriangle,
   ArrowLeft,
+  CalendarDays,
+  CheckCircle2,
   Clock3,
   Download,
   Edit3,
@@ -71,6 +73,9 @@ const defaultForm = (): TimeEntryForm => ({
   notes: '',
 });
 
+const isValidMonthValue = (value: string | null): value is string =>
+  Boolean(value && /^\d{4}-(0[1-9]|1[0-2])$/.test(value));
+
 const formatDate = (value: string | null | undefined) => {
   if (!value) return 'Not set';
 
@@ -82,6 +87,12 @@ const formatDate = (value: string | null | undefined) => {
     year: 'numeric',
   });
 };
+
+const formatMonth = (value: string) =>
+  new Date(`${value}-01T00:00:00`).toLocaleDateString(undefined, {
+    month: 'long',
+    year: 'numeric',
+  });
 
 const formatMinutes = (minutes: number) => {
   const hours = Math.floor(minutes / 60);
@@ -95,7 +106,7 @@ const formatMinutes = (minutes: number) => {
 const formatPaidHours = (minutes: number) =>
   `${paidMinutesToHours(minutes).toLocaleString(undefined, {
     maximumFractionDigits: 2,
-  })} paid hr${minutes === 60 ? '' : 's'}`;
+  })} rounded hr${minutes === 60 ? '' : 's'}`;
 
 const formatCurrency = (cents: number | null | undefined) =>
   new Intl.NumberFormat(undefined, {
@@ -158,10 +169,29 @@ const getStatusLabel = (status: string) =>
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(' ');
 
+const getEntryReviewLabel = (entry: OperatorTimeEntry) => {
+  if (entry.status === 'draft') return 'Draft';
+  if (entry.status === 'paid') return 'Paid';
+  if (entry.status === 'included_in_payout') return 'Included';
+  if (entry.status === 'locked') return 'Locked';
+  if (entry.managerReviewStatus === 'approved') return 'Approved';
+  if (entry.managerReviewStatus === 'needs_correction') return 'Correction requested';
+  return 'Waiting for review';
+};
+
+const getEntryReviewClassName = (entry: OperatorTimeEntry) => {
+  if (entry.status !== 'submitted') return 'border-border bg-muted text-muted-foreground';
+  if (entry.managerReviewStatus === 'approved') return 'border-sage/25 bg-sage-light text-sage';
+  if (entry.managerReviewStatus === 'needs_correction') {
+    return 'border-amber/25 bg-amber/10 text-amber';
+  }
+  return 'border-primary/20 bg-primary/10 text-primary';
+};
+
 const getMachineLabel = (entry: OperatorTimeEntry) =>
   `${entry.machineLabel} - ${entry.locationName}`;
 
-const getContextQueryKey = ['operator-timekeeping'] as const;
+const getContextQueryKey = (workDate: string) => ['operator-timekeeping', workDate] as const;
 const getPayStatementsQueryKey = ['operator-pay-statements'] as const;
 const emptyProfiles: OperatorTimekeepingProfileContext[] = [];
 const timeActionClassName =
@@ -177,10 +207,26 @@ export default function PortalTimePage() {
   const navigate = useNavigate();
   const { entryId } = useParams<{ entryId?: string }>();
   const isTimeEntryScreen = location.pathname === '/portal/time/new' || Boolean(entryId);
+  const requestedMonth = new URLSearchParams(location.search).get('month');
   const [selectedProfileId, setSelectedProfileId] = useState('');
   const [editingEntryId, setEditingEntryId] = useState<string | null>(null);
   const [downloadingStatementId, setDownloadingStatementId] = useState<string | null>(null);
-  const [form, setForm] = useState<TimeEntryForm>(() => defaultForm());
+  const [form, setForm] = useState<TimeEntryForm>(() => {
+    const initialForm = defaultForm();
+
+    return entryId && isValidMonthValue(requestedMonth)
+      ? { ...initialForm, workDate: `${requestedMonth}-01` }
+      : initialForm;
+  });
+  const [viewMonth, setViewMonth] = useState(() =>
+    isValidMonthValue(requestedMonth)
+      ? requestedMonth
+      : todayInputValue().slice(0, 7)
+  );
+  const contextMonth = isTimeEntryScreen
+    ? (form.workDate || todayInputValue()).slice(0, 7)
+    : viewMonth;
+  const contextWorkDate = `${contextMonth}-01`;
 
   const {
     data: context,
@@ -188,8 +234,8 @@ export default function PortalTimePage() {
     isFetching,
     error,
   } = useQuery({
-    queryKey: getContextQueryKey,
-    queryFn: () => fetchMyOperatorTimekeepingContext(),
+    queryKey: getContextQueryKey(contextWorkDate),
+    queryFn: () => fetchMyOperatorTimekeepingContext(contextWorkDate),
     staleTime: 1000 * 20,
   });
 
@@ -220,7 +266,7 @@ export default function PortalTimePage() {
 
     return (
       profiles
-        .flatMap((profile) => profile.currentEntries)
+        .flatMap((profile) => [...profile.currentEntries, ...profile.recentEntries])
         .find((entry) => entry.id === entryId) ?? null
     );
   }, [entryId, profiles]);
@@ -232,13 +278,20 @@ export default function PortalTimePage() {
     [selectedProfile, statementContext?.profiles]
   );
   const issuedStatements = selectedStatementProfile?.statements ?? [];
-  const pastEntries = useMemo(() => {
-    if (!selectedProfile) return [];
+  const periodSummary = useMemo(() => {
+    const entries = selectedProfile?.currentEntries ?? [];
 
-    const { periodStartDate, periodEndDate } = selectedProfile.currentPeriod;
-    return selectedProfile.recentEntries.filter(
-      (entry) => !isDateInsideRange(entry.workDate, periodStartDate, periodEndDate)
-    );
+    return {
+      rawMinutes: entries.reduce((total, entry) => total + entry.rawDurationMinutes, 0),
+      roundedMinutes: entries.reduce((total, entry) => total + entry.roundedPaidMinutes, 0),
+      waiting: entries.filter(
+        (entry) => entry.status === 'submitted' && entry.managerReviewStatus === 'pending'
+      ).length,
+      approved: entries.filter((entry) => entry.managerReviewStatus === 'approved').length,
+      needsCorrection: entries.filter(
+        (entry) => entry.managerReviewStatus === 'needs_correction'
+      ).length,
+    };
   }, [selectedProfile]);
 
   useEffect(() => {
@@ -368,14 +421,19 @@ export default function PortalTimePage() {
       });
     },
     onSuccess: (nextContext) => {
-      queryClient.setQueryData<OperatorTimekeepingContext>(getContextQueryKey, nextContext);
+      const nextMonth = nextContext.workDate.slice(0, 7);
+      queryClient.setQueryData<OperatorTimekeepingContext>(
+        getContextQueryKey(`${nextMonth}-01`),
+        nextContext
+      );
+      setViewMonth(nextMonth);
       setEditingEntryId(null);
       setForm({
         ...defaultForm(),
         machineId: nextContext.profiles[0]?.assignedMachines[0]?.machineId ?? '',
       });
       toast.success('Time entry saved.');
-      navigate('/portal/time');
+      navigate(`/portal/time?month=${nextMonth}`);
     },
     onError: (mutationError: Error) => {
       toast.error(mutationError.message || 'Unable to save time entry.');
@@ -389,7 +447,11 @@ export default function PortalTimePage() {
         reason: 'Operator deleted unlocked shift from Portal Time',
       }),
     onSuccess: (nextContext) => {
-      queryClient.setQueryData<OperatorTimekeepingContext>(getContextQueryKey, nextContext);
+      const nextMonth = nextContext.workDate.slice(0, 7);
+      queryClient.setQueryData<OperatorTimekeepingContext>(
+        getContextQueryKey(`${nextMonth}-01`),
+        nextContext
+      );
       setEditingEntryId(null);
       toast.success('Time entry deleted.');
     },
@@ -400,7 +462,7 @@ export default function PortalTimePage() {
 
   const refresh = async () => {
     await Promise.all([
-      queryClient.invalidateQueries({ queryKey: getContextQueryKey }),
+      queryClient.invalidateQueries({ queryKey: ['operator-timekeeping'] }),
       queryClient.invalidateQueries({ queryKey: getPayStatementsQueryKey }),
     ]);
   };
@@ -421,7 +483,7 @@ export default function PortalTimePage() {
   };
 
   const startEditing = (entry: OperatorTimeEntry) => {
-    navigate(`/portal/time/${entry.id}/edit`);
+    navigate(`/portal/time/${entry.id}/edit?month=${entry.workDate.slice(0, 7)}`);
   };
 
   const cancelEditing = () => {
@@ -430,7 +492,7 @@ export default function PortalTimePage() {
       ...defaultForm(),
       machineId: effectiveMachines[0]?.machineId ?? '',
     });
-    navigate('/portal/time');
+    navigate(`/portal/time?month=${form.workDate.slice(0, 7)}`);
   };
 
   const confirmDelete = (entry: OperatorTimeEntry) => {
@@ -492,25 +554,25 @@ export default function PortalTimePage() {
             title={isTimeEntryScreen ? (editingEntryId ? 'Edit Time' : 'Add Time') : 'Time'}
             description={
               isTimeEntryScreen
-                ? 'Submit one shift at a time.'
-                : 'Add time, review submitted shifts, and download pay statements.'
+                ? 'Enter one completed shift. You can correct it until the period locks.'
+                : 'Enter completed shifts, follow manager review, and access issued statements.'
             }
             badges={[
               {
                 label: selectedProfile
                   ? `${getStatusLabel(selectedProfile.currentPeriod.status)} period`
-                  : 'Operator timekeeping',
+                  : 'Timekeeping',
                 tone: selectedProfile?.currentPeriod.status === 'locked' ? 'warning' : 'default',
               },
               {
-                label: isFetching ? 'Refreshing' : 'Assigned-machine only',
+                label: isFetching ? 'Refreshing' : 'Whole-hour rounding',
                 tone: 'muted',
               },
             ]}
             actions={
               isTimeEntryScreen ? (
                 <Button asChild variant="outline" className={timeActionClassName}>
-                  <Link to="/portal/time">
+                  <Link to={`/portal/time?month=${contextMonth}`}>
                     <ArrowLeft className="mr-2 h-4 w-4" />
                     Time home
                   </Link>
@@ -550,11 +612,11 @@ export default function PortalTimePage() {
               <div className="mx-auto max-w-xl text-center">
                 <Clock3 className="mx-auto h-10 w-10 text-muted-foreground" />
                 <h2 className="mt-4 text-xl font-semibold text-foreground">
-                  No operator pay profile yet
+                  Timekeeping setup needed
                 </h2>
                 <p className="mt-2 text-pretty text-sm text-muted-foreground">
-                  Ask a Bloomjoy admin or machine manager to add your operator pay profile and
-                  assigned machines before submitting time.
+                  Ask a Bloomjoy admin or machine manager to add your timekeeping profile and
+                  assigned machines before entering shifts.
                 </p>
               </div>
             </div>
@@ -573,10 +635,11 @@ export default function PortalTimePage() {
                       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                         <div>
                           <h2 className="text-balance text-lg font-semibold text-foreground">
-                            {editingEntryId ? 'Edit Time' : 'Add Time'}
+                            {editingEntryId ? 'Edit completed shift' : 'Add completed shift'}
                           </h2>
                           <p className="mt-1 text-pretty text-sm text-muted-foreground">
-                            Enter one shift at a time, then return to your time summary.
+                            Use the actual start and end time. Bloomjoy rounds each saved shift up to
+                            the next full hour.
                           </p>
                         </div>
                         {profiles.length > 1 && (
@@ -617,8 +680,7 @@ export default function PortalTimePage() {
                             id="work-date"
                             type="date"
                             value={form.workDate}
-                            min={selectedProfile.currentPeriod.periodStartDate}
-                            max={selectedProfile.currentPeriod.periodEndDate}
+                            max={todayInputValue()}
                             onChange={(event) =>
                               setForm((current) => ({ ...current, workDate: event.target.value }))
                             }
@@ -706,7 +768,7 @@ export default function PortalTimePage() {
                           }
                         />
                         <Metric
-                          label="You'll be paid for"
+                          label="Rounded time"
                           value={
                             roundedPaidMinutes ? formatPaidHours(roundedPaidMinutes) : 'Set times'
                           }
@@ -747,13 +809,14 @@ export default function PortalTimePage() {
                           ) : (
                             <Plus className="mr-2 h-4 w-4" />
                           )}
-                          {editingEntryId ? 'Save Time' : 'Add Time'}
+                          {editingEntryId ? 'Save changes' : 'Submit shift'}
                         </Button>
                       </div>
 
                       {hasBlockingValidation && !saveMutation.isPending && (
                         <p className="mt-3 text-xs text-muted-foreground">
-                          Enter a date, assigned machine, start time, and end time to add time.
+                          Enter a date, assigned machine, start time, and end time to submit the
+                          shift.
                         </p>
                       )}
 
@@ -767,88 +830,140 @@ export default function PortalTimePage() {
                   )}
                 </div>
               ) : (
-                <div className="mt-6 grid gap-6 xl:grid-cols-[minmax(280px,0.85fr)_minmax(0,1.15fr)]">
-                  <div className="space-y-6">
-                    <div className="card-elevated p-4 sm:p-5">
-                      <h2 className="text-balance text-lg font-semibold text-foreground">
-                        What do you need?
-                      </h2>
-                      <div className="mt-4 grid gap-3">
-                        <Button
-                          asChild
-                          size="lg"
-                          className={cn('justify-start', timeActionClassName)}
-                        >
-                          <Link to="/portal/time/new">
-                            <Plus className="mr-2 h-4 w-4" />
-                            Add Time
-                          </Link>
-                        </Button>
-                        <Button
-                          asChild
-                          variant="outline"
-                          className={cn('justify-start', timeActionClassName)}
-                        >
-                          <a href="#this-period">Review submitted time</a>
-                        </Button>
-                        <Button
-                          asChild
-                          variant="outline"
-                          className={cn('justify-start', timeActionClassName)}
-                        >
-                          <a href="#pay-statements">Download pay statements</a>
-                        </Button>
+                <div className="mt-6 space-y-6">
+                  <div className="rounded-[24px] border border-border bg-background p-4 shadow-[var(--shadow-sm)] sm:p-5">
+                    <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                      <div>
+                        <h2 className="font-display text-xl font-semibold text-foreground">
+                          Record completed work
+                        </h2>
+                        <p className="mt-1 max-w-2xl text-sm leading-6 text-muted-foreground">
+                          Add each shift after you finish. Your machine manager will review submitted
+                          time here.
+                        </p>
                       </div>
+                      <Button asChild size="lg" className={timeActionClassName}>
+                        <Link to="/portal/time/new">
+                          <Plus className="mr-2 h-4 w-4" />
+                          Add completed shift
+                        </Link>
+                      </Button>
                     </div>
 
-                    <div className="card-elevated p-4 sm:p-5">
-                      <h2 className="text-balance text-lg font-semibold text-foreground">
-                        Current Period
-                      </h2>
-                      <p className="mt-1 text-pretty text-sm text-muted-foreground">
-                        Time is due by {formatDate(selectedProfile.currentPeriod.submissionDueDate)}
-                        .
+                    {periodSummary.needsCorrection > 0 && (
+                      <a
+                        href="#this-period"
+                        className="mt-5 flex items-start gap-3 rounded-xl border border-amber/25 bg-amber/10 px-3 py-3 text-sm text-foreground transition-colors hover:bg-amber/20"
+                      >
+                        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber" />
+                        <span>
+                          <strong className="font-semibold">
+                            {periodSummary.needsCorrection}{' '}
+                            {periodSummary.needsCorrection === 1 ? 'shift needs' : 'shifts need'} a
+                            correction.
+                          </strong>{' '}
+                          Open the shift below to see your manager&apos;s note.
+                        </span>
+                      </a>
+                    )}
+
+                    <div className="mt-5 border-t border-border pt-5">
+                      <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+                        <div className="grid gap-3 sm:grid-cols-2">
+                          <div>
+                            <label htmlFor="time-month" className="mb-1.5 block text-sm font-medium">
+                              Month
+                            </label>
+                            <div className="relative">
+                              <CalendarDays className="pointer-events-none absolute left-3 top-3.5 h-4 w-4 text-muted-foreground" />
+                              <Input
+                                id="time-month"
+                                type="month"
+                                value={viewMonth}
+                                max={todayInputValue().slice(0, 7)}
+                                onChange={(event) =>
+                                  setViewMonth(event.target.value || todayInputValue().slice(0, 7))
+                                }
+                                className="min-h-11 pl-9 sm:w-52"
+                              />
+                            </div>
+                          </div>
+                          {profiles.length > 1 && (
+                            <div>
+                              <label className="mb-1.5 block text-sm font-medium">
+                                Work profile
+                              </label>
+                              <Select value={selectedProfile.id} onValueChange={setSelectedProfileId}>
+                                <SelectTrigger className="min-h-11 sm:w-64">
+                                  <SelectValue />
+                                </SelectTrigger>
+                                <SelectContent>
+                                  {profiles.map((profile) => (
+                                    <SelectItem key={profile.id} value={profile.id}>
+                                      {profile.accountName}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                            </div>
+                          )}
+                        </div>
+
+                        <div className="flex flex-wrap gap-x-6 gap-y-3 text-sm text-muted-foreground">
+                          <span>
+                            <strong className="block text-base font-semibold tabular-nums text-foreground">
+                              {formatMinutes(periodSummary.rawMinutes)}
+                            </strong>
+                            actual time
+                          </span>
+                          <span>
+                            <strong className="block text-base font-semibold tabular-nums text-foreground">
+                              {formatPaidHours(periodSummary.roundedMinutes)}
+                            </strong>
+                            rounded time
+                          </span>
+                          <span>
+                            <strong className="block text-base font-semibold tabular-nums text-foreground">
+                              {periodSummary.waiting}
+                            </strong>
+                            waiting
+                          </span>
+                          <span>
+                            <strong className="block text-base font-semibold tabular-nums text-foreground">
+                              {periodSummary.approved}
+                            </strong>
+                            approved
+                          </span>
+                        </div>
+                      </div>
+                      <p className="mt-4 text-sm leading-6 text-muted-foreground">
+                        Due {formatDate(selectedProfile.currentPeriod.submissionDueDate)}. Each shift
+                        is rounded up to the next full hour.
                       </p>
-                      <PeriodDetails profile={selectedProfile} />
                     </div>
                   </div>
 
-                  <div className="space-y-6">
-                    <div id="pay-statements">
-                      <PayStatementsPanel
-                        statements={issuedStatements}
-                        isRefreshing={isFetchingStatements}
-                        error={statementError}
-                        downloadingStatementId={downloadingStatementId}
-                        onDownload={downloadStatement}
-                      />
-                    </div>
-
-                    <div id="this-period">
-                      <TimeEntriesPanel
-                        title="This Period"
-                        description={`${formatDate(
-                          selectedProfile.currentPeriod.periodStartDate
-                        )} to ${formatDate(selectedProfile.currentPeriod.periodEndDate)}`}
-                        entries={selectedProfile.currentEntries}
-                        emptyMessage="No time entered for this period yet."
-                        onEdit={startEditing}
-                        onDelete={confirmDelete}
-                        isDeleting={deleteMutation.isPending}
-                      />
-                    </div>
-
+                  <div id="this-period">
                     <TimeEntriesPanel
-                      title="Past Shifts"
-                      description="Earlier pay periods only."
-                      entries={pastEntries}
-                      emptyMessage="No past shifts yet."
+                      title={`${formatMonth(viewMonth)} shifts`}
+                      description={`${formatDate(
+                        selectedProfile.currentPeriod.periodStartDate
+                      )} to ${formatDate(selectedProfile.currentPeriod.periodEndDate)}`}
+                      entries={selectedProfile.currentEntries}
+                      emptyMessage="No shifts entered for this month yet. Add a completed shift to get started."
                       onEdit={startEditing}
                       onDelete={confirmDelete}
                       isDeleting={deleteMutation.isPending}
-                      compact
-                      allowActions={false}
-                      readOnlyMessage="Past shifts are view-only here."
+                    />
+                  </div>
+
+                  <div id="pay-statements">
+                    <PayStatementsPanel
+                      statements={issuedStatements}
+                      isRefreshing={isFetchingStatements}
+                      error={statementError}
+                      downloadingStatementId={downloadingStatementId}
+                      onDownload={downloadStatement}
                     />
                   </div>
                 </div>
@@ -884,7 +999,7 @@ function PayStatementsPanel({
           <div>
             <h2 className="text-balance text-lg font-semibold text-foreground">Pay Statements</h2>
             <p className="mt-1 text-pretty text-sm text-muted-foreground">
-              Download issued pay statements for finalized pay periods.
+              Download issued pay statements here when they become available.
             </p>
           </div>
         </div>
@@ -961,14 +1076,13 @@ function PeriodDetails({ profile }: { profile: OperatorTimekeepingProfileContext
   const period = profile.currentPeriod;
 
   return (
-    <div className={cn('mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4', timeInsetPanelClassName)}>
+    <div className={cn('mt-4 grid gap-3 sm:grid-cols-3', timeInsetPanelClassName)}>
       <Metric
         label="Period"
         value={`${formatDate(period.periodStartDate)} to ${formatDate(period.periodEndDate)}`}
       />
       <Metric label="Time due" value={formatDate(period.submissionDueDate)} />
-      <Metric label="Locks" value={formatDate(period.lockDate)} />
-      <Metric label="Rounding" value={profile.policy.roundingRule.replaceAll('_', ' ')} />
+      <Metric label="Rounding" value="Each shift up to the next full hour" />
     </div>
   );
 }
@@ -1078,8 +1192,13 @@ function TimeEntriesPanel({
                       <h3 className="break-words text-balance font-semibold text-foreground">
                         {entry.machineLabel}
                       </h3>
-                      <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                        {getStatusLabel(entry.status)}
+                      <span
+                        className={cn(
+                          'rounded-full border px-2.5 py-1 text-xs font-semibold',
+                          getEntryReviewClassName(entry)
+                        )}
+                      >
+                        {getEntryReviewLabel(entry)}
                       </span>
                     </div>
                     <p className="mt-1 text-pretty text-sm text-muted-foreground">
@@ -1098,6 +1217,21 @@ function TimeEntriesPanel({
                         {entry.notes}
                       </p>
                     )}
+                    {!compact &&
+                      entry.managerReviewStatus === 'needs_correction' &&
+                      entry.managerReviewReason && (
+                        <div className="mt-3 rounded-xl border border-amber/25 bg-amber/10 px-3 py-3 text-sm leading-6 text-foreground">
+                          <p className="font-semibold">Your manager requested a correction</p>
+                          <p className="mt-1 text-pretty">{entry.managerReviewReason}</p>
+                        </div>
+                      )}
+                    {!compact &&
+                      entry.managerReviewStatus === 'approved' &&
+                      entry.status === 'submitted' && (
+                        <p className="mt-3 text-xs text-muted-foreground">
+                          Editing this shift will send it back for manager review.
+                        </p>
+                      )}
                   </div>
 
                   {allowActions ? (

--- a/src/pages/portal/TimeReview.tsx
+++ b/src/pages/portal/TimeReview.tsx
@@ -1,0 +1,535 @@
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  CalendarDays,
+  Check,
+  CheckCircle2,
+  Clock3,
+  Loader2,
+  Lock,
+  MessageSquareWarning,
+  RefreshCw,
+} from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { toast } from 'sonner';
+import { PortalLayout } from '@/components/portal/PortalLayout';
+import { PortalPageIntro } from '@/components/portal/PortalPageIntro';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  fetchMyTimeReviewContext,
+  reviewOperatorTimeEntry,
+  type OperatorTimeReviewContext,
+  type OperatorTimeReviewEntry,
+  type TimeEntryManagerReviewStatus,
+} from '@/lib/operatorPayouts';
+import { cn } from '@/lib/utils';
+
+type ReviewFilter = 'needs_review' | 'needs_correction' | 'approved' | 'all';
+
+const getLocalDateInputValue = () => {
+  const date = new Date();
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+};
+
+const currentMonthValue = () => getLocalDateInputValue().slice(0, 7);
+
+const formatDate = (value: string) =>
+  new Date(`${value}T00:00:00`).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+const formatMonth = (value: string) =>
+  new Date(`${value}-01T00:00:00`).toLocaleDateString(undefined, {
+    month: 'long',
+    year: 'numeric',
+  });
+
+const formatTime = (value: string) =>
+  new Date(`1970-01-01T${value}:00`).toLocaleTimeString(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+
+const formatDuration = (minutes: number) => {
+  const hours = Math.floor(minutes / 60);
+  const remainder = minutes % 60;
+
+  if (hours === 0) return `${remainder} min`;
+  if (remainder === 0) return `${hours} hr${hours === 1 ? '' : 's'}`;
+  return `${hours} hr ${remainder} min`;
+};
+
+const formatPaidHours = (minutes: number) =>
+  `${(minutes / 60).toLocaleString(undefined, { maximumFractionDigits: 2 })} rounded hr${
+    minutes === 60 ? '' : 's'
+  }`;
+
+const getReviewLabel = (
+  reviewStatus: TimeEntryManagerReviewStatus,
+  entryStatus: OperatorTimeReviewEntry['status']
+) => {
+  if (entryStatus === 'paid') return 'Paid';
+  if (entryStatus === 'included_in_payout') return 'Included';
+  if (entryStatus === 'locked') return 'Locked';
+  if (reviewStatus === 'approved') return 'Approved';
+  if (reviewStatus === 'needs_correction') return 'Correction requested';
+  return 'Needs review';
+};
+
+const getReviewBadgeClass = (
+  reviewStatus: TimeEntryManagerReviewStatus,
+  entryStatus: OperatorTimeReviewEntry['status']
+) => {
+  if (entryStatus !== 'submitted') return 'border-border bg-muted text-muted-foreground';
+  if (reviewStatus === 'approved') return 'border-sage/25 bg-sage-light text-sage';
+  if (reviewStatus === 'needs_correction') return 'border-amber/25 bg-amber/10 text-amber';
+  return 'border-primary/20 bg-primary/10 text-primary';
+};
+
+const matchesFilter = (entry: OperatorTimeReviewEntry, filter: ReviewFilter) => {
+  if (filter === 'all') return true;
+  if (filter === 'needs_review') {
+    return entry.status === 'submitted' && entry.managerReviewStatus === 'pending';
+  }
+
+  return entry.managerReviewStatus === filter;
+};
+
+const reviewQueryKey = (workDate: string) => ['operator-time-review', workDate] as const;
+const emptyReviewEntries: OperatorTimeReviewEntry[] = [];
+
+export default function PortalTimeReviewPage() {
+  const queryClient = useQueryClient();
+  const [month, setMonth] = useState(currentMonthValue);
+  const [machineId, setMachineId] = useState('all');
+  const [filter, setFilter] = useState<ReviewFilter>('needs_review');
+  const [correctionEntry, setCorrectionEntry] = useState<OperatorTimeReviewEntry | null>(null);
+  const [correctionReason, setCorrectionReason] = useState('');
+  const workDate = `${month}-01`;
+
+  const { data: context, isLoading, isFetching, error, refetch } = useQuery({
+    queryKey: reviewQueryKey(workDate),
+    queryFn: () => fetchMyTimeReviewContext(workDate),
+    staleTime: 1000 * 20,
+  });
+
+  const entries = context?.entries ?? emptyReviewEntries;
+  const summary = useMemo(
+    () => ({
+      needsReview: entries.filter(
+        (entry) => entry.status === 'submitted' && entry.managerReviewStatus === 'pending'
+      ).length,
+      approved: entries.filter((entry) => entry.managerReviewStatus === 'approved').length,
+      needsCorrection: entries.filter(
+        (entry) => entry.managerReviewStatus === 'needs_correction'
+      ).length,
+      paidMinutes: entries.reduce((total, entry) => total + entry.roundedPaidMinutes, 0),
+    }),
+    [entries]
+  );
+
+  const visibleEntries = useMemo(
+    () =>
+      entries.filter(
+        (entry) =>
+          (machineId === 'all' || entry.machineId === machineId) && matchesFilter(entry, filter)
+      ),
+    [entries, filter, machineId]
+  );
+
+  const reviewMutation = useMutation({
+    mutationFn: reviewOperatorTimeEntry,
+    onSuccess: (nextContext, variables) => {
+      queryClient.setQueryData<OperatorTimeReviewContext>(
+        reviewQueryKey(variables.workDate ?? workDate),
+        nextContext
+      );
+      void queryClient.invalidateQueries({ queryKey: ['operator-timekeeping'] });
+      toast.success(
+        variables.decision === 'approved' ? 'Shift approved.' : 'Correction requested.'
+      );
+      setCorrectionEntry(null);
+      setCorrectionReason('');
+    },
+    onError: (mutationError) => {
+      toast.error(mutationError instanceof Error ? mutationError.message : 'Unable to review shift.');
+    },
+  });
+
+  const approveEntry = (entry: OperatorTimeReviewEntry) => {
+    reviewMutation.mutate({
+      timeEntryId: entry.id,
+      decision: 'approved',
+      workDate,
+    });
+  };
+
+  const requestCorrection = () => {
+    if (!correctionEntry || correctionReason.trim().length === 0) return;
+
+    reviewMutation.mutate({
+      timeEntryId: correctionEntry.id,
+      decision: 'needs_correction',
+      reason: correctionReason.trim(),
+      workDate,
+    });
+  };
+
+  const isMutatingEntry = (entryId: string) =>
+    reviewMutation.isPending && reviewMutation.variables?.timeEntryId === entryId;
+
+  return (
+    <PortalLayout>
+      <section className="portal-section">
+        <div className="container-page">
+          <PortalPageIntro
+            eyebrow="Manager workspace"
+            title="Review time"
+            description="Approve completed shifts for the machines you manage, or return a shift with a clear correction note."
+            badges={[
+              { label: formatMonth(month), tone: 'muted', icon: CalendarDays },
+              {
+                label: `${summary.needsReview} waiting`,
+                tone: summary.needsReview > 0 ? 'accent' : 'success',
+                icon: summary.needsReview > 0 ? Clock3 : CheckCircle2,
+              },
+            ]}
+            actions={
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => void refetch()}
+                disabled={isFetching}
+              >
+                {isFetching ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <RefreshCw className="mr-2 h-4 w-4" />
+                )}
+                Refresh
+              </Button>
+            }
+          />
+
+          {isLoading ? (
+            <div className="mt-6 rounded-[24px] border border-border bg-background px-5 py-12 text-center text-sm text-muted-foreground shadow-[var(--shadow-sm)]">
+              <Loader2 className="mx-auto mb-3 h-5 w-5 animate-spin" />
+              Loading submitted time...
+            </div>
+          ) : error ? (
+            <div className="mt-6 rounded-[24px] border border-destructive/20 bg-destructive/5 px-5 py-8">
+              <h2 className="font-display text-xl font-semibold text-foreground">
+                Time review is unavailable
+              </h2>
+              <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+                The review queue could not be loaded. Refresh once, then ask Bloomjoy to confirm the
+                timekeeping update is deployed if this continues.
+              </p>
+              <Button type="button" variant="outline" className="mt-5" onClick={() => void refetch()}>
+                Try again
+              </Button>
+            </div>
+          ) : !context?.hasAccess ? (
+            <div className="mt-6 rounded-[24px] border border-border bg-background px-5 py-8 shadow-[var(--shadow-sm)]">
+              <Lock className="h-6 w-6 text-muted-foreground" />
+              <h2 className="mt-4 font-display text-xl font-semibold text-foreground">
+                No managed machines
+              </h2>
+              <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+                This page opens only for people who already manage at least one machine. Ask Bloomjoy
+                to update your machine assignment if you should review time.
+              </p>
+              <Button asChild variant="outline" className="mt-5">
+                <Link to="/portal">Back to dashboard</Link>
+              </Button>
+            </div>
+          ) : (
+            <div className="mt-6 space-y-5">
+              <div className="rounded-[24px] border border-border bg-background p-4 shadow-[var(--shadow-sm)] sm:p-5">
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div>
+                      <label htmlFor="review-month" className="mb-1.5 block text-sm font-medium">
+                        Month
+                      </label>
+                      <Input
+                        id="review-month"
+                        type="month"
+                        value={month}
+                        max={currentMonthValue()}
+                        onChange={(event) => setMonth(event.target.value || currentMonthValue())}
+                        className="min-h-11 sm:w-48"
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="review-machine" className="mb-1.5 block text-sm font-medium">
+                        Machine
+                      </label>
+                      <Select value={machineId} onValueChange={setMachineId}>
+                        <SelectTrigger id="review-machine" className="min-h-11 sm:w-72">
+                          <SelectValue placeholder="All managed machines" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="all">All managed machines</SelectItem>
+                          {context.machines.map((machine) => (
+                            <SelectItem key={machine.machineId} value={machine.machineId}>
+                              {machine.machineLabel} · {machine.locationName}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+
+                  <div className="flex flex-wrap gap-x-5 gap-y-2 text-sm text-muted-foreground">
+                    <span>
+                      <strong className="font-semibold tabular-nums text-foreground">
+                        {summary.approved}
+                      </strong>{' '}
+                      approved
+                    </span>
+                    <span>
+                      <strong className="font-semibold tabular-nums text-foreground">
+                        {summary.needsCorrection}
+                      </strong>{' '}
+                      returned
+                    </span>
+                    <span>
+                      <strong className="font-semibold tabular-nums text-foreground">
+                        {formatPaidHours(summary.paidMinutes)}
+                      </strong>{' '}
+                      entered
+                    </span>
+                  </div>
+                </div>
+
+                <div className="mt-5 flex flex-wrap gap-2" aria-label="Review filters">
+                  {(
+                    [
+                      ['needs_review', `Needs review (${summary.needsReview})`],
+                      ['needs_correction', `Returned (${summary.needsCorrection})`],
+                      ['approved', `Approved (${summary.approved})`],
+                      ['all', `All (${entries.length})`],
+                    ] as const
+                  ).map(([value, label]) => (
+                    <Button
+                      key={value}
+                      type="button"
+                      size="sm"
+                      variant={filter === value ? 'default' : 'outline'}
+                      aria-pressed={filter === value}
+                      className="shrink-0"
+                      onClick={() => setFilter(value)}
+                    >
+                      {label}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+
+              <div className="overflow-hidden rounded-[24px] border border-border bg-background shadow-[var(--shadow-sm)]">
+                <div className="border-b border-border px-4 py-4 sm:px-5">
+                  <h2 className="font-display text-xl font-semibold text-foreground">
+                    {filter === 'needs_review' ? 'Ready for your review' : 'Monthly time'}
+                  </h2>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    {formatDate(context.periodStartDate)} to {formatDate(context.periodEndDate)}
+                  </p>
+                </div>
+
+                {visibleEntries.length === 0 ? (
+                  <div className="px-5 py-12 text-center">
+                    <CheckCircle2 className="mx-auto h-7 w-7 text-sage" />
+                    <h3 className="mt-3 font-semibold text-foreground">
+                      {filter === 'needs_review' ? 'Nothing waiting for review' : 'No matching shifts'}
+                    </h3>
+                    <p className="mx-auto mt-1 max-w-md text-sm leading-6 text-muted-foreground">
+                      {filter === 'needs_review'
+                        ? 'You are caught up for this month. New submitted shifts will appear here.'
+                        : 'Try another status, machine, or month.'}
+                    </p>
+                  </div>
+                ) : (
+                  <div className="divide-y divide-border">
+                    {visibleEntries.map((entry) => {
+                      const canReview = entry.status === 'submitted' && !entry.lockedAt;
+                      const isSaving = isMutatingEntry(entry.id);
+
+                      return (
+                        <article key={entry.id} className="px-4 py-5 sm:px-5">
+                          <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+                            <div className="min-w-0">
+                              <div className="flex flex-wrap items-center gap-2">
+                                <h3 className="font-semibold text-foreground">{entry.operatorName}</h3>
+                                <span
+                                  className={cn(
+                                    'rounded-full border px-2.5 py-1 text-xs font-semibold',
+                                    getReviewBadgeClass(entry.managerReviewStatus, entry.status)
+                                  )}
+                                >
+                                  {getReviewLabel(entry.managerReviewStatus, entry.status)}
+                                </span>
+                              </div>
+                              <p className="mt-1 text-sm text-muted-foreground">
+                                {entry.machineLabel} · {entry.locationName}
+                              </p>
+                              <div className="mt-3 flex flex-wrap gap-x-5 gap-y-2 text-sm tabular-nums text-muted-foreground">
+                                <span className="font-medium text-foreground">
+                                  {formatDate(entry.workDate)}
+                                </span>
+                                <span>
+                                  {formatTime(entry.startTime)}–{formatTime(entry.endTime)}
+                                </span>
+                                <span>{formatDuration(entry.rawDurationMinutes)} actual</span>
+                                <span className="font-medium text-foreground">
+                                  {formatPaidHours(entry.roundedPaidMinutes)}
+                                </span>
+                              </div>
+                              {entry.notes && (
+                                <p className="mt-3 max-w-3xl text-sm leading-6 text-muted-foreground">
+                                  <span className="font-medium text-foreground">Worker note:</span>{' '}
+                                  {entry.notes}
+                                </p>
+                              )}
+                              {entry.managerReviewStatus === 'needs_correction' &&
+                                entry.managerReviewReason && (
+                                  <p className="mt-3 max-w-3xl rounded-xl border border-amber/20 bg-amber/10 px-3 py-2 text-sm leading-6 text-foreground">
+                                    <span className="font-medium">Correction requested:</span>{' '}
+                                    {entry.managerReviewReason}
+                                  </p>
+                                )}
+                            </div>
+
+                            {canReview && (
+                              <div className="flex shrink-0 flex-col gap-2 sm:flex-row lg:justify-end">
+                                <Button
+                                  type="button"
+                                  variant="outline"
+                                  disabled={isSaving}
+                                  onClick={() => {
+                                    setCorrectionEntry(entry);
+                                    setCorrectionReason(entry.managerReviewReason ?? '');
+                                  }}
+                                >
+                                  <MessageSquareWarning className="mr-2 h-4 w-4" />
+                                  Request correction
+                                </Button>
+                                <Button
+                                  type="button"
+                                  disabled={isSaving || entry.managerReviewStatus === 'approved'}
+                                  onClick={() => approveEntry(entry)}
+                                >
+                                  {isSaving ? (
+                                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                  ) : entry.managerReviewStatus === 'approved' ? (
+                                    <Check className="mr-2 h-4 w-4" />
+                                  ) : (
+                                    <CheckCircle2 className="mr-2 h-4 w-4" />
+                                  )}
+                                  {entry.managerReviewStatus === 'approved' ? 'Approved' : 'Approve'}
+                                </Button>
+                              </div>
+                            )}
+                          </div>
+                        </article>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
+
+      <Dialog
+        open={Boolean(correctionEntry)}
+        onOpenChange={(open) => {
+          if (!open && !reviewMutation.isPending) {
+            setCorrectionEntry(null);
+            setCorrectionReason('');
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Request a correction</DialogTitle>
+            <DialogDescription>
+              Tell {correctionEntry?.operatorName ?? 'the worker'} exactly what should change. They
+              will see this note beside the shift.
+            </DialogDescription>
+          </DialogHeader>
+          {correctionEntry && (
+            <div className="rounded-xl border border-border bg-muted/35 px-3 py-3 text-sm">
+              <p className="font-medium text-foreground">
+                {correctionEntry.machineLabel} · {formatDate(correctionEntry.workDate)}
+              </p>
+              <p className="mt-1 text-muted-foreground">
+                {formatTime(correctionEntry.startTime)}–{formatTime(correctionEntry.endTime)} ·{' '}
+                {formatPaidHours(correctionEntry.roundedPaidMinutes)}
+              </p>
+            </div>
+          )}
+          <div>
+            <label htmlFor="correction-reason" className="mb-1.5 block text-sm font-medium">
+              What needs to change?
+            </label>
+            <Textarea
+              id="correction-reason"
+              rows={4}
+              autoFocus
+              value={correctionReason}
+              placeholder="For example: Please change the end time to 4:30 PM."
+              onChange={(event) => setCorrectionReason(event.target.value)}
+            />
+            <p className="mt-1.5 text-xs text-muted-foreground">A reason is required.</p>
+          </div>
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={reviewMutation.isPending}
+              onClick={() => {
+                setCorrectionEntry(null);
+                setCorrectionReason('');
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              disabled={correctionReason.trim().length === 0 || reviewMutation.isPending}
+              onClick={requestCorrection}
+            >
+              {reviewMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Send correction request
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </PortalLayout>
+  );
+}

--- a/supabase/migrations/202607160001_timekeeping_manager_review.sql
+++ b/supabase/migrations/202607160001_timekeeping_manager_review.sql
@@ -1,0 +1,504 @@
+-- Timekeeping V1 manager review
+-- Adds machine-scoped review state without changing payout calculation or payment behavior.
+
+alter table public.time_entries
+  add column if not exists manager_review_status text not null default 'pending',
+  add column if not exists manager_review_reason text,
+  add column if not exists manager_reviewed_at timestamptz,
+  add column if not exists manager_reviewed_by uuid;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'time_entries_manager_review_status_check'
+      and conrelid = 'public.time_entries'::regclass
+  ) then
+    alter table public.time_entries
+      add constraint time_entries_manager_review_status_check
+      check (manager_review_status in ('pending', 'approved', 'needs_correction'));
+  end if;
+
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'time_entries_manager_reviewed_by_fkey'
+      and conrelid = 'public.time_entries'::regclass
+  ) then
+    alter table public.time_entries
+      add constraint time_entries_manager_reviewed_by_fkey
+      foreign key (manager_reviewed_by) references auth.users (id) on delete set null;
+  end if;
+end;
+$$;
+
+create index if not exists time_entries_manager_review_queue_idx
+  on public.time_entries (reporting_machine_id, work_date desc, manager_review_status)
+  where status = 'submitted' and locked_at is null;
+
+create index if not exists time_entries_manager_reviewed_by_idx
+  on public.time_entries (manager_reviewed_by)
+  where manager_reviewed_by is not null;
+
+-- Browser writes use the audited worker/manager RPCs. Removing direct table writes
+-- prevents callers from supplying manager-review fields outside those paths.
+revoke insert, update, delete on table public.time_entries from anon, authenticated;
+grant select on table public.time_entries to authenticated;
+
+create table if not exists public.time_entry_review_events (
+  id uuid primary key default gen_random_uuid(),
+  time_entry_id uuid not null references public.time_entries (id) on delete cascade,
+  account_id uuid not null references public.customer_accounts (id) on delete cascade,
+  operator_profile_id uuid not null references public.operator_payout_profiles (id) on delete cascade,
+  reporting_machine_id uuid not null references public.reporting_machines (id) on delete restrict,
+  decision text not null check (decision in ('approved', 'needs_correction')),
+  reason text,
+  reviewed_by uuid references auth.users (id) on delete set null,
+  created_at timestamptz not null default now(),
+  constraint time_entry_review_events_correction_reason_required check (
+    decision = 'approved' or length(trim(coalesce(reason, ''))) > 0
+  )
+);
+
+create index if not exists time_entry_review_events_entry_created_idx
+  on public.time_entry_review_events (time_entry_id, created_at desc);
+
+create index if not exists time_entry_review_events_machine_created_idx
+  on public.time_entry_review_events (reporting_machine_id, created_at desc);
+
+create index if not exists time_entry_review_events_account_idx
+  on public.time_entry_review_events (account_id);
+
+create index if not exists time_entry_review_events_operator_profile_idx
+  on public.time_entry_review_events (operator_profile_id);
+
+create index if not exists time_entry_review_events_reviewed_by_idx
+  on public.time_entry_review_events (reviewed_by)
+  where reviewed_by is not null;
+
+alter table public.time_entry_review_events enable row level security;
+
+drop policy if exists "time_entry_review_events_select_accessible"
+  on public.time_entry_review_events;
+create policy "time_entry_review_events_select_accessible"
+on public.time_entry_review_events
+for select
+to authenticated
+using (
+  public.can_manage_operator_payout_machine_current_user(reporting_machine_id)
+  or exists (
+    select 1
+    from public.operator_payout_profiles profile
+    where profile.id = time_entry_review_events.operator_profile_id
+      and profile.user_id = (select auth.uid())
+  )
+);
+
+revoke all on table public.time_entry_review_events from anon, authenticated;
+grant select on table public.time_entry_review_events to service_role;
+
+create or replace function public.validate_operator_time_entry_assignment()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if tg_op = 'INSERT' then
+    new.manager_review_status := 'pending';
+    new.manager_review_reason := null;
+    new.manager_reviewed_at := null;
+    new.manager_reviewed_by := null;
+  end if;
+
+  if new.work_date > current_date then
+    raise exception 'Future work dates are not allowed';
+  end if;
+
+  if tg_op = 'INSERT'
+    or new.operator_profile_id is distinct from old.operator_profile_id
+    or new.reporting_machine_id is distinct from old.reporting_machine_id
+    or new.work_date is distinct from old.work_date then
+    if not exists (
+      select 1
+      from public.operator_machine_assignments assignment
+      where assignment.operator_profile_id = new.operator_profile_id
+        and assignment.reporting_machine_id = new.reporting_machine_id
+        and assignment.status = 'active'
+        and assignment.revoked_at is null
+        and assignment.effective_start_date <= new.work_date
+        and (
+          assignment.effective_end_date is null
+          or assignment.effective_end_date >= new.work_date
+        )
+    ) then
+      raise exception 'Time entry machine is not assigned for this work date';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists time_entries_validate_assignment on public.time_entries;
+create trigger time_entries_validate_assignment
+before insert or update on public.time_entries
+for each row execute function public.validate_operator_time_entry_assignment();
+
+create or replace function public.reset_operator_time_entry_manager_review()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+declare
+  shift_details_changed boolean;
+begin
+  shift_details_changed :=
+    new.operator_profile_id is distinct from old.operator_profile_id
+    or new.reporting_machine_id is distinct from old.reporting_machine_id
+    or new.work_date is distinct from old.work_date
+    or new.start_time is distinct from old.start_time
+    or new.end_time is distinct from old.end_time
+    or new.notes is distinct from old.notes;
+
+  if shift_details_changed then
+    new.manager_review_status := 'pending';
+    new.manager_review_reason := null;
+    new.manager_reviewed_at := null;
+    new.manager_reviewed_by := null;
+  elsif (
+    new.manager_review_status is distinct from old.manager_review_status
+    or new.manager_review_reason is distinct from old.manager_review_reason
+    or new.manager_reviewed_at is distinct from old.manager_reviewed_at
+    or new.manager_reviewed_by is distinct from old.manager_reviewed_by
+  ) and coalesce(current_setting('app.time_entry_review_rpc', true), '') <> 'true' then
+    raise exception 'Manager review fields can only be changed through the review action';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists time_entries_reset_manager_review on public.time_entries;
+create trigger time_entries_reset_manager_review
+before update on public.time_entries
+for each row execute function public.reset_operator_time_entry_manager_review();
+
+create or replace function public.operator_time_entry_payload(
+  p_time_entry_id uuid
+)
+returns jsonb
+language sql
+stable
+security definer
+set search_path = public, auth
+as $$
+  select jsonb_build_object(
+    'id', entry.id,
+    'accountId', entry.account_id,
+    'operatorProfileId', entry.operator_profile_id,
+    'machineId', entry.reporting_machine_id,
+    'machineLabel', machine.machine_label,
+    'locationId', entry.reporting_location_id,
+    'locationName', location.name,
+    'payoutPolicyId', entry.payout_policy_id,
+    'payoutPeriodId', entry.payout_period_id,
+    'workDate', entry.work_date,
+    'startTime', to_char(entry.start_time, 'HH24:MI'),
+    'endTime', to_char(entry.end_time, 'HH24:MI'),
+    'rawDurationMinutes', entry.raw_duration_minutes,
+    'roundedPaidMinutes', entry.rounded_paid_minutes,
+    'notes', entry.notes,
+    'status', entry.status,
+    'managerReviewStatus', entry.manager_review_status,
+    'managerReviewReason', entry.manager_review_reason,
+    'managerReviewedAt', entry.manager_reviewed_at,
+    'lockedAt', entry.locked_at,
+    'createdAt', entry.created_at,
+    'updatedAt', entry.updated_at
+  )
+  from public.time_entries entry
+  join public.reporting_machines machine on machine.id = entry.reporting_machine_id
+  join public.reporting_locations location on location.id = entry.reporting_location_id
+  join public.operator_payout_profiles profile on profile.id = entry.operator_profile_id
+  where entry.id = p_time_entry_id
+    and (
+      profile.user_id = (select auth.uid())
+      or public.can_access_operator_payout_profile((select auth.uid()), profile.id)
+    );
+$$;
+
+create or replace function public.get_my_time_review_context(
+  p_work_date date default current_date
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  actor_user_id uuid;
+  target_work_date date;
+  period_start date;
+  period_end date;
+  result jsonb;
+begin
+  actor_user_id := auth.uid();
+  target_work_date := coalesce(p_work_date, current_date);
+  period_start := date_trunc('month', target_work_date)::date;
+  period_end := (date_trunc('month', target_work_date) + interval '1 month - 1 day')::date;
+
+  if actor_user_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  with manageable_machines as materialized (
+    select
+      machine.id,
+      machine.machine_label,
+      location.id as location_id,
+      location.name as location_name
+    from public.reporting_machines machine
+    join public.reporting_locations location on location.id = machine.location_id
+    where public.can_manage_operator_payout_machine(actor_user_id, machine.id)
+  )
+  select jsonb_build_object(
+    'workDate', target_work_date,
+    'periodStartDate', period_start,
+    'periodEndDate', period_end,
+    'hasAccess', exists (select 1 from manageable_machines),
+    'machines', coalesce((
+      select jsonb_agg(
+        jsonb_build_object(
+          'machineId', machine.id,
+          'machineLabel', machine.machine_label,
+          'locationId', machine.location_id,
+          'locationName', machine.location_name
+        )
+        order by machine.location_name, machine.machine_label
+      )
+      from manageable_machines machine
+    ), '[]'::jsonb),
+    'entries', coalesce((
+      select jsonb_agg(
+        jsonb_build_object(
+          'id', entry.id,
+          'accountId', entry.account_id,
+          'accountName', account.name,
+          'operatorProfileId', entry.operator_profile_id,
+          'operatorName', profile.display_name,
+          'machineId', entry.reporting_machine_id,
+          'machineLabel', machine.machine_label,
+          'locationId', entry.reporting_location_id,
+          'locationName', machine.location_name,
+          'payoutPolicyId', entry.payout_policy_id,
+          'payoutPeriodId', entry.payout_period_id,
+          'workDate', entry.work_date,
+          'startTime', to_char(entry.start_time, 'HH24:MI'),
+          'endTime', to_char(entry.end_time, 'HH24:MI'),
+          'rawDurationMinutes', entry.raw_duration_minutes,
+          'roundedPaidMinutes', entry.rounded_paid_minutes,
+          'notes', entry.notes,
+          'status', entry.status,
+          'managerReviewStatus', entry.manager_review_status,
+          'managerReviewReason', entry.manager_review_reason,
+          'managerReviewedAt', entry.manager_reviewed_at,
+          'lockedAt', entry.locked_at,
+          'createdAt', entry.created_at,
+          'updatedAt', entry.updated_at
+        )
+        order by
+          case entry.manager_review_status
+            when 'needs_correction' then 0
+            when 'pending' then 1
+            else 2
+          end,
+          entry.work_date desc,
+          entry.start_time desc,
+          profile.display_name
+      )
+      from public.time_entries entry
+      join manageable_machines machine on machine.id = entry.reporting_machine_id
+      join public.operator_payout_profiles profile on profile.id = entry.operator_profile_id
+      join public.customer_accounts account on account.id = entry.account_id
+      where entry.work_date between period_start and period_end
+        and entry.status in ('submitted', 'locked', 'included_in_payout', 'paid')
+    ), '[]'::jsonb)
+  )
+  into result;
+
+  return coalesce(
+    result,
+    jsonb_build_object(
+      'workDate', target_work_date,
+      'periodStartDate', period_start,
+      'periodEndDate', period_end,
+      'hasAccess', false,
+      'machines', '[]'::jsonb,
+      'entries', '[]'::jsonb
+    )
+  );
+end;
+$$;
+
+create or replace function public.review_operator_time_entry(
+  p_time_entry_id uuid,
+  p_decision text,
+  p_reason text default null,
+  p_work_date date default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  actor_user_id uuid;
+  normalized_decision text;
+  normalized_reason text;
+  before_row public.time_entries;
+  after_row public.time_entries;
+  profile_row public.operator_payout_profiles;
+begin
+  actor_user_id := auth.uid();
+  normalized_decision := lower(trim(coalesce(p_decision, '')));
+  normalized_reason := nullif(trim(coalesce(p_reason, '')), '');
+
+  if actor_user_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  if normalized_decision not in ('approved', 'needs_correction') then
+    raise exception 'Review decision must be approved or needs_correction';
+  end if;
+
+  if normalized_decision = 'needs_correction' and normalized_reason is null then
+    raise exception 'A correction reason is required';
+  end if;
+
+  select *
+  into before_row
+  from public.time_entries entry
+  where entry.id = p_time_entry_id
+  for update;
+
+  if before_row.id is null then
+    raise exception 'Time entry not found';
+  end if;
+
+  if before_row.locked_at is not null or before_row.status <> 'submitted' then
+    raise exception 'Only unlocked submitted time can be reviewed';
+  end if;
+
+  if not public.can_manage_operator_payout_machine(actor_user_id, before_row.reporting_machine_id) then
+    raise exception 'Machine manager access required';
+  end if;
+
+  select *
+  into profile_row
+  from public.operator_payout_profiles profile
+  where profile.id = before_row.operator_profile_id;
+
+  perform set_config('app.time_entry_review_rpc', 'true', true);
+
+  update public.time_entries
+  set
+    manager_review_status = normalized_decision,
+    manager_review_reason = normalized_reason,
+    manager_reviewed_at = now(),
+    manager_reviewed_by = actor_user_id,
+    updated_by = actor_user_id
+  where id = before_row.id
+  returning * into after_row;
+
+  perform set_config('app.time_entry_review_rpc', 'false', true);
+
+  insert into public.time_entry_review_events (
+    time_entry_id,
+    account_id,
+    operator_profile_id,
+    reporting_machine_id,
+    decision,
+    reason,
+    reviewed_by
+  )
+  values (
+    after_row.id,
+    after_row.account_id,
+    after_row.operator_profile_id,
+    after_row.reporting_machine_id,
+    normalized_decision,
+    normalized_reason,
+    actor_user_id
+  );
+
+  insert into public.admin_audit_log (
+    actor_user_id,
+    action,
+    entity_type,
+    entity_id,
+    target_user_id,
+    before,
+    after,
+    meta
+  )
+  values (
+    actor_user_id,
+    case normalized_decision
+      when 'approved' then 'operator_time_entry.manager_approved'
+      else 'operator_time_entry.correction_requested'
+    end,
+    'time_entry',
+    after_row.id::text,
+    profile_row.user_id,
+    to_jsonb(before_row),
+    to_jsonb(after_row),
+    jsonb_build_object(
+      'reason', normalized_reason,
+      'machine_manager_review', true,
+      'payment_behavior_changed', false
+    )
+  );
+
+  return jsonb_build_object(
+    'timeEntry', public.operator_time_entry_payload(after_row.id),
+    'context', public.get_my_time_review_context(coalesce(p_work_date, after_row.work_date))
+  );
+end;
+$$;
+
+comment on table public.time_entry_review_events is
+  'Immutable machine-manager review history for operator time entries. Review decisions do not initiate or alter payments.';
+comment on function public.get_my_time_review_context(date) is
+  'Monthly time-review queue limited to reporting machines the current user can manage.';
+comment on function public.review_operator_time_entry(uuid, text, text, date) is
+  'Machine-scoped approve or request-correction action for unlocked submitted time. Does not change payout calculation or payment state.';
+comment on function public.validate_operator_time_entry_assignment() is
+  'Fail-closed trigger guard forcing new time to pending review and requiring a non-future work date plus an active, effective operator-to-machine assignment.';
+comment on function public.reset_operator_time_entry_manager_review() is
+  'Resets materially edited shifts to pending review and rejects direct review-field writes outside the audited manager-review RPC.';
+
+revoke execute on function public.validate_operator_time_entry_assignment()
+  from public, anon, authenticated;
+revoke execute on function public.reset_operator_time_entry_manager_review()
+  from public, anon, authenticated;
+revoke execute on function public.operator_time_entry_payload(uuid)
+  from public, anon, authenticated;
+revoke execute on function public.get_my_time_review_context(date)
+  from public, anon;
+revoke execute on function public.review_operator_time_entry(uuid, text, text, date)
+  from public, anon;
+
+grant execute on function public.validate_operator_time_entry_assignment()
+  to service_role;
+grant execute on function public.reset_operator_time_entry_manager_review()
+  to service_role;
+grant execute on function public.operator_time_entry_payload(uuid)
+  to service_role;
+grant execute on function public.get_my_time_review_context(date)
+  to authenticated, service_role;
+grant execute on function public.review_operator_time_entry(uuid, text, text, date)
+  to authenticated, service_role;
+
+select pg_notify('pgrst', 'reload schema');


### PR DESCRIPTION
Closes #587

## Summary
- Reworks worker Time into a lightweight monthly completed-shift hub with one dominant entry action, actual/rounded totals, month-aware edits, and clear review states.
- Adds a separate Review Time workspace where existing Machine Managers see only managed-machine shifts, approve them, or return them with a required worker-visible reason.
- Adds immutable review history, audit logging, assignment/future-date guards, and RPC-only browser writes without changing pay-run calculation, statement issuance, or payment behavior.

## Files changed
- `src/pages/portal/Time.tsx`, `src/pages/portal/TimeReview.tsx`: worker and manager workflows.
- `src/lib/operatorPayouts.ts`, routing/navigation/i18n: typed RPC client, route, and discoverability.
- `supabase/migrations/202607160001_timekeeping_manager_review.sql`: review state/history, scoped RPCs, indexes, and direct-write hardening.
- `scripts/validate-operator-timekeeping*.mjs`: static and mocked worker/manager browser journeys.
- `Docs/DECISIONS.md`, `Docs/CURRENT_STATUS.md`, `Docs/QA_SMOKE_TEST_CHECKLIST.md`: durable V1 boundary and UAT coverage.

## Product boundary
- V1 is after-the-fact shift entry and Machine Manager review.
- Monthly calendar periods and per-shift round-up to the next full hour remain the defaults.
- No new payroll approver role is introduced.
- Review state does not create a pay run, issue a statement, mark time paid, or call a payment/provider integration.

## Verification
- `npm ci` — passed (package files unchanged; npm reported the default branch's existing 1 high / 3 moderate audit findings).
- `npm run build` — passed.
- `npm test --if-present` — passed.
- `npm run lint --if-present` — passed with no warnings.
- `npm run operator-payouts:validate-foundation` — passed.
- `npm run operator-payouts:validate-timekeeping` — passed.
- `npm run operator-payouts:validate-review` — passed.
- `npm run operator-payouts:validate-statements` — passed.
- `npm run operator-payouts:validate-timekeeping-uat -- --app-url http://127.0.0.1:8081` — passed worker add/edit/delete, manager approve/correction, desktop/mobile overflow, and browser-console checks.
- `npm run agent:preflight -- --issue 587` — passed.

Local Supabase SQL lint was not available because Docker Desktop's local engine was not running. The migration has targeted static checks and an independent security challenge pass; live persona/RPC verification remains required after deployment.

## How to test
1. Check out this branch and run `npm ci`.
2. Configure the normal local environment from `.env.example`; do not use or commit production secrets.
3. Apply Supabase migrations through the standard development migration flow.
4. Run `npm run dev -- --host 127.0.0.1 --port 8081 --strictPort`.
5. With an active worker profile, open `http://127.0.0.1:8081/portal/time`, select a month, add a completed assigned-machine shift, and verify actual versus rounded time plus Waiting for review.
6. With a Machine Manager assigned to that machine, open `http://127.0.0.1:8081/portal/time-review`, approve one shift, and return another with a required reason.
7. Return to the worker view and verify Approved / Correction requested states, the correction reason, and that editing sends the shift back to pending review.
8. Verify a worker direct table INSERT/UPDATE cannot set manager review fields, and an out-of-scope manager cannot review another machine's entry.
9. Re-run `npm run operator-payouts:validate-timekeeping-uat -- --app-url http://127.0.0.1:8081` and inspect screenshots under `output/playwright/`.

Use configured local operator and Machine Manager personas; no shared test credentials are committed.

## Risk and rollout
- Risky database/auth change: deploy the migration before the frontend so the two new RPCs exist.
- Fail closed: authenticated browser users no longer receive direct INSERT/UPDATE/DELETE on `time_entries`; existing worker and manager SECURITY DEFINER RPCs own all writes.
- Live verification must cover worker, in-scope Machine Manager, and out-of-scope personas before enabling contractor use.
- Payment and admin payout behavior are intentionally unchanged.

## Open-PR overlap
- PR #503 also touches `Docs/QA_SMOKE_TEST_CHECKLIST.md`; this PR does not touch `src/pages/admin/Payouts.tsx`.
- PRs #559 and #560 also touch `Docs/CURRENT_STATUS.md`, `Docs/QA_SMOKE_TEST_CHECKLIST.md`, and `src/lib/operatorPayouts.ts` and are currently conflicting. Reconcile those shared files after merge order is chosen.