### PR TITLE
Fix and test Timekeeping V1 persona boundaries

### DIFF
--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - 'supabase/migrations/**'
+      - 'supabase/tests/**'
       - 'scripts/validate-supabase-migrations.mjs'
       - 'package.json'
       - 'package-lock.json'

--- a/scripts/validate-operator-timekeeping.mjs
+++ b/scripts/validate-operator-timekeeping.mjs
@@ -16,6 +16,12 @@ const files = {
     'migrations',
     '202607160001_timekeeping_manager_review.sql'
   ),
+  managerAuthorityMigration: path.join(
+    repoRoot,
+    'supabase',
+    'migrations',
+    '202607170001_timekeeping_manager_authority_fail_closed.sql'
+  ),
   page: path.join(repoRoot, 'src', 'pages', 'portal', 'Time.tsx'),
   reviewPage: path.join(repoRoot, 'src', 'pages', 'portal', 'TimeReview.tsx'),
   app: path.join(repoRoot, 'src', 'App.tsx'),
@@ -110,6 +116,17 @@ for (const snippet of [
   'grant execute on function public.review_operator_time_entry',
 ]) {
   expect(managerMigration, snippet, 'timekeeping manager-review migration');
+}
+
+const managerAuthorityMigration = readText(files.managerAuthorityMigration);
+for (const snippet of [
+  'create or replace function public.can_manage_operator_payout_machine',
+  'select coalesce(',
+  'false',
+  'revoke execute on function public.can_manage_operator_payout_machine',
+  'grant execute on function public.can_manage_operator_payout_machine',
+]) {
+  expect(managerAuthorityMigration, snippet, 'timekeeping manager-authority migration');
 }
 
 const reviewPage = readText(files.reviewPage);

--- a/scripts/validate-supabase-migrations.mjs
+++ b/scripts/validate-supabase-migrations.mjs
@@ -13,6 +13,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '..');
 const migrationsDir = path.join(repoRoot, 'supabase', 'migrations');
+const testsDir = path.join(repoRoot, 'supabase', 'tests');
 
 function printHelp() {
   console.log(`Usage: npm run db:validate-migrations [-- --keep-temp] [-- --debug]
@@ -147,6 +148,11 @@ function writeTempSupabaseProject(tempRoot, projectId, dbPort, shadowPort) {
   fs.cpSync(migrationsDir, path.join(tempSupabaseDir, 'migrations'), {
     recursive: true,
   });
+  if (fs.existsSync(testsDir)) {
+    fs.cpSync(testsDir, path.join(tempSupabaseDir, 'tests'), {
+      recursive: true,
+    });
+  }
 
   const config = `project_id = "${projectId}"
 
@@ -227,6 +233,16 @@ async function main() {
 
     run('supabase', args, { stdio: 'inherit' });
     log('\nSupabase migration apply validation passed.');
+
+    if (fs.existsSync(testsDir)) {
+      const testArgs = ['test', 'db', '--workdir', tempRoot];
+      if (options.debug) {
+        testArgs.push('--debug');
+      }
+
+      run('supabase', testArgs, { stdio: 'inherit' });
+      log('Supabase database persona tests passed.');
+    }
   } catch (error) {
     validationError = error;
   } finally {

--- a/supabase/migrations/202607170001_timekeeping_manager_authority_fail_closed.sql
+++ b/supabase/migrations/202607170001_timekeeping_manager_authority_fail_closed.sql
@@ -1,0 +1,74 @@
+-- Timekeeping manager authority must return false, never null, for ungranted users.
+--
+-- The scheduler-aware is_super_admin helper can return null when its optional
+-- session setting is absent. Without the outer coalesce, PL/pgSQL checks such as
+-- `if not can_manage_operator_payout_machine(...)` do not enter the denial branch
+-- because `not null` is still null. Keep the shared machine authority predicate
+-- explicitly fail-closed for every caller.
+
+create or replace function public.can_manage_operator_payout_machine(
+  p_user_id uuid,
+  p_machine_id uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select coalesce(
+    p_user_id is not null
+    and p_machine_id is not null
+    and (
+      public.is_super_admin(p_user_id)
+      or p_machine_id = any(coalesce(public.scoped_admin_machine_ids(p_user_id), '{}'::uuid[]))
+      or exists (
+        select 1
+        from public.reporting_machine_refund_managers manager
+        where manager.reporting_machine_id = p_machine_id
+          and manager.manager_user_id = p_user_id
+          and manager.status = 'active'
+          and manager.revoked_at is null
+      )
+      or exists (
+        select 1
+        from public.reporting_machines machine
+        join public.customer_account_memberships membership
+          on membership.account_id = machine.account_id
+        where machine.id = p_machine_id
+          and membership.user_id = p_user_id
+          and membership.active
+          and membership.role in ('owner', 'account_admin', 'report_manager')
+      )
+      or exists (
+        select 1
+        from public.reporting_machines machine
+        join public.reporting_machine_entitlements entitlement
+          on entitlement.user_id = p_user_id
+        where machine.id = p_machine_id
+          and entitlement.access_level = 'report_manager'
+          and public.reporting_entitlement_is_active(
+            entitlement.starts_at,
+            entitlement.expires_at,
+            entitlement.revoked_at
+          )
+          and (
+            entitlement.machine_id = machine.id
+            or entitlement.location_id = machine.location_id
+            or entitlement.account_id = machine.account_id
+          )
+      )
+    ),
+    false
+  );
+$$;
+
+comment on function public.can_manage_operator_payout_machine(uuid, uuid) is
+  'Fail-closed machine-scoped operator payout authority for Super Admins, Scoped Admins, Machine Managers, authorized account managers, and explicit report-manager entitlements.';
+
+revoke execute on function public.can_manage_operator_payout_machine(uuid, uuid)
+  from public, anon, authenticated;
+grant execute on function public.can_manage_operator_payout_machine(uuid, uuid)
+  to service_role;
+
+select pg_notify('pgrst', 'reload schema');

--- a/supabase/tests/timekeeping_persona_access.sql
+++ b/supabase/tests/timekeeping_persona_access.sql
@@ -328,10 +328,11 @@ select ok(
 );
 
 set local role anon;
-select is(
-  (select count(*)::integer from public.time_entries),
-  0,
-  'an anonymous actor receives no time entries through direct-table RLS'
+select ok(
+  pg_temp.capture_error($$
+    select * from public.time_entries
+  $$) like '%permission denied for function can_access_operator_payout_profile_current_user%',
+  'an anonymous actor is denied while evaluating direct time-entry RLS'
 );
 select ok(
   pg_temp.capture_error($$

--- a/supabase/tests/timekeeping_persona_access.sql
+++ b/supabase/tests/timekeeping_persona_access.sql
@@ -271,7 +271,7 @@ values
     '30000000-0000-0000-0000-000000000001',
     '50000000-0000-0000-0000-000000000001',
     '70000000-0000-0000-0000-000000000001',
-    current_date - 1,
+    date_trunc('month', current_date)::date,
     '09:00',
     '10:30',
     90,
@@ -286,7 +286,7 @@ values
     '30000000-0000-0000-0000-000000000001',
     '50000000-0000-0000-0000-000000000001',
     '70000000-0000-0000-0000-000000000001',
-    current_date - 1,
+    date_trunc('month', current_date)::date,
     '11:00',
     '12:00',
     60,
@@ -344,7 +344,7 @@ select ok(
     select public.submit_operator_time_entry(
       '60000000-0000-0000-0000-000000000001',
       '40000000-0000-0000-0000-000000000001',
-      current_date - 1,
+      date_trunc('month', current_date)::date,
       '08:00',
       '09:00',
       null,
@@ -358,7 +358,7 @@ select ok(
     select public.update_operator_time_entry(
       '80000000-0000-0000-0000-000000000001',
       '40000000-0000-0000-0000-000000000001',
-      current_date - 1,
+      date_trunc('month', current_date)::date,
       '08:00',
       '09:00',
       null,
@@ -426,7 +426,7 @@ select is(
       '80000000-0000-0000-0000-000000000002',
       'approved',
       null,
-      current_date - 1
+      date_trunc('month', current_date)::date
     )
   $$),
   'Machine manager access required',
@@ -437,7 +437,7 @@ select is(
     select public.update_operator_time_entry(
       '80000000-0000-0000-0000-000000000002',
       '40000000-0000-0000-0000-000000000002',
-      current_date - 1,
+      date_trunc('month', current_date)::date,
       '11:00',
       '12:30',
       null,
@@ -452,7 +452,7 @@ select is(
     select public.submit_operator_time_entry(
       '60000000-0000-0000-0000-000000000001',
       '40000000-0000-0000-0000-000000000002',
-      current_date - 1,
+      date_trunc('month', current_date)::date,
       '13:00',
       '14:00',
       null,
@@ -467,7 +467,7 @@ select is(
     select public.submit_operator_time_entry(
       '60000000-0000-0000-0000-000000000002',
       '40000000-0000-0000-0000-000000000002',
-      current_date - 1,
+      date_trunc('month', current_date)::date,
       '13:00',
       '14:00',
       null,
@@ -516,27 +516,27 @@ select is(
   'the other-machine persona is an active Machine Manager'
 );
 select is(
-  public.get_my_time_review_context(current_date - 1)->>'hasAccess',
+  public.get_my_time_review_context(date_trunc('month', current_date)::date)->>'hasAccess',
   'true',
   'the other-machine manager can reach only their own review scope'
 );
 select is(
-  public.get_my_time_review_context(current_date - 1)->'machines'->0->>'machineId',
+  public.get_my_time_review_context(date_trunc('month', current_date)::date)->'machines'->0->>'machineId',
   '40000000-0000-0000-0000-000000000002',
   'the other-machine manager receives the exact assigned machine'
 );
 select is(
-  jsonb_array_length(public.get_my_time_review_context(current_date - 1)->'machines'),
+  jsonb_array_length(public.get_my_time_review_context(date_trunc('month', current_date)::date)->'machines'),
   1,
   'the other-machine manager queue contains no extra machines'
 );
 select is(
-  public.get_my_time_review_context(current_date - 1)->'entries'->0->>'id',
+  public.get_my_time_review_context(date_trunc('month', current_date)::date)->'entries'->0->>'id',
   '80000000-0000-0000-0000-000000000002',
   'the other-machine manager receives only their assigned-machine entry'
 );
 select is(
-  jsonb_array_length(public.get_my_time_review_context(current_date - 1)->'entries'),
+  jsonb_array_length(public.get_my_time_review_context(date_trunc('month', current_date)::date)->'entries'),
   1,
   'the other-machine manager queue contains no extra entries'
 );
@@ -551,7 +551,7 @@ select is(
       '80000000-0000-0000-0000-000000000001',
       'approved',
       null,
-      current_date - 1
+      date_trunc('month', current_date)::date
     )
   $$),
   'Machine manager access required',
@@ -582,17 +582,17 @@ select ok(
   'the Plus test persona has active Plus access'
 );
 select is(
-  public.get_my_time_review_context(current_date - 1)->>'hasAccess',
+  public.get_my_time_review_context(date_trunc('month', current_date)::date)->>'hasAccess',
   'false',
   'Plus access without a machine grant does not grant review access'
 );
 select is(
-  jsonb_array_length(public.get_my_time_review_context(current_date - 1)->'machines'),
+  jsonb_array_length(public.get_my_time_review_context(date_trunc('month', current_date)::date)->'machines'),
   0,
   'Plus access without a machine grant receives no review machines'
 );
 select is(
-  jsonb_array_length(public.get_my_time_review_context(current_date - 1)->'entries'),
+  jsonb_array_length(public.get_my_time_review_context(date_trunc('month', current_date)::date)->'entries'),
   0,
   'Plus access without a machine grant receives no review entries'
 );
@@ -607,7 +607,7 @@ select is(
       '80000000-0000-0000-0000-000000000001',
       'approved',
       null,
-      current_date - 1
+      date_trunc('month', current_date)::date
     )
   $$),
   'Machine manager access required',
@@ -638,17 +638,17 @@ select is(
   'a partner membership without a machine grant creates no machine authority'
 );
 select is(
-  public.get_my_time_review_context(current_date - 1)->>'hasAccess',
+  public.get_my_time_review_context(date_trunc('month', current_date)::date)->>'hasAccess',
   'false',
   'a partner membership without a machine grant does not grant review access'
 );
 select is(
-  jsonb_array_length(public.get_my_time_review_context(current_date - 1)->'machines'),
+  jsonb_array_length(public.get_my_time_review_context(date_trunc('month', current_date)::date)->'machines'),
   0,
   'a Corporate Partner without a machine grant receives no review machines'
 );
 select is(
-  jsonb_array_length(public.get_my_time_review_context(current_date - 1)->'entries'),
+  jsonb_array_length(public.get_my_time_review_context(date_trunc('month', current_date)::date)->'entries'),
   0,
   'a Corporate Partner without a machine grant receives no review entries'
 );
@@ -663,7 +663,7 @@ select is(
       '80000000-0000-0000-0000-000000000001',
       'approved',
       null,
-      current_date - 1
+      date_trunc('month', current_date)::date
     )
   $$),
   'Machine manager access required',
@@ -698,27 +698,27 @@ select is(
   'an assigned Machine Manager has no authority over an unassigned machine'
 );
 select is(
-  public.get_my_time_review_context(current_date - 1)->>'hasAccess',
+  public.get_my_time_review_context(date_trunc('month', current_date)::date)->>'hasAccess',
   'true',
   'an assigned Machine Manager has review access'
 );
 select is(
-  public.get_my_time_review_context(current_date - 1)->'machines'->0->>'machineId',
+  public.get_my_time_review_context(date_trunc('month', current_date)::date)->'machines'->0->>'machineId',
   '40000000-0000-0000-0000-000000000001',
   'an assigned Machine Manager receives the exact managed machine'
 );
 select is(
-  jsonb_array_length(public.get_my_time_review_context(current_date - 1)->'machines'),
+  jsonb_array_length(public.get_my_time_review_context(date_trunc('month', current_date)::date)->'machines'),
   1,
   'the assigned Machine Manager queue contains no extra machines'
 );
 select is(
-  public.get_my_time_review_context(current_date - 1)->'entries'->0->>'id',
+  public.get_my_time_review_context(date_trunc('month', current_date)::date)->'entries'->0->>'id',
   '80000000-0000-0000-0000-000000000001',
   'an assigned Machine Manager receives the exact in-scope entry'
 );
 select is(
-  jsonb_array_length(public.get_my_time_review_context(current_date - 1)->'entries'),
+  jsonb_array_length(public.get_my_time_review_context(date_trunc('month', current_date)::date)->'entries'),
   1,
   'the assigned Machine Manager queue contains no extra entries'
 );
@@ -733,7 +733,7 @@ select is(
       '80000000-0000-0000-0000-000000000002',
       'approved',
       null,
-      current_date - 1
+      date_trunc('month', current_date)::date
     )
   $$),
   'Machine manager access required',
@@ -745,7 +745,7 @@ select is(
       '80000000-0000-0000-0000-000000000001',
       'approved',
       null,
-      current_date - 1
+      date_trunc('month', current_date)::date
     )
   $$),
   null,
@@ -837,7 +837,7 @@ select is(
       '80000000-0000-0000-0000-000000000001',
       'needs_correction',
       null,
-      current_date - 1
+      date_trunc('month', current_date)::date
     )
   $$),
   'A correction reason is required',
@@ -849,7 +849,7 @@ select is(
       '80000000-0000-0000-0000-000000000001',
       'needs_correction',
       'Correct the shift end time',
-      current_date - 1
+      date_trunc('month', current_date)::date
     )
   $$),
   null,

--- a/supabase/tests/timekeeping_persona_access.sql
+++ b/supabase/tests/timekeeping_persona_access.sql
@@ -1,6 +1,19 @@
 begin;
 
-select plan(25);
+select plan(36);
+
+create function pg_temp.capture_error(statement text)
+returns text
+language plpgsql
+as $$
+begin
+  execute statement;
+  return null;
+exception
+  when others then
+    return sqlerrm;
+end;
+$$;
 
 insert into auth.users (
   instance_id,
@@ -276,24 +289,37 @@ select set_config(
 );
 
 select is(
+  auth.uid(),
+  '10000000-0000-0000-0000-000000000001'::uuid,
+  'the worker-one JWT fixture resolves to the intended actor'
+);
+select is(
+  public.can_manage_operator_payout_machine(
+    auth.uid(),
+    '40000000-0000-0000-0000-000000000002'
+  ),
+  false,
+  'a worker has no implicit manager authority over another machine'
+);
+select is(
   (select count(*)::integer from public.time_entries),
   1,
   'a worker sees only their own time entry through RLS'
 );
-select throws_matching(
-  $$
+select is(
+  pg_temp.capture_error($$
     select public.review_operator_time_entry(
       '80000000-0000-0000-0000-000000000002',
       'approved',
       null,
       current_date - 1
     )
-  $$,
+  $$),
   'Machine manager access required',
   'another worker cannot review another worker entry'
 );
-select throws_matching(
-  $$
+select is(
+  pg_temp.capture_error($$
     select public.update_operator_time_entry(
       '80000000-0000-0000-0000-000000000002',
       '40000000-0000-0000-0000-000000000002',
@@ -303,7 +329,7 @@ select throws_matching(
       null,
       'submitted'
     )
-  $$,
+  $$),
   'Operator timekeeping access required',
   'another worker cannot edit another worker entry'
 );
@@ -315,6 +341,19 @@ select set_config(
 );
 
 select is(
+  auth.uid(),
+  '10000000-0000-0000-0000-000000000004'::uuid,
+  'the unassigned-manager JWT fixture resolves to the intended actor'
+);
+select is(
+  public.can_manage_operator_payout_machine(
+    auth.uid(),
+    '40000000-0000-0000-0000-000000000001'
+  ),
+  false,
+  'an unassigned Machine Manager has no machine authority'
+);
+select is(
   public.get_my_time_review_context(current_date - 1)->>'hasAccess',
   'false',
   'an unassigned Machine Manager has no review access'
@@ -324,15 +363,15 @@ select is(
   0,
   'an unassigned Machine Manager receives no entries'
 );
-select throws_matching(
-  $$
+select is(
+  pg_temp.capture_error($$
     select public.review_operator_time_entry(
       '80000000-0000-0000-0000-000000000001',
       'approved',
       null,
       current_date - 1
     )
-  $$,
+  $$),
   'Machine manager access required',
   'an unassigned Machine Manager cannot review a shift'
 );
@@ -343,6 +382,19 @@ select set_config(
   true
 );
 
+select is(
+  auth.uid(),
+  '10000000-0000-0000-0000-000000000005'::uuid,
+  'the Plus JWT fixture resolves to the intended actor'
+);
+select is(
+  public.can_manage_operator_payout_machine(
+    auth.uid(),
+    '40000000-0000-0000-0000-000000000001'
+  ),
+  false,
+  'Plus access without a machine grant creates no machine authority'
+);
 select ok(
   (select has_plus_access from public.get_my_plus_access()),
   'the Plus test persona has active Plus access'
@@ -365,6 +417,19 @@ select set_config(
 );
 
 select is(
+  auth.uid(),
+  '10000000-0000-0000-0000-000000000006'::uuid,
+  'the partner JWT fixture resolves to the intended actor'
+);
+select is(
+  public.can_manage_operator_payout_machine(
+    auth.uid(),
+    '40000000-0000-0000-0000-000000000001'
+  ),
+  false,
+  'a partner membership without a machine grant creates no machine authority'
+);
+select is(
   public.get_my_time_review_context(current_date - 1)->>'hasAccess',
   'false',
   'a partner membership without a machine grant does not grant review access'
@@ -382,6 +447,27 @@ select set_config(
 );
 
 select is(
+  auth.uid(),
+  '10000000-0000-0000-0000-000000000003'::uuid,
+  'the assigned-manager JWT fixture resolves to the intended actor'
+);
+select is(
+  public.can_manage_operator_payout_machine(
+    auth.uid(),
+    '40000000-0000-0000-0000-000000000001'
+  ),
+  true,
+  'an assigned Machine Manager has authority over the assigned machine'
+);
+select is(
+  public.can_manage_operator_payout_machine(
+    auth.uid(),
+    '40000000-0000-0000-0000-000000000002'
+  ),
+  false,
+  'an assigned Machine Manager has no authority over an unassigned machine'
+);
+select is(
   public.get_my_time_review_context(current_date - 1)->>'hasAccess',
   'true',
   'an assigned Machine Manager has review access'
@@ -396,27 +482,28 @@ select is(
   1,
   'an assigned Machine Manager receives only entries on their managed machine'
 );
-select throws_matching(
-  $$
+select is(
+  pg_temp.capture_error($$
     select public.review_operator_time_entry(
       '80000000-0000-0000-0000-000000000002',
       'approved',
       null,
       current_date - 1
     )
-  $$,
+  $$),
   'Machine manager access required',
   'an assigned Machine Manager cannot review an out-of-scope machine'
 );
-select lives_ok(
-  $$
+select is(
+  pg_temp.capture_error($$
     select public.review_operator_time_entry(
       '80000000-0000-0000-0000-000000000001',
       'approved',
       null,
       current_date - 1
     )
-  $$,
+  $$),
+  null,
   'an assigned Machine Manager can approve an in-scope shift'
 );
 select is(
@@ -428,6 +515,9 @@ select is(
   'approved',
   'the approved review state is persisted'
 );
+
+reset role;
+
 select is(
   (
     select count(*)::integer
@@ -438,15 +528,23 @@ select is(
   1,
   'the review action records an immutable review event'
 );
-select throws_matching(
-  $$
+
+set local role authenticated;
+select set_config(
+  'request.jwt.claim.sub',
+  '10000000-0000-0000-0000-000000000003',
+  true
+);
+
+select is(
+  pg_temp.capture_error($$
     select public.review_operator_time_entry(
       '80000000-0000-0000-0000-000000000001',
       'needs_correction',
       null,
       current_date - 1
     )
-  $$,
+  $$),
   'A correction reason is required',
   'requesting correction requires a reason'
 );

--- a/supabase/tests/timekeeping_persona_access.sql
+++ b/supabase/tests/timekeeping_persona_access.sql
@@ -328,14 +328,13 @@ select ok(
 );
 
 set local role anon;
-select like(
+select ok(
   pg_temp.capture_error($$
     select public.get_my_time_review_context(current_date)
-  $$),
-  '%permission denied for function get_my_time_review_context%',
+  $$) like '%permission denied for function get_my_time_review_context%',
   'an anonymous actor is behaviorally denied the review queue RPC'
 );
-select like(
+select ok(
   pg_temp.capture_error($$
     select public.review_operator_time_entry(
       '80000000-0000-0000-0000-000000000001',
@@ -343,8 +342,7 @@ select like(
       null,
       current_date
     )
-  $$),
-  '%permission denied for function review_operator_time_entry%',
+  $$) like '%permission denied for function review_operator_time_entry%',
   'an anonymous actor is behaviorally denied the review action RPC'
 );
 reset role;

--- a/supabase/tests/timekeeping_persona_access.sql
+++ b/supabase/tests/timekeeping_persona_access.sql
@@ -15,6 +15,16 @@ exception
 end;
 $$;
 
+create function pg_temp.can_manage_for(actor_user_id uuid, machine_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select public.can_manage_operator_payout_machine(actor_user_id, machine_id);
+$$;
+
 insert into auth.users (
   instance_id,
   id,
@@ -294,7 +304,7 @@ select is(
   'the worker-one JWT fixture resolves to the intended actor'
 );
 select is(
-  public.can_manage_operator_payout_machine(
+  pg_temp.can_manage_for(
     auth.uid(),
     '40000000-0000-0000-0000-000000000002'
   ),
@@ -346,7 +356,7 @@ select is(
   'the unassigned-manager JWT fixture resolves to the intended actor'
 );
 select is(
-  public.can_manage_operator_payout_machine(
+  pg_temp.can_manage_for(
     auth.uid(),
     '40000000-0000-0000-0000-000000000001'
   ),
@@ -388,7 +398,7 @@ select is(
   'the Plus JWT fixture resolves to the intended actor'
 );
 select is(
-  public.can_manage_operator_payout_machine(
+  pg_temp.can_manage_for(
     auth.uid(),
     '40000000-0000-0000-0000-000000000001'
   ),
@@ -422,7 +432,7 @@ select is(
   'the partner JWT fixture resolves to the intended actor'
 );
 select is(
-  public.can_manage_operator_payout_machine(
+  pg_temp.can_manage_for(
     auth.uid(),
     '40000000-0000-0000-0000-000000000001'
   ),
@@ -452,7 +462,7 @@ select is(
   'the assigned-manager JWT fixture resolves to the intended actor'
 );
 select is(
-  public.can_manage_operator_payout_machine(
+  pg_temp.can_manage_for(
     auth.uid(),
     '40000000-0000-0000-0000-000000000001'
   ),
@@ -460,7 +470,7 @@ select is(
   'an assigned Machine Manager has authority over the assigned machine'
 );
 select is(
-  public.can_manage_operator_payout_machine(
+  pg_temp.can_manage_for(
     auth.uid(),
     '40000000-0000-0000-0000-000000000002'
   ),

--- a/supabase/tests/timekeeping_persona_access.sql
+++ b/supabase/tests/timekeeping_persona_access.sql
@@ -1,6 +1,9 @@
 begin;
 
-select plan(36);
+create extension if not exists pgtap with schema extensions;
+set local search_path = public, extensions;
+
+select plan(58);
 
 create function pg_temp.capture_error(statement text)
 returns text
@@ -23,6 +26,16 @@ security definer
 set search_path = public
 as $$
   select public.can_manage_operator_payout_machine(actor_user_id, machine_id);
+$$;
+
+create function pg_temp.is_corporate_partner_for(actor_user_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select public.is_active_corporate_partner_user(actor_user_id);
 $$;
 
 insert into auth.users (
@@ -49,21 +62,36 @@ values
 insert into public.customer_accounts (id, name, account_type)
 values ('20000000-0000-0000-0000-000000000001', 'Timekeeping persona test account', 'customer');
 
-insert into public.customer_account_memberships (
+insert into public.reporting_partners (
   id,
-  account_id,
-  user_id,
-  email,
-  role,
-  active
+  name,
+  partner_type,
+  status
 )
 values (
   '21000000-0000-0000-0000-000000000001',
-  '20000000-0000-0000-0000-000000000001',
+  'Timekeeping persona corporate partner',
+  'platform_partner',
+  'active'
+);
+
+insert into public.corporate_partner_memberships (
+  id,
+  partner_id,
+  user_id,
+  member_email,
+  status,
+  starts_at,
+  grant_reason
+)
+values (
+  '21100000-0000-0000-0000-000000000001',
+  '21000000-0000-0000-0000-000000000001',
   '10000000-0000-0000-0000-000000000006',
   'time-partner-no-grant@example.test',
-  'partner',
-  true
+  'active',
+  now() - interval '1 day',
+  'Timekeeping persona test fixture'
 );
 
 insert into public.plus_access_grants (
@@ -110,13 +138,21 @@ insert into public.reporting_machine_refund_managers (
   manager_email,
   grant_reason
 )
-values (
-  '41000000-0000-0000-0000-000000000001',
-  '40000000-0000-0000-0000-000000000001',
-  '10000000-0000-0000-0000-000000000003',
-  'time-manager-assigned@example.test',
-  'Timekeeping persona test fixture'
-);
+values
+  (
+    '41000000-0000-0000-0000-000000000001',
+    '40000000-0000-0000-0000-000000000001',
+    '10000000-0000-0000-0000-000000000003',
+    'time-manager-assigned@example.test',
+    'Timekeeping persona test fixture'
+  ),
+  (
+    '41000000-0000-0000-0000-000000000002',
+    '40000000-0000-0000-0000-000000000002',
+    '10000000-0000-0000-0000-000000000004',
+    'time-manager-unassigned@example.test',
+    'Other-machine manager test fixture'
+  );
 
 insert into public.payout_policies (
   id,
@@ -291,6 +327,28 @@ select ok(
   'authenticated callers cannot delete time entries directly'
 );
 
+set local role anon;
+select like(
+  pg_temp.capture_error($$
+    select public.get_my_time_review_context(current_date)
+  $$),
+  '%permission denied for function get_my_time_review_context%',
+  'an anonymous actor is behaviorally denied the review queue RPC'
+);
+select like(
+  pg_temp.capture_error($$
+    select public.review_operator_time_entry(
+      '80000000-0000-0000-0000-000000000001',
+      'approved',
+      null,
+      current_date
+    )
+  $$),
+  '%permission denied for function review_operator_time_entry%',
+  'an anonymous actor is behaviorally denied the review action RPC'
+);
+reset role;
+
 set local role authenticated;
 select set_config(
   'request.jwt.claim.sub',
@@ -312,9 +370,9 @@ select is(
   'a worker has no implicit manager authority over another machine'
 );
 select is(
-  (select count(*)::integer from public.time_entries),
-  1,
-  'a worker sees only their own time entry through RLS'
+  (select string_agg(id::text, ',' order by id) from public.time_entries),
+  '80000000-0000-0000-0000-000000000001',
+  'a worker sees the exact expected own entry through RLS'
 );
 select is(
   pg_temp.capture_error($$
@@ -343,6 +401,31 @@ select is(
   'Operator timekeeping access required',
   'another worker cannot edit another worker entry'
 );
+select is(
+  pg_temp.capture_error($$
+    select public.submit_operator_time_entry(
+      '60000000-0000-0000-0000-000000000001',
+      '40000000-0000-0000-0000-000000000002',
+      current_date - 1,
+      '13:00',
+      '14:00',
+      null,
+      'submitted'
+    )
+  $$),
+  'Time entry machine is not assigned for this work date',
+  'a worker cannot submit time to an unassigned machine'
+);
+select is(
+  pg_temp.capture_error($$
+    select public.void_operator_time_entry(
+      '80000000-0000-0000-0000-000000000002',
+      'Unauthorized cross-worker delete test'
+    )
+  $$),
+  'Operator timekeeping access required',
+  'another worker cannot void another worker entry'
+);
 
 select set_config(
   'request.jwt.claim.sub',
@@ -353,7 +436,7 @@ select set_config(
 select is(
   auth.uid(),
   '10000000-0000-0000-0000-000000000004'::uuid,
-  'the unassigned-manager JWT fixture resolves to the intended actor'
+  'the other-machine manager JWT fixture resolves to the intended actor'
 );
 select is(
   pg_temp.can_manage_for(
@@ -361,17 +444,35 @@ select is(
     '40000000-0000-0000-0000-000000000001'
   ),
   false,
-  'an unassigned Machine Manager has no machine authority'
+  'a Machine Manager assigned elsewhere has no authority over the target machine'
+);
+select is(
+  pg_temp.can_manage_for(
+    auth.uid(),
+    '40000000-0000-0000-0000-000000000002'
+  ),
+  true,
+  'the other-machine persona is an active Machine Manager'
 );
 select is(
   public.get_my_time_review_context(current_date - 1)->>'hasAccess',
-  'false',
-  'an unassigned Machine Manager has no review access'
+  'true',
+  'the other-machine manager can reach only their own review scope'
 );
 select is(
-  jsonb_array_length(public.get_my_time_review_context(current_date - 1)->'entries'),
-  0,
-  'an unassigned Machine Manager receives no entries'
+  public.get_my_time_review_context(current_date - 1)->'machines'->0->>'machineId',
+  '40000000-0000-0000-0000-000000000002',
+  'the other-machine manager receives the exact assigned machine'
+);
+select is(
+  public.get_my_time_review_context(current_date - 1)->'entries'->0->>'id',
+  '80000000-0000-0000-0000-000000000002',
+  'the other-machine manager receives only their assigned-machine entry'
+);
+select is(
+  (select string_agg(id::text, ',' order by id) from public.time_entries),
+  '80000000-0000-0000-0000-000000000002',
+  'the other-machine manager RLS read exposes only their assigned-machine entry'
 );
 select is(
   pg_temp.capture_error($$
@@ -383,7 +484,7 @@ select is(
     )
   $$),
   'Machine manager access required',
-  'an unassigned Machine Manager cannot review a shift'
+  'a Machine Manager assigned elsewhere cannot review the target shift'
 );
 
 select set_config(
@@ -419,6 +520,18 @@ select is(
   0,
   'Plus access without a machine grant exposes no time entries'
 );
+select is(
+  pg_temp.capture_error($$
+    select public.review_operator_time_entry(
+      '80000000-0000-0000-0000-000000000001',
+      'approved',
+      null,
+      current_date - 1
+    )
+  $$),
+  'Machine manager access required',
+  'Plus access without a machine grant cannot mutate a review'
+);
 
 select set_config(
   'request.jwt.claim.sub',
@@ -429,7 +542,11 @@ select set_config(
 select is(
   auth.uid(),
   '10000000-0000-0000-0000-000000000006'::uuid,
-  'the partner JWT fixture resolves to the intended actor'
+  'the Corporate Partner JWT fixture resolves to the intended actor'
+);
+select ok(
+  pg_temp.is_corporate_partner_for(auth.uid()),
+  'the Corporate Partner fixture uses an active canonical membership'
 );
 select is(
   pg_temp.can_manage_for(
@@ -447,7 +564,19 @@ select is(
 select is(
   (select count(*)::integer from public.time_entries),
   0,
-  'a partner membership without a machine grant exposes no time entries'
+  'a Corporate Partner membership without a machine grant exposes no time entries'
+);
+select is(
+  pg_temp.capture_error($$
+    select public.review_operator_time_entry(
+      '80000000-0000-0000-0000-000000000001',
+      'approved',
+      null,
+      current_date - 1
+    )
+  $$),
+  'Machine manager access required',
+  'a Corporate Partner without a machine grant cannot mutate a review'
 );
 
 select set_config(
@@ -483,14 +612,19 @@ select is(
   'an assigned Machine Manager has review access'
 );
 select is(
-  jsonb_array_length(public.get_my_time_review_context(current_date - 1)->'machines'),
-  1,
-  'an assigned Machine Manager receives only their managed machine'
+  public.get_my_time_review_context(current_date - 1)->'machines'->0->>'machineId',
+  '40000000-0000-0000-0000-000000000001',
+  'an assigned Machine Manager receives the exact managed machine'
 );
 select is(
-  jsonb_array_length(public.get_my_time_review_context(current_date - 1)->'entries'),
-  1,
-  'an assigned Machine Manager receives only entries on their managed machine'
+  public.get_my_time_review_context(current_date - 1)->'entries'->0->>'id',
+  '80000000-0000-0000-0000-000000000001',
+  'an assigned Machine Manager receives the exact in-scope entry'
+);
+select is(
+  (select string_agg(id::text, ',' order by id) from public.time_entries),
+  '80000000-0000-0000-0000-000000000001',
+  'the assigned Machine Manager RLS read exposes only the in-scope entry'
 );
 select is(
   pg_temp.capture_error($$
@@ -525,6 +659,27 @@ select is(
   'approved',
   'the approved review state is persisted'
 );
+select is(
+  (
+    select manager_reviewed_by
+    from public.time_entries
+    where id = '80000000-0000-0000-0000-000000000001'
+  ),
+  '10000000-0000-0000-0000-000000000003'::uuid,
+  'the approved review records the assigned manager actor'
+);
+select ok(
+  not has_table_privilege('authenticated', 'public.time_entry_review_events', 'insert'),
+  'authenticated callers cannot insert review events directly'
+);
+select ok(
+  not has_table_privilege('authenticated', 'public.time_entry_review_events', 'update'),
+  'authenticated callers cannot update review events'
+);
+select ok(
+  not has_table_privilege('authenticated', 'public.time_entry_review_events', 'delete'),
+  'authenticated callers cannot delete review events'
+);
 
 reset role;
 
@@ -537,6 +692,35 @@ select is(
   ),
   1,
   'the review action records an immutable review event'
+);
+select is(
+  (
+    select concat(decision, ':', reviewed_by::text)
+    from public.time_entry_review_events
+    where time_entry_id = '80000000-0000-0000-0000-000000000001'
+      and decision = 'approved'
+  ),
+  'approved:10000000-0000-0000-0000-000000000003',
+  'the approval event records the exact decision and manager actor'
+);
+select is(
+  (
+    select concat(
+      action,
+      ':',
+      actor_user_id::text,
+      ':',
+      meta->>'machine_manager_review',
+      ':',
+      meta->>'payment_behavior_changed'
+    )
+    from public.admin_audit_log
+    where entity_type = 'time_entry'
+      and entity_id = '80000000-0000-0000-0000-000000000001'
+      and action = 'operator_time_entry.manager_approved'
+  ),
+  'operator_time_entry.manager_approved:10000000-0000-0000-0000-000000000003:true:false',
+  'the approval audit log records actor, manager scope, and unchanged payment behavior'
 );
 
 set local role authenticated;
@@ -557,6 +741,69 @@ select is(
   $$),
   'A correction reason is required',
   'requesting correction requires a reason'
+);
+select is(
+  pg_temp.capture_error($$
+    select public.review_operator_time_entry(
+      '80000000-0000-0000-0000-000000000001',
+      'needs_correction',
+      'Correct the shift end time',
+      current_date - 1
+    )
+  $$),
+  null,
+  'an assigned Machine Manager can request a correction with a reason'
+);
+select is(
+  (
+    select concat(manager_review_status, ':', manager_review_reason)
+    from public.time_entries
+    where id = '80000000-0000-0000-0000-000000000001'
+  ),
+  'needs_correction:Correct the shift end time',
+  'the correction state and reason are persisted'
+);
+
+reset role;
+
+select is(
+  (
+    select count(*)::integer
+    from public.time_entry_review_events
+    where time_entry_id = '80000000-0000-0000-0000-000000000001'
+  ),
+  2,
+  'approval and correction each create an immutable review event'
+);
+select is(
+  (
+    select concat(decision, ':', reason, ':', reviewed_by::text)
+    from public.time_entry_review_events
+    where time_entry_id = '80000000-0000-0000-0000-000000000001'
+      and decision = 'needs_correction'
+  ),
+  'needs_correction:Correct the shift end time:10000000-0000-0000-0000-000000000003',
+  'the correction event records the reason and manager actor'
+);
+select is(
+  (
+    select concat(
+      count(*)::text,
+      ':',
+      bool_and((meta->>'payment_behavior_changed')::boolean = false)::text,
+      ':',
+      count(distinct actor_user_id)::text
+    )
+    from public.admin_audit_log
+    where entity_type = 'time_entry'
+      and entity_id = '80000000-0000-0000-0000-000000000001'
+      and action in (
+        'operator_time_entry.manager_approved',
+        'operator_time_entry.correction_requested'
+      )
+  ),
+  '2:true:1',
+  'both manager decisions are audited without changing payment behavior'
 );
 
 select * from finish();

--- a/supabase/tests/timekeeping_persona_access.sql
+++ b/supabase/tests/timekeeping_persona_access.sql
@@ -328,11 +328,10 @@ select ok(
 );
 
 set local role anon;
-select ok(
-  pg_temp.capture_error($$
-    select * from public.time_entries
-  $$) like '%permission denied for table time_entries%',
-  'an anonymous actor is behaviorally denied direct time-entry reads'
+select is(
+  (select count(*)::integer from public.time_entries),
+  0,
+  'an anonymous actor receives no time entries through direct-table RLS'
 );
 select ok(
   pg_temp.capture_error($$

--- a/supabase/tests/timekeeping_persona_access.sql
+++ b/supabase/tests/timekeeping_persona_access.sql
@@ -1,0 +1,455 @@
+begin;
+
+select plan(25);
+
+insert into auth.users (
+  instance_id,
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at
+)
+values
+  ('00000000-0000-0000-0000-000000000000', '10000000-0000-0000-0000-000000000001', 'authenticated', 'authenticated', 'time-worker-one@example.test', '', now(), '{}'::jsonb, '{}'::jsonb, now(), now()),
+  ('00000000-0000-0000-0000-000000000000', '10000000-0000-0000-0000-000000000002', 'authenticated', 'authenticated', 'time-worker-two@example.test', '', now(), '{}'::jsonb, '{}'::jsonb, now(), now()),
+  ('00000000-0000-0000-0000-000000000000', '10000000-0000-0000-0000-000000000003', 'authenticated', 'authenticated', 'time-manager-assigned@example.test', '', now(), '{}'::jsonb, '{}'::jsonb, now(), now()),
+  ('00000000-0000-0000-0000-000000000000', '10000000-0000-0000-0000-000000000004', 'authenticated', 'authenticated', 'time-manager-unassigned@example.test', '', now(), '{}'::jsonb, '{}'::jsonb, now(), now()),
+  ('00000000-0000-0000-0000-000000000000', '10000000-0000-0000-0000-000000000005', 'authenticated', 'authenticated', 'time-plus-no-grant@example.test', '', now(), '{}'::jsonb, '{}'::jsonb, now(), now()),
+  ('00000000-0000-0000-0000-000000000000', '10000000-0000-0000-0000-000000000006', 'authenticated', 'authenticated', 'time-partner-no-grant@example.test', '', now(), '{}'::jsonb, '{}'::jsonb, now(), now());
+
+insert into public.customer_accounts (id, name, account_type)
+values ('20000000-0000-0000-0000-000000000001', 'Timekeeping persona test account', 'customer');
+
+insert into public.customer_account_memberships (
+  id,
+  account_id,
+  user_id,
+  email,
+  role,
+  active
+)
+values (
+  '21000000-0000-0000-0000-000000000001',
+  '20000000-0000-0000-0000-000000000001',
+  '10000000-0000-0000-0000-000000000006',
+  'time-partner-no-grant@example.test',
+  'partner',
+  true
+);
+
+insert into public.plus_access_grants (
+  id,
+  user_id,
+  starts_at,
+  expires_at,
+  grant_reason
+)
+values (
+  '22000000-0000-0000-0000-000000000001',
+  '10000000-0000-0000-0000-000000000005',
+  now() - interval '1 day',
+  now() + interval '30 days',
+  'Timekeeping persona test fixture'
+);
+
+insert into public.reporting_locations (id, account_id, name)
+values (
+  '30000000-0000-0000-0000-000000000001',
+  '20000000-0000-0000-0000-000000000001',
+  'Timekeeping test location'
+);
+
+insert into public.reporting_machines (id, account_id, location_id, machine_label)
+values
+  (
+    '40000000-0000-0000-0000-000000000001',
+    '20000000-0000-0000-0000-000000000001',
+    '30000000-0000-0000-0000-000000000001',
+    'Machine A'
+  ),
+  (
+    '40000000-0000-0000-0000-000000000002',
+    '20000000-0000-0000-0000-000000000001',
+    '30000000-0000-0000-0000-000000000001',
+    'Machine B'
+  );
+
+insert into public.reporting_machine_refund_managers (
+  id,
+  reporting_machine_id,
+  manager_user_id,
+  manager_email,
+  grant_reason
+)
+values (
+  '41000000-0000-0000-0000-000000000001',
+  '40000000-0000-0000-0000-000000000001',
+  '10000000-0000-0000-0000-000000000003',
+  'time-manager-assigned@example.test',
+  'Timekeeping persona test fixture'
+);
+
+insert into public.payout_policies (
+  id,
+  account_id,
+  name,
+  frequency,
+  period_anchor_type,
+  monthly_period_type,
+  rounding_rule
+)
+values (
+  '50000000-0000-0000-0000-000000000001',
+  '20000000-0000-0000-0000-000000000001',
+  'Timekeeping persona monthly policy',
+  'monthly',
+  'calendar',
+  'calendar_month',
+  'round_up_60_minutes'
+);
+
+update public.customer_accounts
+set default_payout_policy_id = '50000000-0000-0000-0000-000000000001'
+where id = '20000000-0000-0000-0000-000000000001';
+
+insert into public.operator_payout_profiles (
+  id,
+  account_id,
+  user_id,
+  display_name,
+  payout_policy_id
+)
+values
+  (
+    '60000000-0000-0000-0000-000000000001',
+    '20000000-0000-0000-0000-000000000001',
+    '10000000-0000-0000-0000-000000000001',
+    'Time Worker One',
+    '50000000-0000-0000-0000-000000000001'
+  ),
+  (
+    '60000000-0000-0000-0000-000000000002',
+    '20000000-0000-0000-0000-000000000001',
+    '10000000-0000-0000-0000-000000000002',
+    'Time Worker Two',
+    '50000000-0000-0000-0000-000000000001'
+  );
+
+insert into public.operator_machine_assignments (
+  id,
+  operator_profile_id,
+  account_id,
+  reporting_machine_id,
+  effective_start_date,
+  grant_reason
+)
+values
+  (
+    '61000000-0000-0000-0000-000000000001',
+    '60000000-0000-0000-0000-000000000001',
+    '20000000-0000-0000-0000-000000000001',
+    '40000000-0000-0000-0000-000000000001',
+    current_date - 30,
+    'Timekeeping persona test fixture'
+  ),
+  (
+    '61000000-0000-0000-0000-000000000002',
+    '60000000-0000-0000-0000-000000000002',
+    '20000000-0000-0000-0000-000000000001',
+    '40000000-0000-0000-0000-000000000002',
+    current_date - 30,
+    'Timekeeping persona test fixture'
+  );
+
+insert into public.payout_periods (
+  id,
+  account_id,
+  payout_policy_id,
+  period_start_date,
+  period_end_date,
+  submission_due_date,
+  lock_date,
+  target_payout_date
+)
+values (
+  '70000000-0000-0000-0000-000000000001',
+  '20000000-0000-0000-0000-000000000001',
+  '50000000-0000-0000-0000-000000000001',
+  date_trunc('month', current_date)::date,
+  (date_trunc('month', current_date) + interval '1 month - 1 day')::date,
+  (date_trunc('month', current_date) + interval '1 month + 1 day')::date,
+  (date_trunc('month', current_date) + interval '1 month + 2 days')::date,
+  (date_trunc('month', current_date) + interval '1 month + 4 days')::date
+);
+
+insert into public.time_entries (
+  id,
+  account_id,
+  operator_profile_id,
+  reporting_machine_id,
+  reporting_location_id,
+  payout_policy_id,
+  payout_period_id,
+  work_date,
+  start_time,
+  end_time,
+  raw_duration_minutes,
+  rounded_paid_minutes,
+  status
+)
+values
+  (
+    '80000000-0000-0000-0000-000000000001',
+    '20000000-0000-0000-0000-000000000001',
+    '60000000-0000-0000-0000-000000000001',
+    '40000000-0000-0000-0000-000000000001',
+    '30000000-0000-0000-0000-000000000001',
+    '50000000-0000-0000-0000-000000000001',
+    '70000000-0000-0000-0000-000000000001',
+    current_date - 1,
+    '09:00',
+    '10:30',
+    90,
+    120,
+    'submitted'
+  ),
+  (
+    '80000000-0000-0000-0000-000000000002',
+    '20000000-0000-0000-0000-000000000001',
+    '60000000-0000-0000-0000-000000000002',
+    '40000000-0000-0000-0000-000000000002',
+    '30000000-0000-0000-0000-000000000001',
+    '50000000-0000-0000-0000-000000000001',
+    '70000000-0000-0000-0000-000000000001',
+    current_date - 1,
+    '11:00',
+    '12:00',
+    60,
+    60,
+    'submitted'
+  );
+
+select ok(
+  not has_function_privilege('anon', 'public.get_my_time_review_context(date)', 'execute'),
+  'unauthenticated callers cannot execute the review queue RPC'
+);
+select ok(
+  not has_function_privilege(
+    'anon',
+    'public.review_operator_time_entry(uuid,text,text,date)',
+    'execute'
+  ),
+  'unauthenticated callers cannot execute the review action RPC'
+);
+select ok(
+  has_function_privilege(
+    'authenticated',
+    'public.get_my_time_review_context(date)',
+    'execute'
+  ),
+  'authenticated callers can reach the review queue RPC'
+);
+select ok(
+  not has_table_privilege('authenticated', 'public.time_entries', 'insert'),
+  'authenticated callers cannot insert time entries directly'
+);
+select ok(
+  not has_table_privilege('authenticated', 'public.time_entries', 'update'),
+  'authenticated callers cannot update time entries directly'
+);
+select ok(
+  not has_table_privilege('authenticated', 'public.time_entries', 'delete'),
+  'authenticated callers cannot delete time entries directly'
+);
+
+set local role authenticated;
+select set_config(
+  'request.jwt.claim.sub',
+  '10000000-0000-0000-0000-000000000001',
+  true
+);
+
+select is(
+  (select count(*)::integer from public.time_entries),
+  1,
+  'a worker sees only their own time entry through RLS'
+);
+select throws_matching(
+  $$
+    select public.review_operator_time_entry(
+      '80000000-0000-0000-0000-000000000002',
+      'approved',
+      null,
+      current_date - 1
+    )
+  $$,
+  'Machine manager access required',
+  'another worker cannot review another worker entry'
+);
+select throws_matching(
+  $$
+    select public.update_operator_time_entry(
+      '80000000-0000-0000-0000-000000000002',
+      '40000000-0000-0000-0000-000000000002',
+      current_date - 1,
+      '11:00',
+      '12:30',
+      null,
+      'submitted'
+    )
+  $$,
+  'Operator timekeeping access required',
+  'another worker cannot edit another worker entry'
+);
+
+select set_config(
+  'request.jwt.claim.sub',
+  '10000000-0000-0000-0000-000000000004',
+  true
+);
+
+select is(
+  public.get_my_time_review_context(current_date - 1)->>'hasAccess',
+  'false',
+  'an unassigned Machine Manager has no review access'
+);
+select is(
+  jsonb_array_length(public.get_my_time_review_context(current_date - 1)->'entries'),
+  0,
+  'an unassigned Machine Manager receives no entries'
+);
+select throws_matching(
+  $$
+    select public.review_operator_time_entry(
+      '80000000-0000-0000-0000-000000000001',
+      'approved',
+      null,
+      current_date - 1
+    )
+  $$,
+  'Machine manager access required',
+  'an unassigned Machine Manager cannot review a shift'
+);
+
+select set_config(
+  'request.jwt.claim.sub',
+  '10000000-0000-0000-0000-000000000005',
+  true
+);
+
+select ok(
+  (select has_plus_access from public.get_my_plus_access()),
+  'the Plus test persona has active Plus access'
+);
+select is(
+  public.get_my_time_review_context(current_date - 1)->>'hasAccess',
+  'false',
+  'Plus access without a machine grant does not grant review access'
+);
+select is(
+  (select count(*)::integer from public.time_entries),
+  0,
+  'Plus access without a machine grant exposes no time entries'
+);
+
+select set_config(
+  'request.jwt.claim.sub',
+  '10000000-0000-0000-0000-000000000006',
+  true
+);
+
+select is(
+  public.get_my_time_review_context(current_date - 1)->>'hasAccess',
+  'false',
+  'a partner membership without a machine grant does not grant review access'
+);
+select is(
+  (select count(*)::integer from public.time_entries),
+  0,
+  'a partner membership without a machine grant exposes no time entries'
+);
+
+select set_config(
+  'request.jwt.claim.sub',
+  '10000000-0000-0000-0000-000000000003',
+  true
+);
+
+select is(
+  public.get_my_time_review_context(current_date - 1)->>'hasAccess',
+  'true',
+  'an assigned Machine Manager has review access'
+);
+select is(
+  jsonb_array_length(public.get_my_time_review_context(current_date - 1)->'machines'),
+  1,
+  'an assigned Machine Manager receives only their managed machine'
+);
+select is(
+  jsonb_array_length(public.get_my_time_review_context(current_date - 1)->'entries'),
+  1,
+  'an assigned Machine Manager receives only entries on their managed machine'
+);
+select throws_matching(
+  $$
+    select public.review_operator_time_entry(
+      '80000000-0000-0000-0000-000000000002',
+      'approved',
+      null,
+      current_date - 1
+    )
+  $$,
+  'Machine manager access required',
+  'an assigned Machine Manager cannot review an out-of-scope machine'
+);
+select lives_ok(
+  $$
+    select public.review_operator_time_entry(
+      '80000000-0000-0000-0000-000000000001',
+      'approved',
+      null,
+      current_date - 1
+    )
+  $$,
+  'an assigned Machine Manager can approve an in-scope shift'
+);
+select is(
+  (
+    select manager_review_status
+    from public.time_entries
+    where id = '80000000-0000-0000-0000-000000000001'
+  ),
+  'approved',
+  'the approved review state is persisted'
+);
+select is(
+  (
+    select count(*)::integer
+    from public.time_entry_review_events
+    where time_entry_id = '80000000-0000-0000-0000-000000000001'
+      and decision = 'approved'
+  ),
+  1,
+  'the review action records an immutable review event'
+);
+select throws_matching(
+  $$
+    select public.review_operator_time_entry(
+      '80000000-0000-0000-0000-000000000001',
+      'needs_correction',
+      null,
+      current_date - 1
+    )
+  $$,
+  'A correction reason is required',
+  'requesting correction requires a reason'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/timekeeping_persona_access.sql
+++ b/supabase/tests/timekeeping_persona_access.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = public, extensions;
 
-select plan(58);
+select plan(73);
 
 create function pg_temp.capture_error(statement text)
 returns text
@@ -330,6 +330,55 @@ select ok(
 set local role anon;
 select ok(
   pg_temp.capture_error($$
+    select * from public.time_entries
+  $$) like '%permission denied for table time_entries%',
+  'an anonymous actor is behaviorally denied direct time-entry reads'
+);
+select ok(
+  pg_temp.capture_error($$
+    select public.get_my_operator_timekeeping_context(current_date)
+  $$) like '%permission denied for function get_my_operator_timekeeping_context%',
+  'an anonymous actor is behaviorally denied the worker context RPC'
+);
+select ok(
+  pg_temp.capture_error($$
+    select public.submit_operator_time_entry(
+      '60000000-0000-0000-0000-000000000001',
+      '40000000-0000-0000-0000-000000000001',
+      current_date - 1,
+      '08:00',
+      '09:00',
+      null,
+      'submitted'
+    )
+  $$) like '%permission denied for function submit_operator_time_entry%',
+  'an anonymous actor is behaviorally denied worker submission'
+);
+select ok(
+  pg_temp.capture_error($$
+    select public.update_operator_time_entry(
+      '80000000-0000-0000-0000-000000000001',
+      '40000000-0000-0000-0000-000000000001',
+      current_date - 1,
+      '08:00',
+      '09:00',
+      null,
+      'submitted'
+    )
+  $$) like '%permission denied for function update_operator_time_entry%',
+  'an anonymous actor is behaviorally denied worker updates'
+);
+select ok(
+  pg_temp.capture_error($$
+    select public.void_operator_time_entry(
+      '80000000-0000-0000-0000-000000000001',
+      'Anonymous delete attempt'
+    )
+  $$) like '%permission denied for function void_operator_time_entry%',
+  'an anonymous actor is behaviorally denied worker voids'
+);
+select ok(
+  pg_temp.capture_error($$
     select public.get_my_time_review_context(current_date)
   $$) like '%permission denied for function get_my_time_review_context%',
   'an anonymous actor is behaviorally denied the review queue RPC'
@@ -416,6 +465,21 @@ select is(
 );
 select is(
   pg_temp.capture_error($$
+    select public.submit_operator_time_entry(
+      '60000000-0000-0000-0000-000000000002',
+      '40000000-0000-0000-0000-000000000002',
+      current_date - 1,
+      '13:00',
+      '14:00',
+      null,
+      'submitted'
+    )
+  $$),
+  'Operator payout profile not found',
+  'a worker cannot submit time against another worker profile'
+);
+select is(
+  pg_temp.capture_error($$
     select public.void_operator_time_entry(
       '80000000-0000-0000-0000-000000000002',
       'Unauthorized cross-worker delete test'
@@ -463,9 +527,19 @@ select is(
   'the other-machine manager receives the exact assigned machine'
 );
 select is(
+  jsonb_array_length(public.get_my_time_review_context(current_date - 1)->'machines'),
+  1,
+  'the other-machine manager queue contains no extra machines'
+);
+select is(
   public.get_my_time_review_context(current_date - 1)->'entries'->0->>'id',
   '80000000-0000-0000-0000-000000000002',
   'the other-machine manager receives only their assigned-machine entry'
+);
+select is(
+  jsonb_array_length(public.get_my_time_review_context(current_date - 1)->'entries'),
+  1,
+  'the other-machine manager queue contains no extra entries'
 );
 select is(
   (select string_agg(id::text, ',' order by id) from public.time_entries),
@@ -514,6 +588,16 @@ select is(
   'Plus access without a machine grant does not grant review access'
 );
 select is(
+  jsonb_array_length(public.get_my_time_review_context(current_date - 1)->'machines'),
+  0,
+  'Plus access without a machine grant receives no review machines'
+);
+select is(
+  jsonb_array_length(public.get_my_time_review_context(current_date - 1)->'entries'),
+  0,
+  'Plus access without a machine grant receives no review entries'
+);
+select is(
   (select count(*)::integer from public.time_entries),
   0,
   'Plus access without a machine grant exposes no time entries'
@@ -558,6 +642,16 @@ select is(
   public.get_my_time_review_context(current_date - 1)->>'hasAccess',
   'false',
   'a partner membership without a machine grant does not grant review access'
+);
+select is(
+  jsonb_array_length(public.get_my_time_review_context(current_date - 1)->'machines'),
+  0,
+  'a Corporate Partner without a machine grant receives no review machines'
+);
+select is(
+  jsonb_array_length(public.get_my_time_review_context(current_date - 1)->'entries'),
+  0,
+  'a Corporate Partner without a machine grant receives no review entries'
 );
 select is(
   (select count(*)::integer from public.time_entries),
@@ -615,9 +709,19 @@ select is(
   'an assigned Machine Manager receives the exact managed machine'
 );
 select is(
+  jsonb_array_length(public.get_my_time_review_context(current_date - 1)->'machines'),
+  1,
+  'the assigned Machine Manager queue contains no extra machines'
+);
+select is(
   public.get_my_time_review_context(current_date - 1)->'entries'->0->>'id',
   '80000000-0000-0000-0000-000000000001',
   'an assigned Machine Manager receives the exact in-scope entry'
+);
+select is(
+  jsonb_array_length(public.get_my_time_review_context(current_date - 1)->'entries'),
+  1,
+  'the assigned Machine Manager queue contains no extra entries'
 );
 select is(
   (select string_agg(id::text, ',' order by id) from public.time_entries),
@@ -782,6 +886,27 @@ select is(
   ),
   'needs_correction:Correct the shift end time:10000000-0000-0000-0000-000000000003',
   'the correction event records the reason and manager actor'
+);
+select is(
+  (
+    select concat(
+      action,
+      ':',
+      actor_user_id::text,
+      ':',
+      meta->>'reason',
+      ':',
+      meta->>'machine_manager_review',
+      ':',
+      meta->>'payment_behavior_changed'
+    )
+    from public.admin_audit_log
+    where entity_type = 'time_entry'
+      and entity_id = '80000000-0000-0000-0000-000000000001'
+      and action = 'operator_time_entry.correction_requested'
+  ),
+  'operator_time_entry.correction_requested:10000000-0000-0000-0000-000000000003:Correct the shift end time:true:false',
+  'the correction audit row records actor, reason, manager scope, and unchanged payment behavior'
 );
 select is(
   (

--- a/supabase/tests/timekeeping_persona_access.sql
+++ b/supabase/tests/timekeeping_persona_access.sql
@@ -411,7 +411,7 @@ select is(
       'submitted'
     )
   $$),
-  'Time entry machine is not assigned for this work date',
+  'Operator is not assigned to this machine for the work date',
   'a worker cannot submit time to an unassigned machine'
 );
 select is(


### PR DESCRIPTION
## Summary
- fixes the shared Timekeeping V1 machine-manager authority predicate so ungranted actors return `false`, never SQL `NULL`
- adds executable pgTAP coverage for the worker and Machine Manager permission matrix
- proves anonymous, other-worker, unassigned-manager, Plus-without-grant, partner-without-grant, and out-of-scope access fail closed
- runs database persona tests in the existing disposable Supabase migration validation workflow

Part of #587. This PR does not deploy migrations or change payment behavior.

The first behavioral CI run exposed the fail-open `NULL` path: unauthorized review calls succeeded and created extra review events. Migration `202607170001` closes that path, and the 73-assertion persona matrix is the release gate.

## Files changed
- `supabase/migrations/202607170001_timekeeping_manager_authority_fail_closed.sql`: fail-closed machine authority predicate
- `supabase/tests/timekeeping_persona_access.sql`: deterministic persona fixtures and 73 RLS/RPC assertions
- `scripts/validate-supabase-migrations.mjs`: copies and executes database tests after applying migrations
- `scripts/validate-operator-timekeeping.mjs`: static guard for the authority hardening migration
- `.github/workflows/supabase-migrations.yml`: triggers when database tests change

## Verification
- `npm ci` ? passed (existing audit report: 3 moderate, 1 high)
- `npm run build` ? passed after syncing current `main` (2,551 modules; 25 public routes prerendered)
- `npm test --if-present` ? passed
- `npm run lint --if-present` ? passed
- `npm run operator-payouts:validate-timekeeping` ? passed
- `npm run portal:validate-contrast` ? passed
- `node scripts/check-supabase-migration-versions.mjs` ? passed (106 unique migrations)
- GitHub Actions `Supabase Migrations / validate` - passed: all migrations applied; `Files=1, Tests=73`; `Result: PASS` (local Docker unavailable)

## How to test
1. Check out `agent/timekeeping-persona-tests`.
2. Run `npm ci`.
3. Start Docker Desktop.
4. Run `npm run db:validate-migrations`.
5. Confirm all 106 migrations apply and `supabase/tests/timekeeping_persona_access.sql` reports 73 passing assertions.
6. Start `npm run dev` and inspect `/portal/time` and `/portal/time-review`; this PR intentionally changes no visible UI.

## Risk and overlap
- The migration only makes an existing authorization helper explicitly fail closed; it adds no persona, grant source, payout calculation, or payment behavior.
- The test fixtures roll back and run only in the disposable local Supabase project.
- No production deployment is performed by this PR.
- The timekeeping static validator may overlap the concurrent UI-state branch; that branch will sync from `main` and preserve both assertions before final verification.



