### PR TITLE
P0: render portal shell progressively during auth bootstrap

### DIFF
--- a/Docs/CURRENT_STATUS.md
+++ b/Docs/CURRENT_STATUS.md
@@ -30,6 +30,7 @@ GitHub Issues and the Bloomjoy Project board are the operational source of truth
 - Timekeeping V1 is a distinct worker-entry and machine-manager-review workflow: monthly completed shifts, per-shift whole-hour rounding, worker-visible correction notes, and issued-statement self-service. Shift review does not execute or alter payments.
 - Operator Pay calculation, finalization, payment execution, tax/compliance handling, and provider integration remain separate from the Timekeeping V1 replacement for Sheets/AppSheet.
 - Operator pay statements slice `#449` remains the versioned foundation for issued-statement self-service; drafts and manager previews are not worker-visible.
+- Authenticated portal bootstrap is shell-first and permission-neutral: Technician entitlement resolution remains authoritative before access reads, access-sensitive navigation waits for hydration, and session-to-shell/dashboard timing contains no account or identity data.
 - Frontend work should use existing app patterns plus `PRODUCT.md`, `DESIGN.md`, and `impeccable` when the visible experience matters.
 
 ## Safety

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -142,6 +142,11 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 
 ## Auth / portal
 - [ ] Login flow works (magic link or configured method)
+- [ ] Run `npm run portal-bootstrap:uat -- --app-url <local-or-preview-url>` and confirm the permission-neutral shell appears within 2 seconds, useful dashboard content appears within 3 seconds under the normal deterministic fixture, and screenshots are written to `output/playwright`.
+- [ ] With entitlement/access responses delayed, `/portal` and `/admin` render the branded structural shell without generic `Loading...`, baseline upsells, access-sensitive navigation, false zero states, or unauthorized content.
+- [ ] Initial session hydration calls Technician resolution and each access-context RPC once; repeated `SIGNED_IN` and `TOKEN_REFRESHED` events do not restart bootstrap or replace a ready page with loading UI.
+- [ ] Pending Technician first login resolves entitlements before access reads, then exposes assigned Training and Reporting access without a second login.
+- [ ] Signing out or changing users while access is loading invalidates the earlier request; a stale response cannot restore the prior user or permissions.
 - [ ] Login, authenticated portal, and Admin Console primary buttons, selected controls, links, and focus rings use the app-scoped interaction palette; normal text meets WCAG AA 4.5:1 contrast, focus indicators meet 3:1, and public-site colors remain unchanged
 - [ ] Canonical operator login lives at `https://app.bloomjoyusa.com/login`
 - [ ] Temporary alias `https://app.bloomjoyusa.com/login/operator` resolves to `/login`

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "portal:validate-contrast": "node scripts/validate-app-color-contrast.mjs",
     "portal-nav:validate": "node scripts/validate-authenticated-navigation.mjs",
     "portal-nav:uat": "node scripts/validate-authenticated-portal-uat.mjs",
+    "portal-bootstrap:uat": "node scripts/validate-portal-bootstrap-performance.mjs",
     "commerce:preflight": "node scripts/commerce-preflight.mjs",
     "edge-url-allowlists:check": "node scripts/validate-edge-url-allowlists.mjs",
     "db:validate-migrations": "node scripts/validate-supabase-migrations.mjs",

--- a/scripts/validate-portal-bootstrap-performance.mjs
+++ b/scripts/validate-portal-bootstrap-performance.mjs
@@ -1,0 +1,746 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const outputDir = path.join(repoRoot, 'output', 'playwright');
+
+const getArg = (name, fallback) => {
+  const index = process.argv.indexOf(name);
+  return index >= 0 && process.argv[index + 1] ? process.argv[index + 1] : fallback;
+};
+
+const appUrl = getArg('--app-url', 'http://127.0.0.1:8081');
+const expiresAt = Math.floor(Date.now() / 1000) + 3600;
+const criticalAccessRpcs = [
+  'get_my_plus_access',
+  'get_my_admin_access_context',
+  'get_my_portal_access_context',
+  'get_my_reporting_access_context',
+];
+
+const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+const wait = (duration) => new Promise((resolve) => setTimeout(resolve, duration));
+
+const personas = {
+  baseline: {
+    id: '00000000-0000-4000-9000-000000000594',
+    email: 'performance-uat@bloomjoy.localhost',
+    isAdmin: false,
+    pendingTechnician: false,
+  },
+  pendingTechnician: {
+    id: '00000000-0000-4000-9000-000000000595',
+    email: 'pending-technician-uat@bloomjoy.localhost',
+    isAdmin: false,
+    pendingTechnician: true,
+  },
+  admin: {
+    id: '00000000-0000-4000-9000-000000000596',
+    email: 'performance-admin-uat@bloomjoy.localhost',
+    isAdmin: true,
+    pendingTechnician: false,
+  },
+};
+
+const makeUser = (persona) => ({
+  id: persona.id,
+  aud: 'authenticated',
+  role: 'authenticated',
+  email: persona.email,
+  email_confirmed_at: '2026-01-01T00:00:00.000Z',
+  phone: '',
+  app_metadata: { provider: 'email', providers: ['email'] },
+  user_metadata: {},
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+});
+
+const makeSession = (persona) => ({
+  access_token: `uat-access-token-${persona.id}`,
+  refresh_token: `uat-refresh-token-${persona.id}`,
+  expires_at: expiresAt,
+  expires_in: 3600,
+  token_type: 'bearer',
+  user: makeUser(persona),
+});
+
+const rpcResponse = (rpcName, persona, state) => {
+  switch (rpcName) {
+    case 'resolve_my_technician_entitlements':
+      return {
+        technicianEmail: persona.email,
+        resolvedGrantCount: persona.pendingTechnician ? 1 : 0,
+        resolvedOperatorTrainingGrantCount: persona.pendingTechnician ? 1 : 0,
+        upsertedReportingEntitlementCount: persona.pendingTechnician ? 1 : 0,
+        skippedGrantCount: 0,
+      };
+    case 'get_my_plus_access':
+      return {
+        has_plus_access: persona.isAdmin,
+        source: persona.isAdmin ? 'subscription' : null,
+        membership_status: persona.isAdmin ? 'active' : 'none',
+        current_period_end: null,
+        cancel_at_period_end: false,
+        paid_subscription_active: persona.isAdmin,
+        free_grant_id: null,
+        free_grant_starts_at: null,
+        free_grant_expires_at: null,
+        free_grant_active: false,
+      };
+    case 'get_my_admin_access_context':
+      return {
+        isSuperAdmin: persona.isAdmin,
+        isScopedAdmin: false,
+        canAccessAdmin: persona.isAdmin,
+        allowedSurfaces: persona.isAdmin ? ['*'] : [],
+        scopedMachineIds: [],
+      };
+    case 'get_my_portal_access_context':
+      return {
+        access_tier:
+          persona.isAdmin ? 'plus' : persona.pendingTechnician && state.resolutionCompleted
+            ? 'training'
+            : 'baseline',
+        is_plus_member: persona.isAdmin,
+        is_training_operator: persona.pendingTechnician && state.resolutionCompleted,
+        is_admin: persona.isAdmin,
+        can_manage_operator_training: persona.isAdmin,
+        is_corporate_partner: false,
+        has_supply_discount: persona.isAdmin,
+        can_request_support: persona.isAdmin,
+        can_manage_technicians: false,
+        capabilities:
+          persona.pendingTechnician && state.resolutionCompleted
+            ? ['reports.partner.view']
+            : persona.isAdmin
+              ? ['*']
+              : [],
+        effective_presets: [],
+      };
+    case 'get_my_reporting_access_context':
+      return {
+        has_reporting_access:
+          persona.isAdmin || (persona.pendingTechnician && state.resolutionCompleted),
+        accessible_machine_count:
+          persona.isAdmin || (persona.pendingTechnician && state.resolutionCompleted) ? 1 : 0,
+        accessible_location_count:
+          persona.isAdmin || (persona.pendingTechnician && state.resolutionCompleted) ? 1 : 0,
+        can_manage_reporting: persona.isAdmin,
+        latest_sale_date: null,
+        latest_import_completed_at: null,
+      };
+    case 'get_my_operator_timekeeping_context':
+      return { workDate: '2026-07-17', profiles: [] };
+    case 'get_my_technician_management_context':
+      return { canManage: false, seatCap: null, accounts: [] };
+    case 'admin_get_account_summaries':
+    case 'admin_get_audit_log':
+    case 'admin_list_scoped_admin_grants':
+      return [];
+    default:
+      return {};
+  }
+};
+
+const fulfillJson = (route, body) =>
+  route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  });
+
+const createHarness = async (
+  browser,
+  persona,
+  {
+    blockResolver = false,
+    resolverDelayMs = 0,
+    accessDelayMs = 0,
+    seedSession = true,
+    language = 'en',
+    viewport = { width: 1366, height: 768 },
+  } = {},
+) => {
+  const context = await browser.newContext({ viewport });
+  const session = makeSession(persona);
+  const state = {
+    resolutionCompleted: false,
+    resolutionCompletedAt: null,
+    dashboardRequestAt: null,
+    rpcCounts: new Map(),
+    rpcStartTimes: new Map(),
+    rpcTimeline: [],
+  };
+  let releaseResolver;
+  const resolverGate = blockResolver
+    ? new Promise((resolve) => {
+        releaseResolver = resolve;
+      })
+    : null;
+
+  await context.addInitScript(
+    ({ sessionValue, shouldSeedSession, storedLanguage }) => {
+      window.__bloomjoyPerformanceEvents = [];
+      window.__bloomjoyAuthStorageKey = null;
+      window.localStorage.setItem('bloomjoy.language.v1', storedLanguage);
+      window.posthog = {
+        capture(name, properties) {
+          window.__bloomjoyPerformanceEvents.push({ name, properties });
+        },
+        identify() {},
+      };
+
+      const serializedSession = JSON.stringify(sessionValue);
+      const isSupabaseAuthKey = (key) =>
+        typeof key === 'string' && /^sb-.+-auth-token$/.test(key);
+      const originalGetItem = Storage.prototype.getItem;
+      const originalSetItem = Storage.prototype.setItem;
+
+      Storage.prototype.getItem = function getItem(key) {
+        if (isSupabaseAuthKey(key)) {
+          window.__bloomjoyAuthStorageKey = key;
+          return shouldSeedSession ? serializedSession : originalGetItem.call(this, key);
+        }
+
+        return originalGetItem.call(this, key);
+      };
+
+      Storage.prototype.setItem = function setItem(key, nextValue) {
+        if (isSupabaseAuthKey(key)) {
+          window.__bloomjoyAuthStorageKey = key;
+          return originalSetItem.call(
+            this,
+            key,
+            shouldSeedSession ? serializedSession : nextValue,
+          );
+        }
+
+        return originalSetItem.call(this, key, nextValue);
+      };
+    },
+    { sessionValue: session, shouldSeedSession: seedSession, storedLanguage: language },
+  );
+
+  await context.route('**/auth/v1/user', (route) => fulfillJson(route, makeUser(persona)));
+  await context.route('**/auth/v1/token**', (route) => fulfillJson(route, session));
+  await context.route('**/rest/v1/**', async (route) => {
+    const requestUrl = new URL(route.request().url());
+
+    if (!requestUrl.pathname.includes('/rest/v1/rpc/')) {
+      return fulfillJson(route, []);
+    }
+
+    const rpcName = decodeURIComponent(requestUrl.pathname.split('/').pop());
+    state.rpcTimeline.push({ rpcName, phase: 'start', at: Date.now() });
+    state.rpcCounts.set(rpcName, (state.rpcCounts.get(rpcName) ?? 0) + 1);
+    if (!state.rpcStartTimes.has(rpcName)) {
+      state.rpcStartTimes.set(rpcName, Date.now());
+    }
+
+    if (rpcName === 'resolve_my_technician_entitlements') {
+      if (resolverGate) {
+        await resolverGate;
+      }
+      if (resolverDelayMs > 0) {
+        await wait(resolverDelayMs);
+      }
+      state.resolutionCompleted = true;
+      state.resolutionCompletedAt = Date.now();
+    } else if (criticalAccessRpcs.includes(rpcName) && accessDelayMs > 0) {
+      await wait(accessDelayMs);
+    }
+
+    state.rpcTimeline.push({ rpcName, phase: 'end', at: Date.now() });
+    return fulfillJson(route, rpcResponse(rpcName, persona, state));
+  });
+
+  const page = await context.newPage();
+  page.on('request', (request) => {
+    const requestUrl = request.url();
+    if (
+      state.dashboardRequestAt === null &&
+      (requestUrl.includes('/pages/portal/Dashboard') ||
+        /\/Dashboard-[A-Za-z0-9_-]+\.js(?:\?|$)/.test(requestUrl))
+    ) {
+      state.dashboardRequestAt = Date.now();
+    }
+  });
+  page.on('pageerror', (error) => {
+    console.error(`[${persona.email}] page error: ${error.message}`);
+  });
+
+  return {
+    context,
+    page,
+    state,
+    releaseResolver: () => releaseResolver?.(),
+  };
+};
+
+const waitForPerformanceMark = async (page, markName) => {
+  await page.waitForFunction(
+    (name) => performance.getEntriesByName(name, 'mark').length > 0,
+    markName,
+  );
+};
+
+const broadcastAuthEvent = async (page, event, session) => {
+  await page.waitForFunction(() => Boolean(window.__bloomjoyAuthStorageKey));
+  await page.evaluate(
+    ({ eventName, sessionValue }) => {
+      const channel = new BroadcastChannel(window.__bloomjoyAuthStorageKey);
+      channel.postMessage({ event: eventName, session: sessionValue });
+      channel.close();
+    },
+    { eventName: event, sessionValue: session },
+  );
+};
+
+const broadcastAuthEvents = async (page, events) => {
+  await page.waitForFunction(() => Boolean(window.__bloomjoyAuthStorageKey));
+  await page.evaluate((eventValues) => {
+    const channel = new BroadcastChannel(window.__bloomjoyAuthStorageKey);
+    for (const eventValue of eventValues) {
+      channel.postMessage(eventValue);
+    }
+    channel.close();
+  }, events);
+};
+
+const waitForNodeCondition = async (condition, message, timeoutMs = 3_000) => {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (condition()) {
+      return;
+    }
+    await wait(20);
+  }
+
+  throw new Error(message);
+};
+
+const getPerformanceState = (page) =>
+  page.evaluate(() => {
+    const getMark = (name) => performance.getEntriesByName(name, 'mark').at(-1)?.startTime;
+    const session = getMark('bloomjoy.portal.session_accepted');
+    const shell = getMark('bloomjoy.portal.shell_visible');
+    const access = getMark('bloomjoy.portal.access_ready');
+    const dashboard = getMark('bloomjoy.portal.dashboard_visible');
+    const dashboardData = getMark('bloomjoy.portal.dashboard_data_ready');
+
+    return {
+      names: performance
+        .getEntries()
+        .filter((entry) => entry.name.startsWith('bloomjoy.portal.'))
+        .map((entry) => entry.name),
+      navigationToShell: shell ?? null,
+      sessionToShell:
+        session === undefined || shell === undefined ? null : Math.max(0, shell - session),
+      sessionToAccess: session === undefined || access === undefined ? null : access - session,
+      sessionToDashboard:
+        session === undefined || dashboard === undefined ? null : dashboard - session,
+      sessionToDashboardData:
+        session === undefined || dashboardData === undefined ? null : dashboardData - session,
+      events: window.__bloomjoyPerformanceEvents ?? [],
+    };
+  });
+
+const assertSingleCriticalBootstrap = (state, label) => {
+  assert(
+    state.rpcCounts.get('resolve_my_technician_entitlements') === 1,
+    `${label}: entitlement resolution should run exactly once.`,
+  );
+  for (const rpcName of criticalAccessRpcs) {
+    assert(
+      state.rpcCounts.get(rpcName) === 1,
+      `${label}: ${rpcName} should run exactly once.`,
+    );
+  }
+};
+
+const assertAccessStartsAfterResolution = (state, label) => {
+  for (const rpcName of criticalAccessRpcs) {
+    assert(
+      (state.rpcStartTimes.get(rpcName) ?? 0) >= (state.resolutionCompletedAt ?? Infinity),
+      `${label}: ${rpcName} must not read stale access before entitlement resolution completes.`,
+    );
+  }
+};
+
+const validateLifecycleSource = () => {
+  const authSource = fs.readFileSync(path.join(repoRoot, 'src/contexts/AuthContext.tsx'), 'utf8');
+  const loginSource = fs.readFileSync(path.join(repoRoot, 'src/pages/Login.tsx'), 'utf8');
+  const routeSource = fs.readFileSync(path.join(repoRoot, 'src/lib/portalRouteModules.ts'), 'utf8');
+
+  assert(
+    authSource.includes("event === 'TOKEN_REFRESHED'") &&
+      authSource.includes('isAlreadyHydrating || isAlreadyReady'),
+    'Auth bootstrap must ignore token refreshes for the active hydrated session.',
+  );
+  assert(
+    authSource.includes('generation !== bootstrapGenerationRef.current') &&
+      authSource.includes('scheduledGeneration !== bootstrapGenerationRef.current') &&
+      authSource.includes('retryGeneration !== bootstrapGenerationRef.current') &&
+      authSource.includes('bootstrapGenerationRef.current += 1'),
+    'Auth bootstrap must invalidate queued, active, and retry hydration work after sign-out or user change.',
+  );
+  assert(
+    !authSource.includes('void hydrateSession()'),
+    'Initial auth should have one onAuthStateChange source, not a parallel getSession hydration.',
+  );
+  assert(
+    loginSource.includes('if (hasAuthenticatedSession)'),
+    'Login should hand off to the permission-neutral shell as soon as the session is accepted.',
+  );
+  assert(
+    routeSource.includes("import('@/pages/portal/Dashboard')") &&
+      routeSource.includes('loadPortalDashboard().catch(() => undefined)') &&
+      authSource.includes("routeCategory === 'portal-dashboard'"),
+    'The portal dashboard module must preload safely only for the dashboard route.',
+  );
+};
+
+fs.mkdirSync(outputDir, { recursive: true });
+validateLifecycleSource();
+
+const browser = await chromium.launch();
+
+try {
+  const anonymousContext = await browser.newContext({ viewport: { width: 1366, height: 768 } });
+  const anonymousPage = await anonymousContext.newPage();
+  await anonymousPage.goto(`${appUrl}/portal`, { waitUntil: 'domcontentloaded' });
+  await anonymousPage.waitForURL((url) => url.pathname === '/login' && url.searchParams.has('next'));
+  assert(
+    new URL(anonymousPage.url()).searchParams.get('next') === '/portal',
+    'Signed-out portal visits should retain the safe return path when redirecting to login.',
+  );
+  await anonymousContext.close();
+
+  const delayed = await createHarness(browser, personas.baseline, {
+    blockResolver: true,
+  });
+  await delayed.page.goto(`${appUrl}/portal`, { waitUntil: 'domcontentloaded' });
+  await delayed.page
+    .getByText(/Checking your secure session|Preparing your workspace/)
+    .first()
+    .waitFor();
+  await waitForPerformanceMark(delayed.page, 'bloomjoy.portal.shell_visible');
+
+  const delayedTiming = await getPerformanceState(delayed.page);
+  assert(
+    delayedTiming.navigationToShell !== null && delayedTiming.navigationToShell < 2_000,
+    `Delayed bootstrap shell should appear within 2s of navigation; measured ${delayedTiming.navigationToShell}ms.`,
+  );
+  assert(
+    criticalAccessRpcs.every((rpcName) => !delayed.state.rpcCounts.has(rpcName)),
+    'Access RPCs must wait for first-login entitlement resolution.',
+  );
+  assert(
+    delayed.state.dashboardRequestAt !== null,
+    'Portal dashboard module should preload before access hydration completes.',
+  );
+  const delayedBody = await delayed.page.locator('body').innerText();
+  assert(
+    !/Loading\.\.\.|Admin Console|Reporting|Team|Timekeeping|Upgrade to Plus/.test(delayedBody),
+    'Unknown access must show a neutral shell without generic loading or capability-sensitive labels.',
+  );
+  await delayed.page.screenshot({
+    path: path.join(outputDir, 'portal-bootstrap-delayed-shell.png'),
+    fullPage: true,
+  });
+  await delayed.page.setViewportSize({ width: 390, height: 844 });
+  const mobileOverflow = await delayed.page.evaluate(
+    () => document.documentElement.scrollWidth - window.innerWidth,
+  );
+  assert(mobileOverflow <= 1, 'Permission-neutral loading shell must not overflow at 390px.');
+  await delayed.page.screenshot({
+    path: path.join(outputDir, 'portal-bootstrap-delayed-shell-mobile.png'),
+    fullPage: true,
+  });
+  const statusInsideBusyRegion = await delayed.page
+    .locator('[role="status"]')
+    .evaluate((element) => Boolean(element.closest('[aria-busy="true"]')));
+  assert(
+    !statusInsideBusyRegion,
+    'Loading status must remain announceable outside the busy decorative region.',
+  );
+  assert(
+    (await delayed.page.getByRole('navigation').count()) === 0,
+    'Decorative loading placeholders must not create an empty navigation landmark.',
+  );
+  await delayed.page.emulateMedia({ reducedMotion: 'reduce' });
+  const animatedPlaceholderCount = await delayed.page.evaluate(
+    () =>
+      [...document.querySelectorAll('.animate-pulse')].filter(
+        (element) => getComputedStyle(element).animationName !== 'none',
+      ).length,
+  );
+  assert(
+    animatedPlaceholderCount === 0,
+    'Loading placeholders must stop pulsing when reduced motion is requested.',
+  );
+  await delayed.page.getByText('Still checking your access securely…').waitFor({
+    timeout: 9_000,
+  });
+  assert(
+    await delayed.page.getByRole('button', { name: 'Sign out' }).isVisible(),
+    'A stalled access check should expose Sign out.',
+  );
+
+  delayed.releaseResolver();
+  await delayed.page.getByRole('heading', { name: 'Welcome back', level: 1 }).waitFor();
+  await waitForPerformanceMark(delayed.page, 'bloomjoy.portal.dashboard_visible');
+  await waitForPerformanceMark(delayed.page, 'bloomjoy.portal.dashboard_data_ready');
+  assertSingleCriticalBootstrap(delayed.state, 'Delayed baseline');
+  assertAccessStartsAfterResolution(delayed.state, 'Delayed baseline');
+  await delayed.context.close();
+
+  const normal = await createHarness(browser, personas.baseline, {
+    resolverDelayMs: 100,
+    accessDelayMs: 75,
+  });
+  await normal.page.goto(`${appUrl}/portal`, { waitUntil: 'domcontentloaded' });
+  await normal.page.getByRole('heading', { name: 'Welcome back', level: 1 }).waitFor();
+  await waitForPerformanceMark(normal.page, 'bloomjoy.portal.dashboard_visible');
+  await waitForPerformanceMark(normal.page, 'bloomjoy.portal.dashboard_data_ready');
+  const normalTiming = await getPerformanceState(normal.page);
+
+  assert(
+    normalTiming.navigationToShell !== null && normalTiming.navigationToShell < 2_000,
+    `Normal bootstrap shell should appear within 2s of navigation; measured ${normalTiming.navigationToShell}ms.`,
+  );
+  assert(
+    normalTiming.sessionToDashboard !== null && normalTiming.sessionToDashboard < 3_000,
+    `Useful portal content should appear in under 3s; measured ${normalTiming.sessionToDashboard}ms.`,
+  );
+  assert(
+    normalTiming.sessionToDashboardData !== null &&
+      normalTiming.sessionToDashboardData >= normalTiming.sessionToDashboard,
+    'Dashboard data-ready timing must be recorded after useful dashboard content is visible.',
+  );
+  assertSingleCriticalBootstrap(normal.state, 'Normal baseline');
+  assertAccessStartsAfterResolution(normal.state, 'Normal baseline');
+
+  const timingEvents = normalTiming.events.filter(
+    (event) => event.name === 'portal_bootstrap_timing',
+  );
+  assert(timingEvents.length === 1, 'Portal bootstrap timing analytics should emit exactly once.');
+  const timingPayloadText = JSON.stringify(timingEvents[0]);
+  assert(
+    !timingPayloadText.includes(personas.baseline.email) &&
+      !timingPayloadText.includes(personas.baseline.id) &&
+      !timingPayloadText.includes('uat-access-token') &&
+      normalTiming.names.every((name) => /^bloomjoy\.portal\.[a-z_]+$/.test(name)),
+    'Portal timing marks and analytics must not contain identity, token, machine, or account data.',
+  );
+
+  const countsBeforeRefresh = new Map(normal.state.rpcCounts);
+  await broadcastAuthEvent(normal.page, 'TOKEN_REFRESHED', makeSession(personas.baseline));
+  await broadcastAuthEvent(normal.page, 'SIGNED_IN', makeSession(personas.baseline));
+  await normal.page.waitForTimeout(200);
+  for (const rpcName of ['resolve_my_technician_entitlements', ...criticalAccessRpcs]) {
+    assert(
+      normal.state.rpcCounts.get(rpcName) === countsBeforeRefresh.get(rpcName),
+      `${rpcName} must not rerun for TOKEN_REFRESHED or repeated SIGNED_IN events.`,
+    );
+  }
+  assert(
+    await normal.page.getByRole('heading', { name: 'Welcome back', level: 1 }).isVisible(),
+    'Token refresh and repeated SIGNED_IN events must not replace a ready dashboard.',
+  );
+  await normal.page.screenshot({
+    path: path.join(outputDir, 'portal-bootstrap-normal-dashboard.png'),
+    fullPage: true,
+  });
+  await normal.context.close();
+
+  const technician = await createHarness(browser, personas.pendingTechnician, {
+    resolverDelayMs: 150,
+    accessDelayMs: 50,
+  });
+  await technician.page.goto(`${appUrl}/portal`, { waitUntil: 'domcontentloaded' });
+  await technician.page.getByRole('heading', { name: 'Welcome back', level: 1 }).waitFor();
+  assertSingleCriticalBootstrap(technician.state, 'Pending Technician');
+  assertAccessStartsAfterResolution(technician.state, 'Pending Technician');
+  assert(
+    (await technician.page.locator('aside nav a[href="/portal/training"]').count()) === 1,
+    'Newly resolved Technician should receive Training access on the first login.',
+  );
+  assert(
+    (await technician.page.locator('aside nav a[href="/portal/reports"]').count()) === 1,
+    'Newly resolved Technician should receive Reporting access on the first login.',
+  );
+  await technician.context.close();
+
+  const accountRoute = await createHarness(browser, personas.baseline);
+  await accountRoute.page.goto(`${appUrl}/portal/account`, { waitUntil: 'domcontentloaded' });
+  await accountRoute.page
+    .getByRole('heading', { name: 'Account Settings', level: 1 })
+    .waitFor();
+  await accountRoute.page.waitForTimeout(150);
+  assert(
+    accountRoute.state.dashboardRequestAt === null,
+    'Portal subroutes must not preload the dashboard chunk and compete with their own route chunk.',
+  );
+  await accountRoute.context.close();
+
+  const localized = await createHarness(browser, personas.baseline, {
+    blockResolver: true,
+    language: 'zh-Hans',
+    viewport: { width: 390, height: 844 },
+  });
+  await localized.page.goto(`${appUrl}/portal`, { waitUntil: 'domcontentloaded' });
+  await localized.page.getByText('正在准备您的工作区…').waitFor();
+  localized.releaseResolver();
+  await waitForPerformanceMark(localized.page, 'bloomjoy.portal.access_ready');
+  await localized.context.close();
+
+  const login = await createHarness(browser, personas.baseline, {
+    seedSession: false,
+  });
+  await login.page.goto(`${appUrl}/login`, { waitUntil: 'domcontentloaded' });
+  await login.page.getByLabel('Email address').fill(personas.baseline.email);
+  await login.page.getByLabel('Password').fill('uat-password');
+  await login.page.getByRole('button', { name: 'Sign in with password' }).click();
+  await login.page.waitForURL((url) => url.pathname === '/portal');
+  await login.page.getByRole('heading', { name: 'Welcome back', level: 1 }).waitFor();
+  assertSingleCriticalBootstrap(login.state, 'Password sign-in');
+  await login.context.close();
+
+  const nonAdmin = await createHarness(browser, personas.baseline);
+  await nonAdmin.page.goto(`${appUrl}/admin`, { waitUntil: 'domcontentloaded' });
+  await nonAdmin.page
+    .getByRole('heading', { name: 'Admin Access Required', level: 1 })
+    .waitFor();
+  assert(
+    (await nonAdmin.page.getByRole('heading', { name: 'Overview', level: 1 }).count()) === 0,
+    'A baseline session must not render Admin Console content after access resolves.',
+  );
+  await nonAdmin.context.close();
+
+  const admin = await createHarness(browser, personas.admin, {
+    blockResolver: true,
+  });
+  await admin.page.goto(`${appUrl}/admin`, { waitUntil: 'domcontentloaded' });
+  await admin.page
+    .getByText(/Checking your secure session|Preparing your workspace/)
+    .first()
+    .waitFor();
+  const adminPendingBody = await admin.page.locator('body').innerText();
+  assert(
+    !/Admin Console|Administration|Customers|Partners & Reporting/.test(adminPendingBody),
+    'Direct Admin load must not expose admin navigation until server-backed access is ready.',
+  );
+  admin.releaseResolver();
+  await admin.page.getByRole('heading', { name: 'Overview', level: 1 }).waitFor();
+  assertSingleCriticalBootstrap(admin.state, 'Delayed admin');
+  await admin.context.close();
+
+  const stale = await createHarness(browser, personas.baseline, {
+    blockResolver: true,
+  });
+  await stale.page.goto(`${appUrl}/portal`, { waitUntil: 'domcontentloaded' });
+  await waitForNodeCondition(
+    () => stale.state.rpcCounts.get('resolve_my_technician_entitlements') === 1,
+    'Stale-work test did not start entitlement resolution.',
+  );
+  await broadcastAuthEvent(stale.page, 'SIGNED_OUT', null);
+  await stale.page.waitForURL((url) => url.pathname === '/login');
+  stale.releaseResolver();
+  await stale.page.waitForTimeout(250);
+  assert(
+    stale.page.url().includes('/login') &&
+      (await stale.page.getByRole('heading', { name: 'Welcome back', level: 1 }).count()) === 0,
+    'A stale in-flight bootstrap must not restore the signed-out user.',
+  );
+  const staleTiming = await getPerformanceState(stale.page);
+  assert(
+    !staleTiming.names.includes('bloomjoy.portal.access_ready'),
+    'Stale bootstrap work must not mark authoritative access ready after sign-out.',
+  );
+  await stale.context.close();
+
+  const rapidSignOut = await createHarness(browser, personas.baseline, {
+    blockResolver: true,
+    seedSession: false,
+  });
+  await rapidSignOut.page.goto(`${appUrl}/login`, { waitUntil: 'domcontentloaded' });
+  await broadcastAuthEvents(rapidSignOut.page, [
+    { event: 'SIGNED_IN', session: makeSession(personas.baseline) },
+    { event: 'SIGNED_OUT', session: null },
+  ]);
+  await rapidSignOut.page.waitForTimeout(100);
+  rapidSignOut.releaseResolver();
+  await rapidSignOut.page.waitForTimeout(250);
+  const rapidTiming = await getPerformanceState(rapidSignOut.page);
+  assert(
+    new URL(rapidSignOut.page.url()).pathname === '/login' &&
+      !rapidTiming.names.includes('bloomjoy.portal.access_ready'),
+    'A queued sign-in bootstrap must not resurrect a session after an immediate sign-out event.',
+  );
+  await rapidSignOut.context.close();
+
+  const forcedRefresh = await createHarness(browser, personas.baseline, {
+    blockResolver: true,
+  });
+  await forcedRefresh.page.goto(`${appUrl}/portal`, { waitUntil: 'domcontentloaded' });
+  await waitForNodeCondition(
+    () => forcedRefresh.state.rpcCounts.get('resolve_my_technician_entitlements') === 1,
+    'Forced-refresh test did not start the initial entitlement resolution.',
+  );
+  await broadcastAuthEvents(forcedRefresh.page, [
+    { event: 'USER_UPDATED', session: makeSession(personas.baseline) },
+    { event: 'PASSWORD_RECOVERY', session: makeSession(personas.baseline) },
+    { event: 'USER_UPDATED', session: makeSession(personas.baseline) },
+  ]);
+  await forcedRefresh.page.waitForTimeout(100);
+  assert(
+    forcedRefresh.state.rpcCounts.get('resolve_my_technician_entitlements') === 1,
+    'Forced auth updates must coalesce while the current bootstrap is in flight.',
+  );
+  forcedRefresh.releaseResolver();
+  await forcedRefresh.page.getByRole('heading', { name: 'Welcome back', level: 1 }).waitFor();
+  await waitForNodeCondition(
+    () => forcedRefresh.state.rpcCounts.get('resolve_my_technician_entitlements') === 2,
+    'Coalesced auth update did not run one authoritative follow-up hydration.',
+  );
+  assert(
+    forcedRefresh.state.rpcCounts.get('resolve_my_technician_entitlements') === 2 &&
+      criticalAccessRpcs.every(
+        (rpcName) => forcedRefresh.state.rpcCounts.get(rpcName) === 2,
+      ),
+    'Multiple forced auth events should coalesce into one sequential follow-up bootstrap.',
+  );
+  const resolverStarts = forcedRefresh.state.rpcTimeline.filter(
+    (entry) =>
+      entry.rpcName === 'resolve_my_technician_entitlements' && entry.phase === 'start',
+  );
+  const firstAccessEnds = criticalAccessRpcs.map(
+    (rpcName) =>
+      forcedRefresh.state.rpcTimeline.find(
+        (entry) => entry.rpcName === rpcName && entry.phase === 'end',
+      )?.at ?? 0,
+  );
+  assert(
+    resolverStarts[1]?.at >= Math.max(...firstAccessEnds),
+    'Forced access refresh must run sequentially after the current bootstrap, never concurrently.',
+  );
+  await forcedRefresh.context.close();
+
+  console.log(`Portal bootstrap performance UAT passed at ${appUrl}`);
+  console.log(
+    `Measured normal navigation-to-shell ${Math.round(normalTiming.navigationToShell)}ms, session-to-shell ${Math.round(normalTiming.sessionToShell)}ms, session-to-dashboard ${Math.round(normalTiming.sessionToDashboard)}ms, and session-to-dashboard-data ${Math.round(normalTiming.sessionToDashboardData)}ms.`,
+  );
+  console.log('Verified shell <2s, useful dashboard <3s, single hydration, first-login access, and privacy.');
+  console.log(`Screenshots written to ${path.relative(repoRoot, outputDir)}`);
+} finally {
+  await browser.close();
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,12 +11,15 @@ import { BrowserRouter, Navigate, Route, Routes, useLocation } from "react-route
 import { AuthProvider } from "@/contexts/AuthContext";
 import { LanguageProvider, useLanguage } from "@/contexts/LanguageContext";
 import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
+import { AuthenticatedShellSkeleton } from "@/components/auth/AuthenticatedShellSkeleton";
 import { MemberRoute } from "@/components/auth/MemberRoute";
 import { AdminRoute, RefundOperationsRoute } from "@/components/auth/AdminRoute";
 import { HostRedirectGate } from "@/components/routing/HostRedirectGate";
 import { RouteErrorBoundary } from "@/components/routing/RouteErrorBoundary";
 import { RouteSeoManager } from "@/components/seo/RouteSeoManager";
 import { lazyRoute } from "@/lib/lazyRoute";
+import { loadPortalDashboard } from "@/lib/portalRouteModules";
+import { useAuth } from "@/contexts/auth-context";
 
 import Index from "./pages/Index";
 
@@ -49,7 +52,7 @@ const RefundRequest = lazyRoute(() => import("./pages/RefundRequest"));
 const RefundThankYou = lazyRoute(() => import("./pages/RefundThankYou"));
 const Login = lazyRoute(() => import("./pages/Login"));
 const ResetPassword = lazyRoute(() => import("./pages/ResetPassword"));
-const PortalDashboard = lazyRoute(() => import("./pages/portal/Dashboard"));
+const PortalDashboard = lazyRoute(loadPortalDashboard);
 const PortalTraining = lazyRoute(() => import("./pages/portal/Training"));
 const PortalTrainingDetail = lazyRoute(() => import("./pages/portal/TrainingDetail"));
 const PortalSupport = lazyRoute(() => import("./pages/portal/Support"));
@@ -76,9 +79,23 @@ const NotFound = lazyRoute(() => import("./pages/NotFound"));
 
 const browserQueryClient = new QueryClient();
 
-const RouteFallback = () => (
-  <div className="container-page py-10 text-sm text-muted-foreground">Loading page...</div>
-);
+const RouteFallback = () => {
+  const { hasAuthenticatedSession } = useAuth();
+  const { pathname } = useLocation();
+  const isAuthenticatedSurface =
+    pathname === "/portal" ||
+    pathname.startsWith("/portal/") ||
+    pathname === "/admin" ||
+    pathname.startsWith("/admin/");
+
+  if (isAuthenticatedSurface && hasAuthenticatedSession) {
+    return <AuthenticatedShellSkeleton status="route-loading" />;
+  }
+
+  return (
+    <div className="container-page py-10 text-sm text-muted-foreground">Loading page...</div>
+  );
+};
 
 const RedirectWithSearch = ({ to }: { to: string }) => {
   const location = useLocation();

--- a/src/components/auth/AuthenticatedShellSkeleton.tsx
+++ b/src/components/auth/AuthenticatedShellSkeleton.tsx
@@ -1,0 +1,246 @@
+import { useEffect, useLayoutEffect, useState } from 'react';
+import { AlertCircle, LoaderCircle, LogOut, RotateCcw } from 'lucide-react';
+import logo from '@/assets/logo.png';
+import { Button } from '@/components/ui/button';
+import { useLanguage } from '@/contexts/LanguageContext';
+import { markPortalShellHidden, markPortalShellVisible } from '@/lib/portalPerformance';
+import { cn } from '@/lib/utils';
+
+type AuthenticatedShellSkeletonProps = {
+  status?: 'checking-session' | 'hydrating-access' | 'route-loading' | 'error';
+  errorMessage?: string | null;
+  onRetry?: () => void;
+  onSignOut?: () => void;
+};
+
+const SkeletonLine = ({ className }: { className?: string }) => (
+  <span
+    className={cn('block animate-pulse rounded-full bg-muted motion-reduce:animate-none', className)}
+    aria-hidden="true"
+  />
+);
+
+export function AuthenticatedShellSkeleton({
+  status = 'hydrating-access',
+  errorMessage,
+  onRetry,
+  onSignOut,
+}: AuthenticatedShellSkeletonProps) {
+  const { language } = useLanguage();
+  const [isStalled, setIsStalled] = useState(false);
+  const [retryCycle, setRetryCycle] = useState(0);
+  const isError = status === 'error';
+  const isChinese = language === 'zh-Hans';
+  const copy = isChinese
+    ? {
+        checking: '正在检查您的安全会话…',
+        hydrating: '正在准备您的工作区…',
+        routeLoading: '正在打开您的工作区…',
+        error: '无法完成工作区加载。',
+        stalled: '仍在安全地检查您的访问权限…',
+        loadingDescription: '正在确认您的帐户访问权限。准备完成后才会显示导航。',
+        stalledDescription: '这比平时花费更长时间。您可以退出登录后再试一次。',
+        errorDescription: '您的帐户仍然安全。请重试安全访问检查或退出登录。',
+        retry: '重试',
+        signOut: '退出登录',
+        workspaceLoading: '工作区内容正在加载',
+      }
+    : {
+        checking: 'Checking your secure session…',
+        hydrating: 'Preparing your workspace…',
+        routeLoading: 'Opening your workspace…',
+        error: 'We could not finish opening your workspace.',
+        stalled: 'Still checking your access securely…',
+        loadingDescription:
+          'Your account access is being confirmed. Navigation will appear only after it is ready.',
+        stalledDescription:
+          'This is taking longer than usual. You can sign out and try again.',
+        errorDescription:
+          'Your account is safe. Retry the secure access check or sign out.',
+        retry: 'Retry',
+        signOut: 'Sign out',
+        workspaceLoading: 'Workspace content is loading',
+      };
+  const baseStatusMessage =
+    status === 'checking-session'
+      ? copy.checking
+      : status === 'route-loading'
+        ? copy.routeLoading
+        : isError
+          ? copy.error
+          : copy.hydrating;
+  const statusMessage = isStalled ? copy.stalled : baseStatusMessage;
+  const statusDescription = isError
+    ? errorMessage ?? copy.errorDescription
+    : isStalled
+      ? copy.stalledDescription
+      : copy.loadingDescription;
+
+  useEffect(() => {
+    setIsStalled(false);
+
+    if (isError || status === 'route-loading') {
+      return;
+    }
+
+    const timer = window.setTimeout(() => setIsStalled(true), 8_000);
+    return () => window.clearTimeout(timer);
+  }, [isError, retryCycle, status]);
+
+  useLayoutEffect(() => {
+    document.body.classList.add('app-surface');
+
+    return () => {
+      document.body.classList.remove('app-surface');
+    };
+  }, []);
+
+  useEffect(() => {
+    const frame = window.requestAnimationFrame(markPortalShellVisible);
+    return () => {
+      window.cancelAnimationFrame(frame);
+      markPortalShellHidden();
+    };
+  }, []);
+
+  return (
+    <div className="app-surface min-h-screen bg-background text-foreground lg:grid lg:grid-cols-[17.5rem_minmax(0,1fr)]">
+      <aside className="hidden border-r border-border/70 bg-sidebar/80 lg:flex lg:min-h-screen lg:flex-col">
+        <div className="flex min-h-[4.25rem] items-center gap-3 border-b border-border/70 px-4">
+          <img
+            src={logo}
+            alt="Bloomjoy Sweets"
+            width={40}
+            height={40}
+            decoding="async"
+            className="h-10 w-10 shrink-0"
+          />
+          <div className="min-w-0 flex-1 space-y-2">
+            <SkeletonLine className="h-2.5 w-24" />
+            <SkeletonLine className="h-3.5 w-32" />
+          </div>
+        </div>
+        <div className="space-y-6 px-4 py-6" aria-hidden="true">
+          {[0, 1].map((section) => (
+            <div className="space-y-3" key={section}>
+              <SkeletonLine className="h-2.5 w-16" />
+              {[0, 1, 2].map((item) => (
+                <div className="flex min-h-10 items-center gap-3 rounded-lg px-2" key={item}>
+                  <span className="h-8 w-8 animate-pulse rounded-lg bg-muted motion-reduce:animate-none" />
+                  <SkeletonLine className={cn('h-3', item === 1 ? 'w-24' : 'w-28')} />
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </aside>
+
+      <div className="min-w-0">
+        <header className="flex min-h-[4.25rem] items-center border-b border-border/70 bg-background/95 px-4 sm:px-6">
+          <div className="flex w-full items-center gap-3">
+            <img
+              src={logo}
+              alt=""
+              width={36}
+              height={36}
+              decoding="async"
+              className="h-9 w-9 shrink-0 lg:hidden"
+            />
+            <div className="min-w-0 flex-1 space-y-2">
+              <SkeletonLine className="h-2.5 w-24" />
+              <SkeletonLine className="h-4 w-36 sm:w-48" />
+            </div>
+            <SkeletonLine className="h-11 w-11 sm:h-9 sm:w-24" />
+          </div>
+        </header>
+
+        <main className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6 sm:py-8">
+          <div
+            className={cn(
+              'rounded-2xl border p-5 shadow-sm sm:p-7',
+              isError ? 'border-destructive/30 bg-destructive/5' : 'border-border bg-card'
+            )}
+          >
+            <div className="flex items-start gap-3">
+              {isError ? (
+                <AlertCircle className="mt-0.5 h-5 w-5 shrink-0 text-destructive" />
+              ) : (
+                <LoaderCircle className="mt-0.5 h-5 w-5 shrink-0 animate-spin text-primary motion-reduce:animate-none" />
+              )}
+              <div className="min-w-0 flex-1">
+                <div role="status" aria-live="polite" aria-atomic="true">
+                  <p className="font-display text-lg font-semibold text-foreground">
+                    {statusMessage}
+                  </p>
+                  <p className="mt-1 max-w-2xl text-sm leading-6 text-muted-foreground">
+                    {statusDescription}
+                  </p>
+                </div>
+                {(isError || isStalled) && (
+                  <div className="mt-5 flex flex-wrap gap-3">
+                    {isError && onRetry && (
+                      <Button
+                        type="button"
+                        className="min-h-11"
+                        onClick={() => {
+                          setIsStalled(false);
+                          setRetryCycle((cycle) => cycle + 1);
+                          onRetry();
+                        }}
+                      >
+                        <RotateCcw className="h-4 w-4" />
+                        {copy.retry}
+                      </Button>
+                    )}
+                    {onSignOut && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="min-h-11"
+                        onClick={onSignOut}
+                      >
+                        <LogOut className="h-4 w-4" />
+                        {copy.signOut}
+                      </Button>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {!isError && (
+              <section
+                className="mt-7"
+                role="region"
+                aria-label={copy.workspaceLoading}
+                aria-busy="true"
+              >
+                <div
+                  className="grid gap-4 lg:grid-cols-[minmax(0,1.5fr)_minmax(16rem,0.8fr)]"
+                  aria-hidden="true"
+                >
+                <div className="rounded-xl border border-border/70 p-5">
+                  <SkeletonLine className="h-3 w-28" />
+                  <SkeletonLine className="mt-4 h-6 w-52 max-w-full" />
+                  <SkeletonLine className="mt-3 h-3 w-full max-w-lg" />
+                  <SkeletonLine className="mt-2 h-3 w-4/5 max-w-md" />
+                  <SkeletonLine className="mt-6 h-10 w-32 rounded-lg" />
+                </div>
+                <div className="space-y-4">
+                  {[0, 1].map((item) => (
+                    <div className="rounded-xl border border-border/70 p-5" key={item}>
+                      <SkeletonLine className="h-3 w-24" />
+                      <SkeletonLine className="mt-4 h-5 w-40" />
+                      <SkeletonLine className="mt-3 h-3 w-full" />
+                    </div>
+                  ))}
+                </div>
+                </div>
+              </section>
+            )}
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -1,22 +1,43 @@
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { AuthenticatedShellSkeleton } from '@/components/auth/AuthenticatedShellSkeleton';
 import { useAuth } from '@/contexts/auth-context';
 
 export function ProtectedRoute() {
-  const { isAuthenticated, loading } = useAuth();
+  const {
+    bootstrapError,
+    bootstrapStatus,
+    hasAuthenticatedSession,
+    isAuthenticated,
+    retryBootstrap,
+    signOut,
+  } = useAuth();
   const location = useLocation();
 
-  if (loading) {
+  if (bootstrapStatus === 'error') {
     return (
-      <div className="flex min-h-screen items-center justify-center text-sm text-muted-foreground">
-        Loading...
-      </div>
+      <AuthenticatedShellSkeleton
+        status="error"
+        errorMessage={bootstrapError}
+        onRetry={() => void retryBootstrap()}
+        onSignOut={() => void signOut()}
+      />
     );
   }
 
-  if (!isAuthenticated) {
+  if (bootstrapStatus === 'signed-out' && !hasAuthenticatedSession) {
     const nextPath = `${location.pathname}${location.search}${location.hash}`;
     const loginSearch = new URLSearchParams({ next: nextPath }).toString();
     return <Navigate to={`/login?${loginSearch}`} replace state={{ from: location }} />;
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <AuthenticatedShellSkeleton
+        status={hasAuthenticatedSession ? 'hydrating-access' : 'checking-session'}
+        onRetry={() => void retryBootstrap()}
+        onSignOut={() => void signOut()}
+      />
+    );
   }
 
   return <Outlet />;

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -42,6 +42,7 @@ import { useLanguage } from '@/contexts/LanguageContext';
 import { usePortalTimekeepingAccess } from '@/hooks/usePortalTimekeepingAccess';
 import { usePortalTechnicianManagement } from '@/hooks/usePortalTechnicianManagement';
 import { getCanonicalUrlForSurface } from '@/lib/appSurface';
+import { markPortalShellHidden, markPortalShellVisible } from '@/lib/portalPerformance';
 import type { TranslationKey } from '@/lib/i18n';
 import { cn } from '@/lib/utils';
 
@@ -108,11 +109,18 @@ export function AppLayout({ children }: AppLayoutProps) {
 
   useLayoutEffect(() => {
     document.body.classList.add('app-surface');
+    const frame = isAuthenticated
+      ? window.requestAnimationFrame(markPortalShellVisible)
+      : null;
 
     return () => {
+      if (frame !== null) {
+        window.cancelAnimationFrame(frame);
+        markPortalShellHidden();
+      }
       document.body.classList.remove('app-surface');
     };
-  }, []);
+  }, [isAuthenticated]);
 
   const handleSignOut = async () => {
     await signOut();

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,7 +1,12 @@
-import React, { useState, useEffect, useRef, ReactNode } from 'react';
+import React, { useState, useEffect, useRef, useCallback, ReactNode } from 'react';
 import type { AuthError, User as SupabaseUser } from '@supabase/supabase-js';
 import { useQueryClient } from '@tanstack/react-query';
-import { AuthContext, type AdminAccessContext, type User } from '@/contexts/auth-context';
+import {
+  AuthContext,
+  type AdminAccessContext,
+  type AuthBootstrapStatus,
+  type User,
+} from '@/contexts/auth-context';
 import { supabaseClient } from '@/lib/supabaseClient';
 import { trackEvent, identifyUser } from '@/lib/analytics';
 import { getCanonicalUrlForSurface, getSafeInternalAppPath } from '@/lib/appSurface';
@@ -20,6 +25,12 @@ import {
   type ReportingAccessContext,
 } from '@/lib/reporting';
 import { resolveMyTechnicianEntitlements } from '@/lib/technicianEntitlements';
+import {
+  beginPortalBootstrap,
+  getPortalRouteCategory,
+  markPortalAccessReady,
+} from '@/lib/portalPerformance';
+import { preloadPortalDashboard } from '@/lib/portalRouteModules';
 
 type AdminRoleRecord = {
   role: string;
@@ -240,64 +251,278 @@ const buildAuthUser = async (supabaseUser: SupabaseUser): Promise<User> => {
 export function AuthProvider({ children }: { children: ReactNode }) {
   const queryClient = useQueryClient();
   const activeAuthUserIdRef = useRef<string | null>(null);
+  const bootstrapStatusRef = useRef<AuthBootstrapStatus>('checking-session');
+  const bootstrapGenerationRef = useRef(0);
+  const mountedRef = useRef(false);
+  const hydrationRef = useRef<{
+    userId: string;
+    promise: Promise<User>;
+  } | null>(null);
+  const pendingForcedHydrationRef = useRef<SupabaseUser | null>(null);
+  const hydrateAccessForUserRef = useRef<
+    (supabaseUser: SupabaseUser, force?: boolean) => Promise<void>
+  >(async () => undefined);
   const [user, setUser] = useState<User | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [bootstrapStatus, setBootstrapStatus] =
+    useState<AuthBootstrapStatus>('checking-session');
+  const [bootstrapError, setBootstrapError] = useState<string | null>(null);
+  const [hasAuthenticatedSession, setHasAuthenticatedSession] = useState(false);
 
-  useEffect(() => {
-    let mounted = true;
+  const updateBootstrapStatus = useCallback((nextStatus: AuthBootstrapStatus) => {
+    bootstrapStatusRef.current = nextStatus;
+    setBootstrapStatus(nextStatus);
+  }, []);
 
-    const clearQueryCacheForUserChange = (nextUserId: string | null) => {
-      if (activeAuthUserIdRef.current === nextUserId) return;
-
-      activeAuthUserIdRef.current = nextUserId;
-      queryClient.clear();
-    };
-
-    const setUserFromSession = async (supabaseUser: SupabaseUser | null) => {
-      if (!mounted) return;
-
-      clearQueryCacheForUserChange(supabaseUser?.id ?? null);
-
-      if (!supabaseUser) {
-        setUser(null);
-        setLoading(false);
+  const clearQueryCacheForUserChange = useCallback(
+    (nextUserId: string | null) => {
+      if (activeAuthUserIdRef.current === nextUserId) {
         return;
       }
 
-      const authUser = await buildAuthUser(supabaseUser);
+      activeAuthUserIdRef.current = nextUserId;
+      queryClient.clear();
+    },
+    [queryClient]
+  );
 
-      if (!mounted) return;
-      setUser(authUser);
-      identifyUser(authUser.id, {
-        email: authUser.email,
-        is_admin: authUser.isAdmin,
-        portal_access_tier: authUser.portalAccessTier,
-      });
-      setLoading(false);
-    };
+  const moveToSignedOut = useCallback(() => {
+    bootstrapGenerationRef.current += 1;
+    hydrationRef.current = null;
+    pendingForcedHydrationRef.current = null;
+    clearQueryCacheForUserChange(null);
+    setUser(null);
+    setBootstrapError(null);
+    setHasAuthenticatedSession(false);
+    updateBootstrapStatus('signed-out');
+  }, [clearQueryCacheForUserChange, updateBootstrapStatus]);
 
-    const hydrateSession = async () => {
-      const {
-        data: { session },
-      } = await supabaseClient.auth.getSession();
+  const hydrateAccessForUser = useCallback(
+    async (supabaseUser: SupabaseUser, force = false): Promise<void> => {
+      if (!mountedRef.current) {
+        return;
+      }
 
-      await setUserFromSession(session?.user ?? null);
-    };
+      const sameUser = activeAuthUserIdRef.current === supabaseUser.id;
+      const inFlight =
+        hydrationRef.current?.userId === supabaseUser.id ? hydrationRef.current : null;
 
-    void hydrateSession();
+      if (!force && sameUser && bootstrapStatusRef.current === 'ready') {
+        return;
+      }
+
+      if (!force && inFlight) {
+        await inFlight.promise.catch(() => undefined);
+        return;
+      }
+
+      clearQueryCacheForUserChange(supabaseUser.id);
+      setHasAuthenticatedSession(true);
+      setBootstrapError(null);
+      setUser(null);
+      updateBootstrapStatus('hydrating-access');
+
+      const routeCategory = getPortalRouteCategory();
+      if (!force) {
+        beginPortalBootstrap(routeCategory);
+      }
+      if (routeCategory === 'portal-dashboard') {
+        preloadPortalDashboard();
+      }
+
+      const generation = ++bootstrapGenerationRef.current;
+      const hydrationPromise = buildAuthUser(supabaseUser);
+      hydrationRef.current = {
+        userId: supabaseUser.id,
+        promise: hydrationPromise,
+      };
+
+      try {
+        const authUser = await hydrationPromise;
+
+        if (
+          !mountedRef.current ||
+          generation !== bootstrapGenerationRef.current ||
+          activeAuthUserIdRef.current !== supabaseUser.id
+        ) {
+          return;
+        }
+
+        if (pendingForcedHydrationRef.current?.id === supabaseUser.id) {
+          return;
+        }
+
+        setUser(authUser);
+        identifyUser(authUser.id, {
+          email: authUser.email,
+          is_admin: authUser.isAdmin,
+          portal_access_tier: authUser.portalAccessTier,
+        });
+        updateBootstrapStatus('ready');
+        markPortalAccessReady();
+      } catch {
+        if (
+          !mountedRef.current ||
+          generation !== bootstrapGenerationRef.current ||
+          activeAuthUserIdRef.current !== supabaseUser.id
+        ) {
+          return;
+        }
+
+        if (pendingForcedHydrationRef.current?.id === supabaseUser.id) {
+          return;
+        }
+
+        setUser(null);
+        setBootstrapError('We could not verify your account access. Please retry.');
+        updateBootstrapStatus('error');
+      } finally {
+        if (hydrationRef.current?.promise === hydrationPromise) {
+          hydrationRef.current = null;
+        }
+
+        const pendingUser = pendingForcedHydrationRef.current;
+        if (
+          pendingUser?.id === supabaseUser.id &&
+          mountedRef.current &&
+          generation === bootstrapGenerationRef.current &&
+          activeAuthUserIdRef.current === supabaseUser.id
+        ) {
+          pendingForcedHydrationRef.current = null;
+          const scheduledGeneration = bootstrapGenerationRef.current;
+          setTimeout(() => {
+            if (
+              !mountedRef.current ||
+              scheduledGeneration !== bootstrapGenerationRef.current ||
+              activeAuthUserIdRef.current !== pendingUser.id
+            ) {
+              return;
+            }
+
+            void hydrateAccessForUserRef.current(pendingUser, true);
+          }, 0);
+        }
+      }
+    },
+    [clearQueryCacheForUserChange, updateBootstrapStatus]
+  );
+
+  useEffect(() => {
+    hydrateAccessForUserRef.current = hydrateAccessForUser;
+  }, [hydrateAccessForUser]);
+
+  useEffect(() => {
+    mountedRef.current = true;
 
     const {
       data: { subscription },
-    } = supabaseClient.auth.onAuthStateChange((_event, session) => {
-      setLoading(true);
-      void setUserFromSession(session?.user ?? null);
+    } = supabaseClient.auth.onAuthStateChange((event, session) => {
+      const sessionUser = session?.user ?? null;
+
+      if (event === 'SIGNED_OUT' || !sessionUser) {
+        moveToSignedOut();
+        return;
+      }
+
+      setHasAuthenticatedSession(true);
+
+      const sameUser = activeAuthUserIdRef.current === sessionUser.id;
+
+      if (!sameUser) {
+        bootstrapGenerationRef.current += 1;
+        hydrationRef.current = null;
+        pendingForcedHydrationRef.current = null;
+        clearQueryCacheForUserChange(sessionUser.id);
+        setUser(null);
+        setBootstrapError(null);
+        updateBootstrapStatus('hydrating-access');
+      }
+
+      const isAlreadyHydrating =
+        sameUser &&
+        hydrationRef.current?.userId === sessionUser.id &&
+        bootstrapStatusRef.current === 'hydrating-access';
+      const isAlreadyReady = sameUser && bootstrapStatusRef.current === 'ready';
+      const force = event === 'USER_UPDATED' || event === 'PASSWORD_RECOVERY';
+
+      if (force && sameUser && bootstrapStatusRef.current === 'hydrating-access') {
+        pendingForcedHydrationRef.current = sessionUser;
+        return;
+      }
+
+      if (
+        (event === 'TOKEN_REFRESHED' && (isAlreadyHydrating || isAlreadyReady)) ||
+        ((event === 'INITIAL_SESSION' || event === 'SIGNED_IN') &&
+          (isAlreadyHydrating || isAlreadyReady))
+      ) {
+        return;
+      }
+
+      const scheduledGeneration = bootstrapGenerationRef.current;
+      const scheduledUserId = sessionUser.id;
+      setTimeout(() => {
+        if (
+          !mountedRef.current ||
+          scheduledGeneration !== bootstrapGenerationRef.current ||
+          activeAuthUserIdRef.current !== scheduledUserId
+        ) {
+          return;
+        }
+
+        void hydrateAccessForUser(sessionUser, force);
+      }, 0);
     });
 
     return () => {
-      mounted = false;
+      mountedRef.current = false;
+      bootstrapGenerationRef.current += 1;
+      hydrationRef.current = null;
+      pendingForcedHydrationRef.current = null;
       subscription.unsubscribe();
     };
-  }, [queryClient]);
+  }, [
+    clearQueryCacheForUserChange,
+    hydrateAccessForUser,
+    moveToSignedOut,
+    updateBootstrapStatus,
+  ]);
+
+  const retryBootstrap = useCallback(async () => {
+    const retryGeneration = ++bootstrapGenerationRef.current;
+    const expectedUserId = activeAuthUserIdRef.current;
+    hydrationRef.current = null;
+    pendingForcedHydrationRef.current = null;
+    setBootstrapError(null);
+    updateBootstrapStatus('hydrating-access');
+
+    const {
+      data: { session },
+      error,
+    } = await supabaseClient.auth.getSession();
+
+    if (
+      !mountedRef.current ||
+      retryGeneration !== bootstrapGenerationRef.current ||
+      (expectedUserId !== null &&
+        session?.user?.id !== undefined &&
+        session.user.id !== expectedUserId)
+    ) {
+      return;
+    }
+
+    if (error) {
+      setBootstrapError('We could not recheck your secure session. Please retry.');
+      updateBootstrapStatus('error');
+      return;
+    }
+
+    if (!session?.user) {
+      moveToSignedOut();
+      return;
+    }
+
+    setHasAuthenticatedSession(true);
+    await hydrateAccessForUser(session.user, true);
+  }, [hydrateAccessForUser, moveToSignedOut, updateBootstrapStatus]);
 
   const getAuthRedirectPath = () => {
     if (typeof window === 'undefined') {
@@ -411,17 +636,34 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const signIn = signInWithMagicLink;
 
   const signOut = async () => {
-    activeAuthUserIdRef.current = null;
-    queryClient.clear();
-    await supabaseClient.auth.signOut();
-    setUser(null);
+    moveToSignedOut();
+    const { error } = await supabaseClient.auth.signOut();
+
+    if (!error) {
+      return;
+    }
+
+    const { error: localSignOutError } = await supabaseClient.auth.signOut({ scope: 'local' });
+    if (localSignOutError) {
+      setHasAuthenticatedSession(true);
+      setBootstrapError('We could not complete sign out. Please retry.');
+      updateBootstrapStatus('error');
+    }
   };
+
+  const loading =
+    bootstrapStatus === 'checking-session' || bootstrapStatus === 'hydrating-access';
+  const isAuthenticated = bootstrapStatus === 'ready' && Boolean(user);
 
   return (
     <AuthContext.Provider
       value={{
         user,
         loading,
+        bootstrapStatus,
+        bootstrapError,
+        hasAuthenticatedSession,
+        retryBootstrap,
         signInWithMagicLink,
         signInWithPassword,
         signUpWithPassword,
@@ -431,7 +673,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         updatePassword,
         signIn,
         signOut,
-        isAuthenticated: !!user,
+        isAuthenticated,
         isMember: user?.plusAccess.hasPlusAccess ?? false,
         portalAccessTier: user?.portalAccessTier ?? 'baseline',
         canAccessTraining: hasTrainingAccess(user?.portalAccessTier),

--- a/src/contexts/auth-context.ts
+++ b/src/contexts/auth-context.ts
@@ -33,9 +33,20 @@ export interface User {
   adminAccess: AdminAccessContext;
 }
 
+export type AuthBootstrapStatus =
+  | 'checking-session'
+  | 'hydrating-access'
+  | 'ready'
+  | 'signed-out'
+  | 'error';
+
 interface AuthContextType {
   user: User | null;
   loading: boolean;
+  bootstrapStatus: AuthBootstrapStatus;
+  bootstrapError: string | null;
+  hasAuthenticatedSession: boolean;
+  retryBootstrap: () => Promise<void>;
   signInWithMagicLink: (email: string) => Promise<{ error: AuthError | null }>;
   signInWithPassword: (email: string, password: string) => Promise<{ error: AuthError | null }>;
   signUpWithPassword: (email: string, password: string) => Promise<{ error: AuthError | null }>;

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -19,6 +19,7 @@ type EventName =
   | 'start_plus_checkout'
   | 'plus_subscription_activated'
   | 'login'
+  | 'portal_bootstrap_timing'
   | 'view_dashboard'
   | 'view_training_catalog'
   | 'open_training_item'
@@ -87,12 +88,20 @@ export function trackEvent(name: EventName, properties?: EventProperties): void 
   // PostHog stub
   const analyticsWindow = getAnalyticsWindow();
   if (analyticsWindow?.posthog) {
-    analyticsWindow.posthog.capture(name, properties);
+    try {
+      analyticsWindow.posthog.capture(name, properties);
+    } catch {
+      // Analytics must never interrupt a user-facing flow.
+    }
   }
 
   // GA4 stub
   if (analyticsWindow?.gtag) {
-    analyticsWindow.gtag('event', name, properties);
+    try {
+      analyticsWindow.gtag('event', name, properties);
+    } catch {
+      // Analytics must never interrupt a user-facing flow.
+    }
   }
 }
 
@@ -103,6 +112,10 @@ export function identifyUser(userId: string, traits?: Record<string, unknown>): 
 
   const analyticsWindow = getAnalyticsWindow();
   if (analyticsWindow?.posthog) {
-    analyticsWindow.posthog.identify(userId, traits);
+    try {
+      analyticsWindow.posthog.identify(userId, traits);
+    } catch {
+      // Identification failure must not block authenticated access.
+    }
   }
 }

--- a/src/lib/portalPerformance.ts
+++ b/src/lib/portalPerformance.ts
@@ -1,0 +1,169 @@
+import { trackEvent } from '@/lib/analytics';
+
+const marks = {
+  sessionAccepted: 'bloomjoy.portal.session_accepted',
+  shellVisible: 'bloomjoy.portal.shell_visible',
+  accessReady: 'bloomjoy.portal.access_ready',
+  dashboardVisible: 'bloomjoy.portal.dashboard_visible',
+  dashboardDataReady: 'bloomjoy.portal.dashboard_data_ready',
+} as const;
+
+const measures = {
+  sessionToShell: 'bloomjoy.portal.session_to_shell',
+  sessionToAccess: 'bloomjoy.portal.session_to_access',
+  sessionToDashboard: 'bloomjoy.portal.session_to_dashboard',
+  sessionToDashboardData: 'bloomjoy.portal.session_to_dashboard_data',
+} as const;
+
+type PortalRouteCategory = 'portal-dashboard' | 'portal' | 'admin' | 'other';
+
+let activeRouteCategory: PortalRouteCategory = 'other';
+let timingEventSent = false;
+let shellIsVisible = false;
+let shellVisibleAt: number | null = null;
+
+const hasPerformanceApi = () =>
+  typeof performance !== 'undefined' &&
+  typeof performance.mark === 'function' &&
+  typeof performance.getEntriesByName === 'function';
+
+const hasMark = (name: string) =>
+  hasPerformanceApi() && performance.getEntriesByName(name, 'mark').length > 0;
+
+const markOnce = (name: string) => {
+  if (!hasPerformanceApi() || hasMark(name)) {
+    return;
+  }
+
+  performance.mark(name);
+};
+
+const getMarkStartTime = (name: string) =>
+  hasPerformanceApi()
+    ? performance.getEntriesByName(name, 'mark').at(-1)?.startTime
+    : undefined;
+
+const getElapsedFromSession = (markName: string) => {
+  const sessionStart = getMarkStartTime(marks.sessionAccepted);
+  const phaseStart = getMarkStartTime(markName);
+
+  if (sessionStart === undefined || phaseStart === undefined) {
+    return undefined;
+  }
+
+  return Math.max(0, Math.round(phaseStart - sessionStart));
+};
+
+const measureOnce = (name: string, endMark: string) => {
+  if (
+    !hasPerformanceApi() ||
+    performance.getEntriesByName(name, 'measure').length > 0 ||
+    !hasMark(marks.sessionAccepted) ||
+    !hasMark(endMark)
+  ) {
+    return;
+  }
+
+  const sessionStart = getMarkStartTime(marks.sessionAccepted);
+  const phaseStart = getMarkStartTime(endMark);
+
+  if (sessionStart === undefined || phaseStart === undefined) {
+    return;
+  }
+
+  if (phaseStart < sessionStart) {
+    performance.measure(name, { start: sessionStart, duration: 0 });
+    return;
+  }
+
+  performance.measure(name, marks.sessionAccepted, endMark);
+};
+
+export const getPortalRouteCategory = (): PortalRouteCategory => {
+  if (typeof window === 'undefined') {
+    return 'other';
+  }
+
+  const currentPath = window.location.pathname;
+  const nextPath =
+    currentPath === '/login'
+      ? new URLSearchParams(window.location.search).get('next') ?? ''
+      : currentPath;
+
+  const routePath = nextPath.split(/[?#]/, 1)[0];
+
+  if (routePath.startsWith('/admin')) {
+    return 'admin';
+  }
+
+  if (routePath === '/portal') {
+    return 'portal-dashboard';
+  }
+
+  if (routePath.startsWith('/portal/')) {
+    return 'portal';
+  }
+
+  return 'other';
+};
+
+export const beginPortalBootstrap = (routeCategory = getPortalRouteCategory()): void => {
+  if (!hasPerformanceApi()) {
+    return;
+  }
+
+  const visibleShellStart = shellIsVisible ? shellVisibleAt : null;
+  Object.values(marks).forEach((name) => performance.clearMarks(name));
+  Object.values(measures).forEach((name) => performance.clearMeasures(name));
+  activeRouteCategory = routeCategory;
+  timingEventSent = false;
+  performance.mark(marks.sessionAccepted);
+
+  if (visibleShellStart !== null) {
+    performance.mark(marks.shellVisible, { startTime: visibleShellStart });
+    measureOnce(measures.sessionToShell, marks.shellVisible);
+  }
+};
+
+export const markPortalShellVisible = (): void => {
+  shellIsVisible = true;
+  shellVisibleAt ??= hasPerformanceApi() ? performance.now() : null;
+  markOnce(marks.shellVisible);
+  measureOnce(measures.sessionToShell, marks.shellVisible);
+};
+
+export const markPortalShellHidden = (): void => {
+  shellIsVisible = false;
+  shellVisibleAt = null;
+};
+
+export const markPortalAccessReady = (): void => {
+  markOnce(marks.accessReady);
+  measureOnce(measures.sessionToAccess, marks.accessReady);
+};
+
+export const markPortalDashboardVisible = (): void => {
+  markOnce(marks.dashboardVisible);
+  measureOnce(measures.sessionToDashboard, marks.dashboardVisible);
+};
+
+export const markPortalDashboardDataReady = (): void => {
+  markOnce(marks.dashboardDataReady);
+  measureOnce(measures.sessionToDashboardData, marks.dashboardDataReady);
+
+  if (timingEventSent || !hasMark(marks.sessionAccepted)) {
+    return;
+  }
+
+  timingEventSent = true;
+  trackEvent('portal_bootstrap_timing', {
+    route_category: activeRouteCategory,
+    session_to_shell_ms: getElapsedFromSession(marks.shellVisible),
+    session_to_access_ms: getElapsedFromSession(marks.accessReady),
+    session_to_dashboard_ms: getElapsedFromSession(marks.dashboardVisible),
+    session_to_dashboard_data_ms: getElapsedFromSession(marks.dashboardDataReady),
+    access_ready: hasMark(marks.accessReady),
+  });
+};
+
+export const portalPerformanceNames = { marks, measures } as const;

--- a/src/lib/portalRouteModules.ts
+++ b/src/lib/portalRouteModules.ts
@@ -1,0 +1,15 @@
+type PortalDashboardModule = typeof import('@/pages/portal/Dashboard');
+
+let portalDashboardModulePromise: Promise<PortalDashboardModule> | null = null;
+
+export const loadPortalDashboard = (): Promise<PortalDashboardModule> => {
+  portalDashboardModulePromise ??= import('@/pages/portal/Dashboard').catch((error: unknown) => {
+    portalDashboardModulePromise = null;
+    throw error;
+  });
+  return portalDashboardModulePromise;
+};
+
+export const preloadPortalDashboard = (): void => {
+  void loadPortalDashboard().catch(() => undefined);
+};

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -330,7 +330,7 @@ export default function LoginPage() {
     signInWithGoogle,
     signInWithGoogleIdToken,
     requestPasswordReset,
-    isAuthenticated,
+    hasAuthenticatedSession,
   } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
@@ -352,10 +352,10 @@ export default function LoginPage() {
   const plusUrl = getCanonicalUrlForSurface('marketing', '/plus', '', '', window.location);
 
   useEffect(() => {
-    if (isAuthenticated) {
+    if (hasAuthenticatedSession) {
       navigate(fromPath, { replace: true });
     }
-  }, [fromPath, isAuthenticated, navigate]);
+  }, [fromPath, hasAuthenticatedSession, navigate]);
 
   useEffect(() => {
     signInWithGoogleIdTokenRef.current = signInWithGoogleIdToken;

--- a/src/pages/portal/Dashboard.tsx
+++ b/src/pages/portal/Dashboard.tsx
@@ -21,6 +21,10 @@ import { useLanguage } from '@/contexts/LanguageContext';
 import { usePortalTimekeepingAccess } from '@/hooks/usePortalTimekeepingAccess';
 import { usePortalTechnicianManagement } from '@/hooks/usePortalTechnicianManagement';
 import { trackEvent } from '@/lib/analytics';
+import {
+  markPortalDashboardDataReady,
+  markPortalDashboardVisible,
+} from '@/lib/portalPerformance';
 import type { TranslationKey } from '@/lib/i18n';
 import { getOnboardingProgress } from '@/lib/onboardingChecklist';
 import {
@@ -121,8 +125,10 @@ export default function PortalDashboard() {
   const allowedAdminSurfaces = new Set(adminAccess.allowedSurfaces);
   const hasRefundOperationsAccess =
     isSuperAdmin || allowedAdminSurfaces.has('*') || allowedAdminSurfaces.has('refunds');
-  const { canUsePortalTeam } = usePortalTechnicianManagement();
-  const { canUsePortalTimekeeping } = usePortalTimekeepingAccess();
+  const teamAccess = usePortalTechnicianManagement();
+  const timekeepingAccess = usePortalTimekeepingAccess();
+  const { canUsePortalTeam } = teamAccess;
+  const { canUsePortalTimekeeping } = timekeepingAccess;
   const canAccessPortalAction = (access: PortalAccessLevel) => {
     if (access === 'team') {
       return canUsePortalTeam;
@@ -144,13 +150,32 @@ export default function PortalDashboard() {
     );
   };
   const onboardingProgress = getOnboardingProgress(user?.email);
-  const { data: library = [] } = useTrainingLibrary(canAccessTraining);
-  const { data: trackDefinitions = [] } = useTrainingTracks(canAccessTraining);
-  const { data: trainingProgress = [] } = useTrainingProgress(user?.id, canAccessTraining);
+  const libraryQuery = useTrainingLibrary(canAccessTraining);
+  const tracksQuery = useTrainingTracks(canAccessTraining);
+  const progressQuery = useTrainingProgress(user?.id, canAccessTraining);
+  const { data: library = [] } = libraryQuery;
+  const { data: trackDefinitions = [] } = tracksQuery;
+  const { data: trainingProgress = [] } = progressQuery;
+  const dashboardDataReady =
+    !teamAccess.isLoading &&
+    !timekeepingAccess.isLoading &&
+    (!canAccessTraining ||
+      (!libraryQuery.isLoading && !tracksQuery.isLoading && !progressQuery.isLoading));
 
   useEffect(() => {
     trackEvent('view_dashboard');
+    const frame = window.requestAnimationFrame(markPortalDashboardVisible);
+    return () => window.cancelAnimationFrame(frame);
   }, []);
+
+  useEffect(() => {
+    if (!user?.id || !dashboardDataReady) {
+      return;
+    }
+
+    const frame = window.requestAnimationFrame(markPortalDashboardDataReady);
+    return () => window.cancelAnimationFrame(frame);
+  }, [dashboardDataReady, user?.id]);
 
   if (!user) {
     return null;


### PR DESCRIPTION
Closes #594

## Summary
- replace route-wide authenticated loading text with a permission-neutral, localized shell that appears before access hydration completes
- deduplicate and race-proof auth bootstrap events, preserve Technician-first entitlement ordering, preload only the `/portal` dashboard route, and keep stale work from restoring signed-out/replaced sessions
- add privacy-safe bootstrap timing plus deterministic delayed-network, lifecycle, accessibility, mobile, and persona UAT

## Files changed
- auth bootstrap state and lifecycle: `src/contexts/AuthContext.tsx`, `src/contexts/auth-context.ts`, `src/components/auth/ProtectedRoute.tsx`
- progressive shell and route handoff: `src/components/auth/AuthenticatedShellSkeleton.tsx`, `src/App.tsx`, `src/pages/Login.tsx`, `src/lib/portalRouteModules.ts`
- timing and data-ready instrumentation: `src/lib/portalPerformance.ts`, `src/lib/analytics.ts`, `src/pages/portal/Dashboard.tsx`, `src/components/layout/AppLayout.tsx`
- executable acceptance coverage and durable docs: `scripts/validate-portal-bootstrap-performance.mjs`, `package.json`, `Docs/QA_SMOKE_TEST_CHECKLIST.md`, `Docs/CURRENT_STATUS.md`

## Verification
- `npm ci` ? passed (existing audit reports 3 moderate and 1 high dependency vulnerability)
- `npm run build` ? passed; 25 public routes and 25 private-route SEO heads prerendered
- `npm test --if-present` ? passed
- `npm run lint --if-present` ? passed
- `npx tsc --noEmit` ? passed
- `npm run portal-nav:validate` ? passed
- `npm run portal-nav:uat -- --app-url http://127.0.0.1:8081` ? passed
- `npm run portal:validate-contrast` ? passed (24 app color checks)
- `npm run portal-bootstrap:uat -- --app-url http://127.0.0.1:8081` ? passed
  - navigation to neutral shell: 403 ms
  - session accepted to dashboard visible: 316 ms
  - session accepted to dashboard data ready: 574 ms
  - delayed desktop/mobile, first password sign-in, pending Technician, direct Admin, non-Admin denial, refresh/repeated sign-in, queued/in-flight sign-out, forced-event coalescing, exact-route preload, privacy, localization, reduced motion, and stalled-session recovery all passed
- `npm run agent:preflight -- --issue 594` ? passed
- independent adversarial review ? ship; no remaining P0/P1 findings

## How to test
1. Check out `agent/portal-bootstrap-performance`.
2. Copy the repository-local ignored `.env` used for normal app development into this worktree, then run `npm ci`.
3. Start the app with `npm run dev:uat` and open `http://127.0.0.1:8081/portal`.
4. In another terminal run `npm run portal-bootstrap:uat -- --app-url http://127.0.0.1:8081`.
5. Confirm the generated screenshots in `output/playwright/` show the neutral desktop and `390x844` mobile shells, and that the command reports shell under 2 seconds and useful dashboard content under 3 seconds.
6. With a normal local test account, sign in through `http://127.0.0.1:8081/login`; confirm the shell appears immediately, no Reports/Team/Admin labels flash before access is ready, and the correct persona navigation appears after hydration.
7. Open `http://127.0.0.1:8081/admin` with a non-admin test account and confirm only the neutral shell appears during hydration, followed by `Admin Access Required`.

## Risk and overlap
- No database migration, production deployment, role model, route hierarchy, or client-side permission authority change.
- Technician entitlement resolution still completes before portal/reporting access reads.
- `package.json` overlaps open dependency/payout work only by adding one script; the lockfile is unchanged.
- `Docs/QA_SMOKE_TEST_CHECKLIST.md` overlaps other open QA PRs; this PR adds only the focused #594 checks.

## Merge Autonomy
- Lane: Yellow
- Agent may merge after required GitHub checks complete and the repository merge gate passes.
- Yellow because this changes auth-bootstrap lifecycle and visible loading UI, but it does not change server authorization, roles, routes, database schema, or production state.
- Stop and do not merge if CI reports an auth/navigation regression, the branch falls behind `main`, or focused delayed-bootstrap/persona UAT no longer passes.

## UI / Design Evidence
- Desktop delayed-access shell: `output/playwright/portal-bootstrap-delayed-shell.png` (generated by focused UAT; permission-neutral sidebar/header geometry and structured loading content).
- Mobile delayed-access shell: `output/playwright/portal-bootstrap-delayed-shell-mobile.png` at `390x844`; automated assertion confirms no horizontal overflow.
- Normal dashboard handoff: `output/playwright/portal-bootstrap-normal-dashboard.png`.
- Browser assertions prove no Reports, Team, Timekeeping, Admin Console, upgrade, account, email, machine, or other access-sensitive content appears before server-backed access resolves.
- Loading status is outside the busy decorative region, has `aria-live`/`aria-atomic`, decorative placeholders create no empty navigation landmark, reduced-motion stops pulse animation, and the 8-second stalled state exposes Sign out.
- English and Simplified Chinese loading states are covered; no public-site token or layout change is included.

## Independent Review / QA Evidence
- Initial performance research mapped the exact critical path and required single-source auth initialization, token-refresh stability, stale-generation protection, Technician-first resolution, exact-route preload, and non-PII marks.
- Independent adversarial code/UAT review challenged queued sign-out restoration, forced-event concurrency, metric validity, preload rejection, data-ready semantics, and shell accessibility.
- All P0/P1 findings were fixed and re-reviewed. Final verdict: Ship; no remaining P0/P1 findings.
- Forced `USER_UPDATED`/`PASSWORD_RECOVERY` events now coalesce into exactly one sequential follow-up hydration; timeline assertions prove no concurrent entitlement/access RPCs and no intermediate ready-state flash.
- Real navigation-to-shell timing is asserted independently of session-to-shell: 403 ms navigation-to-shell, 316 ms session-to-dashboard visible, and 574 ms session-to-dashboard data ready in the reviewed deterministic run.
- Existing authenticated persona UAT, navigation validator, color contrast validator, build, lint, TypeScript, and regression test all pass.
