### PR TITLE
Close Timekeeping V1 UI acceptance gaps

### DIFF
--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -197,7 +197,9 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Out-of-scope users, out-of-scope time-entry IDs, locked entries, and non-submitted entries fail closed when calling the manager-review RPC directly.
 - [ ] A worker direct table INSERT/UPDATE attempt cannot self-approve or bypass the audited timekeeping RPCs; browser table writes fail, and the insert guard also forces pending/null review fields as defense in depth.
 - [ ] Manager review does not generate a pay run, issue a pay statement, mark time paid, or invoke payment/provider behavior.
-- [ ] Worker and manager timekeeping pages have no horizontal page overflow at `390x844` and remain usable at desktop width.
+- [ ] Worker and manager timekeeping pages have no horizontal page overflow at `390x844` across loading, load-error, setup/no-access, empty, mutation-failure, correction-dialog, and populated queue states, and remain usable at desktop width.
+- [ ] Timekeeping status badges for correction requested, approved, included in pay, paid, and locked meet WCAG AA normal-text contrast at 12px in light and dark themes.
+- [ ] Multi-profile timekeeping selects have associated visible labels; repeated Edit, Delete, Approve, and Request correction controls announce the shift context; successful manager actions move keyboard focus to the updated review-queue heading.
 
 ### Admin Operator Pay Review
 - [ ] Admin or scoped Operator Pay manager can open `/admin/payouts`; users without Operator Pay admin access see the existing admin access-required state.

--- a/scripts/validate-app-color-contrast.mjs
+++ b/scripts/validate-app-color-contrast.mjs
@@ -8,8 +8,12 @@ const cssPath = path.join(repoRoot, 'src', 'index.css');
 const css = fs.readFileSync(cssPath, 'utf8');
 const trainingPath = path.join(repoRoot, 'src', 'pages', 'portal', 'Training.tsx');
 const partnershipsPath = path.join(repoRoot, 'src', 'pages', 'admin', 'Partnerships.tsx');
+const timePath = path.join(repoRoot, 'src', 'pages', 'portal', 'Time.tsx');
+const timeReviewPath = path.join(repoRoot, 'src', 'pages', 'portal', 'TimeReview.tsx');
 const training = fs.readFileSync(trainingPath, 'utf8');
 const partnerships = fs.readFileSync(partnershipsPath, 'utf8');
+const time = fs.readFileSync(timePath, 'utf8');
+const timeReview = fs.readFileSync(timeReviewPath, 'utf8');
 
 const assert = (condition, message) => {
   if (!condition) {
@@ -92,6 +96,10 @@ assert(darkAppMatch, 'Missing dark app token block.');
 const darkAppBlock = darkAppMatch[1];
 const background = hslToRgb(parseHsl(tokenValue(rootBlock, 'background'), '--background'));
 const card = hslToRgb(parseHsl(tokenValue(rootBlock, 'card'), '--card'));
+const foreground = hslToRgb(parseHsl(tokenValue(rootBlock, 'foreground'), '--foreground'));
+const muted = hslToRgb(parseHsl(tokenValue(rootBlock, 'muted'), '--muted'));
+const amber = hslToRgb(parseHsl(tokenValue(rootBlock, 'amber'), '--amber'));
+const sage = hslToRgb(parseHsl(tokenValue(rootBlock, 'sage'), '--sage'));
 const primary = hslToRgb(parseHsl(tokenValue(appBlock, 'primary'), '--primary'));
 const primaryForeground = hslToRgb(
   parseHsl(tokenValue(appBlock, 'primary-foreground'), '--primary-foreground'),
@@ -105,6 +113,10 @@ const darkBackground = hslToRgb(
   parseHsl(tokenValue(darkBlock, 'background'), 'dark --background'),
 );
 const darkCard = hslToRgb(parseHsl(tokenValue(darkBlock, 'card'), 'dark --card'));
+const darkForeground = hslToRgb(
+  parseHsl(tokenValue(darkBlock, 'foreground'), 'dark --foreground'),
+);
+const darkMuted = hslToRgb(parseHsl(tokenValue(darkBlock, 'muted'), 'dark --muted'));
 const darkPrimary = hslToRgb(
   parseHsl(tokenValue(darkAppBlock, 'primary'), 'dark --primary'),
 );
@@ -117,6 +129,12 @@ const darkCoralDark = hslToRgb(
 );
 const darkPrimaryTint = composite(darkPrimary, darkBackground, 0.1);
 const darkPrimaryAtEightyPercent = composite(darkPrimary, darkBackground, 0.8);
+const approvedBadgeTint = composite(sage, background, 0.1);
+const correctionBadgeTint = composite(amber, background, 0.1);
+const settledBadgeTint = composite(muted, background, 0.6);
+const darkApprovedBadgeTint = composite(sage, darkBackground, 0.1);
+const darkCorrectionBadgeTint = composite(amber, darkBackground, 0.1);
+const darkSettledBadgeTint = composite(darkMuted, darkBackground, 0.6);
 
 const checks = [
   {
@@ -209,6 +227,36 @@ const checks = [
     ratio: contrastRatio(darkCoralDark, darkPrimaryForeground),
     minimum: 4.5,
   },
+  {
+    label: '12px approved badge text',
+    ratio: contrastRatio(foreground, approvedBadgeTint),
+    minimum: 4.5,
+  },
+  {
+    label: '12px correction badge text',
+    ratio: contrastRatio(foreground, correctionBadgeTint),
+    minimum: 4.5,
+  },
+  {
+    label: '12px included, paid, and locked badge text',
+    ratio: contrastRatio(foreground, settledBadgeTint),
+    minimum: 4.5,
+  },
+  {
+    label: 'dark 12px approved badge text',
+    ratio: contrastRatio(darkForeground, darkApprovedBadgeTint),
+    minimum: 4.5,
+  },
+  {
+    label: 'dark 12px correction badge text',
+    ratio: contrastRatio(darkForeground, darkCorrectionBadgeTint),
+    minimum: 4.5,
+  },
+  {
+    label: 'dark 12px included, paid, and locked badge text',
+    ratio: contrastRatio(darkForeground, darkSettledBadgeTint),
+    minimum: 4.5,
+  },
 ];
 
 for (const check of checks) {
@@ -235,6 +283,23 @@ assert(
   partnerships.includes("? 'border-primary bg-primary/10'"),
   'The active mobile partnership step needs a full-strength primary border.',
 );
+for (const [source, label] of [
+  [time, 'Operator Time'],
+  [timeReview, 'Time Review'],
+]) {
+  assert(
+    source.includes('border-sage/40 bg-sage/10 text-foreground'),
+    `${label} approved badges need theme-safe normal-text contrast classes.`,
+  );
+  assert(
+    source.includes('border-amber/40 bg-amber/10 text-foreground'),
+    `${label} correction badges need theme-safe normal-text contrast classes.`,
+  );
+  assert(
+    source.includes('border-border bg-muted/60 text-foreground'),
+    `${label} included, paid, and locked badges need theme-safe normal-text contrast classes.`,
+  );
+}
 
 console.log('Authenticated app color contrast validation passed.');
 process.exit(0);

--- a/scripts/validate-operator-timekeeping-uat.mjs
+++ b/scripts/validate-operator-timekeeping-uat.mjs
@@ -874,6 +874,20 @@ const run = async () => {
 
     recorder.assert('Portal Time route loads after auth', new URL(page.url()).pathname === '/portal/time', page.url());
     recorder.assert(
+      'Portal access probe sends a null date instead of React Query context',
+      state.rpcCalls.some(
+        (call) =>
+          call.rpcName === 'get_my_operator_timekeeping_context' &&
+          call.body?.p_work_date === null
+      ) &&
+        !state.rpcCalls.some(
+          (call) =>
+            call.rpcName === 'get_my_operator_timekeeping_context' &&
+            typeof call.body?.p_work_date === 'object' &&
+            call.body?.p_work_date !== null
+        )
+    );
+    recorder.assert(
       'Time hub keeps data entry out of the dashboard',
       (await page.locator('#work-date').count()) === 0
     );

--- a/scripts/validate-operator-timekeeping-uat.mjs
+++ b/scripts/validate-operator-timekeeping-uat.mjs
@@ -863,9 +863,16 @@ const run = async () => {
   const capture390State = async (screenshotName, assertionLabel) => {
     await page.setViewportSize({ width: 390, height: 844 });
     await page.evaluate(() => window.scrollTo(0, 0));
-    const hasOverflow = await page.evaluate(
-      () => document.documentElement.scrollWidth > window.innerWidth + 1
-    );
+    await page.waitForTimeout(250);
+    const hasOverflow = await page.evaluate(() => {
+      const documentOverflows = document.documentElement.scrollWidth > window.innerWidth + 1;
+      const dialogOverflows = [...document.querySelectorAll('[role="dialog"]')].some((dialog) => {
+        const rect = dialog.getBoundingClientRect();
+        return rect.left < -1 || rect.right > window.innerWidth + 1;
+      });
+
+      return documentOverflows || dialogOverflows;
+    });
     recorder.assert(`390px ${assertionLabel} has no horizontal overflow`, !hasOverflow);
     await page.screenshot({
       path: path.join(args.artifactDir, screenshotName),

--- a/scripts/validate-operator-timekeeping-uat.mjs
+++ b/scripts/validate-operator-timekeeping-uat.mjs
@@ -74,6 +74,7 @@ const mockSession = {
 };
 
 const profileId = '66000000-0000-4000-8000-000000000010';
+const secondaryProfileId = '66000000-0000-4000-8000-000000000017';
 const accountId = '66000000-0000-4000-8000-000000000011';
 const periodId = '66000000-0000-4000-8000-000000000012';
 const policyId = '66000000-0000-4000-8000-000000000013';
@@ -132,10 +133,21 @@ const buildContext = (state, requestedWorkDate = workDate) => {
     };
   }
 
-  return {
-    workDate: requestedWorkDate,
-    profiles: [
-      {
+  const assignedMachines =
+    state.workerContextMode === 'no_assignments'
+      ? []
+      : [
+          {
+            assignmentId: '66000000-0000-4000-8000-000000000016',
+            machineId,
+            machineLabel: 'Cotton Candy 01',
+            locationId,
+            locationName: 'Mall Atrium',
+            effectiveStartDate: '2026-01-01',
+            effectiveEndDate: null,
+          },
+        ];
+  const primaryProfile = {
       id: profileId,
       accountId,
       accountName: 'Bloomjoy UAT',
@@ -150,20 +162,7 @@ const buildContext = (state, requestedWorkDate = workDate) => {
         reviewModel: 'final_review_only',
       },
       currentPeriod: period,
-      assignedMachines:
-        state.workerContextMode === 'no_assignments'
-          ? []
-          : [
-              {
-                assignmentId: '66000000-0000-4000-8000-000000000016',
-                machineId,
-                machineLabel: 'Cotton Candy 01',
-                locationId,
-                locationName: 'Mall Atrium',
-                effectiveStartDate: '2026-01-01',
-                effectiveEndDate: null,
-              },
-            ],
+      assignedMachines,
       currentEntries:
         state.workerContextMode === 'empty'
           ? []
@@ -171,6 +170,19 @@ const buildContext = (state, requestedWorkDate = workDate) => {
               (entry) => entry.status !== 'voided' && entryIsInPeriod(entry, period)
             ),
       recentEntries: state.entries.filter((entry) => entry.status !== 'voided'),
+  };
+
+  return {
+    workDate: requestedWorkDate,
+    profiles: [
+      primaryProfile,
+      {
+        ...primaryProfile,
+        id: secondaryProfileId,
+        accountName: 'Bloomjoy UAT East',
+        displayName: 'East operator time',
+        currentEntries: [],
+        recentEntries: [],
       },
     ],
   };
@@ -846,6 +858,75 @@ const run = async () => {
 
   const page = await context.newPage();
   const consoleErrors = [];
+  const desktopViewport = { width: 1365, height: 900 };
+
+  const capture390State = async (screenshotName, assertionLabel) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.evaluate(() => window.scrollTo(0, 0));
+    const hasOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > window.innerWidth + 1
+    );
+    recorder.assert(`390px ${assertionLabel} has no horizontal overflow`, !hasOverflow);
+    await page.screenshot({
+      path: path.join(args.artifactDir, screenshotName),
+      fullPage: true,
+    });
+    await page.setViewportSize(desktopViewport);
+  };
+
+  const readContrast = async (locator) =>
+    locator.evaluate((element) => {
+      const parseColor = (value) => {
+        const channels = value.match(/[\d.]+/g)?.map(Number) ?? [];
+        return {
+          red: channels[0] ?? 0,
+          green: channels[1] ?? 0,
+          blue: channels[2] ?? 0,
+          alpha: channels[3] ?? 1,
+        };
+      };
+      const composite = (foreground, background) => ({
+        red: foreground.red * foreground.alpha + background.red * (1 - foreground.alpha),
+        green:
+          foreground.green * foreground.alpha + background.green * (1 - foreground.alpha),
+        blue: foreground.blue * foreground.alpha + background.blue * (1 - foreground.alpha),
+        alpha: 1,
+      });
+      const layers = [];
+      let node = element;
+      while (node instanceof Element) {
+        layers.push(parseColor(getComputedStyle(node).backgroundColor));
+        node = node.parentElement;
+      }
+      const background = layers
+        .reverse()
+        .reduce(
+          (currentBackground, layer) => composite(layer, currentBackground),
+          { red: 255, green: 255, blue: 255, alpha: 1 }
+        );
+      const foreground = composite(parseColor(getComputedStyle(element).color), background);
+      const luminance = (color) =>
+        [color.red, color.green, color.blue]
+          .map((channel) => channel / 255)
+          .map((channel) =>
+            channel <= 0.04045
+              ? channel / 12.92
+              : ((channel + 0.055) / 1.055) ** 2.4
+          )
+          .reduce(
+            (total, channel, index) => total + channel * [0.2126, 0.7152, 0.0722][index],
+            0
+          );
+      const foregroundLuminance = luminance(foreground);
+      const backgroundLuminance = luminance(background);
+
+      return {
+        ratio:
+          (Math.max(foregroundLuminance, backgroundLuminance) + 0.05) /
+          (Math.min(foregroundLuminance, backgroundLuminance) + 0.05),
+        fontSize: Number.parseFloat(getComputedStyle(element).fontSize),
+      };
+    });
 
   page.on('console', (message) => {
     if (message.type() === 'error') {
@@ -894,7 +975,8 @@ const run = async () => {
     recorder.assert(
       'Monthly hub shows the primary entry action and month control',
       (await page.getByRole('link', { name: /add completed shift/i }).isVisible()) &&
-        (await page.locator('#time-month').isVisible())
+        (await page.locator('#time-month').isVisible()) &&
+        (await page.getByLabel('Work profile').isVisible())
     );
     recorder.assert(
       'Fixed-period mock keeps selected month, date range, and due date aligned',
@@ -933,12 +1015,56 @@ const run = async () => {
               (await entry.getByRole('button', { name: /delete/i }).isDisabled())))
       );
     }
+    const pendingWorkerEntry = page.locator('article', {
+      hasText: 'Pending shift for manager review.',
+    });
+    recorder.assert(
+      'Repeated worker actions include shift context in their accessible names',
+      (await pendingWorkerEntry
+        .getByRole('button', {
+          name: /Edit shift on May 20, 2026, 08:00 to 09:15, Cotton Candy 01 - Mall Atrium/i,
+        })
+        .isVisible()) &&
+        (await pendingWorkerEntry
+          .getByRole('button', {
+            name: /Delete shift on May 20, 2026, 08:00 to 09:15, Cotton Candy 01 - Mall Atrium/i,
+          })
+          .isVisible())
+    );
     recorder.assert(
       'Worker correction state includes manager reason',
       await page
         .getByText('Please update the end time to match the venue log.', { exact: true })
         .isVisible()
     );
+    const contrastBadgeLabels = [
+      'Correction requested',
+      'Approved',
+      'Included in pay',
+      'Paid',
+      'Locked',
+    ];
+    for (const theme of ['light', 'dark']) {
+      await page.evaluate((nextTheme) => {
+        document.documentElement.classList.toggle('dark', nextTheme === 'dark');
+      }, theme);
+      await page.waitForTimeout(50);
+      for (const label of contrastBadgeLabels) {
+        const result = await readContrast(
+          page.locator(`[data-time-status-badge="${label}"]`).first()
+        );
+        recorder.assert(
+          `${theme} ${label} 12px badge meets WCAG AA normal-text contrast`,
+          result.fontSize === 12 && result.ratio >= 4.5,
+          `${result.ratio.toFixed(2)}:1 at ${result.fontSize}px`
+        );
+      }
+    }
+    await capture390State(
+      'portal-time-worker-status-badges-dark-mobile.png',
+      'dark worker status-badge page'
+    );
+    await page.evaluate(() => document.documentElement.classList.remove('dark'));
     recorder.assert(
       'Pay statement download is visible',
       (await page.getByRole('heading', { name: 'Pay Statements' }).isVisible()) &&
@@ -989,18 +1115,12 @@ const run = async () => {
       path: path.join(args.artifactDir, 'portal-time-worker-states-desktop.png'),
       fullPage: true,
     });
-    await page.setViewportSize({ width: 390, height: 844 });
-    const workerStateOverflow = await page.evaluate(
-      () => document.documentElement.scrollWidth > window.innerWidth + 1
+    await capture390State(
+      'portal-time-worker-states-mobile.png',
+      'worker state-rich monthly hub'
     );
-    recorder.assert('Mobile Time state-rich page has no horizontal overflow', !workerStateOverflow);
-    await page.screenshot({
-      path: path.join(args.artifactDir, 'portal-time-worker-states-mobile.png'),
-      fullPage: true,
-    });
-    await page.setViewportSize({ width: 1365, height: 900 });
 
-    state.workerLoadDelayMs = 900;
+    state.workerLoadDelayMs = 4000;
     await page.reload({ waitUntil: 'domcontentloaded' });
     await page.getByText('Loading timekeeping...', { exact: true }).waitFor({ timeout: 5000 });
     recorder.assert(
@@ -1012,6 +1132,7 @@ const run = async () => {
       path: path.join(args.artifactDir, 'portal-time-loading-desktop.png'),
       fullPage: true,
     });
+    await capture390State('portal-time-loading-mobile.png', 'worker loading state');
     state.workerLoadDelayMs = 0;
     await page.getByRole('heading', { name: 'Record completed work' }).waitFor({ timeout: 10000 });
 
@@ -1030,6 +1151,7 @@ const run = async () => {
       path: path.join(args.artifactDir, 'portal-time-load-error-desktop.png'),
       fullPage: true,
     });
+    await capture390State('portal-time-load-error-mobile.png', 'worker load-error state');
     state.workerLoadError = false;
     await page.getByRole('button', { name: 'Try again' }).click();
     await page.getByRole('heading', { name: 'Record completed work' }).waitFor({ timeout: 10000 });
@@ -1048,6 +1170,7 @@ const run = async () => {
       path: path.join(args.artifactDir, 'portal-time-setup-desktop.png'),
       fullPage: true,
     });
+    await capture390State('portal-time-setup-mobile.png', 'worker setup state');
     state.workerContextMode = 'normal';
     await page.getByRole('button', { name: 'Check setup again' }).click();
     await page.getByRole('heading', { name: 'Record completed work' }).waitFor({ timeout: 10000 });
@@ -1066,6 +1189,7 @@ const run = async () => {
       path: path.join(args.artifactDir, 'portal-time-empty-desktop.png'),
       fullPage: true,
     });
+    await capture390State('portal-time-empty-mobile.png', 'worker empty state');
     state.workerContextMode = 'normal';
     await page.getByRole('button', { name: 'Refresh' }).click();
     await page.getByText('Pending shift for manager review.', { exact: true }).waitFor({
@@ -1077,17 +1201,30 @@ const run = async () => {
       nextNote,
       endTime,
       screenshotName,
+      expectedCorrectionReason,
     }) => {
       const sourceEntry = page.locator('article', { hasText: sourceNote });
       await sourceEntry.getByRole('button', { name: /edit/i }).click();
       await page.locator('h1').filter({ hasText: /^Edit Time$/ }).waitFor({ timeout: 10000 });
+      recorder.assert(
+        'Focused Edit Time associates the multi-profile select with its visible label',
+        await page.getByLabel('Operator profile').isVisible()
+      );
+      if (expectedCorrectionReason) {
+        recorder.assert(
+          'Focused Edit Time keeps the manager correction reason visible',
+          (await page
+            .getByRole('note')
+            .getByText(expectedCorrectionReason, { exact: true })
+            .isVisible()) &&
+            (await page
+              .getByRole('note')
+              .getByText('Your manager requested a correction', { exact: true })
+              .isVisible())
+        );
+      }
       if (screenshotName) {
-        await page.setViewportSize({ width: 390, height: 844 });
-        await page.screenshot({
-          path: path.join(args.artifactDir, screenshotName),
-          fullPage: true,
-        });
-        await page.setViewportSize({ width: 1365, height: 900 });
+        await capture390State(screenshotName, 'focused Edit Time correction state');
       }
       await page.fill('#end-time', endTime);
       await page.fill('#time-notes', nextNote);
@@ -1106,6 +1243,7 @@ const run = async () => {
       nextNote: 'Corrected shift after manager note.',
       endTime: '13:25',
       screenshotName: 'portal-time-correction-edit-mobile.png',
+      expectedCorrectionReason: 'Please update the end time to match the venue log.',
     });
     recorder.assert(
       'Editing a correction-requested shift resets review and clears the old reason',
@@ -1177,6 +1315,10 @@ const run = async () => {
       path: path.join(args.artifactDir, 'portal-time-mutation-error-desktop.png'),
       fullPage: true,
     });
+    await capture390State(
+      'portal-time-mutation-error-mobile.png',
+      'worker mutation-failure state'
+    );
     await page.getByRole('button', { name: /submit shift/i }).click();
     await page.waitForURL(/\/portal\/time\?month=2026-05$/, { timeout: 10000 });
     await page.getByText('Time entry saved.').last().waitFor({ timeout: 10000 });
@@ -1252,16 +1394,7 @@ const run = async () => {
       sawLongShiftConfirmation && new URL(page.url()).pathname === '/portal/time/new'
     );
 
-    await page.setViewportSize({ width: 390, height: 844 });
-    const workerFormOverflow = await page.evaluate(
-      () => document.documentElement.scrollWidth > window.innerWidth + 1
-    );
-    recorder.assert('Mobile Add Time page has no horizontal overflow', !workerFormOverflow);
-    await page.screenshot({
-      path: path.join(args.artifactDir, 'portal-time-add-mobile.png'),
-      fullPage: true,
-    });
-    await page.setViewportSize({ width: 1365, height: 900 });
+    await capture390State('portal-time-add-mobile.png', 'Add Time validation state');
     await page.getByRole('link', { name: /time home/i }).click();
     await page.waitForURL(/\/portal\/time\?month=2026-05$/, { timeout: 10000 });
 
@@ -1280,8 +1413,8 @@ const run = async () => {
     );
 
     state.managerMode = true;
-    state.reviewLoadDelayMs = 900;
-    await page.setViewportSize({ width: 1365, height: 900 });
+    state.reviewLoadDelayMs = 4000;
+    await page.setViewportSize(desktopViewport);
     await page.goto(`${args.appUrl}/portal/time-review`, { waitUntil: 'domcontentloaded' });
     await page.getByText('Loading submitted time...', { exact: true }).waitFor({ timeout: 5000 });
     recorder.assert(
@@ -1293,6 +1426,10 @@ const run = async () => {
       path: path.join(args.artifactDir, 'portal-time-review-loading-desktop.png'),
       fullPage: true,
     });
+    await capture390State(
+      'portal-time-review-loading-mobile.png',
+      'manager loading state'
+    );
     state.reviewLoadDelayMs = 0;
     await page.locator('#review-month').waitFor({ timeout: 10000 });
 
@@ -1311,6 +1448,10 @@ const run = async () => {
       path: path.join(args.artifactDir, 'portal-time-review-load-error-desktop.png'),
       fullPage: true,
     });
+    await capture390State(
+      'portal-time-review-load-error-mobile.png',
+      'manager load-error state'
+    );
     state.reviewLoadError = false;
     await page.getByRole('button', { name: 'Try again' }).click();
     await page.locator('#review-month').waitFor({ timeout: 10000 });
@@ -1328,6 +1469,10 @@ const run = async () => {
       path: path.join(args.artifactDir, 'portal-time-review-no-access-desktop.png'),
       fullPage: true,
     });
+    await capture390State(
+      'portal-time-review-no-access-mobile.png',
+      'manager no-access state'
+    );
     state.reviewContextMode = 'normal';
     await page.getByRole('button', { name: 'Refresh' }).click();
     await page.locator('#review-month').waitFor({ timeout: 10000 });
@@ -1342,6 +1487,11 @@ const run = async () => {
         (await page.getByText('No managed machines', { exact: true }).count()) === 0 &&
         (await page.getByText('Time review is unavailable', { exact: true }).count()) === 0
     );
+    await page.screenshot({
+      path: path.join(args.artifactDir, 'portal-time-review-empty-desktop.png'),
+      fullPage: true,
+    });
+    await capture390State('portal-time-review-empty-mobile.png', 'manager empty-queue state');
     state.reviewContextMode = 'normal';
     await page.getByRole('button', { name: 'Refresh' }).click();
     await page.getByText('Jordan Contractor', { exact: true }).waitFor({ timeout: 10000 });
@@ -1360,11 +1510,24 @@ const run = async () => {
 
     state.failNextReview = true;
     const jordanEntry = page.locator('article', { hasText: 'Jordan Contractor' });
-    await jordanEntry.getByRole('button', { name: /^approve$/i }).click();
+    const jordanApproveButton = jordanEntry.getByRole('button', {
+      name: /^Approve Jordan Contractor's shift on May 19, 2026/i,
+    });
+    recorder.assert(
+      'Repeated manager actions include shift context in their accessible names',
+      (await jordanApproveButton.isVisible()) &&
+        (await page
+          .locator('article', { hasText: 'Sam Contractor' })
+          .getByRole('button', {
+            name: /^Request correction for Sam Contractor's shift on May 20, 2026/i,
+          })
+          .isVisible())
+    );
+    await jordanApproveButton.click();
     await page.getByText('Review was not saved', { exact: true }).waitFor({ timeout: 10000 });
     recorder.assert(
       'Manager mutation failure keeps the shift actionable for retry',
-      (await jordanEntry.getByRole('button', { name: /^approve$/i }).isEnabled()) &&
+      (await jordanApproveButton.isEnabled()) &&
         state.reviewEntries.find((entry) => entry.id === 'time-entry-manager-approve')
           ?.managerReviewStatus === 'pending'
     );
@@ -1372,8 +1535,20 @@ const run = async () => {
       path: path.join(args.artifactDir, 'portal-time-review-mutation-error-desktop.png'),
       fullPage: true,
     });
-    await jordanEntry.getByRole('button', { name: /^approve$/i }).click();
+    await capture390State(
+      'portal-time-review-mutation-error-mobile.png',
+      'manager mutation-failure state'
+    );
+    await jordanApproveButton.click();
     await page.getByText('Shift approved.').last().waitFor({ timeout: 10000 });
+    const queueFocusedAfterApprove = await page
+      .waitForFunction(
+        () => document.activeElement?.id === 'time-review-queue-heading',
+        undefined,
+        { timeout: 5000 }
+      )
+      .then(() => true)
+      .catch(() => false);
     recorder.assert(
       'Approve retry uses the machine-manager review RPC',
       state.rpcCalls.filter(
@@ -1383,14 +1558,41 @@ const run = async () => {
           call.body?.p_decision === 'approved'
       ).length === 2
     );
-
+    recorder.assert(
+      'Successful approve moves keyboard focus to the live review queue heading',
+      queueFocusedAfterApprove &&
+        (await page
+          .getByText('Shift approved. The review queue is updated.', { exact: true })
+          .isVisible())
+    );
     await page
-      .locator('article', { hasText: 'Sam Contractor' })
-      .getByRole('button', { name: /request correction/i })
+      .getByText('Shift approved.', { exact: true })
+      .last()
+      .waitFor({ state: 'hidden', timeout: 10000 });
+
+    const samEntry = page.locator('article', { hasText: 'Sam Contractor' });
+    await samEntry
+      .getByRole('button', {
+        name: /^Request correction for Sam Contractor's shift on May 20, 2026/i,
+      })
       .click();
+    await page.getByRole('dialog').waitFor({ timeout: 10000 });
+    await page.waitForTimeout(300);
+    await capture390State(
+      'portal-time-review-correction-dialog-mobile.png',
+      'manager correction-dialog state'
+    );
     await page.fill('#correction-reason', 'Please confirm the end time; the venue log shows 2:45 PM.');
     await page.getByRole('button', { name: /send correction request/i }).click();
     await page.getByText('Correction requested.').last().waitFor({ timeout: 10000 });
+    const queueFocusedAfterCorrection = await page
+      .waitForFunction(
+        () => document.activeElement?.id === 'time-review-queue-heading',
+        undefined,
+        { timeout: 5000 }
+      )
+      .then(() => true)
+      .catch(() => false);
     recorder.assert(
       'Correction action sends a required worker-visible reason',
       state.rpcCalls.some(
@@ -1400,6 +1602,13 @@ const run = async () => {
           call.body?.p_decision === 'needs_correction' &&
           call.body?.p_reason === 'Please confirm the end time; the venue log shows 2:45 PM.'
       )
+    );
+    recorder.assert(
+      'Successful correction moves keyboard focus to the live review queue heading',
+      queueFocusedAfterCorrection &&
+        (await page
+          .getByText('Correction requested. The review queue is updated.', { exact: true })
+          .isVisible())
     );
 
     await page.getByRole('button', { name: /Returned \(1\)/i }).click();
@@ -1415,16 +1624,7 @@ const run = async () => {
       fullPage: true,
     });
 
-    await page.setViewportSize({ width: 390, height: 844 });
-    await page.evaluate(() => window.scrollTo(0, 0));
-    const reviewOverflow = await page.evaluate(
-      () => document.documentElement.scrollWidth > window.innerWidth + 1
-    );
-    recorder.assert('Mobile Time Review page has no horizontal overflow', !reviewOverflow);
-    await page.screenshot({
-      path: path.join(args.artifactDir, 'portal-time-review-mobile.png'),
-      fullPage: true,
-    });
+    await capture390State('portal-time-review-mobile.png', 'manager returned-shift queue');
 
     const unexpectedConsoleErrors = consoleErrors.filter(
       (message) => !/status of (500|503)/i.test(message)

--- a/scripts/validate-operator-timekeeping-uat.mjs
+++ b/scripts/validate-operator-timekeeping-uat.mjs
@@ -80,6 +80,7 @@ const policyId = '66000000-0000-4000-8000-000000000013';
 const machineId = '66000000-0000-4000-8000-000000000014';
 const locationId = '66000000-0000-4000-8000-000000000015';
 const workDate = '2026-05-20';
+const selectedMonth = workDate.slice(0, 7);
 
 const roundUpHour = (minutes) => Math.ceil(Math.max(minutes, 0) / 60) * 60;
 
@@ -90,13 +91,51 @@ const minutesForTime = (value) => {
 
 const rawMinutes = (startTime, endTime) => minutesForTime(endTime) - minutesForTime(startTime);
 
-const isCurrentPeriodEntry = (entry) =>
-  entry.workDate >= '2026-05-01' && entry.workDate <= '2026-05-31';
+const formatDateInput = (date) =>
+  `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}-${String(
+    date.getUTCDate()
+  ).padStart(2, '0')}`;
 
-const buildContext = (state) => ({
-  workDate,
-  profiles: [
-    {
+const getMockPeriod = (requestedWorkDate = workDate) => {
+  const requestedMonth = String(requestedWorkDate || workDate).slice(0, 7);
+  const [year, month] = requestedMonth.split('-').map(Number);
+  const periodStart = new Date(Date.UTC(year, month - 1, 1));
+  const periodEnd = new Date(Date.UTC(year, month, 0));
+  const dueDate = new Date(periodEnd);
+  const lockDate = new Date(periodEnd);
+  const targetPayoutDate = new Date(periodEnd);
+  dueDate.setUTCDate(dueDate.getUTCDate() + 2);
+  lockDate.setUTCDate(lockDate.getUTCDate() + 3);
+  targetPayoutDate.setUTCDate(targetPayoutDate.getUTCDate() + 5);
+
+  return {
+    id: requestedMonth === selectedMonth ? periodId : `mock-period-${requestedMonth}`,
+    periodStartDate: formatDateInput(periodStart),
+    periodEndDate: formatDateInput(periodEnd),
+    submissionDueDate: formatDateInput(dueDate),
+    lockDate: formatDateInput(lockDate),
+    targetPayoutDate: formatDateInput(targetPayoutDate),
+    status: 'open',
+  };
+};
+
+const entryIsInPeriod = (entry, period) =>
+  entry.workDate >= period.periodStartDate && entry.workDate <= period.periodEndDate;
+
+const buildContext = (state, requestedWorkDate = workDate) => {
+  const period = getMockPeriod(requestedWorkDate);
+
+  if (state.workerContextMode === 'setup') {
+    return {
+      workDate: requestedWorkDate,
+      profiles: [],
+    };
+  }
+
+  return {
+    workDate: requestedWorkDate,
+    profiles: [
+      {
       id: profileId,
       accountId,
       accountName: 'Bloomjoy UAT',
@@ -110,49 +149,58 @@ const buildContext = (state) => ({
         roundingRule: 'round_up_60_minutes',
         reviewModel: 'final_review_only',
       },
-      currentPeriod: {
-        id: periodId,
-        periodStartDate: '2026-05-01',
-        periodEndDate: '2026-05-31',
-        submissionDueDate: '2026-06-02',
-        lockDate: '2026-06-03',
-        targetPayoutDate: '2026-06-05',
-        status: 'open',
-      },
-      assignedMachines: [
-        {
-          assignmentId: '66000000-0000-4000-8000-000000000016',
-          machineId,
-          machineLabel: 'Cotton Candy 01',
-          locationId,
-          locationName: 'Mall Atrium',
-          effectiveStartDate: '2026-05-01',
-          effectiveEndDate: null,
-        },
-      ],
-      currentEntries: state.entries.filter(
-        (entry) => entry.status !== 'voided' && isCurrentPeriodEntry(entry)
-      ),
+      currentPeriod: period,
+      assignedMachines:
+        state.workerContextMode === 'no_assignments'
+          ? []
+          : [
+              {
+                assignmentId: '66000000-0000-4000-8000-000000000016',
+                machineId,
+                machineLabel: 'Cotton Candy 01',
+                locationId,
+                locationName: 'Mall Atrium',
+                effectiveStartDate: '2026-01-01',
+                effectiveEndDate: null,
+              },
+            ],
+      currentEntries:
+        state.workerContextMode === 'empty'
+          ? []
+          : state.entries.filter(
+              (entry) => entry.status !== 'voided' && entryIsInPeriod(entry, period)
+            ),
       recentEntries: state.entries.filter((entry) => entry.status !== 'voided'),
-    },
-  ],
-});
+      },
+    ],
+  };
+};
 
-const buildReviewContext = (state) => ({
-  workDate,
-  periodStartDate: '2026-05-01',
-  periodEndDate: '2026-05-31',
-  hasAccess: true,
-  machines: [
-    {
-      machineId,
-      machineLabel: 'Cotton Candy 01',
-      locationId,
-      locationName: 'Mall Atrium',
-    },
-  ],
-  entries: state.reviewEntries,
-});
+const buildReviewContext = (state, requestedWorkDate = workDate) => {
+  const period = getMockPeriod(requestedWorkDate);
+  const hasAccess = state.reviewContextMode !== 'no_access';
+
+  return {
+    workDate: requestedWorkDate,
+    periodStartDate: period.periodStartDate,
+    periodEndDate: period.periodEndDate,
+    hasAccess,
+    machines: hasAccess
+      ? [
+          {
+            machineId,
+            machineLabel: 'Cotton Candy 01',
+            locationId,
+            locationName: 'Mall Atrium',
+          },
+        ]
+      : [],
+    entries:
+      state.reviewContextMode === 'empty' || !hasAccess
+        ? []
+        : state.reviewEntries.filter((entry) => entryIsInPeriod(entry, period)),
+  };
+};
 
 const makeEntry = (body, state, id = `time-entry-${state.nextEntryId++}`) => {
   const minutes = rawMinutes(body.p_start_time, body.p_end_time);
@@ -166,7 +214,7 @@ const makeEntry = (body, state, id = `time-entry-${state.nextEntryId++}`) => {
     locationId,
     locationName: 'Mall Atrium',
     payoutPolicyId: policyId,
-    payoutPeriodId: periodId,
+    payoutPeriodId: getMockPeriod(body.p_work_date).id,
     workDate: body.p_work_date,
     startTime: body.p_start_time,
     endTime: body.p_end_time,
@@ -180,6 +228,45 @@ const makeEntry = (body, state, id = `time-entry-${state.nextEntryId++}`) => {
     lockedAt: null,
     createdAt: now.toISOString(),
     updatedAt: now.toISOString(),
+  };
+};
+
+const makeWorkerFixture = ({
+  id,
+  notes,
+  startTime,
+  endTime,
+  status = 'submitted',
+  managerReviewStatus = 'pending',
+  managerReviewReason = null,
+  managerReviewedAt = null,
+  lockedAt = null,
+}) => {
+  const minutes = rawMinutes(startTime, endTime);
+
+  return {
+    id,
+    accountId,
+    operatorProfileId: profileId,
+    machineId,
+    machineLabel: 'Cotton Candy 01',
+    locationId,
+    locationName: 'Mall Atrium',
+    payoutPolicyId: policyId,
+    payoutPeriodId: periodId,
+    workDate,
+    startTime,
+    endTime,
+    rawDurationMinutes: minutes,
+    roundedPaidMinutes: roundUpHour(minutes),
+    notes,
+    status,
+    managerReviewStatus,
+    managerReviewReason,
+    managerReviewedAt,
+    lockedAt,
+    createdAt: isoHoursAgo(24),
+    updatedAt: isoHoursAgo(12),
   };
 };
 
@@ -293,6 +380,22 @@ const jsonResponse = (body) => ({
   body: JSON.stringify(body),
 });
 
+const rpcErrorResponse = (message, status = 503) => ({
+  status,
+  contentType: 'application/json',
+  body: JSON.stringify({
+    code: 'MOCK_UAT_FAILURE',
+    details: null,
+    hint: null,
+    message,
+  }),
+});
+
+const wait = (milliseconds) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+
 const installMockSupabaseRoutes = async (context, state) => {
   await context.route('**/auth/v1/**', async (route) => {
     const url = route.request().url();
@@ -399,14 +502,33 @@ const installMockSupabaseRoutes = async (context, state) => {
     }
 
     if (rpcName === 'get_my_operator_timekeeping_context') {
-      return route.fulfill(jsonResponse(buildContext(state)));
+      const requestedWorkerDate =
+        typeof body?.p_work_date === 'string' ? body.p_work_date : workDate;
+      const isWorkerPageRequest = typeof body?.p_work_date === 'string';
+      if (isWorkerPageRequest && state.workerLoadDelayMs > 0) {
+        await wait(state.workerLoadDelayMs);
+      }
+      if (isWorkerPageRequest && state.workerLoadError) {
+        return route.fulfill(rpcErrorResponse('Mock worker timekeeping load failed.'));
+      }
+      return route.fulfill(jsonResponse(buildContext(state, requestedWorkerDate)));
     }
 
     if (rpcName === 'get_my_time_review_context') {
-      return route.fulfill(jsonResponse(buildReviewContext(state)));
+      if (state.reviewLoadDelayMs > 0) {
+        await wait(state.reviewLoadDelayMs);
+      }
+      if (state.reviewLoadError) {
+        return route.fulfill(rpcErrorResponse('Mock manager review load failed.'));
+      }
+      return route.fulfill(jsonResponse(buildReviewContext(state, body?.p_work_date ?? workDate)));
     }
 
     if (rpcName === 'review_operator_time_entry') {
+      if (state.failNextReview) {
+        state.failNextReview = false;
+        return route.fulfill(rpcErrorResponse('Mock review save failed. Try again.', 500));
+      }
       state.reviewEntries = state.reviewEntries.map((entry) =>
         entry.id === body.p_time_entry_id
           ? {
@@ -421,7 +543,7 @@ const installMockSupabaseRoutes = async (context, state) => {
       return route.fulfill(
         jsonResponse({
           timeEntry: state.reviewEntries.find((entry) => entry.id === body.p_time_entry_id),
-          context: buildReviewContext(state),
+          context: buildReviewContext(state, body?.p_work_date ?? workDate),
         })
       );
     }
@@ -466,9 +588,18 @@ const installMockSupabaseRoutes = async (context, state) => {
     }
 
     if (rpcName === 'submit_operator_time_entry') {
+      if (state.failNextSubmit) {
+        state.failNextSubmit = false;
+        return route.fulfill(rpcErrorResponse('Mock shift save failed. Try again.', 500));
+      }
       const entry = makeEntry(body, state);
       state.entries.push(entry);
-      return route.fulfill(jsonResponse({ timeEntry: entry, context: buildContext(state) }));
+      return route.fulfill(
+        jsonResponse({
+          timeEntry: entry,
+          context: buildContext(state, body?.p_work_date ?? workDate),
+        })
+      );
     }
 
     if (rpcName === 'update_operator_time_entry') {
@@ -477,15 +608,24 @@ const installMockSupabaseRoutes = async (context, state) => {
         state.entries[index] = makeEntry(body, state, body.p_time_entry_id);
       }
       return route.fulfill(
-        jsonResponse({ timeEntry: state.entries[index], context: buildContext(state) })
+        jsonResponse({
+          timeEntry: state.entries[index],
+          context: buildContext(state, body?.p_work_date ?? workDate),
+        })
       );
     }
 
     if (rpcName === 'void_operator_time_entry') {
+      const voidedEntry = state.entries.find((entry) => entry.id === body.p_time_entry_id);
       state.entries = state.entries.map((entry) =>
         entry.id === body.p_time_entry_id ? { ...entry, status: 'voided' } : entry
       );
-      return route.fulfill(jsonResponse({ timeEntryId: body.p_time_entry_id, context: buildContext(state) }));
+      return route.fulfill(
+        jsonResponse({
+          timeEntryId: body.p_time_entry_id,
+          context: buildContext(state, voidedEntry?.workDate ?? workDate),
+        })
+      );
     }
 
     return route.fulfill(jsonResponse({}));
@@ -551,6 +691,14 @@ const run = async () => {
   const recorder = createRecorder();
   const state = {
     managerMode: false,
+    workerContextMode: 'normal',
+    reviewContextMode: 'normal',
+    workerLoadDelayMs: 0,
+    reviewLoadDelayMs: 0,
+    workerLoadError: false,
+    reviewLoadError: false,
+    failNextSubmit: false,
+    failNextReview: false,
     entries: [
       {
         id: 'time-entry-past',
@@ -576,6 +724,57 @@ const run = async () => {
         createdAt: isoHoursAgo(96),
         updatedAt: isoHoursAgo(72),
       },
+      makeWorkerFixture({
+        id: 'time-entry-worker-pending',
+        notes: 'Pending shift for manager review.',
+        startTime: '08:00',
+        endTime: '09:15',
+      }),
+      makeWorkerFixture({
+        id: 'time-entry-worker-approved',
+        notes: 'Approved shift ready for edit-reset QA.',
+        startTime: '10:00',
+        endTime: '11:30',
+        managerReviewStatus: 'approved',
+        managerReviewedAt: isoHoursAgo(8),
+      }),
+      makeWorkerFixture({
+        id: 'time-entry-worker-correction',
+        notes: 'Correction shift needs an updated end time.',
+        startTime: '12:00',
+        endTime: '13:10',
+        managerReviewStatus: 'needs_correction',
+        managerReviewReason: 'Please update the end time to match the venue log.',
+        managerReviewedAt: isoHoursAgo(6),
+      }),
+      makeWorkerFixture({
+        id: 'time-entry-worker-included',
+        notes: 'Included shift cannot be changed.',
+        startTime: '14:00',
+        endTime: '15:20',
+        status: 'included_in_payout',
+        managerReviewStatus: 'approved',
+        managerReviewedAt: isoHoursAgo(5),
+        lockedAt: isoHoursAgo(4),
+      }),
+      makeWorkerFixture({
+        id: 'time-entry-worker-paid',
+        notes: 'Paid shift cannot be changed.',
+        startTime: '16:00',
+        endTime: '17:10',
+        status: 'paid',
+        managerReviewStatus: 'approved',
+        managerReviewedAt: isoHoursAgo(4),
+        lockedAt: isoHoursAgo(3),
+      }),
+      makeWorkerFixture({
+        id: 'time-entry-worker-locked',
+        notes: 'Locked shift cannot be changed.',
+        startTime: '18:00',
+        endTime: '19:05',
+        status: 'locked',
+        lockedAt: isoHoursAgo(2),
+      }),
     ],
     reviewEntries: [
       {
@@ -658,13 +857,15 @@ const run = async () => {
   });
 
   try {
-    await page.goto(`${args.appUrl}/portal/time`, { waitUntil: 'domcontentloaded' });
+    await page.goto(`${args.appUrl}/portal/time?month=${selectedMonth}`, {
+      waitUntil: 'domcontentloaded',
+    });
     await page.waitForURL('**/login', { timeout: 10000 }).catch(() => undefined);
     await page.waitForSelector('#email-password', { timeout: 10000 });
     await page.fill('#email-password', mockUser.email);
     await page.fill('#password', 'mock-password');
     await Promise.all([
-      page.waitForURL(/\/portal\/time(?:\?month=\d{4}-\d{2})?$/, { timeout: 20000 }),
+      page.waitForURL(/\/portal\/time\?month=2026-05$/, { timeout: 20000 }),
       page.getByRole('button', { name: /sign in/i }).click(),
     ]);
 
@@ -680,6 +881,49 @@ const run = async () => {
       'Monthly hub shows the primary entry action and month control',
       (await page.getByRole('link', { name: /add completed shift/i }).isVisible()) &&
         (await page.locator('#time-month').isVisible())
+    );
+    recorder.assert(
+      'Fixed-period mock keeps selected month, date range, and due date aligned',
+      (await page.locator('#time-month').inputValue()) === selectedMonth &&
+        (await page.getByRole('heading', { name: 'May 2026 shifts' }).isVisible()) &&
+        (await page
+          .getByText('May 1, 2026 to May 31, 2026', { exact: true })
+          .first()
+          .isVisible()) &&
+        (await page.getByText(/Due Jun 2, 2026\./).isVisible())
+    );
+    recorder.assert(
+      'Worker summary shows submitted-shift count',
+      await page
+        .locator('span')
+        .filter({ hasText: /submitted shifts/i })
+        .getByText('3', { exact: true })
+        .isVisible()
+    );
+
+    const workerStatusCases = [
+      ['Pending shift for manager review.', 'Waiting for review', false],
+      ['Approved shift ready for edit-reset QA.', 'Approved', false],
+      ['Correction shift needs an updated end time.', 'Correction requested', false],
+      ['Included shift cannot be changed.', 'Included in pay', true],
+      ['Paid shift cannot be changed.', 'Paid', true],
+      ['Locked shift cannot be changed.', 'Locked', true],
+    ];
+    for (const [note, status, shouldBeLocked] of workerStatusCases) {
+      const entry = page.locator('article', { hasText: note });
+      recorder.assert(
+        `Worker ${status} state is visible`,
+        (await entry.getByText(status, { exact: true }).isVisible()) &&
+          (!shouldBeLocked ||
+            ((await entry.getByRole('button', { name: /edit/i }).isDisabled()) &&
+              (await entry.getByRole('button', { name: /delete/i }).isDisabled())))
+      );
+    }
+    recorder.assert(
+      'Worker correction state includes manager reason',
+      await page
+        .getByText('Please update the end time to match the venue log.', { exact: true })
+        .isVisible()
     );
     recorder.assert(
       'Pay statement download is visible',
@@ -718,19 +962,161 @@ const run = async () => {
         ) &&
         payStatementDownload.suggestedFilename() === 'may-2026-pay-statement.html'
     );
+    await page
+      .getByText('Pay statement downloaded.', { exact: true })
+      .last()
+      .waitFor({ state: 'hidden', timeout: 10000 });
     recorder.assert(
       'Worker review summary is visible',
       (await page.getByRole('heading', { name: 'Record completed work' }).isVisible()) &&
         (await page.locator('#time-month').isVisible())
     );
-    await page.waitForTimeout(4500);
     await page.screenshot({
-      path: path.join(args.artifactDir, 'portal-time-hub-desktop.png'),
+      path: path.join(args.artifactDir, 'portal-time-worker-states-desktop.png'),
       fullPage: true,
     });
+    await page.setViewportSize({ width: 390, height: 844 });
+    const workerStateOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > window.innerWidth + 1
+    );
+    recorder.assert('Mobile Time state-rich page has no horizontal overflow', !workerStateOverflow);
+    await page.screenshot({
+      path: path.join(args.artifactDir, 'portal-time-worker-states-mobile.png'),
+      fullPage: true,
+    });
+    await page.setViewportSize({ width: 1365, height: 900 });
+
+    state.workerLoadDelayMs = 900;
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.getByText('Loading timekeeping...', { exact: true }).waitFor({ timeout: 5000 });
+    recorder.assert(
+      'Worker loading state is exclusive',
+      (await page.getByText('Timekeeping is unavailable', { exact: true }).count()) === 0 &&
+        (await page.getByText('Timekeeping setup needed', { exact: true }).count()) === 0
+    );
+    await page.screenshot({
+      path: path.join(args.artifactDir, 'portal-time-loading-desktop.png'),
+      fullPage: true,
+    });
+    state.workerLoadDelayMs = 0;
+    await page.getByRole('heading', { name: 'Record completed work' }).waitFor({ timeout: 10000 });
+
+    state.workerLoadError = true;
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page
+      .getByText('Timekeeping is unavailable', { exact: true })
+      .waitFor({ timeout: 10000 });
+    recorder.assert(
+      'Worker load error is exclusive and actionable',
+      (await page.getByRole('button', { name: 'Try again' }).isVisible()) &&
+        (await page.getByRole('heading', { name: 'Record completed work' }).count()) === 0 &&
+        (await page.getByText('Timekeeping setup needed', { exact: true }).count()) === 0
+    );
+    await page.screenshot({
+      path: path.join(args.artifactDir, 'portal-time-load-error-desktop.png'),
+      fullPage: true,
+    });
+    state.workerLoadError = false;
+    await page.getByRole('button', { name: 'Try again' }).click();
+    await page.getByRole('heading', { name: 'Record completed work' }).waitFor({ timeout: 10000 });
+    recorder.pass('Worker load retry restores the monthly hub');
+
+    state.workerContextMode = 'no_assignments';
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.getByText('Timekeeping setup needed', { exact: true }).waitFor({ timeout: 10000 });
+    recorder.assert(
+      'Worker setup state explains assignment recovery without showing an empty shift list',
+      (await page.getByText(/assign at least one machine/i).isVisible()) &&
+        (await page.getByRole('button', { name: 'Check setup again' }).isVisible()) &&
+        (await page.getByText(/No shifts entered for this month yet/i).count()) === 0
+    );
+    await page.screenshot({
+      path: path.join(args.artifactDir, 'portal-time-setup-desktop.png'),
+      fullPage: true,
+    });
+    state.workerContextMode = 'normal';
+    await page.getByRole('button', { name: 'Check setup again' }).click();
+    await page.getByRole('heading', { name: 'Record completed work' }).waitFor({ timeout: 10000 });
+    recorder.pass('Worker setup recovery restores the monthly hub');
+
+    state.workerContextMode = 'empty';
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.getByText(/No shifts entered for this month yet/i).waitFor({ timeout: 10000 });
+    recorder.assert(
+      'Worker empty state stays distinct from setup and load failure',
+      (await page.getByRole('link', { name: /add completed shift/i }).isVisible()) &&
+        (await page.getByText('Timekeeping setup needed', { exact: true }).count()) === 0 &&
+        (await page.getByText('Timekeeping is unavailable', { exact: true }).count()) === 0
+    );
+    await page.screenshot({
+      path: path.join(args.artifactDir, 'portal-time-empty-desktop.png'),
+      fullPage: true,
+    });
+    state.workerContextMode = 'normal';
+    await page.getByRole('button', { name: 'Refresh' }).click();
+    await page.getByText('Pending shift for manager review.', { exact: true }).waitFor({
+      timeout: 10000,
+    });
+
+    const editAndAssertReviewReset = async ({
+      sourceNote,
+      nextNote,
+      endTime,
+      screenshotName,
+    }) => {
+      const sourceEntry = page.locator('article', { hasText: sourceNote });
+      await sourceEntry.getByRole('button', { name: /edit/i }).click();
+      await page.locator('h1').filter({ hasText: /^Edit Time$/ }).waitFor({ timeout: 10000 });
+      if (screenshotName) {
+        await page.setViewportSize({ width: 390, height: 844 });
+        await page.screenshot({
+          path: path.join(args.artifactDir, screenshotName),
+          fullPage: true,
+        });
+        await page.setViewportSize({ width: 1365, height: 900 });
+      }
+      await page.fill('#end-time', endTime);
+      await page.fill('#time-notes', nextNote);
+      await page.getByRole('button', { name: /save changes/i }).click();
+      await page.waitForURL(/\/portal\/time\?month=2026-05$/, { timeout: 10000 });
+      await page.getByText('Time entry saved.').last().waitFor({ timeout: 10000 });
+      const updatedEntry = page.locator('article', { hasText: nextNote });
+      await updatedEntry.getByText('Waiting for review', { exact: true }).waitFor({
+        timeout: 10000,
+      });
+      return updatedEntry;
+    };
+
+    const correctedEntry = await editAndAssertReviewReset({
+      sourceNote: 'Correction shift needs an updated end time.',
+      nextNote: 'Corrected shift after manager note.',
+      endTime: '13:25',
+      screenshotName: 'portal-time-correction-edit-mobile.png',
+    });
+    recorder.assert(
+      'Editing a correction-requested shift resets review and clears the old reason',
+      (await correctedEntry.getByText('Waiting for review', { exact: true }).isVisible()) &&
+        (await correctedEntry
+          .getByText('Please update the end time to match the venue log.', { exact: true })
+          .count()) === 0
+    );
+
+    const approvedEntry = await editAndAssertReviewReset({
+      sourceNote: 'Approved shift ready for edit-reset QA.',
+      nextNote: 'Approved shift updated by worker.',
+      endTime: '11:40',
+    });
+    recorder.assert(
+      'Editing an approved shift resets review to pending',
+      await approvedEntry.getByText('Waiting for review', { exact: true }).isVisible()
+    );
+    recorder.assert(
+      'Edit reset uses audited update RPC',
+      state.rpcCalls.filter((call) => call.rpcName === 'update_operator_time_entry').length >= 2
+    );
 
     await Promise.all([
-      page.waitForURL('**/portal/time/new', { timeout: 10000 }),
+      page.waitForURL(/\/portal\/time\/new\?month=2026-05$/, { timeout: 10000 }),
       page.getByRole('link', { name: /add completed shift/i }).click(),
     ]);
     await page.locator('h1').filter({ hasText: /^Add Time$/ }).waitFor({ timeout: 10000 });
@@ -745,10 +1131,16 @@ const run = async () => {
       'Assigned machine is visible on focused Add Time route',
       await page.getByText(/Cotton Candy 01/).first().isVisible()
     );
+    recorder.assert(
+      'Focused Add Time keeps the selected mock period',
+      (await page.locator('#work-date').inputValue()) === '2026-05-01' &&
+        (await page.getByText('May 1, 2026 to May 31, 2026', { exact: true }).isVisible()) &&
+        (await page.getByText('Jun 2, 2026', { exact: true }).isVisible())
+    );
 
     await page.fill('#work-date', workDate);
-    await page.fill('#start-time', '09:00');
-    await page.fill('#end-time', '09:30');
+    await page.fill('#start-time', '20:30');
+    await page.fill('#end-time', '21:00');
     await page.fill('#time-notes', 'Restocked sugar and cleaned spinner head.');
 
     recorder.assert('Actual time preview updates', await page.getByText('30 min').isVisible());
@@ -757,42 +1149,58 @@ const run = async () => {
       await page.getByText('1 rounded hr').isVisible()
     );
 
+    state.failNextSubmit = true;
     await page.getByRole('button', { name: /submit shift/i }).click();
-    await page.waitForURL(/\/portal\/time(?:\?month=\d{4}-\d{2})?$/, { timeout: 10000 });
+    await page.getByText('Shift was not saved', { exact: true }).waitFor({ timeout: 10000 });
+    recorder.assert(
+      'Worker mutation failure preserves form for retry',
+      new URL(page.url()).pathname === '/portal/time/new' &&
+        (await page.locator('#time-notes').inputValue()) ===
+          'Restocked sugar and cleaned spinner head.' &&
+        (await page.locator('#start-time').inputValue()) === '20:30'
+    );
+    await page.screenshot({
+      path: path.join(args.artifactDir, 'portal-time-mutation-error-desktop.png'),
+      fullPage: true,
+    });
+    await page.getByRole('button', { name: /submit shift/i }).click();
+    await page.waitForURL(/\/portal\/time\?month=2026-05$/, { timeout: 10000 });
     await page.getByText('Time entry saved.').last().waitFor({ timeout: 10000 });
     await page.screenshot({
       path: path.join(args.artifactDir, 'portal-time-after-save.png'),
       fullPage: true,
     });
     await page.getByText('Restocked sugar and cleaned spinner head.').waitFor({ timeout: 10000 });
-    await page.getByText('Waiting for review').waitFor({ timeout: 10000 });
+    await page
+      .locator('article', { hasText: 'Restocked sugar and cleaned spinner head.' })
+      .getByText('Waiting for review', { exact: true })
+      .waitFor({ timeout: 10000 });
 
     recorder.assert(
-      'Submit RPC receives assigned machine and date',
-      state.rpcCalls.some(
+      'Worker mutation retry submits assigned machine and date',
+      state.rpcCalls.filter(
         (call) =>
           call.rpcName === 'submit_operator_time_entry' &&
           call.body?.p_reporting_machine_id === machineId &&
           call.body?.p_work_date === workDate
-      ),
-      JSON.stringify(state.rpcCalls.filter((call) => call.rpcName === 'submit_operator_time_entry'))
+      ).length === 2
     );
 
     await Promise.all([
-      page.waitForURL('**/portal/time/new', { timeout: 10000 }),
+      page.waitForURL(/\/portal\/time\/new\?month=2026-05$/, { timeout: 10000 }),
       page.getByRole('link', { name: /add completed shift/i }).click(),
     ]);
     await page.fill('#work-date', workDate);
-    await page.fill('#start-time', '09:00');
-    await page.fill('#end-time', '09:30');
+    await page.fill('#start-time', '20:30');
+    await page.fill('#end-time', '21:00');
     await page.getByText(/duplicate of an existing shift/i).waitFor({ timeout: 10000 });
     recorder.assert(
       'Exact duplicate blocks save',
       await page.getByRole('button', { name: /submit shift/i }).isDisabled()
     );
 
-    await page.fill('#start-time', '09:15');
-    await page.fill('#end-time', '10:00');
+    await page.fill('#start-time', '20:45');
+    await page.fill('#end-time', '21:15');
     await page.getByText(/overlaps 1 existing entry/i).waitFor({ timeout: 10000 });
     recorder.pass('Overlap warning appears before saving');
     let sawOverlapConfirmation = false;
@@ -810,6 +1218,7 @@ const run = async () => {
       sawOverlapConfirmation && new URL(page.url()).pathname === '/portal/time/new'
     );
 
+    await page.fill('#work-date', '2026-05-21');
     await page.fill('#start-time', '08:00');
     await page.fill('#end-time', '20:00');
     await page.getByText(/10\+ hours/i).waitFor({ timeout: 10000 });
@@ -829,104 +1238,136 @@ const run = async () => {
       sawLongShiftConfirmation && new URL(page.url()).pathname === '/portal/time/new'
     );
 
-    await page.goto(`${args.appUrl}/portal/time`, { waitUntil: 'domcontentloaded' });
-    await Promise.all([
-      page.waitForURL(/\/portal\/time\/time-entry-1\/edit\?month=2026-05$/, { timeout: 10000 }),
-      page.locator('article', { hasText: 'Restocked sugar' }).getByRole('button', { name: /edit/i }).click(),
-    ]);
-    await page.locator('h1').filter({ hasText: /^Edit Time$/ }).waitFor({ timeout: 10000 });
     await page.setViewportSize({ width: 390, height: 844 });
-    await page.evaluate(() => window.scrollTo(0, 0));
+    const workerFormOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth > window.innerWidth + 1
+    );
+    recorder.assert('Mobile Add Time page has no horizontal overflow', !workerFormOverflow);
     await page.screenshot({
-      path: path.join(args.artifactDir, 'portal-time-edit-mobile.png'),
+      path: path.join(args.artifactDir, 'portal-time-add-mobile.png'),
       fullPage: true,
     });
     await page.setViewportSize({ width: 1365, height: 900 });
-    await page.fill('#start-time', '10:00');
-    await page.fill('#end-time', '11:01');
-    await page.getByText('2 rounded hrs').waitFor({ timeout: 10000 });
-    await page.fill('#time-notes', 'Updated shift after manager text.');
-    await page.getByRole('button', { name: /save changes/i }).click();
-    await page.waitForURL(/\/portal\/time(?:\?month=\d{4}-\d{2})?$/, { timeout: 10000 });
-    await waitForCondition(
-      () => state.rpcCalls.some((call) => call.rpcName === 'update_operator_time_entry'),
-      'Timed out waiting for update_operator_time_entry RPC'
-    );
-    await page.getByText('Time entry saved.').last().waitFor({ timeout: 10000 });
-    await page.getByText('Updated shift after manager text.').waitFor({ timeout: 10000 });
-
-    recorder.assert(
-      'Update RPC receives edited time entry',
-      state.rpcCalls.some(
-        (call) =>
-          call.rpcName === 'update_operator_time_entry' &&
-          call.body?.p_start_time === '10:00' &&
-          call.body?.p_end_time === '11:01'
-      ),
-      JSON.stringify(state.rpcCalls.filter((call) => call.rpcName.includes('time_entry')))
-    );
+    await page.getByRole('link', { name: /time home/i }).click();
+    await page.waitForURL(/\/portal\/time\?month=2026-05$/, { timeout: 10000 });
 
     page.once('dialog', async (dialog) => {
       await dialog.accept();
     });
-    await page.locator('article', { hasText: 'Updated shift' }).getByRole('button', { name: /delete/i }).click();
+    await page
+      .locator('article', { hasText: 'Restocked sugar and cleaned spinner head.' })
+      .getByRole('button', { name: /delete/i })
+      .click();
     await page.getByText('Time entry deleted.').last().waitFor({ timeout: 10000 });
-    await page.getByText(/No shifts entered for this month yet/i).waitFor({ timeout: 10000 });
 
     recorder.assert(
       'Delete uses void RPC instead of direct hard delete',
       state.rpcCalls.some((call) => call.rpcName === 'void_operator_time_entry')
     );
 
-    await page.setViewportSize({ width: 390, height: 844 });
-    await page.evaluate(() => window.scrollTo(0, 0));
-    await page.waitForTimeout(4500);
-
-    const overflow = await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth + 1);
-    recorder.assert('Mobile Time page has no horizontal overflow', !overflow);
-
-    await page.screenshot({
-      path: path.join(args.artifactDir, 'portal-time-mobile.png'),
-      fullPage: true,
-    });
-
-    await Promise.all([
-      page.waitForURL('**/portal/time/new', { timeout: 10000 }),
-      page.getByRole('link', { name: /add completed shift/i }).click(),
-    ]);
-    await page.locator('h1').filter({ hasText: /^Add Time$/ }).waitFor({ timeout: 10000 });
-    await page.screenshot({
-      path: path.join(args.artifactDir, 'portal-time-add-mobile.png'),
-      fullPage: true,
-    });
-
     state.managerMode = true;
+    state.reviewLoadDelayMs = 900;
     await page.setViewportSize({ width: 1365, height: 900 });
     await page.goto(`${args.appUrl}/portal/time-review`, { waitUntil: 'domcontentloaded' });
-    await page.locator('h1').filter({ hasText: /^Review time$/ }).waitFor({ timeout: 10000 });
-    await page.fill('#review-month', '2026-05');
+    await page.getByText('Loading submitted time...', { exact: true }).waitFor({ timeout: 5000 });
+    recorder.assert(
+      'Manager loading state is exclusive',
+      (await page.getByText('Time review is unavailable', { exact: true }).count()) === 0 &&
+        (await page.getByText('No managed machines', { exact: true }).count()) === 0
+    );
+    await page.screenshot({
+      path: path.join(args.artifactDir, 'portal-time-review-loading-desktop.png'),
+      fullPage: true,
+    });
+    state.reviewLoadDelayMs = 0;
+    await page.locator('#review-month').waitFor({ timeout: 10000 });
+
+    state.reviewLoadError = true;
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.getByText('Time review is unavailable', { exact: true }).waitFor({
+      timeout: 30000,
+    });
+    recorder.assert(
+      'Manager load error is exclusive and actionable',
+      (await page.getByRole('button', { name: 'Try again' }).isVisible()) &&
+        (await page.locator('#review-month').count()) === 0 &&
+        (await page.getByText('No managed machines', { exact: true }).count()) === 0
+    );
+    await page.screenshot({
+      path: path.join(args.artifactDir, 'portal-time-review-load-error-desktop.png'),
+      fullPage: true,
+    });
+    state.reviewLoadError = false;
+    await page.getByRole('button', { name: 'Try again' }).click();
+    await page.locator('#review-month').waitFor({ timeout: 10000 });
+    recorder.pass('Manager load retry restores review controls');
+
+    state.reviewContextMode = 'no_access';
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.getByText('No managed machines', { exact: true }).waitFor({ timeout: 10000 });
+    recorder.assert(
+      'Manager setup state explains assignment recovery without showing the queue',
+      (await page.getByText(/update your machine assignment/i).isVisible()) &&
+        (await page.locator('#review-month').count()) === 0
+    );
+    await page.screenshot({
+      path: path.join(args.artifactDir, 'portal-time-review-no-access-desktop.png'),
+      fullPage: true,
+    });
+    state.reviewContextMode = 'normal';
+    await page.getByRole('button', { name: 'Refresh' }).click();
+    await page.locator('#review-month').waitFor({ timeout: 10000 });
+    recorder.pass('Manager setup refresh restores review controls');
+
+    state.reviewContextMode = 'empty';
+    await page.fill('#review-month', selectedMonth);
+    await page.getByText('Nothing waiting for review', { exact: true }).waitFor({ timeout: 10000 });
+    recorder.assert(
+      'Manager empty queue stays distinct from setup and load failure',
+      (await page.getByText(/caught up for this month/i).isVisible()) &&
+        (await page.getByText('No managed machines', { exact: true }).count()) === 0 &&
+        (await page.getByText('Time review is unavailable', { exact: true }).count()) === 0
+    );
+    state.reviewContextMode = 'normal';
+    await page.getByRole('button', { name: 'Refresh' }).click();
     await page.getByText('Jordan Contractor', { exact: true }).waitFor({ timeout: 10000 });
 
+    recorder.assert(
+      'Manager fixed-period evidence matches the selected month',
+      (await page.locator('#review-month').inputValue()) === selectedMonth &&
+        (await page.getByText('May 1, 2026 to May 31, 2026', { exact: true }).isVisible())
+    );
     recorder.assert(
       'Machine Manager review queue loads managed-machine shifts',
       (await page.getByText('Jordan Contractor', { exact: true }).isVisible()) &&
         (await page.getByText('Sam Contractor', { exact: true }).isVisible()) &&
-        (await page.getByText('Cotton Candy 01 · Mall Atrium').first().isVisible())
+        (await page.getByText(/Cotton Candy 01.*Mall Atrium/).first().isVisible())
     );
 
-    await page
-      .locator('article', { hasText: 'Jordan Contractor' })
-      .getByRole('button', { name: /^approve$/i })
-      .click();
+    state.failNextReview = true;
+    const jordanEntry = page.locator('article', { hasText: 'Jordan Contractor' });
+    await jordanEntry.getByRole('button', { name: /^approve$/i }).click();
+    await page.getByText('Review was not saved', { exact: true }).waitFor({ timeout: 10000 });
+    recorder.assert(
+      'Manager mutation failure keeps the shift actionable for retry',
+      (await jordanEntry.getByRole('button', { name: /^approve$/i }).isEnabled()) &&
+        state.reviewEntries.find((entry) => entry.id === 'time-entry-manager-approve')
+          ?.managerReviewStatus === 'pending'
+    );
+    await page.screenshot({
+      path: path.join(args.artifactDir, 'portal-time-review-mutation-error-desktop.png'),
+      fullPage: true,
+    });
+    await jordanEntry.getByRole('button', { name: /^approve$/i }).click();
     await page.getByText('Shift approved.').last().waitFor({ timeout: 10000 });
     recorder.assert(
-      'Approve action uses the machine-manager review RPC',
-      state.rpcCalls.some(
+      'Approve retry uses the machine-manager review RPC',
+      state.rpcCalls.filter(
         (call) =>
           call.rpcName === 'review_operator_time_entry' &&
           call.body?.p_time_entry_id === 'time-entry-manager-approve' &&
           call.body?.p_decision === 'approved'
-      )
+      ).length === 2
     );
 
     await page
@@ -951,6 +1392,10 @@ const run = async () => {
     await page
       .getByText('Please confirm the end time; the venue log shows 2:45 PM.')
       .waitFor({ timeout: 10000 });
+    await page
+      .getByText('Correction requested.', { exact: true })
+      .last()
+      .waitFor({ state: 'hidden', timeout: 10000 });
     await page.screenshot({
       path: path.join(args.artifactDir, 'portal-time-review-desktop.png'),
       fullPage: true,
@@ -967,10 +1412,13 @@ const run = async () => {
       fullPage: true,
     });
 
+    const unexpectedConsoleErrors = consoleErrors.filter(
+      (message) => !/status of (500|503)/i.test(message)
+    );
     recorder.assert(
-      'No browser console/page errors during mocked Operator Time QA pass',
-      consoleErrors.length === 0,
-      consoleErrors.slice(0, 3).join(' | ')
+      'No unexpected browser console/page errors during mocked Operator Time QA pass',
+      unexpectedConsoleErrors.length === 0,
+      unexpectedConsoleErrors.slice(0, 3).join(' | ')
     );
   } finally {
     await context.close();
@@ -984,7 +1432,7 @@ const run = async () => {
   }
 
   console.log('\nOperator Time UAT validation passed.');
-  console.log(`Screenshot written to ${path.join(args.artifactDir, 'portal-time-mobile.png')}`);
+  console.log(`Screenshots written to ${args.artifactDir}`);
 };
 
 run().catch((error) => {

--- a/scripts/validate-operator-timekeeping.mjs
+++ b/scripts/validate-operator-timekeeping.mjs
@@ -21,6 +21,7 @@ const files = {
   app: path.join(repoRoot, 'src', 'App.tsx'),
   nav: path.join(repoRoot, 'src', 'components', 'portal', 'portalNavigation.ts'),
   helper: path.join(repoRoot, 'src', 'lib', 'operatorPayouts.ts'),
+  accessHook: path.join(repoRoot, 'src', 'hooks', 'usePortalTimekeepingAccess.ts'),
   smoke: path.join(repoRoot, 'Docs', 'QA_SMOKE_TEST_CHECKLIST.md'),
 };
 
@@ -80,8 +81,12 @@ for (const snippet of [
   'Delete this submitted time entry',
   'duplicate of an existing shift',
   'Record completed work',
+  'submitted shifts',
   'Waiting for review',
   'Correction requested',
+  'Timekeeping is unavailable',
+  'Check setup again',
+  'Shift was not saved',
   'Each shift up to the next full hour',
 ]) {
   if (!page.includes(snippet)) {
@@ -121,6 +126,7 @@ for (const snippet of [
   'Request correction',
   'A reason is required',
   'No managed machines',
+  'Review was not saved',
 ]) {
   if (!reviewPage.includes(snippet)) {
     fail(`Time Review page missing ${snippet}`);
@@ -136,6 +142,11 @@ expect(readText(files.nav), "href: '/portal/time-review'", 'portal review naviga
 expect(readText(files.helper), 'fetchMyOperatorTimekeepingContext', 'operator payout helper');
 expect(readText(files.helper), 'fetchMyTimeReviewContext', 'time review context helper');
 expect(readText(files.helper), 'reviewOperatorTimeEntry', 'time review action helper');
+expect(
+  readText(files.accessHook),
+  'queryFn: () => fetchMyOperatorTimekeepingContext()',
+  'timekeeping access query'
+);
 expect(readText(files.smoke), 'Operator Time (`/portal/time`)', 'smoke checklist');
 expect(readText(files.smoke), 'Review Time (`/portal/time-review`)', 'review smoke checklist');
 

--- a/scripts/validate-operator-timekeeping.mjs
+++ b/scripts/validate-operator-timekeeping.mjs
@@ -94,6 +94,15 @@ for (const snippet of [
   'Check setup again',
   'Shift was not saved',
   'Each shift up to the next full hour',
+  'id="operator-profile-select"',
+  'id="work-profile-select"',
+  'Your manager requested a correction',
+  'data-time-status-badge',
+  'border-sage/40 bg-sage/10 text-foreground',
+  'border-amber/40 bg-amber/10 text-foreground',
+  'border-border bg-muted/60 text-foreground',
+  'aria-label={`Edit shift on',
+  'aria-label={`Delete shift on',
 ]) {
   if (!page.includes(snippet)) {
     fail(`Time page missing ${snippet}`);
@@ -144,6 +153,15 @@ for (const snippet of [
   'A reason is required',
   'No managed machines',
   'Review was not saved',
+  'time-review-queue-heading',
+  'role="status"',
+  'aria-live="polite"',
+  'data-time-status-badge',
+  'border-sage/40 bg-sage/10 text-foreground',
+  'border-amber/40 bg-amber/10 text-foreground',
+  'border-border bg-muted/60 text-foreground',
+  'aria-label={`Request correction for',
+  "aria-label={`${entry.managerReviewStatus === 'approved' ? 'Approved' : 'Approve'}",
 ]) {
   if (!reviewPage.includes(snippet)) {
     fail(`Time Review page missing ${snippet}`);

--- a/src/hooks/usePortalTimekeepingAccess.ts
+++ b/src/hooks/usePortalTimekeepingAccess.ts
@@ -8,7 +8,7 @@ export function usePortalTimekeepingAccess() {
 
   const query = useQuery({
     queryKey: ['operator-timekeeping-access', user?.id],
-    queryFn: fetchMyOperatorTimekeepingContext,
+    queryFn: () => fetchMyOperatorTimekeepingContext(),
     enabled: Boolean(user?.id),
     staleTime: 30_000,
   });

--- a/src/pages/portal/Time.tsx
+++ b/src/pages/portal/Time.tsx
@@ -172,7 +172,7 @@ const getStatusLabel = (status: string) =>
 const getEntryReviewLabel = (entry: OperatorTimeEntry) => {
   if (entry.status === 'draft') return 'Draft';
   if (entry.status === 'paid') return 'Paid';
-  if (entry.status === 'included_in_payout') return 'Included';
+  if (entry.status === 'included_in_payout') return 'Included in pay';
   if (entry.status === 'locked') return 'Locked';
   if (entry.managerReviewStatus === 'approved') return 'Approved';
   if (entry.managerReviewStatus === 'needs_correction') return 'Correction requested';
@@ -233,10 +233,12 @@ export default function PortalTimePage() {
     isLoading,
     isFetching,
     error,
+    refetch: refetchTimekeeping,
   } = useQuery({
     queryKey: getContextQueryKey(contextWorkDate),
     queryFn: () => fetchMyOperatorTimekeepingContext(contextWorkDate),
     staleTime: 1000 * 20,
+    retry: false,
   });
 
   const {
@@ -253,7 +255,9 @@ export default function PortalTimePage() {
 
   useEffect(() => {
     if (!selectedProfileId && profiles.length > 0) {
-      setSelectedProfileId(profiles[0].id);
+      setSelectedProfileId(
+        profiles.find((profile) => profile.assignedMachines.length > 0)?.id ?? profiles[0].id
+      );
     }
   }, [profiles, selectedProfileId]);
 
@@ -284,12 +288,16 @@ export default function PortalTimePage() {
     return {
       rawMinutes: entries.reduce((total, entry) => total + entry.rawDurationMinutes, 0),
       roundedMinutes: entries.reduce((total, entry) => total + entry.roundedPaidMinutes, 0),
+      submitted: entries.filter((entry) => entry.status === 'submitted').length,
       waiting: entries.filter(
         (entry) => entry.status === 'submitted' && entry.managerReviewStatus === 'pending'
       ).length,
-      approved: entries.filter((entry) => entry.managerReviewStatus === 'approved').length,
+      approved: entries.filter(
+        (entry) => entry.status === 'submitted' && entry.managerReviewStatus === 'approved'
+      ).length,
       needsCorrection: entries.filter(
-        (entry) => entry.managerReviewStatus === 'needs_correction'
+        (entry) =>
+          entry.status === 'submitted' && entry.managerReviewStatus === 'needs_correction'
       ).length,
     };
   }, [selectedProfile]);
@@ -305,6 +313,13 @@ export default function PortalTimePage() {
 
     if (!entryId) {
       setEditingEntryId(null);
+      setForm(() => {
+        const nextForm = defaultForm();
+
+        return isValidMonthValue(requestedMonth)
+          ? { ...nextForm, workDate: `${requestedMonth}-01` }
+          : nextForm;
+      });
       return;
     }
 
@@ -318,7 +333,7 @@ export default function PortalTimePage() {
       endTime: routeEntry.endTime,
       notes: routeEntry.notes ?? '',
     });
-  }, [entryId, isTimeEntryScreen, routeEntry]);
+  }, [entryId, isTimeEntryScreen, requestedMonth, routeEntry]);
 
   useEffect(() => {
     if (!isTimeEntryScreen && editingEntryId) {
@@ -467,6 +482,10 @@ export default function PortalTimePage() {
     ]);
   };
 
+  const retryTimekeeping = async () => {
+    await refetchTimekeeping();
+  };
+
   const downloadStatement = async (statement: OperatorPayStatementSummary) => {
     setDownloadingStatementId(statement.id);
     try {
@@ -595,19 +614,36 @@ export default function PortalTimePage() {
             }
           />
 
-          {error && (
-            <div className="mt-4 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
-              Unable to load timekeeping. Please refresh and try again.
-            </div>
-          )}
-
-          {isLoading && (
+          {isLoading ? (
             <div className="mt-6 card-elevated px-5 py-10 text-center text-sm text-muted-foreground">
+              <Loader2 className="mx-auto mb-3 h-5 w-5 animate-spin" />
               Loading timekeeping...
             </div>
-          )}
-
-          {!isLoading && profiles.length === 0 && (
+          ) : error ? (
+            <div className="mt-6 card-elevated px-5 py-8">
+              <AlertTriangle className="h-6 w-6 text-destructive" />
+              <h2 className="mt-4 text-xl font-semibold text-foreground">
+                Timekeeping is unavailable
+              </h2>
+              <p className="mt-2 max-w-2xl text-pretty text-sm leading-6 text-muted-foreground">
+                Your shifts could not be loaded. Try again before entering or changing time.
+              </p>
+              <Button
+                type="button"
+                variant="outline"
+                className={cn('mt-5', timeActionClassName)}
+                onClick={() => void retryTimekeeping()}
+                disabled={isFetching}
+              >
+                {isFetching ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <RefreshCw className="mr-2 h-4 w-4" />
+                )}
+                Try again
+              </Button>
+            </div>
+          ) : !selectedProfile || selectedProfile.assignedMachines.length === 0 ? (
             <div className="mt-6 card-elevated px-5 py-10">
               <div className="mx-auto max-w-xl text-center">
                 <Clock3 className="mx-auto h-10 w-10 text-muted-foreground" />
@@ -615,14 +651,32 @@ export default function PortalTimePage() {
                   Timekeeping setup needed
                 </h2>
                 <p className="mt-2 text-pretty text-sm text-muted-foreground">
-                  Ask a Bloomjoy admin or machine manager to add your timekeeping profile and
-                  assigned machines before entering shifts.
+                  {selectedProfile
+                    ? 'Ask a Bloomjoy admin or machine manager to assign at least one machine before entering shifts.'
+                    : 'Ask a Bloomjoy admin or machine manager to add your timekeeping profile and assigned machines before entering shifts.'}
                 </p>
+                <div className="mt-5 flex flex-col justify-center gap-3 sm:flex-row">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => void retryTimekeeping()}
+                    disabled={isFetching}
+                    className={timeActionClassName}
+                  >
+                    {isFetching ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      <RefreshCw className="mr-2 h-4 w-4" />
+                    )}
+                    Check setup again
+                  </Button>
+                  <Button asChild variant="ghost" className={timeActionClassName}>
+                    <Link to="/portal">Back to dashboard</Link>
+                  </Button>
+                </div>
               </div>
             </div>
-          )}
-
-          {selectedProfile && (
+          ) : (
             <>
               {isTimeEntryScreen ? (
                 <div className="mx-auto mt-6 max-w-3xl">
@@ -813,6 +867,18 @@ export default function PortalTimePage() {
                         </Button>
                       </div>
 
+                      {saveMutation.isError && (
+                        <div
+                          role="alert"
+                          className="mt-4 rounded-lg border border-destructive/25 bg-destructive/5 px-3 py-3 text-sm text-foreground"
+                        >
+                          <p className="font-semibold">Shift was not saved</p>
+                          <p className="mt-1 text-pretty text-muted-foreground">
+                            Your entries are still here. Check your connection and try again.
+                          </p>
+                        </div>
+                      )}
+
                       {hasBlockingValidation && !saveMutation.isPending && (
                         <p className="mt-3 text-xs text-muted-foreground">
                           Enter a date, assigned machine, start time, and end time to submit the
@@ -843,7 +909,7 @@ export default function PortalTimePage() {
                         </p>
                       </div>
                       <Button asChild size="lg" className={timeActionClassName}>
-                        <Link to="/portal/time/new">
+                        <Link to={`/portal/time/new?month=${viewMonth}`}>
                           <Plus className="mr-2 h-4 w-4" />
                           Add completed shift
                         </Link>
@@ -921,6 +987,12 @@ export default function PortalTimePage() {
                               {formatPaidHours(periodSummary.roundedMinutes)}
                             </strong>
                             rounded time
+                          </span>
+                          <span>
+                            <strong className="block text-base font-semibold tabular-nums text-foreground">
+                              {periodSummary.submitted}
+                            </strong>
+                            submitted shifts
                           </span>
                           <span>
                             <strong className="block text-base font-semibold tabular-nums text-foreground">

--- a/src/pages/portal/Time.tsx
+++ b/src/pages/portal/Time.tsx
@@ -180,10 +180,12 @@ const getEntryReviewLabel = (entry: OperatorTimeEntry) => {
 };
 
 const getEntryReviewClassName = (entry: OperatorTimeEntry) => {
-  if (entry.status !== 'submitted') return 'border-border bg-muted text-muted-foreground';
-  if (entry.managerReviewStatus === 'approved') return 'border-sage/25 bg-sage-light text-sage';
+  if (entry.status !== 'submitted') return 'border-border bg-muted/60 text-foreground';
+  if (entry.managerReviewStatus === 'approved') {
+    return 'border-sage/40 bg-sage/10 text-foreground';
+  }
   if (entry.managerReviewStatus === 'needs_correction') {
-    return 'border-amber/25 bg-amber/10 text-amber';
+    return 'border-amber/40 bg-amber/10 text-foreground';
   }
   return 'border-primary/20 bg-primary/10 text-primary';
 };
@@ -701,7 +703,10 @@ export default function PortalTimePage() {
                         </div>
                         {profiles.length > 1 && (
                           <div className="w-full sm:w-56">
-                            <label className="mb-1 block text-sm font-medium text-foreground">
+                            <label
+                              htmlFor="operator-profile-select"
+                              className="mb-1 block text-sm font-medium text-foreground"
+                            >
                               Operator profile
                             </label>
                             <Select
@@ -711,7 +716,7 @@ export default function PortalTimePage() {
                                 setEditingEntryId(null);
                               }}
                             >
-                              <SelectTrigger>
+                              <SelectTrigger id="operator-profile-select">
                                 <SelectValue />
                               </SelectTrigger>
                               <SelectContent>
@@ -725,6 +730,22 @@ export default function PortalTimePage() {
                           </div>
                         )}
                       </div>
+
+                      {entryBeingEdited?.managerReviewStatus === 'needs_correction' &&
+                        entryBeingEdited.managerReviewReason && (
+                          <div
+                            role="note"
+                            aria-labelledby="edit-time-correction-heading"
+                            className="mt-5 rounded-xl border border-amber/40 bg-amber/10 px-3 py-3 text-sm leading-6 text-foreground"
+                          >
+                            <p id="edit-time-correction-heading" className="font-semibold">
+                              Your manager requested a correction
+                            </p>
+                            <p className="mt-1 text-pretty">
+                              {entryBeingEdited.managerReviewReason}
+                            </p>
+                          </div>
+                        )}
 
                       <PeriodDetails profile={selectedProfile} />
 
@@ -959,11 +980,17 @@ export default function PortalTimePage() {
                           </div>
                           {profiles.length > 1 && (
                             <div>
-                              <label className="mb-1.5 block text-sm font-medium">
+                              <label
+                                htmlFor="work-profile-select"
+                                className="mb-1.5 block text-sm font-medium"
+                              >
                                 Work profile
                               </label>
                               <Select value={selectedProfile.id} onValueChange={setSelectedProfileId}>
-                                <SelectTrigger className="min-h-11 sm:w-64">
+                                <SelectTrigger
+                                  id="work-profile-select"
+                                  className="min-h-11 sm:w-64"
+                                >
                                   <SelectValue />
                                 </SelectTrigger>
                                 <SelectContent>
@@ -1268,6 +1295,7 @@ function TimeEntriesPanel({
                         {entry.machineLabel}
                       </h3>
                       <span
+                        data-time-status-badge={getEntryReviewLabel(entry)}
                         className={cn(
                           'rounded-full border px-2.5 py-1 text-xs font-semibold',
                           getEntryReviewClassName(entry)
@@ -1317,6 +1345,7 @@ function TimeEntriesPanel({
                         size="sm"
                         onClick={() => onEdit(entry)}
                         disabled={locked}
+                        aria-label={`Edit shift on ${formatDate(entry.workDate)}, ${entry.startTime} to ${entry.endTime}, ${getMachineLabel(entry)}`}
                         className={timeSmallActionClassName}
                       >
                         <Edit3 className="mr-1.5 h-4 w-4" />
@@ -1328,6 +1357,7 @@ function TimeEntriesPanel({
                         size="sm"
                         onClick={() => onDelete(entry)}
                         disabled={locked || isDeleting}
+                        aria-label={`Delete shift on ${formatDate(entry.workDate)}, ${entry.startTime} to ${entry.endTime}, ${getMachineLabel(entry)}`}
                         className={timeSmallActionClassName}
                       >
                         {isDeleting ? (

--- a/src/pages/portal/Time.tsx
+++ b/src/pages/portal/Time.tsx
@@ -262,7 +262,10 @@ export default function PortalTimePage() {
   }, [profiles, selectedProfileId]);
 
   const selectedProfile = useMemo(
-    () => profiles.find((profile) => profile.id === selectedProfileId) ?? profiles[0],
+    () =>
+      profiles.find((profile) => profile.id === selectedProfileId) ??
+      profiles.find((profile) => profile.assignedMachines.length > 0) ??
+      profiles[0],
     [profiles, selectedProfileId]
   );
   const routeEntry = useMemo(() => {

--- a/src/pages/portal/TimeReview.tsx
+++ b/src/pages/portal/TimeReview.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   CalendarDays,
@@ -103,9 +103,11 @@ const getReviewBadgeClass = (
   reviewStatus: TimeEntryManagerReviewStatus,
   entryStatus: OperatorTimeReviewEntry['status']
 ) => {
-  if (entryStatus !== 'submitted') return 'border-border bg-muted text-muted-foreground';
-  if (reviewStatus === 'approved') return 'border-sage/25 bg-sage-light text-sage';
-  if (reviewStatus === 'needs_correction') return 'border-amber/25 bg-amber/10 text-amber';
+  if (entryStatus !== 'submitted') return 'border-border bg-muted/60 text-foreground';
+  if (reviewStatus === 'approved') return 'border-sage/40 bg-sage/10 text-foreground';
+  if (reviewStatus === 'needs_correction') {
+    return 'border-amber/40 bg-amber/10 text-foreground';
+  }
   return 'border-primary/20 bg-primary/10 text-primary';
 };
 
@@ -128,6 +130,8 @@ export default function PortalTimeReviewPage() {
   const [filter, setFilter] = useState<ReviewFilter>('needs_review');
   const [correctionEntry, setCorrectionEntry] = useState<OperatorTimeReviewEntry | null>(null);
   const [correctionReason, setCorrectionReason] = useState('');
+  const [reviewAnnouncement, setReviewAnnouncement] = useState('');
+  const queueHeadingRef = useRef<HTMLHeadingElement>(null);
   const workDate = `${month}-01`;
 
   const { data: context, isLoading, isFetching, error, refetch } = useQuery({
@@ -172,6 +176,11 @@ export default function PortalTimeReviewPage() {
       toast.success(
         variables.decision === 'approved' ? 'Shift approved.' : 'Correction requested.'
       );
+      setReviewAnnouncement(
+        variables.decision === 'approved'
+          ? 'Shift approved. The review queue is updated.'
+          : 'Correction requested. The review queue is updated.'
+      );
       setCorrectionEntry(null);
       setCorrectionReason('');
     },
@@ -201,6 +210,12 @@ export default function PortalTimeReviewPage() {
 
   const isMutatingEntry = (entryId: string) =>
     reviewMutation.isPending && reviewMutation.variables?.timeEntryId === entryId;
+
+  useEffect(() => {
+    if (!reviewAnnouncement) return;
+
+    queueHeadingRef.current?.focus();
+  }, [reviewAnnouncement, visibleEntries.length]);
 
   return (
     <PortalLayout>
@@ -366,11 +381,23 @@ export default function PortalTimeReviewPage() {
 
               <div className="overflow-hidden rounded-[24px] border border-border bg-background shadow-[var(--shadow-sm)]">
                 <div className="border-b border-border px-4 py-4 sm:px-5">
-                  <h2 className="font-display text-xl font-semibold text-foreground">
+                  <h2
+                    id="time-review-queue-heading"
+                    ref={queueHeadingRef}
+                    tabIndex={-1}
+                    aria-describedby="time-review-queue-status"
+                    className="font-display text-xl font-semibold text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  >
                     {filter === 'needs_review' ? 'Ready for your review' : 'Monthly time'}
                   </h2>
-                  <p className="mt-1 text-sm text-muted-foreground">
-                    {formatDate(context.periodStartDate)} to {formatDate(context.periodEndDate)}
+                  <p
+                    id="time-review-queue-status"
+                    role="status"
+                    aria-live="polite"
+                    className="mt-1 text-sm text-muted-foreground"
+                  >
+                    {reviewAnnouncement ||
+                      `${formatDate(context.periodStartDate)} to ${formatDate(context.periodEndDate)}`}
                   </p>
                 </div>
 
@@ -399,6 +426,10 @@ export default function PortalTimeReviewPage() {
                               <div className="flex flex-wrap items-center gap-2">
                                 <h3 className="font-semibold text-foreground">{entry.operatorName}</h3>
                                 <span
+                                  data-time-status-badge={getReviewLabel(
+                                    entry.managerReviewStatus,
+                                    entry.status
+                                  )}
                                   className={cn(
                                     'rounded-full border px-2.5 py-1 text-xs font-semibold',
                                     getReviewBadgeClass(entry.managerReviewStatus, entry.status)
@@ -443,6 +474,7 @@ export default function PortalTimeReviewPage() {
                                   type="button"
                                   variant="outline"
                                   disabled={isSaving}
+                                  aria-label={`Request correction for ${entry.operatorName}'s shift on ${formatDate(entry.workDate)}, ${formatTime(entry.startTime)} to ${formatTime(entry.endTime)}, ${entry.machineLabel} at ${entry.locationName}`}
                                   onClick={() => {
                                     setCorrectionEntry(entry);
                                     setCorrectionReason(entry.managerReviewReason ?? '');
@@ -454,6 +486,7 @@ export default function PortalTimeReviewPage() {
                                 <Button
                                   type="button"
                                   disabled={isSaving || entry.managerReviewStatus === 'approved'}
+                                  aria-label={`${entry.managerReviewStatus === 'approved' ? 'Approved' : 'Approve'} ${entry.operatorName}'s shift on ${formatDate(entry.workDate)}, ${formatTime(entry.startTime)} to ${formatTime(entry.endTime)}, ${entry.machineLabel} at ${entry.locationName}`}
                                   onClick={() => approveEntry(entry)}
                                 >
                                   {isSaving ? (

--- a/src/pages/portal/TimeReview.tsx
+++ b/src/pages/portal/TimeReview.tsx
@@ -92,7 +92,7 @@ const getReviewLabel = (
   entryStatus: OperatorTimeReviewEntry['status']
 ) => {
   if (entryStatus === 'paid') return 'Paid';
-  if (entryStatus === 'included_in_payout') return 'Included';
+  if (entryStatus === 'included_in_payout') return 'Included in pay';
   if (entryStatus === 'locked') return 'Locked';
   if (reviewStatus === 'approved') return 'Approved';
   if (reviewStatus === 'needs_correction') return 'Correction requested';
@@ -134,6 +134,7 @@ export default function PortalTimeReviewPage() {
     queryKey: reviewQueryKey(workDate),
     queryFn: () => fetchMyTimeReviewContext(workDate),
     staleTime: 1000 * 20,
+    retry: false,
   });
 
   const entries = context?.entries ?? emptyReviewEntries;
@@ -252,7 +253,7 @@ export default function PortalTimeReviewPage() {
                 Try again
               </Button>
             </div>
-          ) : !context?.hasAccess ? (
+          ) : !context?.hasAccess || context.machines.length === 0 ? (
             <div className="mt-6 rounded-[24px] border border-border bg-background px-5 py-8 shadow-[var(--shadow-sm)]">
               <Lock className="h-6 w-6 text-muted-foreground" />
               <h2 className="mt-4 font-display text-xl font-semibold text-foreground">
@@ -268,6 +269,19 @@ export default function PortalTimeReviewPage() {
             </div>
           ) : (
             <div className="mt-6 space-y-5">
+              {reviewMutation.isError && (
+                <div
+                  role="alert"
+                  className="rounded-[20px] border border-destructive/20 bg-destructive/5 px-4 py-4 text-sm"
+                >
+                  <p className="font-semibold text-foreground">Review was not saved</p>
+                  <p className="mt-1 max-w-2xl text-pretty leading-6 text-muted-foreground">
+                    The shift is unchanged. Check your connection, then approve it or request a
+                    correction again.
+                  </p>
+                </div>
+              )}
+
               <div className="rounded-[24px] border border-border bg-background p-4 shadow-[var(--shadow-sm)] sm:p-5">
                 <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
                   <div className="grid gap-3 sm:grid-cols-2">


### PR DESCRIPTION
## Summary
- adds submitted-shift evidence and coherent, mutually exclusive worker loading/error/setup/empty/content states
- preserves retryable worker and manager actions after load or mutation failures and keeps selected-month context through add/edit flows
- verifies pending, approved, correction, included-in-pay, paid, locked, audit-reset, recovery, accessible-name/focus, rendered contrast, and responsive states in mocked desktop/mobile UAT
- fixes the portal access query so React Query does not serialize its QueryFunctionContext as `p_work_date`

Part of #587.

## Files changed
- `src/pages/portal/Time.tsx`: submitted count, exclusive recovery states, mutation guidance, state labels, and selected-month preservation
- `src/pages/portal/TimeReview.tsx`: exclusive access/setup state and retryable review mutation guidance
- `src/hooks/usePortalTimekeepingAccess.ts`: correct zero-argument timekeeping-context RPC invocation
- `scripts/validate-operator-timekeeping-uat.mjs`: expanded worker/manager desktop and 390px state matrix
- `scripts/validate-operator-timekeeping.mjs`: static acceptance guards for UI recovery copy and the access-query fix

## Verification
- `npm ci` ? passed (existing audit report: 3 moderate, 1 high)
- `npm run build` ? passed after syncing current `main` (2,551 modules; 25 public routes prerendered)
- `npm test --if-present` ? passed
- `npm run lint --if-present` ? passed
- `npm run portal:validate-contrast` ? passed
- `npm run operator-payouts:validate-foundation` ? passed
- `npm run operator-payouts:validate-timekeeping` ? passed
- `npm run operator-payouts:validate-review` ? passed
- `npm run operator-payouts:validate-statements` ? passed
- `npm run operator-payouts:validate-timekeeping-uat -- --app-url http://127.0.0.1:8081 --artifact-dir output/playwright/timekeeping-acceptance-ui-final` - passed 85 worker/manager assertions with no unexpected console/page errors or 390px horizontal overflow
- independent challenge - GO at `8925f2d`: all prior badge-contrast, correction-recovery, focus, accessible-name, and mobile-matrix gaps resolved; settled 390px dialog is 358px wide with 16px margins

## How to test
1. Check out `agent/timekeeping-acceptance-ui` and run `npm ci`.
2. Configure local Supabase per `Docs/LOCAL_DEV.md`, or for mocked UAT set non-secret local placeholders:
   - PowerShell: `$env:VITE_SUPABASE_URL='http://127.0.0.1:54321'`
   - PowerShell: `$env:VITE_SUPABASE_ANON_KEY='uat-anon-key'`
3. Run `npm run dev:uat`.
4. In another terminal, run `npm run operator-payouts:validate-timekeeping-uat -- --app-url http://127.0.0.1:8081 --artifact-dir output/playwright/timekeeping-acceptance-ui`.
5. Inspect `/portal/time`, `/portal/time/new?month=2026-05`, `/portal/time/:entryId/edit`, and `/portal/time-review` at desktop and 390px.
6. Confirm worker submitted/approved/correction/included/paid/locked labels, correction reason, edit reset, load/setup/empty recovery, mutation retry, manager approve/correction, and responsive overflow behavior.

The mocked UAT uses no password or production credential.

## Risk and overlap
- No schema, grant, payout calculation, payment, or production deployment behavior changes.
- The access-hook fix removes an invalid RPC parameter shape; it does not broaden access.
- Synced merged PR #590 at `b1c5380`; both fail-closed migration and UI/static-validator assertion sets are preserved.

