### PR TITLE
Polish authenticated shell brand, language placement, and alignment

### DIFF
--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -148,11 +148,14 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Pending Technician first login resolves entitlements before access reads, then exposes assigned Training and Reporting access without a second login.
 - [ ] Signing out or changing users while access is loading invalidates the earlier request; a stale response cannot restore the prior user or permissions.
 - [ ] Login, authenticated portal, and Admin Console primary buttons, selected controls, links, and focus rings use the app-scoped interaction palette; normal text meets WCAG AA 4.5:1 contrast, focus indicators meet 3:1, and public-site colors remain unchanged
+- [ ] Run `npm run portal:validate-contrast` and confirm the bright authenticated action fill, foreground, hover, active, deeper link/selection ink, and focus ring pass in light and dark token states while public primary/action tokens remain unchanged
+- [ ] Reporting `Export polished PDF` and representative shared primary actions use bright Bloomjoy pink with dark readable text, a pink app hover shadow, and no burgundy/red or orange action treatment
 - [ ] Canonical operator login lives at `https://app.bloomjoyusa.com/login`
 - [ ] Temporary alias `https://app.bloomjoyusa.com/login/operator` resolves to `/login`
 - [ ] On mobile `/login`, the sign-in form appears before the operator-feature highlights, the top app header stays compact without an extra context row pushing content below the fold, and visible auth/header/menu controls have touch-friendly hit areas
 - [ ] Login errors show actionable copy (for example: expired link, send rate-limit)
 - [ ] Language selector on `/login` switches between English and Simplified Chinese and the selected language persists after refresh on desktop
+- [ ] `/login` renders exactly one visible language selector on desktop and `390x844`, including while the mobile navigation drawer is open; both language targets are at least `44x44` CSS px with a visible keyboard focus ring
 - [ ] Magic link email is received in the configured inbox and login completes via Supabase auth callback
 - [ ] First-time sign-in copy clearly explains signup-confirmation-first behavior when applicable
 - [ ] Password sign-in works for an existing email/password user
@@ -229,6 +232,11 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Portal section navigation labels `/portal/account` as Settings and does not show a separate Admin link for admin users
 - [ ] Mobile app navigation keeps Account Settings and Sign Out as session utilities without duplicate session or admin actions in the same sheet
 - [ ] Signed-in `/portal/account` language preference switches core portal navigation, dashboard/reporting/training/support/account entry labels, then persists after refresh
+- [ ] Authenticated desktop sidebar and mobile drawer render no persistent language selector; `/portal/account` renders exactly one labeled Preferences > Language preference section with full `English` and `简体中文` labels
+- [ ] If account preference sync fails, changing language still persists on the current device and Account Settings reports the non-blocking sync failure instead of claiming account sync succeeded
+- [ ] Training-only users retain their existing restricted route permissions; language recovery remains available by signing out and using the single selector on `/login`
+- [ ] At desktop widths, normal portal, normal admin, Scoped Admin, and permission-neutral loading shells align sidebar/content header dividers within `1` CSS px, use one divider color, and keep EN/ZH scoped context inside the fixed header row
+- [ ] Run `npm run portal-nav:uat -- --app-url http://127.0.0.1:8081` and review desktop/`390x844` screenshots for login, dashboard, Account Settings EN/ZH, Reporting export, normal/scoped headers, and mobile overflow in `output/playwright`
 - [ ] On mobile (`390x844`), Chinese app-shell and portal navigation labels fit without horizontal page overflow
 - [ ] User with reporting access sees Reporting in portal navigation, quick actions, and the above-the-fold dashboard reporting card linking to `/portal/reports`
 - [ ] User without reporting access does not see Reporting in portal navigation or dashboard quick actions

--- a/scripts/validate-app-color-contrast.mjs
+++ b/scripts/validate-app-color-contrast.mjs
@@ -10,10 +10,22 @@ const trainingPath = path.join(repoRoot, 'src', 'pages', 'portal', 'Training.tsx
 const partnershipsPath = path.join(repoRoot, 'src', 'pages', 'admin', 'Partnerships.tsx');
 const timePath = path.join(repoRoot, 'src', 'pages', 'portal', 'Time.tsx');
 const timeReviewPath = path.join(repoRoot, 'src', 'pages', 'portal', 'TimeReview.tsx');
+const buttonVariantsPath = path.join(
+  repoRoot,
+  'src',
+  'components',
+  'ui',
+  'button-variants.ts',
+);
 const training = fs.readFileSync(trainingPath, 'utf8');
 const partnerships = fs.readFileSync(partnershipsPath, 'utf8');
 const time = fs.readFileSync(timePath, 'utf8');
 const timeReview = fs.readFileSync(timeReviewPath, 'utf8');
+const buttonVariants = fs.readFileSync(buttonVariantsPath, 'utf8');
+const reports = fs.readFileSync(
+  path.join(repoRoot, 'src', 'pages', 'portal', 'Reports.tsx'),
+  'utf8',
+);
 
 const assert = (condition, message) => {
   if (!condition) {
@@ -101,11 +113,17 @@ const muted = hslToRgb(parseHsl(tokenValue(rootBlock, 'muted'), '--muted'));
 const amber = hslToRgb(parseHsl(tokenValue(rootBlock, 'amber'), '--amber'));
 const sage = hslToRgb(parseHsl(tokenValue(rootBlock, 'sage'), '--sage'));
 const primary = hslToRgb(parseHsl(tokenValue(appBlock, 'primary'), '--primary'));
-const primaryForeground = hslToRgb(
-  parseHsl(tokenValue(appBlock, 'primary-foreground'), '--primary-foreground'),
-);
 const ring = hslToRgb(parseHsl(tokenValue(appBlock, 'ring'), '--ring'));
-const coralDark = hslToRgb(parseHsl(tokenValue(appBlock, 'coral-dark'), '--coral-dark'));
+const action = hslToRgb(parseHsl(tokenValue(appBlock, 'action'), '--action'));
+const actionForeground = hslToRgb(
+  parseHsl(tokenValue(appBlock, 'action-foreground'), '--action-foreground'),
+);
+const actionHover = hslToRgb(
+  parseHsl(tokenValue(appBlock, 'action-hover'), '--action-hover'),
+);
+const actionActive = hslToRgb(
+  parseHsl(tokenValue(appBlock, 'action-active'), '--action-active'),
+);
 const primaryTint = composite(primary, background, 0.1);
 const primaryAtEightyPercent = composite(primary, background, 0.8);
 
@@ -120,12 +138,18 @@ const darkMuted = hslToRgb(parseHsl(tokenValue(darkBlock, 'muted'), 'dark --mute
 const darkPrimary = hslToRgb(
   parseHsl(tokenValue(darkAppBlock, 'primary'), 'dark --primary'),
 );
-const darkPrimaryForeground = hslToRgb(
-  parseHsl(tokenValue(darkAppBlock, 'primary-foreground'), 'dark --primary-foreground'),
-);
 const darkRing = hslToRgb(parseHsl(tokenValue(darkAppBlock, 'ring'), 'dark --ring'));
-const darkCoralDark = hslToRgb(
-  parseHsl(tokenValue(darkAppBlock, 'coral-dark'), 'dark --coral-dark'),
+const darkAction = hslToRgb(
+  parseHsl(tokenValue(darkAppBlock, 'action'), 'dark --action'),
+);
+const darkActionForeground = hslToRgb(
+  parseHsl(tokenValue(darkAppBlock, 'action-foreground'), 'dark --action-foreground'),
+);
+const darkActionHover = hslToRgb(
+  parseHsl(tokenValue(darkAppBlock, 'action-hover'), 'dark --action-hover'),
+);
+const darkActionActive = hslToRgb(
+  parseHsl(tokenValue(darkAppBlock, 'action-active'), 'dark --action-active'),
 );
 const darkPrimaryTint = composite(darkPrimary, darkBackground, 0.1);
 const darkPrimaryAtEightyPercent = composite(darkPrimary, darkBackground, 0.8);
@@ -139,7 +163,17 @@ const darkSettledBadgeTint = composite(darkMuted, darkBackground, 0.6);
 const checks = [
   {
     label: 'filled primary action text',
-    ratio: contrastRatio(primary, primaryForeground),
+    ratio: contrastRatio(action, actionForeground),
+    minimum: 4.5,
+  },
+  {
+    label: 'filled primary action hover text',
+    ratio: contrastRatio(actionHover, actionForeground),
+    minimum: 4.5,
+  },
+  {
+    label: 'filled primary action active text',
+    ratio: contrastRatio(actionActive, actionForeground),
     minimum: 4.5,
   },
   {
@@ -158,11 +192,6 @@ const checks = [
     minimum: 4.5,
   },
   {
-    label: 'text on 80% primary hover fill',
-    ratio: contrastRatio(primaryAtEightyPercent, primaryForeground),
-    minimum: 4.5,
-  },
-  {
     label: 'focus ring on app background',
     ratio: contrastRatio(ring, background),
     minimum: 3,
@@ -178,13 +207,18 @@ const checks = [
     minimum: 3,
   },
   {
-    label: 'primary button hover fill',
-    ratio: contrastRatio(coralDark, primaryForeground),
+    label: 'dark filled primary action text',
+    ratio: contrastRatio(darkAction, darkActionForeground),
     minimum: 4.5,
   },
   {
-    label: 'dark filled primary action text',
-    ratio: contrastRatio(darkPrimary, darkPrimaryForeground),
+    label: 'dark filled primary action hover text',
+    ratio: contrastRatio(darkActionHover, darkActionForeground),
+    minimum: 4.5,
+  },
+  {
+    label: 'dark filled primary action active text',
+    ratio: contrastRatio(darkActionActive, darkActionForeground),
     minimum: 4.5,
   },
   {
@@ -203,11 +237,6 @@ const checks = [
     minimum: 4.5,
   },
   {
-    label: 'dark text on 80% primary hover fill',
-    ratio: contrastRatio(darkPrimaryAtEightyPercent, darkPrimaryForeground),
-    minimum: 4.5,
-  },
-  {
     label: 'dark focus ring on app background',
     ratio: contrastRatio(darkRing, darkBackground),
     minimum: 3,
@@ -221,11 +250,6 @@ const checks = [
     label: 'dark selected-state border on app background',
     ratio: contrastRatio(darkPrimary, darkBackground),
     minimum: 3,
-  },
-  {
-    label: 'dark primary button hover fill',
-    ratio: contrastRatio(darkCoralDark, darkPrimaryForeground),
-    minimum: 4.5,
   },
   {
     label: '12px approved badge text',
@@ -274,6 +298,43 @@ assert(
 assert(
   tokenValue(rootBlock, 'primary') !== tokenValue(appBlock, 'primary'),
   'App and public primary tokens must remain independently scoped.',
+);
+assert(
+  tokenValue(rootBlock, 'action') === tokenValue(rootBlock, 'primary') &&
+    tokenValue(rootBlock, 'action-foreground') === tokenValue(rootBlock, 'primary-foreground'),
+  'Public action tokens must preserve the existing public primary treatment.',
+);
+assert(
+  tokenValue(rootBlock, 'action-shadow-hover') ===
+    '0 6px 20px -3px hsl(16 85% 55% / 0.35)',
+  'Public buttons must preserve their existing hover shadow.',
+);
+assert(
+  tokenValue(appBlock, 'action') === '345 72% 68%' &&
+    tokenValue(appBlock, 'action-foreground') === '220 20% 14%' &&
+    tokenValue(appBlock, 'action-hover') === '345 72% 64%' &&
+    tokenValue(appBlock, 'action-active') === '345 72% 62%',
+  'Authenticated light actions must use the approved bright Bloomjoy semantic treatment.',
+);
+assert(
+  tokenValue(appBlock, 'primary') === '335 65% 40%' &&
+    tokenValue(appBlock, 'ring') === '335 65% 40%',
+  'Authenticated links and focus rings must retain the approved deeper interaction ink.',
+);
+assert(
+  buttonVariants.includes(
+    'bg-action text-action-foreground shadow-action hover:bg-action-hover',
+  ) && buttonVariants.includes('active:bg-action-active'),
+  'Shared default and hero buttons must use the semantic action treatment.',
+);
+assert(
+  !buttonVariants.includes('hsl(16_85%_55%'),
+  'Shared buttons must not reintroduce the hard-coded orange hover shadow.',
+);
+assert(
+  reports.includes('data-portal-report-export="operator-pdf"') &&
+    reports.includes('data-portal-report-export="partner"'),
+  'Reporting exports must expose shared-action UAT contracts.',
 );
 assert(
   training.includes("? 'border-primary bg-primary/5 shadow-sm'"),

--- a/scripts/validate-authenticated-navigation.mjs
+++ b/scripts/validate-authenticated-navigation.mjs
@@ -95,6 +95,25 @@ assert(
   !appLayout.includes('<h1 className="truncate font-display text-lg font-semibold text-foreground sm:text-xl">'),
   'The app shell title must not render as an H1 because pages render their own H1.',
 );
+const authenticatedSidebarSource = appLayout.slice(
+  appLayout.indexOf('function AuthenticatedSidebar'),
+);
+assert(
+  !authenticatedSidebarSource.includes('LanguagePreferenceControl'),
+  'Authenticated desktop and mobile navigation must keep language preference in Account Settings.',
+);
+assert(
+  appLayout.includes('data-app-shell-sidebar-header') &&
+    appLayout.includes('data-app-shell-content-header'),
+  'Authenticated shell headers must expose the shared divider contract.',
+);
+
+const accountPage = read('src/pages/portal/Account.tsx');
+assert(
+  (accountPage.match(/<LanguagePreferenceControl/g) ?? []).length === 1 &&
+    accountPage.includes("t('account.preferences')"),
+  'Account Settings must own exactly one labeled language preference section.',
+);
 
 const adminDashboard = includes(
   'src/pages/admin/Dashboard.tsx',

--- a/scripts/validate-authenticated-portal-uat.mjs
+++ b/scripts/validate-authenticated-portal-uat.mjs
@@ -19,6 +19,7 @@ const getArg = (name, fallback) => {
 const appUrl = getArg('--app-url', 'http://127.0.0.1:8081');
 const expiresAt = Math.floor(Date.now() / 1000) + 3600;
 const debug = process.env.PORTAL_UAT_DEBUG === '1';
+const unexpectedBrowserErrors = [];
 
 const personas = {
   admin: {
@@ -68,6 +69,38 @@ const personas = {
     isCorporatePartner: false,
     capabilities: ['operator.timekeeping'],
     timekeeping: true,
+  },
+  training: {
+    id: '00000000-0000-4000-9000-000000000004',
+    email: 'training-uat@bloomjoy.localhost',
+    plus: false,
+    portalAccessTier: 'training',
+    isSuperAdmin: false,
+    isScopedAdmin: false,
+    canAccessAdmin: false,
+    allowedSurfaces: [],
+    hasReportingAccess: false,
+    canManageTechnicians: false,
+    canManageTeam: false,
+    isCorporatePartner: false,
+    capabilities: [],
+    timekeeping: false,
+  },
+  scopedAdmin: {
+    id: '00000000-0000-4000-9000-000000000005',
+    email: 'scoped-admin-uat@bloomjoy.localhost',
+    plus: false,
+    portalAccessTier: 'baseline',
+    isSuperAdmin: false,
+    isScopedAdmin: true,
+    canAccessAdmin: true,
+    allowedSurfaces: ['orders'],
+    hasReportingAccess: false,
+    canManageTechnicians: false,
+    canManageTeam: false,
+    isCorporatePartner: false,
+    capabilities: [],
+    timekeeping: false,
   },
 };
 
@@ -199,6 +232,40 @@ const rpcResponse = (rpcName, persona) => {
         latest_sale_date: '2026-06-26',
         latest_import_completed_at: '2026-06-27T12:00:00.000Z',
       };
+    case 'get_reporting_dimensions':
+      return persona.hasReportingAccess
+        ? [
+            {
+              account_id: 'account-uat',
+              account_name: 'UAT Account',
+              location_id: 'location-uat',
+              location_name: 'UAT Location',
+              machine_id: 'machine-uat',
+              machine_label: 'UAT Machine',
+              machine_type: 'robotic_cotton_candy',
+              sunze_machine_id: 'sunze-uat',
+              latest_sale_date: '2026-06-26',
+              status: 'active',
+            },
+          ]
+        : [];
+    case 'get_sales_report':
+      return persona.hasReportingAccess
+        ? [
+            {
+              period_start: '2026-06-26',
+              machine_id: 'machine-uat',
+              machine_label: 'UAT Machine',
+              location_id: 'location-uat',
+              location_name: 'UAT Location',
+              payment_method: 'credit',
+              net_sales_cents: 12500,
+              refund_amount_cents: 500,
+              gross_sales_cents: 13000,
+              transaction_count: 26,
+            },
+          ]
+        : [];
     case 'get_my_technician_management_context':
       return {
         canManage: persona.canManageTeam,
@@ -259,7 +326,12 @@ const rpcResponse = (rpcName, persona) => {
   }
 };
 
-const createPageForPersona = async (browser, persona, viewport) => {
+const createPageForPersona = async (
+  browser,
+  persona,
+  viewport,
+  { failLanguageSync = false } = {},
+) => {
   const context = await browser.newContext({ viewport });
   const session = makeSession(persona);
 
@@ -331,6 +403,18 @@ const createPageForPersona = async (browser, persona, viewport) => {
         });
       }
 
+      if (
+        failLanguageSync &&
+        requestUrl.pathname.endsWith('/customer_profiles') &&
+        route.request().method() !== 'GET'
+      ) {
+        return route.fulfill({
+          status: 503,
+          contentType: 'application/json',
+          body: JSON.stringify({ message: 'Language preference sync unavailable in UAT.' }),
+        });
+      }
+
       if (debug) {
         console.log(`[${persona.email}] rest ${route.request().method()} ${route.request().url()}`);
       }
@@ -344,12 +428,20 @@ const createPageForPersona = async (browser, persona, viewport) => {
 
   const page = await context.newPage();
   page.on('console', (message) => {
-    if (message.type() === 'error') {
-      console.error(`[${persona.email}] console error: ${message.text()}`);
+    const isExpectedLanguageSyncFailure =
+      failLanguageSync &&
+      message.type() === 'error' &&
+      message.text().includes('503 (Service Unavailable)');
+    if (message.type() === 'error' && !isExpectedLanguageSyncFailure) {
+      const errorMessage = `[${persona.email}] console error: ${message.text()}`;
+      unexpectedBrowserErrors.push(errorMessage);
+      console.error(errorMessage);
     }
   });
   page.on('pageerror', (error) => {
-    console.error(`[${persona.email}] page error: ${error.message}`);
+    const errorMessage = `[${persona.email}] page error: ${error.message}`;
+    unexpectedBrowserErrors.push(errorMessage);
+    console.error(errorMessage);
   });
 
   return page;
@@ -370,6 +462,109 @@ const waitForHeading = async (page, options, screenshotName) => {
     console.error(bodyText.slice(0, 1200));
     throw error;
   }
+};
+
+const visibleLanguageControls = (page) =>
+  page.locator('[data-language-preference-control]:visible');
+
+const assertNoHorizontalOverflow = async (page, label) => {
+  const dimensions = await page.evaluate(() => ({
+    viewportWidth: window.innerWidth,
+    documentWidth: document.documentElement.scrollWidth,
+  }));
+  await assert(
+    dimensions.documentWidth <= dimensions.viewportWidth + 1,
+    `${label} must not overflow horizontally (${dimensions.documentWidth}px > ${dimensions.viewportWidth}px).`,
+  );
+};
+
+const assertHeaderAlignment = async (page, label) => {
+  const sidebarHeader = page.locator('[data-app-shell-sidebar-header]');
+  const contentHeader = page.locator('[data-app-shell-content-header]');
+  await assert(
+    (await sidebarHeader.count()) === 1 && (await contentHeader.count()) === 1,
+    `${label} must render one sidebar header and one content header.`,
+  );
+
+  const [sidebarBox, contentBox, sidebarBorder, contentBorder] = await Promise.all([
+    sidebarHeader.boundingBox(),
+    contentHeader.boundingBox(),
+    sidebarHeader.evaluate((element) => getComputedStyle(element).borderBottomColor),
+    contentHeader.evaluate((element) => getComputedStyle(element).borderBottomColor),
+  ]);
+  await assert(sidebarBox && contentBox, `${label} header boxes must be measurable.`);
+
+  const dividerDelta = Math.abs(
+    sidebarBox.y + sidebarBox.height - (contentBox.y + contentBox.height),
+  );
+  await assert(
+    dividerDelta <= 1,
+    `${label} header dividers must align within 1 CSS px; measured ${dividerDelta.toFixed(2)}px.`,
+  );
+  await assert(
+    sidebarBorder === contentBorder,
+    `${label} header dividers must use the same color token.`,
+  );
+};
+
+const readActionTreatment = async (locator) =>
+  locator.evaluate((element) => {
+    const surface = element.closest('.app-surface');
+    const surfaceStyles = getComputedStyle(surface);
+    const normalizeColor = (tokenName) => {
+      const token = surfaceStyles.getPropertyValue(tokenName).trim();
+      const probe = document.createElement('span');
+      probe.style.color = `hsl(${token})`;
+      document.body.appendChild(probe);
+      const color = getComputedStyle(probe).color;
+      probe.remove();
+      return color;
+    };
+    const styles = getComputedStyle(element);
+
+    return {
+      background: styles.backgroundColor,
+      color: styles.color,
+      boxShadow: styles.boxShadow,
+      expectedAction: normalizeColor('--action'),
+      expectedForeground: normalizeColor('--action-foreground'),
+      expectedHover: normalizeColor('--action-hover'),
+      expectedActive: normalizeColor('--action-active'),
+    };
+  });
+
+const assertActionTreatment = async (page, selector, label) => {
+  const action = page.locator(selector);
+  await action.waitFor();
+  await assert((await action.count()) === 1, `${label} must resolve to one action.`);
+
+  const normal = await readActionTreatment(action);
+  await assert(
+    normal.background === normal.expectedAction && normal.color === normal.expectedForeground,
+    `${label} must use the semantic action fill and foreground.`,
+  );
+  await assert(normal.boxShadow !== 'none', `${label} must use the semantic action shadow.`);
+
+  await action.hover();
+  await page.waitForTimeout(250);
+  const hovered = await readActionTreatment(action);
+  await assert(
+    hovered.background === hovered.expectedHover,
+    `${label} hover must use the semantic hover fill.`,
+  );
+
+  const box = await action.boundingBox();
+  await assert(box, `${label} must have a pointer target.`);
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  await page.waitForTimeout(250);
+  const active = await readActionTreatment(action);
+  await page.mouse.move(0, 0);
+  await page.mouse.up();
+  await assert(
+    active.background === active.expectedActive,
+    `${label} active state must use the semantic active fill.`,
+  );
 };
 
 fs.mkdirSync(outputDir, { recursive: true });
@@ -420,6 +615,11 @@ try {
     !adminNavText.includes('admin_roles') && !adminNavText.includes('is_super_admin'),
     'Visible admin nav must not expose implementation role names.',
   );
+  await assert(
+    (await visibleLanguageControls(adminPage).count()) === 0,
+    'Authenticated desktop shell must not render a persistent language selector.',
+  );
+  await assertHeaderAlignment(adminPage, 'Admin desktop shell');
 
   const activeAdminHome = await adminPage.locator('aside nav a[aria-current="page"]').allTextContents();
   await assert(
@@ -443,6 +643,10 @@ try {
     height: 844,
   });
   await mobileAdminPage.goto(`${appUrl}/admin`, { waitUntil: 'networkidle' });
+  await assert(
+    (await visibleLanguageControls(mobileAdminPage).count()) === 0,
+    'Authenticated mobile header must not render a language selector.',
+  );
   await mobileAdminPage.getByRole('button', { name: 'Open operator navigation menu' }).click();
   await mobileAdminPage.waitForTimeout(150);
   const focusedText = await mobileAdminPage.evaluate(() => document.activeElement?.textContent ?? '');
@@ -463,6 +667,11 @@ try {
       mobileDrawerText.indexOf('Administration') < mobileDrawerText.indexOf('Partners & Reporting'),
     'Mobile admin drawer should expose the streamlined Admin Console IA order.',
   );
+  await assert(
+    (await visibleLanguageControls(mobileAdminPage).count()) === 0,
+    'Authenticated mobile drawer must not duplicate the Account language preference.',
+  );
+  await assertNoHorizontalOverflow(mobileAdminPage, 'Admin mobile drawer');
   await mobileAdminPage.screenshot({
     path: path.join(outputDir, 'portal-shell-admin-mobile-drawer.png'),
     fullPage: true,
@@ -487,6 +696,11 @@ try {
     (await customerPage.getByText('See access details').count()) === 0,
     'Portal dashboard should not render locked quick-action cards.',
   );
+  await assertHeaderAlignment(customerPage, 'Portal desktop shell');
+  await customerPage.screenshot({
+    path: path.join(outputDir, 'portal-shell-dashboard-desktop.png'),
+    fullPage: true,
+  });
   await customerPage.goto(`${appUrl}/portal/time`, { waitUntil: 'networkidle' });
   await customerPage.getByText('Timekeeping setup required').waitFor();
   await assert(
@@ -529,6 +743,322 @@ try {
   });
   await timekeeperPage.close();
 
+  const loginDesktopContext = await browser.newContext({
+    viewport: { width: 1366, height: 768 },
+  });
+  const loginDesktopPage = await loginDesktopContext.newPage();
+  await loginDesktopPage.goto(`${appUrl}/login`, { waitUntil: 'networkidle' });
+  await waitForHeading(
+    loginDesktopPage,
+    { name: 'Sign in to the Bloomjoy operator app', level: 1 },
+    'portal-shell-login-desktop-debug-failed.png',
+  );
+  await assert(
+    (await visibleLanguageControls(loginDesktopPage).count()) === 1,
+    'Desktop login must render exactly one visible language selector.',
+  );
+  const loginLanguageButtons = visibleLanguageControls(loginDesktopPage).locator('button');
+  const loginLanguageButtonBoxes = await loginLanguageButtons.evaluateAll((buttons) =>
+    buttons.map((button) => {
+      const box = button.getBoundingClientRect();
+      return { width: box.width, height: box.height };
+    }),
+  );
+  await assert(
+    loginLanguageButtonBoxes.every((box) => box.width >= 44 && box.height >= 44),
+    'Login language targets must be at least 44 by 44 CSS px.',
+  );
+  const loginEnglishButton = loginDesktopPage.getByRole('button', {
+    name: 'English',
+    exact: true,
+  });
+  await loginDesktopPage.keyboard.press('Tab');
+  await loginEnglishButton.focus();
+  const loginFocusState = await loginEnglishButton.evaluate((button) => ({
+    focusVisible: button.matches(':focus-visible'),
+    boxShadow: getComputedStyle(button).boxShadow,
+  }));
+  await assert(
+    loginFocusState.focusVisible && loginFocusState.boxShadow !== 'none',
+    'Login language buttons must expose a visible keyboard focus ring.',
+  );
+  await loginDesktopPage.screenshot({
+    path: path.join(outputDir, 'portal-shell-login-desktop.png'),
+    fullPage: true,
+  });
+  await loginDesktopContext.close();
+
+  const loginMobileContext = await browser.newContext({
+    viewport: { width: 390, height: 844 },
+  });
+  const loginMobilePage = await loginMobileContext.newPage();
+  await loginMobilePage.goto(`${appUrl}/login`, { waitUntil: 'networkidle' });
+  await waitForHeading(
+    loginMobilePage,
+    { name: 'Sign in to the Bloomjoy operator app', level: 1 },
+    'portal-shell-login-mobile-debug-failed.png',
+  );
+  await assert(
+    (await visibleLanguageControls(loginMobilePage).count()) === 1,
+    'Mobile login must render exactly one visible language selector.',
+  );
+  await assertNoHorizontalOverflow(loginMobilePage, 'Login mobile');
+  await loginMobilePage.screenshot({
+    path: path.join(outputDir, 'portal-shell-login-mobile.png'),
+    fullPage: true,
+  });
+  await loginMobilePage.getByRole('button', { name: 'Open operator navigation menu' }).click();
+  await assert(
+    (await visibleLanguageControls(loginMobilePage).count()) === 1,
+    'Opening the login drawer must not create a second visible language selector.',
+  );
+  await loginMobileContext.close();
+
+  const mobileDashboardPage = await createPageForPersona(browser, personas.customer, {
+    width: 390,
+    height: 844,
+  });
+  await mobileDashboardPage.goto(`${appUrl}/portal`, { waitUntil: 'networkidle' });
+  await waitForHeading(
+    mobileDashboardPage,
+    { name: 'Welcome back', level: 1 },
+    'portal-shell-dashboard-mobile-debug-failed.png',
+  );
+  await assert(
+    (await visibleLanguageControls(mobileDashboardPage).count()) === 0,
+    'Mobile dashboard shell must not render a language selector.',
+  );
+  await assertNoHorizontalOverflow(mobileDashboardPage, 'Dashboard mobile');
+  await mobileDashboardPage.screenshot({
+    path: path.join(outputDir, 'portal-shell-dashboard-mobile.png'),
+    fullPage: true,
+  });
+  await mobileDashboardPage.close();
+
+  const accountPage = await createPageForPersona(browser, personas.customer, {
+    width: 1366,
+    height: 768,
+  });
+  await accountPage.goto(`${appUrl}/portal/account`, { waitUntil: 'networkidle' });
+  await waitForHeading(
+    accountPage,
+    { name: 'Account Settings', level: 1 },
+    'portal-shell-account-desktop-debug-failed.png',
+  );
+  await assert(
+    (await visibleLanguageControls(accountPage).count()) === 1,
+    'Account Settings must render exactly one visible language preference.',
+  );
+  await accountPage.getByText('Preferences', { exact: true }).waitFor();
+  const accountLanguageButtons = visibleLanguageControls(accountPage).locator('button');
+  const accountLanguageButtonBoxes = await accountLanguageButtons.evaluateAll((buttons) =>
+    buttons.map((button) => {
+      const box = button.getBoundingClientRect();
+      return { width: box.width, height: box.height };
+    }),
+  );
+  await assert(
+    accountLanguageButtonBoxes.every((box) => box.width >= 44 && box.height >= 44),
+    'Account language targets must be at least 44 by 44 CSS px.',
+  );
+  await accountPage.screenshot({
+    path: path.join(outputDir, 'portal-shell-account-desktop-en.png'),
+    fullPage: true,
+  });
+  const chineseLanguageButton = accountPage.getByRole('button', {
+    name: '简体中文',
+    exact: true,
+  });
+  await accountPage.keyboard.press('Tab');
+  await chineseLanguageButton.focus();
+  const accountFocusState = await chineseLanguageButton.evaluate((button) => ({
+    focusVisible: button.matches(':focus-visible'),
+    boxShadow: getComputedStyle(button).boxShadow,
+  }));
+  await assert(
+    accountFocusState.focusVisible && accountFocusState.boxShadow !== 'none',
+    'Account language buttons must expose a visible keyboard focus ring.',
+  );
+  await chineseLanguageButton.click();
+  await waitForHeading(
+    accountPage,
+    { name: '账户设置 / Account Settings', level: 1 },
+    'portal-shell-account-zh-debug-failed.png',
+  );
+  await accountPage.getByText('已保存在此设备，并已同步到您的账号。', { exact: true }).waitFor();
+  await assert(
+    (await accountPage.evaluate(
+      () => window.localStorage.getItem('bloomjoy.language.v1'),
+    )) === 'zh-Hans',
+    'Language switching must persist the Chinese preference locally.',
+  );
+  const chineseAccountNav = await textContent(
+    accountPage.locator('aside nav a[href="/portal/account"]'),
+  );
+  await assert(
+    chineseAccountNav.includes('账户设置 / Account Settings'),
+    'Account Settings must remain recognizable when the current language is Chinese.',
+  );
+  await accountPage.reload({ waitUntil: 'networkidle' });
+  await waitForHeading(
+    accountPage,
+    { name: '账户设置 / Account Settings', level: 1 },
+    'portal-shell-account-refresh-debug-failed.png',
+  );
+  await accountPage.screenshot({
+    path: path.join(outputDir, 'portal-shell-account-desktop-zh.png'),
+    fullPage: true,
+  });
+  await accountPage.close();
+
+  const accountSyncFailurePage = await createPageForPersona(
+    browser,
+    personas.customer,
+    { width: 1366, height: 768 },
+    { failLanguageSync: true },
+  );
+  await accountSyncFailurePage.goto(`${appUrl}/portal/account`, { waitUntil: 'networkidle' });
+  await waitForHeading(
+    accountSyncFailurePage,
+    { name: 'Account Settings', level: 1 },
+    'portal-shell-account-sync-failure-debug-failed.png',
+  );
+  await accountSyncFailurePage
+    .getByText('Saved on this device. Account sync is unavailable; try again later.', {
+      exact: true,
+    })
+    .waitFor();
+  await accountSyncFailurePage.getByRole('button', { name: '简体中文', exact: true }).click();
+  await accountSyncFailurePage
+    .getByText('已保存在此设备。账号同步暂不可用，请稍后再试。', { exact: true })
+    .waitFor();
+  await assert(
+    (await accountSyncFailurePage.evaluate(
+      () => window.localStorage.getItem('bloomjoy.language.v1'),
+    )) === 'zh-Hans',
+    'A profile-sync failure must not block device-local language persistence.',
+  );
+  await accountSyncFailurePage.close();
+
+  const mobileAccountPage = await createPageForPersona(browser, personas.customer, {
+    width: 390,
+    height: 844,
+  });
+  await mobileAccountPage.goto(`${appUrl}/portal/account`, { waitUntil: 'networkidle' });
+  await waitForHeading(
+    mobileAccountPage,
+    { name: 'Account Settings', level: 1 },
+    'portal-shell-account-mobile-debug-failed.png',
+  );
+  await assert(
+    (await visibleLanguageControls(mobileAccountPage).count()) === 1,
+    'Mobile Account Settings must render exactly one language preference.',
+  );
+  await assertNoHorizontalOverflow(mobileAccountPage, 'Account Settings mobile');
+  await mobileAccountPage.screenshot({
+    path: path.join(outputDir, 'portal-shell-account-mobile.png'),
+    fullPage: true,
+  });
+  await mobileAccountPage.close();
+
+  const reportingPage = await createPageForPersona(browser, personas.admin, {
+    width: 1366,
+    height: 768,
+  });
+  await reportingPage.goto(`${appUrl}/portal/reports`, { waitUntil: 'networkidle' });
+  await waitForHeading(
+    reportingPage,
+    { name: 'Reporting', level: 1 },
+    'portal-shell-reporting-desktop-debug-failed.png',
+  );
+  await assertActionTreatment(
+    reportingPage,
+    '[data-portal-report-export="operator-pdf"]',
+    'Reporting PDF export',
+  );
+  await assertHeaderAlignment(reportingPage, 'Reporting desktop shell');
+  await reportingPage.screenshot({
+    path: path.join(outputDir, 'portal-shell-reporting-desktop.png'),
+    fullPage: true,
+  });
+  await reportingPage.close();
+
+  const mobileReportingPage = await createPageForPersona(browser, personas.admin, {
+    width: 390,
+    height: 844,
+  });
+  await mobileReportingPage.goto(`${appUrl}/portal/reports`, { waitUntil: 'networkidle' });
+  await waitForHeading(
+    mobileReportingPage,
+    { name: 'Reporting', level: 1 },
+    'portal-shell-reporting-mobile-debug-failed.png',
+  );
+  await mobileReportingPage.locator('[data-portal-report-export="operator-pdf"]').waitFor();
+  await assertNoHorizontalOverflow(mobileReportingPage, 'Reporting mobile');
+  await mobileReportingPage.screenshot({
+    path: path.join(outputDir, 'portal-shell-reporting-mobile.png'),
+    fullPage: true,
+  });
+  await mobileReportingPage.close();
+
+  const scopedAdminPage = await createPageForPersona(browser, personas.scopedAdmin, {
+    width: 1366,
+    height: 768,
+  });
+  await scopedAdminPage.goto(`${appUrl}/admin/orders`, { waitUntil: 'networkidle' });
+  await scopedAdminPage.locator('[data-app-shell-content-header]').waitFor();
+  await assertHeaderAlignment(scopedAdminPage, 'Scoped Admin desktop shell');
+  const scopedHeaderFitsEnglish = await scopedAdminPage
+    .locator('[data-app-shell-content-header]')
+    .evaluate((header) => {
+      const content = header.firstElementChild;
+      return content.scrollHeight <= content.clientHeight + 1;
+    });
+  await assert(scopedHeaderFitsEnglish, 'Scoped Admin English header must fit its fixed desktop row.');
+  await scopedAdminPage.evaluate(() => {
+    window.localStorage.setItem('bloomjoy.language.v1', 'zh-Hans');
+  });
+  await scopedAdminPage.reload({ waitUntil: 'networkidle' });
+  await assertHeaderAlignment(scopedAdminPage, 'Scoped Admin Chinese desktop shell');
+  const scopedHeaderFitsChinese = await scopedAdminPage
+    .locator('[data-app-shell-content-header]')
+    .evaluate((header) => {
+      const content = header.firstElementChild;
+      return content.scrollHeight <= content.clientHeight + 1;
+    });
+  await assert(scopedHeaderFitsChinese, 'Scoped Admin Chinese header must fit its fixed desktop row.');
+  await scopedAdminPage.screenshot({
+    path: path.join(outputDir, 'portal-shell-scoped-admin-desktop-zh.png'),
+    fullPage: true,
+  });
+  await scopedAdminPage.close();
+
+  const trainingPage = await createPageForPersona(browser, personas.training, {
+    width: 1366,
+    height: 768,
+  });
+  await trainingPage.goto(`${appUrl}/portal`, { waitUntil: 'networkidle' });
+  await waitForHeading(
+    trainingPage,
+    { name: 'Welcome back', level: 1 },
+    'portal-shell-training-debug-failed.png',
+  );
+  await assert(
+    (await trainingPage.locator('aside nav a[href="/portal/account"]').count()) === 0,
+    'Training-only permissions must not be broadened to expose Account Settings.',
+  );
+  await assert(
+    (await visibleLanguageControls(trainingPage).count()) === 0,
+    'Training-only authenticated shell must not reintroduce the language selector.',
+  );
+  await trainingPage.getByRole('button', { name: 'Open profile menu' }).click();
+  await trainingPage.getByText('Sign Out', { exact: true }).waitFor();
+  await trainingPage.close();
+
+  await assert(
+    unexpectedBrowserErrors.length === 0,
+    `Authenticated portal UAT encountered unexpected browser errors:\n${unexpectedBrowserErrors.join('\n')}`,
+  );
   console.log(`Authenticated portal UAT passed at ${appUrl}`);
   console.log(`Screenshots written to ${path.relative(repoRoot, outputDir)}`);
 } finally {

--- a/src/components/auth/AuthenticatedShellSkeleton.tsx
+++ b/src/components/auth/AuthenticatedShellSkeleton.tsx
@@ -105,8 +105,11 @@ export function AuthenticatedShellSkeleton({
 
   return (
     <div className="app-surface min-h-screen bg-background text-foreground lg:grid lg:grid-cols-[17.5rem_minmax(0,1fr)]">
-      <aside className="hidden border-r border-border/70 bg-sidebar/80 lg:flex lg:min-h-screen lg:flex-col">
-        <div className="flex min-h-[4.25rem] items-center gap-3 border-b border-border/70 px-4">
+      <aside className="hidden border-r border-[hsl(var(--app-shell-divider))] bg-sidebar/80 lg:flex lg:min-h-screen lg:flex-col">
+        <div
+          className="app-shell-header-row flex min-h-[4.25rem] items-center gap-3 px-4 lg:min-h-0"
+          data-app-shell-sidebar-header
+        >
           <img
             src={logo}
             alt="Bloomjoy Sweets"
@@ -136,7 +139,10 @@ export function AuthenticatedShellSkeleton({
       </aside>
 
       <div className="min-w-0">
-        <header className="flex min-h-[4.25rem] items-center border-b border-border/70 bg-background/95 px-4 sm:px-6">
+        <header
+          className="app-shell-header-row flex min-h-[4.25rem] items-center bg-background/95 px-4 sm:px-6 lg:min-h-0"
+          data-app-shell-content-header
+        >
           <div className="flex w-full items-center gap-3">
             <img
               src={logo}

--- a/src/components/i18n/LanguagePreferenceControl.tsx
+++ b/src/components/i18n/LanguagePreferenceControl.tsx
@@ -15,21 +15,40 @@ export function LanguagePreferenceControl({
   showText = false,
   fullWidth = false,
 }: LanguagePreferenceControlProps) {
-  const { language, setLanguage, supportedLanguages, t } = useLanguage();
+  const {
+    language,
+    languageSyncStatus,
+    setLanguage,
+    supportedLanguages,
+    t,
+  } = useLanguage();
+  const statusKey =
+    languageSyncStatus === 'syncing'
+      ? 'language.syncing'
+      : languageSyncStatus === 'synced'
+        ? 'language.synced'
+        : languageSyncStatus === 'sync-unavailable'
+          ? 'language.syncUnavailable'
+          : 'language.deviceOnly';
 
   return (
     <div
       className={cn(
         'flex min-w-0 items-center gap-3',
         fullWidth && 'w-full justify-between',
+        fullWidth && showText && 'flex-col items-stretch',
         className
       )}
     >
       {showText && (
         <div className="min-w-0">
           <p className="text-sm font-medium text-foreground">{t('language.selectorLabel')}</p>
-          <p className="mt-1 text-xs leading-5 text-muted-foreground">
-            {t('language.savedLocally')}
+          <p
+            className="mt-1 text-xs leading-5 text-muted-foreground"
+            role="status"
+            aria-live="polite"
+          >
+            {t(statusKey)}
           </p>
         </div>
       )}
@@ -37,10 +56,11 @@ export function LanguagePreferenceControl({
         className={cn(
           'inline-flex shrink-0 items-center gap-1 rounded-full border border-border bg-background p-1 shadow-[var(--shadow-sm)]',
           compact && 'gap-0 p-0.5',
-          fullWidth && !showText && 'w-full'
+          fullWidth && 'w-full'
         )}
         role="group"
         aria-label={t('language.selectorLabel')}
+        data-language-preference-control
       >
         {!compact && (
           <Languages className="ml-2 h-4 w-4 text-muted-foreground" aria-hidden="true" />
@@ -53,14 +73,15 @@ export function LanguagePreferenceControl({
               key={supportedLanguage.code}
               type="button"
               aria-pressed={isActive}
-              title={t('language.current', { language: supportedLanguage.label })}
+              aria-label={supportedLanguage.label}
+              title={supportedLanguage.label}
               className={cn(
-                'min-h-10 rounded-full px-2.5 text-xs font-semibold transition-colors sm:px-3',
+                'min-h-11 rounded-full border border-transparent px-2.5 text-xs font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 sm:px-3',
                 compact && 'min-h-11 min-w-11 px-2 text-[11px]',
                 isActive
-                  ? 'bg-primary text-primary-foreground'
+                  ? 'border-primary/30 bg-primary/10 text-primary'
                   : 'text-muted-foreground hover:bg-muted hover:text-foreground',
-                fullWidth && !showText && 'min-h-11 flex-1'
+                fullWidth && 'min-h-11 flex-1'
               )}
               onClick={() => setLanguage(supportedLanguage.code)}
             >

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -64,7 +64,6 @@ export function AppLayout({ children }: AppLayoutProps) {
     capabilities,
     hasReportingAccess,
     isAuthenticated,
-    isCorporatePartner,
     isScopedAdmin,
     isSuperAdmin,
     portalAccessTier,
@@ -80,7 +79,7 @@ export function AppLayout({ children }: AppLayoutProps) {
   const marketingHomeUrl = getCanonicalUrlForSurface('marketing', '/', '', '', currentLocation);
   const accountUrl = '/portal/account';
   const showAccountLink = portalAccessTier !== 'training' || adminAccess.isScopedAdmin;
-  const accountLinkLabel = isCorporatePartner ? 'Account Settings' : t('app.account');
+  const accountLinkLabel = t('app.account');
   const signedInEmail = user?.email ?? '';
   const profileMenuLabel = signedInEmail ? signedInEmail.split('@')[0] : t('app.profileMenu');
   const scopedMachineCount = adminAccess.scopedMachineIds.length;
@@ -246,7 +245,6 @@ export function AppLayout({ children }: AppLayoutProps) {
                       <SheetDescription>{t(appContext.descriptionKey)}</SheetDescription>
                     </SheetHeader>
                     <div className="mt-6 space-y-3">
-                      <LanguagePreferenceControl fullWidth />
                       <a
                         href={marketingHomeUrl}
                         className="flex items-center justify-between rounded-xl border border-border bg-background px-4 py-3 text-sm font-medium text-foreground transition-colors hover:bg-muted/40"
@@ -278,7 +276,7 @@ export function AppLayout({ children }: AppLayoutProps) {
 
   return (
     <div className="app-surface min-h-screen bg-background text-foreground lg:grid lg:grid-cols-[17.5rem_minmax(0,1fr)]">
-      <aside className="hidden border-r border-border/70 bg-sidebar/80 lg:sticky lg:top-0 lg:flex lg:h-screen lg:flex-col">
+      <aside className="hidden border-r border-[hsl(var(--app-shell-divider))] bg-sidebar/80 lg:sticky lg:top-0 lg:flex lg:h-screen lg:flex-col">
         <AuthenticatedSidebar
           appTitle={t('app.operatorAppTitle')}
           currentPathname={location.pathname}
@@ -288,8 +286,11 @@ export function AppLayout({ children }: AppLayoutProps) {
       </aside>
 
       <div className="flex min-h-screen min-w-0 flex-col bg-gradient-to-b from-background via-background to-muted/20">
-        <header className="sticky top-0 z-40 border-b border-border/70 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/85 lg:static lg:bg-background/80">
-          <div className="flex min-h-[4.25rem] items-center justify-between gap-3 px-4 sm:px-6 lg:px-8">
+        <header
+          className="app-shell-header-row sticky top-0 z-40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/85 lg:static lg:bg-background/80"
+          data-app-shell-content-header
+        >
+          <div className="flex min-h-[4.25rem] items-center justify-between gap-3 px-4 sm:px-6 lg:h-full lg:min-h-0 lg:px-8">
             <div className="min-w-0">
               <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground sm:text-[11px]">
                 {t('app.operatorApp')}
@@ -297,13 +298,14 @@ export function AppLayout({ children }: AppLayoutProps) {
               <p className="truncate font-display text-lg font-semibold text-foreground sm:text-xl">
                 {t(appContext.titleKey)}
               </p>
-              <p className="hidden max-w-3xl truncate text-sm text-muted-foreground md:block">
-                {t(appContext.descriptionKey)}
-              </p>
-              {scopedAdminContext && (
+              {scopedAdminContext ? (
                 <p className="mt-1 flex max-w-3xl items-center gap-1.5 text-xs font-medium text-muted-foreground">
                   <ShieldCheck className="h-3.5 w-3.5 shrink-0 text-primary" />
                   <span className="truncate">{scopedAdminContext}</span>
+                </p>
+              ) : (
+                <p className="hidden max-w-3xl truncate text-sm text-muted-foreground md:block">
+                  {t(appContext.descriptionKey)}
                 </p>
               )}
             </div>
@@ -375,8 +377,8 @@ function AuthenticatedSidebar({
   const shell = (
     <div className={cn('flex min-h-0 flex-1 flex-col', mobile ? 'h-full overflow-y-auto' : 'h-screen')}>
       {!mobile && (
-        <div className="border-b border-sidebar-border px-4 py-3">
-          <Link to="/portal" className="flex min-w-0 items-center gap-3">
+        <div className="app-shell-header-row" data-app-shell-sidebar-header>
+          <Link to="/portal" className="flex h-full min-w-0 items-center gap-3 px-4">
             <img
               src={logo}
               alt="Bloomjoy Sweets"
@@ -459,11 +461,6 @@ function AuthenticatedSidebar({
       <div className="border-t border-sidebar-border p-3">
         <div className="rounded-xl border border-border bg-background p-2.5 shadow-[var(--shadow-sm)]">
           <div className="grid gap-1.5">
-            <LanguagePreferenceControl
-              compact={!mobile}
-              fullWidth={mobile}
-              className={mobile ? undefined : '[&_button]:min-h-8 [&_button]:min-w-9'}
-            />
             {mobile ? (
               <MobileUtilityLinks {...utilities} />
             ) : (

--- a/src/components/ui/button-variants.ts
+++ b/src/components/ui/button-variants.ts
@@ -5,13 +5,13 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-coral-dark shadow-warm hover:shadow-[0_6px_20px_-3px_hsl(16_85%_55%/0.35)]",
+        default: "bg-action text-action-foreground shadow-action hover:bg-action-hover hover:shadow-action-hover active:bg-action-active",
         destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline: "border-2 border-foreground/20 bg-transparent text-foreground hover:border-primary hover:text-primary",
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
-        hero: "bg-primary text-primary-foreground hover:bg-coral-dark shadow-warm hover:shadow-[0_6px_20px_-3px_hsl(16_85%_55%/0.35)] text-base",
+        hero: "bg-action text-action-foreground shadow-action hover:bg-action-hover hover:shadow-action-hover active:bg-action-active text-base",
         "hero-outline": "border-2 border-foreground/20 bg-transparent text-foreground hover:border-primary hover:text-primary text-base",
         muted: "bg-muted text-muted-foreground hover:bg-muted/80",
       },

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -27,10 +27,17 @@ import {
 
 type LanguageContextValue = {
   language: LanguageCode;
+  languageSyncStatus: LanguageSyncStatus;
   setLanguage: (language: LanguageCode) => void;
   supportedLanguages: typeof supportedLanguages;
   t: (key: TranslationKey, params?: TranslationParams) => string;
 };
+
+export type LanguageSyncStatus =
+  | 'device-only'
+  | 'syncing'
+  | 'synced'
+  | 'sync-unavailable';
 
 const LanguageContext = createContext<LanguageContextValue | undefined>(undefined);
 
@@ -46,8 +53,12 @@ const readStoredLanguage = (): LanguageCode => {
 export function LanguageProvider({ children }: { children: ReactNode }) {
   const { user } = useAuth();
   const [language, setLanguageState] = useState<LanguageCode>(readStoredLanguage);
+  const [languageSyncStatus, setLanguageSyncStatus] =
+    useState<LanguageSyncStatus>('device-only');
   const languageRef = useRef(language);
   const manualChangeCounterRef = useRef(0);
+  const syncGenerationRef = useRef(0);
+  const activeUserIdRef = useRef<string | null>(user?.id ?? null);
 
   useEffect(() => {
     languageRef.current = language;
@@ -59,44 +70,103 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
   }, [language]);
 
   useEffect(() => {
-    if (!user?.id) {
-      return;
+    const requestUserId = user?.id ?? null;
+    const requestGeneration = syncGenerationRef.current + 1;
+    syncGenerationRef.current = requestGeneration;
+    activeUserIdRef.current = requestUserId;
+
+    const isCurrentAuthRequest = () =>
+      syncGenerationRef.current === requestGeneration &&
+      activeUserIdRef.current === requestUserId;
+    const invalidateAuthRequest = () => {
+      if (syncGenerationRef.current === requestGeneration) {
+        syncGenerationRef.current += 1;
+        activeUserIdRef.current = null;
+      }
+    };
+
+    if (!requestUserId) {
+      setLanguageSyncStatus('device-only');
+      return invalidateAuthRequest;
     }
 
     let active = true;
     const requestCounter = manualChangeCounterRef.current;
+    setLanguageSyncStatus('syncing');
 
     const syncProfilePreference = async () => {
-      const profileLanguage = await fetchPortalLanguagePreference(user.id);
+      try {
+        const profileLanguage = await fetchPortalLanguagePreference(requestUserId);
 
-      if (!active) {
-        return;
-      }
-
-      if (profileLanguage) {
-        if (manualChangeCounterRef.current === requestCounter) {
-          setLanguageState(profileLanguage);
+        if (
+          !active ||
+          !isCurrentAuthRequest() ||
+          manualChangeCounterRef.current !== requestCounter
+        ) {
+          return;
         }
-        return;
-      }
 
-      await savePortalLanguagePreference(user.id, languageRef.current).catch(() => undefined);
+        if (profileLanguage) {
+          setLanguageState(profileLanguage);
+          setLanguageSyncStatus('synced');
+          return;
+        }
+
+        await savePortalLanguagePreference(requestUserId, languageRef.current);
+
+        if (
+          active &&
+          isCurrentAuthRequest() &&
+          manualChangeCounterRef.current === requestCounter
+        ) {
+          setLanguageSyncStatus('synced');
+        }
+      } catch {
+        if (
+          active &&
+          isCurrentAuthRequest() &&
+          manualChangeCounterRef.current === requestCounter
+        ) {
+          setLanguageSyncStatus('sync-unavailable');
+        }
+      }
     };
 
-    void syncProfilePreference().catch(() => undefined);
+    void syncProfilePreference();
 
     return () => {
       active = false;
+      invalidateAuthRequest();
     };
   }, [user?.id]);
 
   const setLanguage = useCallback(
     (nextLanguage: LanguageCode) => {
       manualChangeCounterRef.current += 1;
+      const requestCounter = manualChangeCounterRef.current;
       setLanguageState(nextLanguage);
 
       if (user?.id) {
-        void savePortalLanguagePreference(user.id, nextLanguage).catch(() => undefined);
+        const requestUserId = user.id;
+        const requestGeneration = syncGenerationRef.current;
+        const isCurrentManualRequest = () =>
+          manualChangeCounterRef.current === requestCounter &&
+          syncGenerationRef.current === requestGeneration &&
+          activeUserIdRef.current === requestUserId;
+        setLanguageSyncStatus('syncing');
+        void savePortalLanguagePreference(requestUserId, nextLanguage)
+          .then(() => {
+            if (isCurrentManualRequest()) {
+              setLanguageSyncStatus('synced');
+            }
+          })
+          .catch(() => {
+            if (isCurrentManualRequest()) {
+              setLanguageSyncStatus('sync-unavailable');
+            }
+          });
+      } else {
+        setLanguageSyncStatus('device-only');
       }
     },
     [user?.id]
@@ -110,11 +180,12 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
   const value = useMemo<LanguageContextValue>(
     () => ({
       language,
+      languageSyncStatus,
       setLanguage,
       supportedLanguages,
       t,
     }),
-    [language, setLanguage, t]
+    [language, languageSyncStatus, setLanguage, t]
   );
 
   return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;

--- a/src/index.css
+++ b/src/index.css
@@ -20,6 +20,12 @@
     /* Cotton candy pink primary */
     --primary: 345 72% 68%;
     --primary-foreground: 0 0% 100%;
+    --action: 345 72% 68%;
+    --action-foreground: 0 0% 100%;
+    --action-hover: 345 72% 58%;
+    --action-active: 345 72% 58%;
+    --action-shadow: 0 4px 14px -3px hsl(345 72% 68% / 0.3);
+    --action-shadow-hover: 0 6px 20px -3px hsl(16 85% 55% / 0.35);
 
     /* Soft pink secondary */
     --secondary: 340 40% 96%;
@@ -79,6 +85,8 @@
     --sidebar-accent-foreground: 240 5.9% 10%;
     --sidebar-border: 340 20% 92%;
     --sidebar-ring: 345 72% 68%;
+    --app-shell-header-height: 4.25rem;
+    --app-shell-divider: 340 20% 90%;
   }
 
   .app-surface {
@@ -87,14 +95,21 @@
      * Keep the lighter candy pink on public marketing pages while giving
      * login, portal, admin, and portalled controls AA-safe action colors.
      */
-    --primary: 345 56% 40%;
+    --primary: 335 65% 40%;
     --primary-foreground: 340 30% 99%;
-    --ring: 345 56% 40%;
-    --coral-dark: 345 60% 34%;
-    --shadow-warm: 0 4px 14px -3px hsl(345 56% 40% / 0.24);
-    --sidebar-primary: 345 56% 40%;
+    --ring: 335 65% 40%;
+    --coral-dark: 335 65% 34%;
+    --action: 345 72% 68%;
+    --action-foreground: 220 20% 14%;
+    --action-hover: 345 72% 64%;
+    --action-active: 345 72% 62%;
+    --action-shadow: 0 4px 14px -3px hsl(345 72% 68% / 0.26);
+    --action-shadow-hover: 0 6px 20px -3px hsl(345 72% 68% / 0.36);
+    --shadow-warm: var(--action-shadow);
+    --sidebar-primary: 335 65% 40%;
     --sidebar-primary-foreground: 340 30% 99%;
-    --sidebar-ring: 345 56% 40%;
+    --sidebar-ring: 335 65% 40%;
+    --app-shell-divider: 340 20% 90%;
   }
 
   .dark {
@@ -109,6 +124,10 @@
 
     --primary: 345 72% 68%;
     --primary-foreground: 0 0% 100%;
+    --action: 345 72% 68%;
+    --action-foreground: 0 0% 100%;
+    --action-hover: 345 72% 58%;
+    --action-active: 345 72% 58%;
 
     --secondary: 220 15% 18%;
     --secondary-foreground: 340 20% 96%;
@@ -125,6 +144,7 @@
     --border: 220 15% 20%;
     --input: 220 15% 20%;
     --ring: 345 72% 68%;
+    --app-shell-divider: 220 15% 20%;
   }
 
   .dark.app-surface,
@@ -133,9 +153,16 @@
     --primary-foreground: 220 20% 10%;
     --ring: 345 68% 72%;
     --coral-dark: 345 68% 78%;
+    --action: 345 68% 72%;
+    --action-foreground: 220 20% 10%;
+    --action-hover: 345 68% 68%;
+    --action-active: 345 68% 66%;
+    --action-shadow: 0 4px 14px -3px hsl(345 68% 72% / 0.24);
+    --action-shadow-hover: 0 6px 20px -3px hsl(345 68% 72% / 0.34);
     --sidebar-primary: 345 68% 72%;
     --sidebar-primary-foreground: 220 20% 10%;
     --sidebar-ring: 345 68% 72%;
+    --app-shell-divider: 220 15% 20%;
   }
 }
 
@@ -180,6 +207,16 @@
     @apply space-y-6 sm:space-y-8;
   }
 
+  .app-shell-header-row {
+    border-bottom: 1px solid hsl(var(--app-shell-divider));
+  }
+
+  @media (min-width: 1024px) {
+    .app-shell-header-row {
+      height: var(--app-shell-header-height);
+    }
+  }
+
   .text-balance {
     text-wrap: balance;
   }
@@ -209,7 +246,7 @@
   }
 
   .btn-shadow:hover {
-    box-shadow: 0 6px 20px -3px hsl(345 72% 68% / 0.4);
+    box-shadow: var(--action-shadow-hover);
   }
 
   .gradient-candy {

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -29,6 +29,11 @@ export const translations = {
     'language.english': 'English',
     'language.chineseSimplified': 'Simplified Chinese',
     'language.savedLocally': 'Saved on this device and synced to your account when available.',
+    'language.deviceOnly': 'Saved on this device.',
+    'language.syncing': 'Saved on this device. Syncing to your account…',
+    'language.synced': 'Saved on this device and synced to your account.',
+    'language.syncUnavailable':
+      'Saved on this device. Account sync is unavailable; try again later.',
 
     'app.operatorApp': 'Operator App',
     'app.operatorLogin': 'Operator login',
@@ -624,6 +629,7 @@ export const translations = {
     'support.unableSubmit': 'Unable to submit support request.',
 
     'account.title': 'Account Settings',
+    'account.preferences': 'Preferences',
     'account.description':
       'Manage the profile information, shipping address, and language preference that keep portal work running smoothly.',
     'team.title': 'Team',
@@ -661,6 +667,10 @@ export const translations = {
     'language.english': 'English',
     'language.chineseSimplified': '简体中文',
     'language.savedLocally': '会保存在此设备；可用时也会同步到账号。',
+    'language.deviceOnly': '已保存在此设备。',
+    'language.syncing': '已保存在此设备。正在同步到您的账号…',
+    'language.synced': '已保存在此设备，并已同步到您的账号。',
+    'language.syncUnavailable': '已保存在此设备。账号同步暂不可用，请稍后再试。',
 
     'app.operatorApp': '运营应用',
     'app.operatorLogin': '运营登录',
@@ -1166,6 +1176,7 @@ export const translations = {
     'support.unableSubmit': '无法提交支持请求。',
 
     'account.title': '账户设置 / Account Settings',
+    'account.preferences': '偏好设置 / Preferences',
     'account.description': '管理资料、收货地址和语言偏好，让门户工作更顺畅。',
     'team.title': '团队 / Team',
     'team.description': '添加 Technician、发送邀请，并管理每个人可以查看报表的机器。',

--- a/src/pages/portal/Account.tsx
+++ b/src/pages/portal/Account.tsx
@@ -7,6 +7,7 @@ import {
   MapPin,
   CreditCard,
   ExternalLink,
+  Languages,
   ShieldCheck,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -492,9 +493,30 @@ export default function AccountPage() {
 
             {/* Billing */}
             <div className="min-w-0">
-              <div className="mt-6 card-elevated min-w-0 p-5 sm:p-6">
-                <LanguagePreferenceControl showText fullWidth />
-              </div>
+              <section
+                className="mt-6 card-elevated min-w-0 p-5 sm:p-6"
+                aria-labelledby="account-preferences-title"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+                    <Languages className="h-5 w-5 text-primary" aria-hidden="true" />
+                  </div>
+                  <div className="min-w-0">
+                    <h2
+                      id="account-preferences-title"
+                      className="font-display text-lg font-semibold text-foreground"
+                    >
+                      {t('account.preferences')}
+                    </h2>
+                    <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                      {t('language.selectorDescription')}
+                    </p>
+                  </div>
+                </div>
+                <div className="mt-5">
+                  <LanguagePreferenceControl showText fullWidth />
+                </div>
+              </section>
 
               {!isScopedAdminOnly && !isCorporatePartnerOnly && (
                 <div className="mt-6 card-elevated min-w-0 p-5 sm:p-6">

--- a/src/pages/portal/Reports.tsx
+++ b/src/pages/portal/Reports.tsx
@@ -819,7 +819,11 @@ function OperatorReportingView({ accessContext }: { accessContext: ReportingAcce
               </CardDescription>
             </div>
             <div className="flex flex-col gap-2 sm:flex-row">
-              <Button onClick={exportPdf} disabled={isExporting || reportRows.length === 0}>
+              <Button
+                onClick={exportPdf}
+                disabled={isExporting || reportRows.length === 0}
+                data-portal-report-export="operator-pdf"
+              >
                 {isExporting ? (
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                 ) : (
@@ -1686,7 +1690,11 @@ function PartnerDashboardView() {
               <div className="flex flex-col gap-2 sm:flex-row lg:col-span-2 lg:justify-end xl:col-span-1">
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
-                    <Button disabled={partnerExportDisabled} className="w-full justify-center sm:w-auto">
+                    <Button
+                      disabled={partnerExportDisabled}
+                      className="w-full justify-center sm:w-auto"
+                      data-portal-report-export="partner"
+                    >
                       {exportingPartnerFormat ? (
                         <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                       ) : (

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -28,6 +28,12 @@ export default {
           DEFAULT: "hsl(var(--primary))",
           foreground: "hsl(var(--primary-foreground))",
         },
+        action: {
+          DEFAULT: "hsl(var(--action))",
+          foreground: "hsl(var(--action-foreground))",
+          hover: "hsl(var(--action-hover))",
+          active: "hsl(var(--action-active))",
+        },
         secondary: {
           DEFAULT: "hsl(var(--secondary))",
           foreground: "hsl(var(--secondary-foreground))",
@@ -83,6 +89,8 @@ export default {
         'warm': 'var(--shadow-warm)',
         'elevated': 'var(--shadow-md)',
         'elevated-lg': 'var(--shadow-lg)',
+        'action': 'var(--action-shadow)',
+        'action-hover': 'var(--action-shadow-hover)',
       },
       keyframes: {
         "accordion-down": {


### PR DESCRIPTION
## Summary

- Restores Bloomjoy's bright-pink authenticated action treatment while keeping deeper accessible ink for links, focus, and selection states; public storefront tokens remain unchanged.
- Moves the authenticated language preference into Account Settings, keeps one selector on login, and reports truthful device/account sync state with stale-request protection.
- Aligns live and loading shell header dividers and adds deterministic desktop/mobile coverage for palette states, language persistence, permissions, alignment, overflow, and browser errors.

Closes #595

## Files changed

- Authenticated shell/layout, loading skeleton, semantic action tokens, and Reporting export actions.
- Language context, translations, selector accessibility, and Account Settings preferences.
- Contrast/navigation validators, full browser UAT, and QA smoke-test documentation.

## Verification

- npm ci ? passed (existing audit: 3 moderate, 1 high vulnerability)
- npm run build ? passed; 25 public and 25 private routes prerendered
- npm test --if-present ? passed
- npm run lint --if-present ? passed
- npx tsc --noEmit ? passed
- npm run portal:validate-contrast ? passed; filled action states 5.57:1 / 4.88:1 / 4.58:1
- npm run portal-nav:validate ? passed
- npm run portal-nav:uat -- --app-url http://127.0.0.1:8081 ? passed; desktop and 390px screenshots generated
- npm run portal-bootstrap:uat -- --app-url http://127.0.0.1:8081 ? passed; navigation-to-shell 291ms, session-to-shell 0ms, dashboard 265ms, data-ready 334ms
- git diff --check and staged secret-like addition scan ? passed

## How to test

1. Run npm ci.
2. Run npm run dev -- --host 127.0.0.1 --port 8081.
3. Open http://127.0.0.1:8081/login and confirm there is one EN / ?? selector on desktop and mobile, including with the mobile drawer open.
4. Sign in and open http://127.0.0.1:8081/portal/account; confirm the only authenticated selector is under Preferences, both controls have clear focus treatment, changing EN / ???? persists after refresh, and sync status is truthful.
5. Open http://127.0.0.1:8081/portal/reports; confirm the export action is bright pink with dark readable text and coherent hover/pressed states.
6. On desktop, compare the sidebar and content header divider; on a 390px viewport, confirm the shell, drawer, Account, and Reporting pages have no horizontal overflow.
7. For deterministic coverage without credentials, run npm run portal-nav:uat -- --app-url http://127.0.0.1:8081. It uses local mocked personas and makes no production writes.

Training-only permissions intentionally remain restricted: Account Settings is not exposed; the tested recovery path for changing language is Sign Out, then use the selector on /login.

## Merge Autonomy

- Lane: Yellow
- Rationale: visible authenticated UI and preference-sync feedback change, with no route, authorization, schema, payment, or production-data mutation.
- Merge basis: the P1 acceptance criteria have deterministic desktop/mobile UAT, passing CI, measured contrast and performance evidence, and independent design, visual, and code ship reviews. No executive or external signoff remains.

## Risk and overlap

- Merge autonomy: Yellow. This changes visible authenticated UI and language persistence feedback, but does not change routes, authorization, database schema, or production data.
- No runtime-file overlap found with open PRs. Docs/QA_SMOKE_TEST_CHECKLIST.md may overlap #561 and #562.
- Preserves the #594 permission-neutral loading shell and performance lifecycle.

## UI / design evidence

- Browser UAT captured login, dashboard, Account, Reporting, admin, mobile drawer, and scoped-admin EN/ZH states.
- Computed styles verify normal, hover, and active semantic action colors; divider positions are asserted within 1 CSS px.
- Contrast validator passes both light and dark authenticated palettes.

## Independent review / QA evidence

- Design audit: no remaining P0/P1 findings after training-only recovery and comprehensive UAT were documented.
- Visual review: Ship; no P0/P1 issues, with desktop export evidence confirmed bright pink and readable.
- Code review: Ship; no remaining P0/P1/P2 blockers after account-aware sync invalidation and fail-closed browser error collection.
