### PR TITLE
P0: make refund pilot and cutover evidence executable

### DIFF
--- a/Docs/MACHINE_MANAGER_SHADOW_UAT_SCRIPT.md
+++ b/Docs/MACHINE_MANAGER_SHADOW_UAT_SCRIPT.md
@@ -1,102 +1,128 @@
 # Machine Manager Shadow UAT Script
 
-Last updated: 2026-05-12
+Last updated: 2026-07-21
 
 ## Purpose
-Use this script when Bloomjoy invites managers, operators, or partner operators into the new refund workflow during shadow mode. The goal is to confirm the workflow is easy to use before replacing the Google Form/AppSheet fallback.
 
-Keep the current Google Form/AppSheet flow live. Managers should not use the new workflow as the only operational source until the shadow-pilot go/no-go checklist passes.
+Use this script with a clean Machine Manager-only account to prove that Refund Operations is simple, safe, and correctly scoped before cutover. Keep the Google Form/Sheet/AppSheet fallback live throughout UAT.
 
-## Before The Session
-- Use synthetic or owner-approved shadow-mode cases only.
-- Do not paste real customer names, emails, phone numbers, card digits, Zelle contacts, complaint text, screenshots, or raw provider data into GitHub, docs, chat, or feedback notes.
-- Confirm the tester has the right persona:
-  - Machine Manager/operator: sees only assigned-machine refund cases at `/refunds`.
-  - Scoped admin: sees only scoped-machine refund cases.
-  - Super admin: sees all refund cases and manages Machine Managers from Admin > Machines.
-- Confirm the tester knows refunds are still completed manually in Nayax or Zelle for MVP.
-- For agent visual QA, start the app with `npm run dev:uat` and use `http://127.0.0.1:8081`. Append `?demo=on` for clearly labeled demo-only review on `/refunds/request`, `/refunds`, and `/admin/machines`. Demo mode is not evidence that saves, access scope, Nayax lookup, automation emails, or reporting write-through work.
-- For functional QA, use seeded synthetic users/cases or post-production shadow-mode data with authenticated Machine Managers. The executive sponsor does not need to run this script before agents prove it works.
+This is a manager-experience test, not an Admin setup test. Use synthetic or sponsor-approved pilot cases and record sanitized aggregate evidence only.
 
-## Manager Script
-1. Sign in to the Bloomjoy operator app.
-2. Open `/refunds`.
-3. Confirm `Refunds` appears inside the Portal navigation, not as a top-level workspace tab.
-4. Confirm the queue only shows refund cases for machines you manage.
-5. Search for a known test case or select the first visible case.
-6. Review the case summary:
-   - customer contact
-   - refund path
-   - location and machine
-   - issue summary
-   - correlation evidence
-7. Confirm the `Decision and next action` section is easy to find before event history.
-8. Expand `Event timeline`.
-9. Expand `Customer messages`.
-10. For a card case, review the card lookup evidence and confirm no raw provider IDs are shown.
-11. For a cash case, confirm the refund path says cash refund by Zelle and the Zelle contact is available only in the authorized workflow.
-12. Try a decision path appropriate for the test case:
-    - keep in review
-    - waiting on customer
-    - approve
-    - deny
-    - mark card refund pending
-    - mark cash/Zelle pending
-    - completed
-13. If saving is blocked, confirm the error message tells you what is missing.
-14. On a phone-sized screen, confirm the queue and detail are readable without sideways scrolling.
+## Before the session
 
-## Expected Results
-- Machine Managers can open `/refunds`.
-- Machine Managers do not see the Admin workspace, Admin tools, Machine Manager setup, Nayax setup controls, machine setup identifiers, or raw provider payloads.
-- `/admin` and `/admin/refunds` redirect refund-only users back to `/refunds`.
-- The queue is understandable at a glance.
-- The selected case shows the decision area before timeline and message history.
-- Timeline and customer messages are available but not crowding the default view.
-- Denied cases require a friendly reason.
-- Completed cases require the correct manual refund reference and correlation evidence.
-- Nothing in the workflow suggests Bloomjoy automatically sends final approval, denial, or completion replies in MVP.
+- Confirm the tester has Machine Manager assignments only and no scoped-admin, super-admin, corporate-partner, or unrelated machine access. Record this setup in `#435`.
+- Confirm the selected machines and manager are approved in `#427`.
+- Confirm the tested release commit and Refund Operations release manifest match the deployed environment.
+- Confirm live Nayax execution state:
+  - **Shadow mode:** execution disabled, dry run on, kill switch on, and sponsor flag unset.
+  - **Controlled execution:** only after the explicit `#430` sponsor gate; use the approved low-value case, allowlist, and caps.
+- Confirm customer-email and automation tests use synthetic addresses unless the sponsor approved a real pilot case.
+- Do not capture customer names, contact details, card digits, payout contacts, complaint text, raw provider identifiers/payloads, Gmail content, or secrets in screenshots or notes.
+- Do not use `?demo=on` as functional evidence. Demo mode is for visual review only.
 
-## Super Admin Machine Setup Check
-Use this only for super-admin/admin UAT, not for ordinary Machine Manager testers.
+## A. Access boundary
 
-1. Open `/admin/machines`.
-2. Edit a machine.
-3. In `Machine Managers`, search for an authenticated user by name or email.
-4. Add the user and confirm the status changes from saving to `Saved`.
-5. Confirm there is no separate `Save Machine Managers` button.
-6. Close the edit sheet and confirm the machine row shows the assigned manager email.
-7. Reopen the same machine and confirm the assigned manager is still shown.
-8. Confirm no machine can have more than 3 Machine Managers.
-9. In `Customer Refund Setup`, turn on `Show on refund request form` only for pilot machines.
-10. Optionally set a customer-facing refund form label.
-11. Enter the Nayax machine ID/account key only when read-only card lookup should work for that machine.
-12. Save machine changes and confirm the row shows `Intake enabled` and `Card lookup ready` when both are configured.
-13. Confirm the setup copy says live card refund execution remains disabled/manual.
+1. Sign in with the clean manager-only account.
+2. Open `/refunds` directly.
+3. Confirm the queue contains only cases for assigned pilot machines.
+4. Confirm unrelated machines and cases are absent from search, filters, counts, and direct links.
+5. Confirm `/admin`, `/admin/refunds`, and machine setup controls are unavailable or redirect safely.
+6. Confirm the manager cannot see machine mapping identifiers, provider secrets, raw Nayax payloads, Gmail provider identifiers, or internal policy tables.
 
-Functional UAT note: a Machine Manager email must belong to a user who has signed in to Bloomjoy at least once. If a non-authenticated email is entered, the UI should explain that the person needs to sign in once before assignment.
+Pass only if every boundary holds. Any access leak stops the pilot.
 
-## Feedback Prompts
-Capture manager feedback in GitHub issues or PR comments using this format.
+## B. Ordinary matched card case
 
-```md
-## Machine Manager shadow feedback
-- Tester persona:
-- Machine/location scope:
+1. Open a prepared high-confidence card case.
+2. Without coaching, ask the manager what they believe the next action is.
+3. Confirm the screen shows the customer request beside the **Recommended card sale** on a typical laptop viewport.
+4. Confirm the explanation includes the mapped location/machine, amount, local time difference, card-last-four evidence when available, and any wallet warning without exposing raw provider IDs or internal score points.
+5. Confirm alternate candidates, timeline, internal notes, and retry tools are not competing with the normal path.
+6. Confirm exactly one dominant action is visible: **Refund $X and notify customer**. No manual status or decision selector should be required on this path.
+7. Clear the selected sale. Confirm the old refund action disappears immediately and an unsaved candidate cannot expose final refund execution.
+8. Re-select the recommended sale and use **Confirm this card sale**. Confirm execution eligibility appears only after the server saves the manager confirmation.
+9. Open the refund confirmation. Confirm it restates location, machine, transaction time, amount, card last four, and the completion-email preview.
+10. Choose **Go back**. Confirm no provider call, case completion, or email occurs.
+11. Reopen the confirmation and submit once:
+    - In shadow mode, confirm the safe blocked result keeps the case open and sends no completion email.
+    - In an approved `#430` execution pilot, confirm the button disables while processing and provider-confirmed success produces one receipt, one completed case, and one customer email.
+12. Refresh the page and confirm the durable state is correct.
+
+Record time-to-decision, click/decision count, recommendation accepted yes/no, structured disagreement reason if no, and whether coaching was needed.
+
+## C. Card exception cases
+
+Run one prepared case for each state:
+
+- ambiguous candidates
+- no safe match
+- wallet/manual exception
+- setup or lookup failure
+- duplicate or already-refunded transaction
+- provider outcome unknown
+
+For each case, confirm there is one plain-language recovery action, alternate evidence stays secondary, and no enabled refund action or completion email is available. An unknown outcome must tell the manager to reconcile Nayax before retrying.
+
+## D. Cash/manual payout case
+
+1. Open a matched cash/Zelle case.
+2. Confirm no Nayax or card-refund action appears in the primary workflow.
+3. Confirm the current state has one dominant next action and denial/missing-information choices are behind **Other decisions**.
+4. Approve the cash refund. Confirm the approval email and next step are clear; Bloomjoy Hub must not claim it sent the external payout.
+5. After the approved manual payout is actually sent, enter:
+   - refund amount no greater than the recorded customer payment
+   - payment sent date/time
+   - a short non-sensitive confirmation/reference
+   - the explicit **payment was sent** confirmation
+6. Confirm account/routing/card/contact/credential-like values are rejected.
+7. Open the final confirmation and verify the amount, time, reference summary, and customer-email preview.
+8. Submit once and confirm one completion, one redacted audit event, one reporting adjustment when eligible, and one customer email.
+9. Repeat/double-submit and confirm no duplicate state change, audit event, adjustment, or email.
+10. Run one denied or missing-information cash case and confirm no reporting adjustment is created.
+
+## E. Communications and recovery
+
+1. Verify acknowledgement and more-information message state from the case.
+2. Preview approval, denial, and completion copy. Confirm it is empathetic, includes the case reference, and does not overpromise timing or approval.
+3. Simulate a failed send and confirm the case remains accurate with one clear retry path.
+4. Simulate an uncertain send and confirm the manager is told to reconcile the mailbox before retrying.
+5. Confirm a retry produces no duplicate customer message.
+6. Confirm automation health is understandable to the manager without exposing run ledgers or customer data.
+
+## F. Mobile and keyboard check
+
+1. Repeat queue selection and one card or cash action at `390x844`.
+2. Confirm there is no horizontal page overflow, clipped action, hidden confirmation detail, or unreadable table.
+3. Navigate the primary action and confirmation using the keyboard.
+4. Confirm focus is visible, the dialog traps focus, **Go back** works, and loading disables repeat submission.
+
+## Expected result
+
+- The manager immediately understands the case and next action.
+- A normal card case needs one transaction confirmation and one refund confirmation, not manual status editing.
+- Unsafe card states fail closed.
+- Cash completion records a manual payout without storing sensitive payment data.
+- Provider success is required before case completion and customer success email.
+- Access, emails, audit history, reporting, and duplicate controls behave consistently after refresh.
+- The manager completes three consecutive ordinary cases without PM/backchannel help and with fewer manual decisions than the legacy workflow.
+
+## Feedback template
+
+```markdown
+## Machine Manager UAT checkpoint
+- Date/environment/release commit:
+- Tester role (no name/email):
+- Assigned machine count:
 - Device: Desktop / Mobile
-- Case reference:
-- Result: PASS / PARTIAL / BLOCKED
+- Scenarios and sample count:
+- Result: PASS / PARTIAL / FAIL
+- Median time to decision:
+- Median manager decisions/clicks:
+- Recommendation accepted count:
+- Coaching needed: yes/no
 - What was confusing:
-- What felt slower than the old process:
-- What felt faster than the old process:
-- Missing information:
-- Suggested change:
+- What was faster/slower than the legacy process:
+- Safety or access concern:
+- Defects opened:
 - Go/no-go impact:
 ```
-
-## PM/PO Go/No-Go Notes
-- Any access-boundary failure is a P0 blocker.
-- Any private-data leakage is a P0 blocker.
-- Any decision path that can write settlement adjustments without approved, completed, correlated evidence is a P0 blocker.
-- Minor wording, spacing, or filter improvements can be parked as follow-up issues if managers can still complete the workflow without PM help.
-- Cutover is not approved until shadow-mode cases complete end to end with fewer manual steps than the Google Form/AppSheet fallback.

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -31,7 +31,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] `/machines` has no horizontal page overflow at `360x800`, `390x844`, or `414x896`; the buyer comparison uses readable mobile cards, and the public header switches to the mobile menu at `768x1024`
 
 ## Refund Operations MVP
-- [ ] Follow the PM/PO shadow-pilot runbook in `Docs/REFUND_OPERATIONS_SHADOW_PILOT.md`; PR `#410` is merged, and Google Form/AppSheet remains live until the cutover gate passes.
+- [ ] Follow `Docs/REFUND_PRODUCTION_CUTOVER_PACKET.md` and the shadow-pilot runbook in `Docs/REFUND_OPERATIONS_SHADOW_PILOT.md`; verify the final integrated `main` release rather than an individual PR head, and keep Google Form/Sheet/AppSheet live until sponsor approval in `#409`.
 - [ ] Run `npm run refunds:validate-portal-uat -- --app-url <local-or-preview-url>` and confirm it passes with desktop/mobile screenshots written to `output/playwright`.
 - [ ] Run `npm run refunds:validate-customer-comms` and confirm primary refund actions send/log customer emails, failures surface as retry work, and the normal path has no separate send-email step.
 - [ ] Use `Docs/MACHINE_MANAGER_SHADOW_UAT_SCRIPT.md` for manager/operator shadow-pilot feedback collection.
@@ -70,7 +70,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Approved card path confirms the refund amount, calls guarded in-app `nayax-card-refund`, leaves the case open and customer uncontacted when execution is blocked, and completes only after a successful execution response without showing raw provider IDs in the UI.
 - [ ] Approved cash/Zelle path requires manager approval, conservative match, refund amount, and manual completion before reporting write-through.
 - [ ] Completed correlated cases create/update one `sales_adjustment_facts` row with `source='refund_case'`, linked `refund_case_id`, positive amount, applied match status, and no raw customer/payment/free-text payload.
-- [ ] Run manager-wide shadow-mode UAT with all current authenticated Machine Managers while the Google Form/AppSheet process remains available as fallback; do not cut over until pilot evidence is clean.
+- [ ] Run the current manager UAT script with a clean Machine Manager-only account from `#435`; a scoped-admin/super-admin account is not valid boundary evidence, and the approved pilot cohort remains narrow until `#427` and `#409` are signed off.
 
 ## Public site
 - [ ] Home loads and key CTAs navigate correctly

--- a/Docs/REFUND_OPERATIONS_SHADOW_PILOT.md
+++ b/Docs/REFUND_OPERATIONS_SHADOW_PILOT.md
@@ -1,119 +1,135 @@
 # Refund Operations Shadow Pilot Runbook
 
-Last updated: 2026-05-12
+Last updated: 2026-07-21
 
 ## Purpose
-Run the merged Refund Operations MVP through production rollout readiness checks and a selected Commercial/Mini shadow pilot before cutting over from the Google Form/AppSheet fallback.
 
-This runbook is the PM/PO control artifact for issues `#402`-`#409`.
-Use `Docs/MACHINE_MANAGER_SHADOW_UAT_SCRIPT.md` for the manager-facing shadow pilot script.
-Use `Docs/REFUND_FULL_AUTOMATION_GO_NO_GO.md` for PR `#432` production setup and merge-readiness gates.
+Prove the Refund Operations workflow in a narrow production shadow pilot before Bloomjoy enables live Nayax execution or retires the Google Form, Google Sheet, and AppSheet fallback.
 
-## Operating Rules
-- Codex acts as Bloomjoy PM/PO using the `bloomjoy-sprint-orchestrator` workflow.
-- No human planning session is required. Use this runbook, PR comments, issue comments, and owner go/no-go checkpoints.
-- Executive sponsor review is proof review, not first-pass UAT. Agents must validate seeded functional UAT or post-production shadow-mode flows and produce a pass/fail evidence packet before asking the sponsor to touch the feature.
-- Pilot scope is selected authenticated Machine Managers assigned to configured Bloomjoy Commercial/Mini pilot machines, still in shadow mode. Broader manager-wide rollout follows only after this selected pilot produces clean evidence.
-- Keep the Google Form/AppSheet process live until cutover criteria pass.
-- PR `#410` is merged. Merge is not cutover; production rollout, manager feedback, customer communication review, and shadow-pilot results remain cutover gates.
-- Do not paste secrets, customer PII, raw refund exports, card digits, raw Nayax payloads, or complaint free text into docs, issues, PRs, screenshots, or chat.
-- Nayax refund execution remains fail-closed until the separate full-automation gates pass. The manager workbench should still use the guarded in-app `nayax-card-refund` action for card cases, then show a clear blocker if execution is disabled; Google/AppSheet and manual Nayax remain the operational fallback during shadow mode.
+Epic `#628` owns the production-ready outcome. Issue `#427` owns the pilot evidence, issue `#409` owns the final cutover decision, and `Docs/MACHINE_MANAGER_SHADOW_UAT_SCRIPT.md` is the manager-facing test script.
 
-## Lane Checklist
-Use one GitHub issue or PR comment per checkpoint. Defects become PR-sized GitHub issues under epic `#402`.
+## Non-negotiable rules
 
-### PM/PO Control Lane
-- [x] Confirm PR `#410` merged with green GitHub CI, Vercel, and Supabase migration checks.
-- [x] Confirm issues `#402`-`#409` have current PM status comments through the merge checkpoint.
-- [ ] Track one go/no-go summary covering Nayax lookup, manager access, customer communications, reporting write-through, and shadow-pilot results.
-- [ ] Confirm Google Form/AppSheet fallback remains live during pilot.
-- [ ] Run `npm run refunds:validate-portal-uat -- --app-url <local-or-preview-url>` before manager shadow UAT when the app is reachable.
-- [ ] Confirm demo mode is labeled `DEMO DATA - visual review only` and is never used as evidence that saves, access boundaries, Nayax lookup, or reporting write-through work.
-- [ ] Prepare an executive proof packet only after agent QA has passed or documented blockers.
-- [ ] Confirm production migrations, Edge Functions, and server-only secret names are deployed through the production runbook before public QR/direct-link promotion.
+- Keep the legacy Google Form/Sheet/AppSheet workflow live until the sponsor explicitly approves retirement in `#409`.
+- Use a clean Machine Manager-only account from `#435`. Broader scoped-admin or super-admin access is not valid evidence for the manager boundary.
+- Keep live Nayax execution fail-closed until the provider contract and sponsor gate in `#430` are approved. Shadow mode may exercise the complete UI and a blocked execution response without making a live provider call.
+- The manager, not GPT or the matching score, makes the final decision.
+- Gmail and GPT are separate human-reviewed pilot lanes. Keep both Gmail enable switches off until `#634` approvals pass, and send no GPT draft without human approval during the pilot.
+- Do not place customer names, email addresses, phone numbers, card digits, payout contacts, complaint text, raw provider identifiers/payloads, Gmail content, or secrets in GitHub, screenshots, logs, or this packet.
+- Demo mode proves layout only. It does not prove persistence, permissions, provider behavior, email delivery, automation, or reporting write-through.
 
-### Nayax Validation Lane
-- [ ] Verify target environment has server-only `NAYAX_LYNX_BASE_URL=https://lynx.nayax.com/operational/v1`.
-- [ ] Verify target environment has server-only `NAYAX_LYNX_API_TOKEN_TGPACI_USA_DB` or fallback `NAYAX_LYNX_API_TOKEN` by name only, never by value.
-- [ ] Confirm refund-ready machines are mapped to server-side Nayax machine IDs before managers use `/refunds` for card lookup.
-- [ ] Validate at least one real card case against `GET /machines/{MachineID}/lastSales`.
-- [ ] Confirm manager workbench and automation sweep use the approved +/- 6 hour Nayax lookup window and only expose tokenized candidate evidence.
-- [ ] Validate Apple Pay/wallet last-four mismatch behavior with real or owner-approved test evidence.
-- [ ] Confirm lookup responses show only sanitized candidate evidence in Bloomjoy Hub.
+## Release gates before the pilot
 
-### Manager Workflow Lane
-- [ ] Enable selected authenticated Machine Managers through assigned-machine access for configured Commercial/Mini pilot machines.
-- [ ] Confirm each manager sees only assigned-machine cases.
-- [ ] Confirm super-admins see all refund cases.
-- [ ] Validate approve, deny, waiting-on-customer, card-refund-pending, cash/Zelle-pending, and completed states.
-- [ ] Validate the guided manager workbench sections: case summary, suggested transaction match, next action, customer message, guarded card execution or Zelle completion, and collapsed timeline/history.
-- [ ] Capture manager friction as GitHub issues, not private notes.
+### Integrated release
 
-### Customer Communication Lane
-- [ ] Review confirmation email tone.
-- [ ] Review more-info email tone.
-- [ ] Confirm approval, denial, completion, reminder, and escalation automation sends only after agent QA validates message rows and redacted logs.
-- [ ] Review denial decision reasons before managers send manual replies.
-- [ ] Confirm automated messages and manual-reply reasons are empathetic, clear, and do not overpromise timing or approval.
-- [ ] Confirm portal-sent customer messages use editable Bloomjoy-approved templates, include the case reference, and reply to `info@bloomjoysweets.com` during pilot.
+- [ ] Merge the approved PR train in dependency order, starting with production alignment `#636`, then `#637` through `#641`.
+- [ ] After each merge, sync the next branch with current `main` and rerun its full verification profile.
+- [ ] On the final integrated `main` commit, regenerate and review the Refund Operations release manifest. It must include every in-scope migration and the final transitive source digest for each approved refund function.
+- [ ] Run the repository verification suite, migration validation, release-tooling checks, and the relevant refund validators on that same final commit.
+- [ ] Confirm production migrations and Edge Functions match the final reviewed release; a sanitized dry run must show no unexpected migration.
+- [ ] Confirm Bubble Planet and every other pilot option has a distinct customer-facing label and an unambiguous canonical machine/location mapping.
+- [ ] Capture a restore source and dry-run the documented rollback path before changing production.
 
-### Full Automation Lane
-- [ ] Confirm `refund-case-admin-update` wraps manager updates and logs customer messages.
-- [ ] Confirm `refund-case-automation-sweep` sends reminders/escalations with redacted evidence only.
-- [ ] Confirm `nayax-card-refund` fails closed with default env and records only sanitized attempt metadata.
-- [ ] Confirm cross-workflow duplicate fingerprints block likely duplicate settlement write-through between hosted cases and Google/AppSheet rows.
-- [ ] Do not enable live Nayax refund execution until sponsor go/no-go, provider-contract validation, amount caps, per-machine allowlist, and kill-switch tests pass.
+### Safety and access
 
-### Reporting And Settlement Lane
-- [ ] Confirm only manager-approved, fully correlated, completed cases write through with `source='refund_case'`.
-- [ ] Confirm denied, waiting-on-customer, uncorrelated, and review-only cases do not write settlement adjustments.
-- [ ] Confirm partner-facing reporting excludes customer PII, card digits, raw complaint text, and raw Nayax payloads.
+- [ ] `#430` records the approved Nayax provider fields and semantics for a stable machine/site identity and a confirmed successful sale, or explicitly approves a safe substitute contract.
+- [ ] The global kill switch, execution-enabled flag, dry-run flag, sponsor flag, caps, machine allowlist, and idempotency controls are checked by name and expected state without printing values.
+- [ ] A clean authenticated manager from `#435` sees only assigned machines/cases and cannot reach Admin setup, unrelated cases, provider secrets, or raw payloads.
+- [ ] The selected machines and named managers are recorded in `#427`; broader fleet access remains off.
+- [ ] Google Form/Sheet/AppSheet fallback ownership and the same-day stop/go contact are named in `#409`.
 
-## Required UAT Scenarios
-- [ ] Card exact match.
-- [ ] Apple Pay/wallet last-four mismatch.
-- [ ] Cash single match.
-- [ ] No match sends more-info workflow.
-- [ ] Multiple candidates require manager decision.
-- [ ] Denied request.
-- [ ] Approved card refund with guarded in-app Nayax execution attempt.
-- [ ] Approved Zelle refund.
-- [ ] Photo upload.
-- [ ] Manager access boundary.
-- [ ] Super-admin access.
-- [ ] Reporting write-through.
-- [ ] Automated approval/denial/completion customer messages.
-- [ ] Reminder/escalation sweep.
-- [ ] Nayax execution preflight blocked by default flags.
-- [ ] Legacy Google/AppSheet duplicate reconciliation.
+### Communications and automation
 
-## Merged PR `#410` Evidence
-PR `#410` merged on 2026-05-12 after these gates passed:
-- GitHub CI, Vercel, and Supabase migration checks were green.
-- A real Nayax Edge lookup succeeded for a mapped UAT machine with sanitized evidence only.
-- Assigned-machine access boundaries and max-3 Machine Manager enforcement were validated with synthetic authenticated users.
-- Customer communication copy was approved for MVP scope.
-- Reporting write-through was validated with no private data leakage.
+- [ ] Customer acknowledgement, missing-information, approval, denial, completion, and retry paths pass with synthetic evidence.
+- [ ] Manager notification reaches the assigned managers and operations fallback without customer PII in logs.
+- [ ] Automation is deployed with both controls off, then proves one synthetic action, duplicate suppression, PII-free failure alerting, visible health, and quick disable before scheduled enablement.
+- [ ] Gmail retention, attachment quarantine, OAuth scope, mailbox ownership, and security review are approved before either Gmail switch is enabled.
+- [ ] GPT evaluation uses only the approved schema and sanitized test set; it cannot match a transaction, decide a refund, send mail, or execute payment.
 
-## Cutover Gate
-Cut over from the Google Form/AppSheet fallback only when all are true:
-- Shadow-mode cases complete end to end with fewer manual steps than the old process.
-- Managers can process cases without PM intervention.
-- Nayax lookup is reliable enough for ordinary card correlation.
-- Google Form/AppSheet remains available as fallback until pilot evidence is clean.
+## Proposed pilot cohort
 
-## Evidence Template
-Use this template in issue `#409` or follow-up issues after each checkpoint.
+The previously reviewed six-machine cohort is a proposal, not standing approval:
+
+- Bubble Planet - Atlanta
+- Bubble Planet DC
+- Bubble Planet Seattle
+- Merlin Chicago
+- Merlin Dallas / Grapevine Mills
+- Merlin Minneapolis / Mall of America
+
+Before the pilot starts, the sponsor must confirm the exact machines, the named manager for each machine, fallback ownership, and the stop/go contact. Do not add PREIT, Snapcase, or the broader fleet by inference.
+
+## Minimum evidence set
+
+This is a release-safety sample, not a statistical accuracy claim.
+
+| Lane | Minimum proof | Pass condition |
+|---|---|---|
+| Ordinary card | Five high-confidence cases across at least two approved locations | Intended sale ranks first; manager agrees or records a structured disagreement; one primary action is shown; no manual status editing is required |
+| Card safety | One each for ambiguous, no-safe-match, wallet/manual, provider anomaly, duplicate/already-refunded, and provider-outcome-unknown | No unsafe case exposes an enabled refund action or sends a completion email |
+| Controlled Nayax execution | One approved low-value test only after `#430` sponsor approval | Exactly one provider attempt; provider-confirmed success precedes completion and customer email; retry/double-click creates no second attempt |
+| Cash/manual payout | Two matched cases plus one missing-information or denied case | One primary next action; amount cannot exceed recorded payment; non-sensitive reference only; double-submit creates no duplicate event/email/adjustment |
+| Customer email | Acknowledgement, more-info, approval/denial, completion, and one simulated failure/retry | Correct thread/reference, empathetic copy, no premature success message, and no duplicate send |
+| Automation | One due action, replay of the same window, one forced failure, and quick disable | One action only, duplicate suppressed, PII-free alert delivered, and core manual workflow remains available when disabled |
+| Access | Clean manager-only account plus super-admin comparison | Manager sees assigned scope only; super-admin sees authorized global scope; Admin controls remain hidden from the manager |
+| Reporting | One completed correlated case plus denied/waiting/duplicate controls | Exactly one safe adjustment for the completed case and none for the controls |
+| Gmail | One labeled synthetic thread, replay, customer reply, approved reply, attachment controls, and revoked authorization | One linked case/thread; unrelated mail untouched; no duplicate; safe health failure; form cases still work |
+| GPT | Approved sanitized evaluation set from `#635` | No unsafe action; strict schema only; sensitive/uncertain cases route to a person; every outbound draft is reviewed |
+
+## Manager-experience measurements
+
+Record these in aggregate only:
+
+- time from opening a normal card case to a final manager decision
+- number of manager decisions/clicks on the normal card path
+- whether the recommended transaction was accepted
+- structured reason when it was not accepted
+- match state and sanitized factor labels
+- email sent, failed, uncertain, or retried
+- whether the manager needed PM/backchannel help
+- manager feedback on what was slower or clearer than the legacy process
+
+The core experience passes only when a manager who did not build the feature completes three consecutive ordinary cases without coaching and with fewer manual decisions than the legacy workflow.
+
+## Stop conditions
+
+Pause the affected lane immediately if any of these occur:
+
+- an unauthorized machine, case, Admin control, or inbox thread is visible
+- customer PII, card data, payout details, raw Gmail content, raw Nayax identifiers/payloads, or secrets appear in evidence or logs
+- an ambiguous/manual/duplicate/failed case becomes one-click eligible
+- a customer completion email sends before confirmed payment success
+- a duplicate provider attempt, customer message, audit event, or reporting adjustment is created
+- a cash payout can exceed the recorded customer payment or store account/routing/card-like data
+- an unknown provider outcome is presented as success or encourages an immediate retry
+- a manager cannot finish the workflow without PM/manual backchannel help
+- the legacy fallback becomes unavailable before cutover approval
+
+Use the relevant quick-disable control first, preserve sanitized audit evidence, and open a P0 issue for any payment, access, privacy, or duplicate-settlement failure.
+
+## Go/no-go sequence
+
+1. **Core shadow pilot:** form intake, matching, manager workbench, cash workflow, email, automation health, permissions, and reporting. Nayax execution stays off.
+2. **Controlled Nayax execution:** starts only after `#430` records the provider contract, caps, allowlist, kill-switch proof, and sponsor approval.
+3. **Gmail/GPT lane:** starts only after `#634` data/OAuth approvals and a secure server-side OpenAI key destination for `#635`. All drafts remain human-reviewed.
+4. **Cutover:** `#409` receives the complete packet and explicit sponsor approval. Only then may the legacy workflow be retired; rollback and a staffed support window must remain ready.
+
+## Evidence template
+
+Post one sanitized checkpoint in `#427` for each lane and one final summary in `#409`.
 
 ```markdown
-## Refund shadow pilot checkpoint
-- Date:
-- Lane:
-- Environment:
-- Machines/managers covered:
-- Scenarios tested:
-- Result: PASS / PARTIAL / BLOCKED
-- Evidence summary:
+## Refund pilot checkpoint
+- Date/time and environment:
+- Release commit / manifest ID:
+- Lane and scenarios:
+- Approved machines/managers covered (aggregate only):
+- Sample count:
+- Result: PASS / PARTIAL / FAIL
+- Timing and interaction summary:
+- Safety/duplicate summary:
+- Manager feedback summary:
 - Defects opened:
+- Stop condition triggered: yes/no
 - Go/no-go impact:
 ```

--- a/Docs/REFUND_PRODUCTION_CUTOVER_PACKET.md
+++ b/Docs/REFUND_PRODUCTION_CUTOVER_PACKET.md
@@ -1,0 +1,117 @@
+# Refund Operations Production Cutover Packet
+
+Last updated: 2026-07-21
+
+## Outcome
+
+Use this packet to move epic `#628` from individually verified PRs to one tested production release. A green PR is necessary but is not deployment, live-payment, Gmail, GPT, or legacy-retirement approval.
+
+## Evidence ledger
+
+| Gate | Required evidence | Authority to close |
+|---|---|---|
+| `#629` production alignment | Final integrated release manifest, reviewed migration dry run, deployed function parity, redacted intake/email smoke, distinct location mappings, restore source | Release and technical owners |
+| `#630` Nayax recommendation | Deterministic fixture suite, documented thresholds/exclusions, sanitized production lookup evidence, manager agreement/disagreement sample | Technical and QA owners |
+| `#631` manager workbench | Desktop/mobile/keyboard evidence for every major state plus clean manager completion without coaching | QA owner and pilot manager |
+| `#633` cash workflow | Amount cap, sensitive-reference rejection, idempotent completion, customer email ordering, reporting proof | QA and operations owners |
+| `#632` automation | One due action, replay suppression, PII-free alert, visible health, and quick disable | Operations and release owners |
+| `#430` live Nayax execution | Provider contract, machine allowlist, caps, kill switch, idempotency, success/failure/unknown proof | Executive sponsor and technical owner |
+| `#435` clean manager account | Assigned-only visibility and Admin denial using an account with no broader role | Access owner and QA owner |
+| `#634` Gmail | Approved OAuth/mailbox/retention/quarantine policy plus synthetic thread, replay, reply, attachment, revocation evidence | Operations, auth, and privacy/security owners |
+| `#635` GPT triage | Secure server-side key destination, sanitized evaluation metrics, strict schema, human-review proof, rollback control | Technical, support, privacy/security, and sponsor owners |
+| `#427` shadow pilot | Complete lane evidence, manager friction, timing/decision comparison, defects, and recommendation | Pilot owner and QA owner |
+| `#409` legacy cutover | All required evidence above, staffed rollback window, and explicit fallback-retirement decision | Executive sponsor |
+
+## Merge and integrated-verification sequence
+
+1. Freeze unrelated Refund Operations changes for the release window.
+2. Merge `#636` first so release/drift tooling is available on `main`.
+3. Sync `#637` with current `main`, resolve overlap, commit the code/migration changes, run `npm run refunds:release:write-local`, review and commit the manifest update, run the full verification profile, then merge.
+4. Repeat that sync, manifest, verification, and merge cycle for `#638`, `#639`, `#640`, and `#641`.
+5. Before `#641` merges, extend the release-tool function allowlist and manifest to cover `refund-gmail-sync`; the six-function core manifest from `#636` does not by itself prove the Gmail function deployed correctly. Apply the same rule to any later GPT server function.
+6. Do not deploy from an individual PR head. Use the final integrated `main` commit only.
+7. On that final commit, require:
+
+```bash
+npm ci
+npm run agent:preflight -- --issue 628
+npm run agent:validate-workflow
+npm run refunds:validate-release-tooling
+npm run refunds:release:check
+npm run refunds:validate-nayax-matching
+npm run refunds:validate-nayax-execution
+npm run refunds:validate-automation
+npm run refunds:validate-gmail
+npm run db:validate-migrations
+npm run build
+npm test --if-present
+npm run lint --if-present
+git diff --check
+```
+
+8. Review `supabase db push --dry-run`; it must list exactly the expected pending migrations and no surprise.
+9. Capture the production pre-deployment baseline and confirm the approved restore source without including secrets or downloaded bundles in Git.
+10. Attach the final commit, manifest ID, aggregate test totals, migration list, and restore-source reference to `#629` and `#409`.
+
+If a downstream merge changes any in-scope migration or refund function after the manifest was generated, the manifest is stale and the release must repeat steps 7-10.
+
+## Deploy with all optional execution switches off
+
+Deploy the approved migrations, functions, and frontend following `Docs/PRODUCTION_RUNBOOK.md`. During initial smoke testing:
+
+- Nayax execution enabled: `false`
+- Nayax dry run: `true`
+- Nayax kill switch: `true`
+- Nayax sponsor flag: unset
+- Refund automation GitHub switch: `false`
+- Refund automation Edge switch: `false`
+- Gmail GitHub switch: `false`
+- Gmail Edge switch: `false`
+
+Check switch values without printing secrets. A code deploy must not silently enable any lane.
+
+## Production smoke order
+
+1. Verify the production drift check against the final manifest.
+2. Verify every expected refund function route responds and the manual/retry email route no longer returns `404`.
+3. Submit one sanitized hosted-form card case and one cash case; verify acknowledgement and assigned-manager notification.
+4. Use the clean manager account to prove assigned-only queue access and Admin denial.
+5. Prove high-confidence, ambiguous, no-match, wallet/manual, failed/unknown, and duplicate card states with live execution still off.
+6. Prove cash approve/deny/missing-info/completion and idempotency with a sponsor-approved test payout or a non-paying shadow fixture.
+7. Prove one reporting write-through and the negative controls.
+8. Enable and test automation only after its manual-run evidence passes; keep the quick-disable sequence ready.
+9. Enable Gmail only after `#634` approvals and synthetic thread evidence pass.
+10. Start GPT human-review evaluation only after the server-side key destination and privacy controls in `#635` are approved.
+11. Start live Nayax execution only after the separate `#430` decision. Use the approved low-value case, cohort, allowlist, and caps.
+
+## Rollback and stop order
+
+For an incident, disable the affected optional lane first:
+
+1. live Nayax: activate kill switch and disable execution
+2. automation: disable the GitHub schedule, then the Edge switch
+3. Gmail: disable the GitHub schedule, then the Edge switch
+4. GPT: disable draft generation; Gmail/form-created cases remain available
+
+If the core release must be rolled back, redeploy the approved frontend and function restore source from the release manifest. Use forward-only database repair; do not delete audit evidence or run destructive rollback SQL during incident response. Keep the legacy workflow available until recovery is verified.
+
+## Final sponsor decision
+
+Post this exact decision record in `#409`:
+
+```markdown
+## Refund Operations production decision
+- Final release commit / manifest ID:
+- Core shadow pilot: PASS / FAIL
+- Clean manager boundary: PASS / FAIL
+- Controlled Nayax execution: APPROVED / NOT APPROVED / NOT RUN
+- Automation: ENABLED / DISABLED
+- Gmail: ENABLED / DISABLED / DEFERRED
+- GPT human-review lane: ENABLED / DISABLED / DEFERRED
+- Open P0/P1 defects:
+- Rollback owner and staffed window:
+- Legacy Google Form/Sheet/AppSheet: KEEP / RETIRE
+- Sponsor decision and date:
+```
+
+Do not interpret silence, a merged PR, or a successful shadow test as approval to enable live payments or retire the legacy workflow.


### PR DESCRIPTION
## Summary

- Replace the stale refund shadow-pilot and manager-UAT guidance with the current `#628` recommendation-first card flow, fail-closed exception states, short manual cash flow, and clean manager-only boundary proof.
- Add one production cutover packet covering the `#636`-`#641` merge train, final integrated-main manifest refresh, deployment with optional switches off, smoke order, rollback, and sponsor decision record.
- Make the final release explicitly add `refund-gmail-sync` to release verification before Gmail can be enabled; the six-function core manifest from `#636` is not sufficient for that lane.

No production deployment, secret, mailbox, scheduler, Gmail, GPT, or live Nayax setting is changed by this PR.

## Files changed

- `Docs/REFUND_OPERATIONS_SHADOW_PILOT.md`
- `Docs/MACHINE_MANAGER_SHADOW_UAT_SCRIPT.md`
- `Docs/REFUND_PRODUCTION_CUTOVER_PACKET.md`
- `Docs/QA_SMOKE_TEST_CHECKLIST.md`

## Verification

- `npm ci` - pass (existing audit output: 5 vulnerabilities on this branch dependency set)
- `npm run agent:validate-workflow` - pass
- `npm run build` - pass; 25 public routes and 25 private route heads prerendered
- `npm test --if-present` - pass
- `npm run lint --if-present` - pass
- `git diff --check` - pass
- `npm run agent:preflight -- --issue 409` - pass

## How to test

1. Checkout `agent/refund-cutover-packet` in its worktree.
2. Run `npm ci`, `npm run build`, `npm test --if-present`, and `npm run lint --if-present`.
3. Review `Docs/REFUND_PRODUCTION_CUTOVER_PACKET.md` from top to bottom and confirm each `#628` child issue has a named evidence gate and owner.
4. Compare `Docs/MACHINE_MANAGER_SHADOW_UAT_SCRIPT.md` with `/refunds` on the relevant implementation preview: normal card path, six exception states, cash completion, communications, manager-only permissions, mobile, and keyboard.
5. Confirm the cutover packet keeps Nayax execution, automation, Gmail, and GPT off until their separate gates and keeps Google Form/Sheet/AppSheet live until sponsor approval in `#409`.

Key URLs:

- `/refunds`
- `/refunds/request`
- `/admin/machines` (super-admin setup comparison only)

## Overlap

`Docs/QA_SMOKE_TEST_CHECKLIST.md` is also touched by open Refund Operations PRs `#637`-`#641`. Sync and reverify this PR after those foundations merge; preserve the final-integrated-release and clean-manager-only rows during conflict resolution.

Refs #628 #629 #430 #435 #427 #409 #634 #635
