### PR TITLE
Fix authenticated app interaction contrast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist
 dist-ssr
 sunze-sync-diagnostic.json
 output/
+.playwright-cli/
 
 # Env
 .env

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -142,6 +142,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 
 ## Auth / portal
 - [ ] Login flow works (magic link or configured method)
+- [ ] Login, authenticated portal, and Admin Console primary buttons, selected controls, links, and focus rings use the app-scoped interaction palette; normal text meets WCAG AA 4.5:1 contrast, focus indicators meet 3:1, and public-site colors remain unchanged
 - [ ] Canonical operator login lives at `https://app.bloomjoyusa.com/login`
 - [ ] Temporary alias `https://app.bloomjoyusa.com/login/operator` resolves to `/login`
 - [ ] On mobile `/login`, the sign-in form appears before the operator-feature highlights, the top app header stays compact without an extra context row pushing content below the fold, and visible auth/header/menu controls have touch-friendly hit areas

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "agent:merge-gate": "node scripts/agent-merge-gate.mjs",
     "agent:validate-workflow": "node scripts/validate-agent-workflow.mjs",
     "auth:validate-admin-boundaries": "node scripts/validate-admin-permission-boundaries.mjs",
+    "portal:validate-contrast": "node scripts/validate-app-color-contrast.mjs",
     "portal-nav:validate": "node scripts/validate-authenticated-navigation.mjs",
     "portal-nav:uat": "node scripts/validate-authenticated-portal-uat.mjs",
     "commerce:preflight": "node scripts/commerce-preflight.mjs",

--- a/scripts/validate-app-color-contrast.mjs
+++ b/scripts/validate-app-color-contrast.mjs
@@ -1,0 +1,240 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const cssPath = path.join(repoRoot, 'src', 'index.css');
+const css = fs.readFileSync(cssPath, 'utf8');
+const trainingPath = path.join(repoRoot, 'src', 'pages', 'portal', 'Training.tsx');
+const partnershipsPath = path.join(repoRoot, 'src', 'pages', 'admin', 'Partnerships.tsx');
+const training = fs.readFileSync(trainingPath, 'utf8');
+const partnerships = fs.readFileSync(partnershipsPath, 'utf8');
+
+const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+const selectorBlock = (selector) => {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = css.match(new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\n\\s*\\}`));
+  assert(match, `Missing ${selector} token block in ${path.relative(repoRoot, cssPath)}.`);
+  return match[1];
+};
+
+const tokenValue = (block, token) => {
+  const match = block.match(new RegExp(`--${token}:\\s*([^;]+);`));
+  assert(match, `Missing --${token} in the app token block.`);
+  return match[1].trim();
+};
+
+const parseHsl = (value, label) => {
+  const parts = value.split(/\s+/).map((part) => Number(part.replace('%', '')));
+  assert(
+    parts.length === 3 && parts.every(Number.isFinite),
+    `${label} must be a three-part HSL token, received "${value}".`,
+  );
+  return parts;
+};
+
+const hslToRgb = ([hue, saturationPercent, lightnessPercent]) => {
+  const saturation = saturationPercent / 100;
+  const lightness = lightnessPercent / 100;
+  const chroma = (1 - Math.abs(2 * lightness - 1)) * saturation;
+  const huePrime = ((hue % 360) + 360) % 360 / 60;
+  const secondary = chroma * (1 - Math.abs((huePrime % 2) - 1));
+  const match = lightness - chroma / 2;
+
+  let channels;
+  if (huePrime < 1) channels = [chroma, secondary, 0];
+  else if (huePrime < 2) channels = [secondary, chroma, 0];
+  else if (huePrime < 3) channels = [0, chroma, secondary];
+  else if (huePrime < 4) channels = [0, secondary, chroma];
+  else if (huePrime < 5) channels = [secondary, 0, chroma];
+  else channels = [chroma, 0, secondary];
+
+  return channels.map((channel) => channel + match);
+};
+
+const relativeLuminance = (rgb) =>
+  rgb
+    .map((channel) =>
+      channel <= 0.04045
+        ? channel / 12.92
+        : ((channel + 0.055) / 1.055) ** 2.4,
+    )
+    .reduce(
+      (sum, channel, index) => sum + channel * [0.2126, 0.7152, 0.0722][index],
+      0,
+    );
+
+const contrastRatio = (first, second) => {
+  const firstLuminance = relativeLuminance(first);
+  const secondLuminance = relativeLuminance(second);
+  return (
+    (Math.max(firstLuminance, secondLuminance) + 0.05) /
+    (Math.min(firstLuminance, secondLuminance) + 0.05)
+  );
+};
+
+const composite = (foreground, background, alpha) =>
+  foreground.map((channel, index) => channel * alpha + background[index] * (1 - alpha));
+
+const rootBlock = selectorBlock(':root');
+const appBlock = selectorBlock('.app-surface');
+const darkBlock = selectorBlock('.dark');
+const darkAppMatch = css.match(
+  /\.dark\.app-surface,\s*\.dark \.app-surface\s*\{([\s\S]*?)\n\s*\}/,
+);
+assert(darkAppMatch, 'Missing dark app token block.');
+const darkAppBlock = darkAppMatch[1];
+const background = hslToRgb(parseHsl(tokenValue(rootBlock, 'background'), '--background'));
+const card = hslToRgb(parseHsl(tokenValue(rootBlock, 'card'), '--card'));
+const primary = hslToRgb(parseHsl(tokenValue(appBlock, 'primary'), '--primary'));
+const primaryForeground = hslToRgb(
+  parseHsl(tokenValue(appBlock, 'primary-foreground'), '--primary-foreground'),
+);
+const ring = hslToRgb(parseHsl(tokenValue(appBlock, 'ring'), '--ring'));
+const coralDark = hslToRgb(parseHsl(tokenValue(appBlock, 'coral-dark'), '--coral-dark'));
+const primaryTint = composite(primary, background, 0.1);
+const primaryAtEightyPercent = composite(primary, background, 0.8);
+
+const darkBackground = hslToRgb(
+  parseHsl(tokenValue(darkBlock, 'background'), 'dark --background'),
+);
+const darkCard = hslToRgb(parseHsl(tokenValue(darkBlock, 'card'), 'dark --card'));
+const darkPrimary = hslToRgb(
+  parseHsl(tokenValue(darkAppBlock, 'primary'), 'dark --primary'),
+);
+const darkPrimaryForeground = hslToRgb(
+  parseHsl(tokenValue(darkAppBlock, 'primary-foreground'), 'dark --primary-foreground'),
+);
+const darkRing = hslToRgb(parseHsl(tokenValue(darkAppBlock, 'ring'), 'dark --ring'));
+const darkCoralDark = hslToRgb(
+  parseHsl(tokenValue(darkAppBlock, 'coral-dark'), 'dark --coral-dark'),
+);
+const darkPrimaryTint = composite(darkPrimary, darkBackground, 0.1);
+const darkPrimaryAtEightyPercent = composite(darkPrimary, darkBackground, 0.8);
+
+const checks = [
+  {
+    label: 'filled primary action text',
+    ratio: contrastRatio(primary, primaryForeground),
+    minimum: 4.5,
+  },
+  {
+    label: 'primary link text on app background',
+    ratio: contrastRatio(primary, background),
+    minimum: 4.5,
+  },
+  {
+    label: 'primary text on 10% primary tint',
+    ratio: contrastRatio(primary, primaryTint),
+    minimum: 4.5,
+  },
+  {
+    label: '80% primary hover text on app background',
+    ratio: contrastRatio(primaryAtEightyPercent, background),
+    minimum: 4.5,
+  },
+  {
+    label: 'text on 80% primary hover fill',
+    ratio: contrastRatio(primaryAtEightyPercent, primaryForeground),
+    minimum: 4.5,
+  },
+  {
+    label: 'focus ring on app background',
+    ratio: contrastRatio(ring, background),
+    minimum: 3,
+  },
+  {
+    label: 'focus ring on app card',
+    ratio: contrastRatio(ring, card),
+    minimum: 3,
+  },
+  {
+    label: 'selected-state border on app background',
+    ratio: contrastRatio(primary, background),
+    minimum: 3,
+  },
+  {
+    label: 'primary button hover fill',
+    ratio: contrastRatio(coralDark, primaryForeground),
+    minimum: 4.5,
+  },
+  {
+    label: 'dark filled primary action text',
+    ratio: contrastRatio(darkPrimary, darkPrimaryForeground),
+    minimum: 4.5,
+  },
+  {
+    label: 'dark primary link text on app background',
+    ratio: contrastRatio(darkPrimary, darkBackground),
+    minimum: 4.5,
+  },
+  {
+    label: 'dark primary text on 10% primary tint',
+    ratio: contrastRatio(darkPrimary, darkPrimaryTint),
+    minimum: 4.5,
+  },
+  {
+    label: 'dark 80% primary hover text on app background',
+    ratio: contrastRatio(darkPrimaryAtEightyPercent, darkBackground),
+    minimum: 4.5,
+  },
+  {
+    label: 'dark text on 80% primary hover fill',
+    ratio: contrastRatio(darkPrimaryAtEightyPercent, darkPrimaryForeground),
+    minimum: 4.5,
+  },
+  {
+    label: 'dark focus ring on app background',
+    ratio: contrastRatio(darkRing, darkBackground),
+    minimum: 3,
+  },
+  {
+    label: 'dark focus ring on app card',
+    ratio: contrastRatio(darkRing, darkCard),
+    minimum: 3,
+  },
+  {
+    label: 'dark selected-state border on app background',
+    ratio: contrastRatio(darkPrimary, darkBackground),
+    minimum: 3,
+  },
+  {
+    label: 'dark primary button hover fill',
+    ratio: contrastRatio(darkCoralDark, darkPrimaryForeground),
+    minimum: 4.5,
+  },
+];
+
+for (const check of checks) {
+  assert(
+    check.ratio >= check.minimum,
+    `${check.label} contrast ${check.ratio.toFixed(2)}:1 is below ${check.minimum}:1.`,
+  );
+  console.log(`${check.label}: ${check.ratio.toFixed(2)}:1`);
+}
+
+assert(
+  tokenValue(rootBlock, 'primary') === '345 72% 68%',
+  'Public-site --primary changed; app palette must remain route-scoped.',
+);
+assert(
+  tokenValue(rootBlock, 'primary') !== tokenValue(appBlock, 'primary'),
+  'App and public primary tokens must remain independently scoped.',
+);
+assert(
+  training.includes("? 'border-primary bg-primary/5 shadow-sm'"),
+  'Selected Training tracks need a full-strength primary border.',
+);
+assert(
+  partnerships.includes("? 'border-primary bg-primary/10'"),
+  'The active mobile partnership step needs a full-strength primary border.',
+);
+
+console.log('Authenticated app color contrast validation passed.');
+process.exit(0);

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { useLayoutEffect, type ReactNode } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import {
   ChevronDown,
@@ -106,6 +106,14 @@ export function AppLayout({ children }: AppLayoutProps) {
       })
     : [];
 
+  useLayoutEffect(() => {
+    document.body.classList.add('app-surface');
+
+    return () => {
+      document.body.classList.remove('app-surface');
+    };
+  }, []);
+
   const handleSignOut = async () => {
     await signOut();
     navigate('/login', { replace: true });
@@ -170,7 +178,7 @@ export function AppLayout({ children }: AppLayoutProps) {
 
   if (!isAuthenticated) {
     return (
-      <div className="flex min-h-screen flex-col bg-gradient-to-b from-background via-background to-muted/20">
+      <div className="app-surface flex min-h-screen flex-col bg-gradient-to-b from-background via-background to-muted/20">
         <header className="sticky top-0 z-50 border-b border-border/60 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/85">
           <div className="container-page py-2.5 sm:py-4">
             <div className="flex items-center justify-between gap-4">
@@ -261,7 +269,7 @@ export function AppLayout({ children }: AppLayoutProps) {
   }
 
   return (
-    <div className="min-h-screen bg-background text-foreground lg:grid lg:grid-cols-[17.5rem_minmax(0,1fr)]">
+    <div className="app-surface min-h-screen bg-background text-foreground lg:grid lg:grid-cols-[17.5rem_minmax(0,1fr)]">
       <aside className="hidden border-r border-border/70 bg-sidebar/80 lg:sticky lg:top-0 lg:flex lg:h-screen lg:flex-col">
         <AuthenticatedSidebar
           appTitle={t('app.operatorAppTitle')}

--- a/src/index.css
+++ b/src/index.css
@@ -81,6 +81,22 @@
     --sidebar-ring: 345 72% 68%;
   }
 
+  .app-surface {
+    /*
+     * Authenticated app interaction palette.
+     * Keep the lighter candy pink on public marketing pages while giving
+     * login, portal, admin, and portalled controls AA-safe action colors.
+     */
+    --primary: 345 56% 40%;
+    --primary-foreground: 340 30% 99%;
+    --ring: 345 56% 40%;
+    --coral-dark: 345 60% 34%;
+    --shadow-warm: 0 4px 14px -3px hsl(345 56% 40% / 0.24);
+    --sidebar-primary: 345 56% 40%;
+    --sidebar-primary-foreground: 340 30% 99%;
+    --sidebar-ring: 345 56% 40%;
+  }
+
   .dark {
     --background: 220 20% 10%;
     --foreground: 340 20% 96%;
@@ -109,6 +125,17 @@
     --border: 220 15% 20%;
     --input: 220 15% 20%;
     --ring: 345 72% 68%;
+  }
+
+  .dark.app-surface,
+  .dark .app-surface {
+    --primary: 345 68% 72%;
+    --primary-foreground: 220 20% 10%;
+    --ring: 345 68% 72%;
+    --coral-dark: 345 68% 78%;
+    --sidebar-primary: 345 68% 72%;
+    --sidebar-primary-foreground: 220 20% 10%;
+    --sidebar-ring: 345 68% 72%;
   }
 }
 

--- a/src/pages/admin/Partnerships.tsx
+++ b/src/pages/admin/Partnerships.tsx
@@ -1491,9 +1491,9 @@ function StepRail({
               disabled={isDisabled}
               onClick={() => onStepChange(step.key)}
               aria-current={isActive ? 'step' : undefined}
-              className={`flex w-full items-start gap-3 rounded-md border px-3 py-3 text-left transition-colors ${
+              className={`flex w-full items-start gap-3 rounded-md border px-3 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
                 isActive
-                  ? 'border-primary/40 bg-primary/10'
+                  ? 'border-primary bg-primary/10'
                   : 'border-border bg-background hover:bg-muted/40'
               } ${isDisabled ? 'cursor-not-allowed opacity-50' : ''}`}
             >

--- a/src/pages/portal/Training.tsx
+++ b/src/pages/portal/Training.tsx
@@ -805,9 +805,9 @@ export default function TrainingPage() {
                     key={trackDefinition.id}
                     type="button"
                     onClick={() => handleSelectTrack(trackDefinition.id)}
-                    className={`min-h-24 rounded-2xl border p-4 text-left transition-all ${
+                    className={`min-h-24 rounded-2xl border p-4 text-left transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
                       isActive
-                        ? 'border-primary/30 bg-primary/5 shadow-sm'
+                        ? 'border-primary bg-primary/5 shadow-sm'
                         : 'border-border bg-background hover:border-primary/20 hover:bg-muted/20'
                     }`}
                   >


### PR DESCRIPTION
## Summary
- scopes an AA-safe interaction palette to login, portal, Admin Console, refunds, and Radix portalled controls without changing public marketing colors
- strengthens selected Training and mobile Partnership states with 3:1+ borders and keyboard focus rings
- adds deterministic light/dark contrast regression checks for base, hover, selected, focus, card, and public-isolation cases

Part of #587.

## Files changed
- `src/index.css` and `src/components/layout/AppLayout.tsx`: route-aware app color tokens and deterministic body scoping
- `src/pages/portal/Training.tsx` and `src/pages/admin/Partnerships.tsx`: selected/focus state indicators
- `scripts/validate-app-color-contrast.mjs` and `package.json`: repeatable WCAG contrast validation
- `Docs/QA_SMOKE_TEST_CHECKLIST.md`: app interaction palette smoke coverage
- `.gitignore`: ignores local Playwright CLI state

## Verification
- `npm ci` — passed (existing audit report: 3 moderate, 1 high)
- `npm run build` — passed (2,551 modules; 25 public routes prerendered)
- `npm test --if-present` — passed
- `npm run lint --if-present` — passed
- `npm run portal:validate-contrast` — passed (18 light/dark assertions; lowest normal-text case 4.60:1)
- `npm run portal-nav:validate` — passed
- `npm run portal-nav:uat -- --app-url http://127.0.0.1:8081` — passed at desktop and 390px mobile widths with no UAT console errors or horizontal overflow
- independent UX challenge — GO after the hover, selected-state, dark-mode, and public-isolation remediation

## How to test
1. Check out `agent/portal-accessible-colors` and run `npm ci`.
2. Run `npm run dev:uat`.
3. Open `/login`, `/portal`, `/portal/time`, `/portal/training`, `/admin`, `/admin/partnerships`, and `/refunds` with the applicable local UAT personas.
4. Verify primary buttons, links, active navigation, selected tracks/steps, hover states, and keyboard focus rings are legible in light and dark mode.
5. At 390px, open the authenticated mobile drawer and confirm selected navigation remains legible with no horizontal scroll.
6. Navigate from an app route to `/plus` and confirm the public candy-pink palette is unchanged.
7. Run `npm run portal:validate-contrast` and `npm run portal-nav:uat -- --app-url http://127.0.0.1:8081`.

No passwords or secrets are required for the mocked portal UAT script.

## Risk and overlap
- CSS-token and two targeted selected-state changes only; no database, auth grant, payment, payout, or production deployment behavior.
- The palette is intentionally app-scoped so public marketing pages retain the existing brand colors.
- No overlap with the concurrent Timekeeping V1 state or persona-test branches.