### PR TITLE
Stabilize live operator-report grouping verification

### DIFF
--- a/scripts/validate-reporting-uat.mjs
+++ b/scripts/validate-reporting-uat.mjs
@@ -997,6 +997,7 @@ const assertOperatorDesktop = async (browser) => {
       await breakdown.getByRole('radio', { name: 'Monthly', exact: true }).click();
       await page.getByRole('heading', { name: 'Sales by month', exact: true }).waitFor();
       const monthlyRows = page.locator(`${selectors.operatorPeriodSummary} [data-reporting-period-row]:visible`);
+      await monthlyRows.first().waitFor();
       assert((await monthlyRows.count()) === 1, `Monthly summary must show one selected-period row. Found ${await monthlyRows.count()}.`);
       const monthlySummaryText = await textOf(page.locator(selectors.operatorPeriodSummary));
       assert(


### PR DESCRIPTION
Closes #659

## Summary

- Waits for the Monthly period row to become visible after the report-grain query refetch completes.
- Preserves every existing exact row-count, partial-period label, reconciliation, permission, export, responsive, and browser-error assertion.
- Changes no application UI, report data, authorization, fixture, or screenshot design behavior.

## Root cause

After executive-approved PR #658 deployed, two live runs against the canonical production host reached `Sales by month` but asserted the row count while React Query was still showing the new-grain loading skeleton. Local and preview fixture responses were fast enough to hide the race. The application produced the correct row once the refetch completed; the verifier lacked an explicit synchronization point.

## Files changed

- `scripts/validate-reporting-uat.mjs`: adds one visibility wait before the existing exact Monthly row-count assertion.

## Verification

- `npm ci` — PASS (409 packages; existing audit advisories only, with no dependency changes)
- `npm run build` — PASS (existing Reports chunk-size warning only)
- `npm test --if-present` — PASS
- `npm run lint --if-present` — PASS
- `npm run reporting:validate-portal-uat -- --app-url https://app.bloomjoyusa.com` — PASS, 32/32 against the deployed application with no unexpected browser errors
- GitHub CI `verify` — PASS
- Vercel preview — PASS
- `git diff --check` — PASS apart from the repository’s standard LF/CRLF warning

## How to test

1. Check out `agent/reporting-uat-live-wait`.
2. Run `npm ci`.
3. Run `npm run reporting:validate-portal-uat -- --app-url https://app.bloomjoyusa.com`.
4. Confirm the run reaches Daily, Weekly, and Monthly grouping, reports 32/32 PASS, and writes sanitized results under `output/playwright/issue-656-657`.

No credentials or production records are used; the verifier intercepts authentication, RPC, REST, and export responses with sanitized fixtures.

## Risk And Overlap

- Low runtime risk: the change adds one Playwright locator wait in a verifier and cannot alter the deployed application, reporting calculations, permissions, network requests, or customer data.
- The existing exact row-count and partial-month-label assertions still run after synchronization, so the fix does not turn a product failure into a false pass.
- No application or screenshot files changed. The executive-reviewed UI and permanent screenshot packet from #658 remain byte-for-byte untouched.
- No known open PR owns this production-timing synchronization line. The branch starts from the #658 squash merge on `main` and changes only `scripts/validate-reporting-uat.mjs`.
- Rollback is a one-commit revert with no database, secret, deployment-setting, or data migration consequence.

## Merge Autonomy

- **Lane: Yellow** — the linked issue is labeled `uat-required`, even though the diff itself is test-only.
- Required Yellow evidence is complete: canonical-production browser UAT passes 32/32, GitHub CI and Vercel preview are green, and the underlying UI already received explicit executive screenshot approval before #658 merged.
- No new sponsor decision, visual approval, credential, production write, or external-account action is introduced by this follow-up.
- Agent merge is authorized once `npm run agent:merge-gate -- --pr 660` passes against head `66ed554ea327e8b5d1fc1c143bea45107d52530a`.