### PR TITLE
Consolidate sprint coordination guardrails

### DIFF
--- a/.agents/skills/bloomjoy-agent-workflow/SKILL.md
+++ b/.agents/skills/bloomjoy-agent-workflow/SKILL.md
@@ -28,6 +28,13 @@ description: Use for Bloomjoy Hub GitHub issue or PR work, agent workflow upgrad
 - Do not commit secrets, raw customer data, payment IDs, vendor exports, or free-text complaint content.
 - For visible UI work, use `PRODUCT.md`, `DESIGN.md`, and `impeccable` guidance when design quality matters.
 
+## Proportional Coordination
+
+- Use sprint-style coordination only for an explicitly requested multi-issue, multi-PR, or genuinely independent multi-lane delivery.
+- Keep single issues, read-only reviews or audits, QA-only work, and ordinary planning with the primary agent unless independent delegation materially reduces risk or elapsed time.
+- Never create extra agents, issues, PRs, or documents merely to mirror a process template.
+- Escalate only decisions involving business or scope tradeoffs, new platforms or paid vendors, credentials or production actions, legal or privacy commitments, destructive data operations, or unresolved acceptance choices that materially change user outcomes. Handle routine product, implementation, verification, PR, issue, and board decisions autonomously.
+
 ## Subagents
 
 - Keep small single-lane fixes local to the primary agent.
@@ -44,4 +51,5 @@ description: Use for Bloomjoy Hub GitHub issue or PR work, agent workflow upgrad
 - Every repo change gets a PR into `main` with linked issue, summary, files changed, verification results, risk/overlap, and how-to-test steps.
 - Before an agent-initiated merge, run `npm run agent:merge-gate -- --pr <number>` and record the result in the PR.
 - Agents should proactively test, review, merge, and clean up Green and Yellow lane PRs after required evidence is complete. Red lane means an executive decision or unresolved blocker exists and requires explicit owner direction or blocker resolution.
+- Run a retro only after a meaningful multi-PR milestone, a materially troubled delivery, or an explicit request.
 - Put task chronology and closeout evidence in the issue or PR, not static markdown docs.


### PR DESCRIPTION
Closes #720

## Summary

- Consolidates the useful Sprint Orchestrator boundaries into the repo-local Bloomjoy agent workflow.
- Limits sprint ceremony to explicit multi-issue, multi-PR, or genuinely independent multi-lane delivery.
- Defines sponsor-only escalation and proportional retro boundaries while keeping routine delivery autonomous.

## Files changed

- `.agents/skills/bloomjoy-agent-workflow/SKILL.md` — adds eight concise lines covering proportional coordination, escalation, and retros.

## Verification

- `npm ci` — passed; current lockfile reports 8 existing audit findings (3 moderate, 5 high).
- `npm run agent:preflight -- --issue 720` — passed.
- `npm run agent:validate-workflow` — passed.
- Skill `quick_validate.py` — passed.
- `npm run build` — passed; existing chunk-size warning remains.
- `npm test --if-present` — passed.
- `npm run lint --if-present` — passed.
- `git diff --check` — passed.
- `npm run auth:preflight` — could not complete in this isolated worktree because `.env` / `.env.local` is intentionally absent, so `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` are unavailable. No auth behavior changed.

## How to test

1. In this branch worktree, run `npm ci`.
2. Run `npm run agent:preflight -- --issue 720`.
3. Run `npm run agent:validate-workflow`.
4. Inspect `.agents/skills/bloomjoy-agent-workflow/SKILL.md` and confirm:
   - ordinary single-lane/read-only/QA work stays with the primary agent;
   - sprint coordination is explicit and proportional;
   - only sponsor-level decisions are escalated;
   - retros are conditional.
5. No localhost route or UI URL is affected by this workflow-only change.

## Risk / overlap / rollback

- Merge lane: Yellow because this is shared workflow guidance; no executive decision or external blocker remains.
- Open-PR overlap check: no open PR currently touches the changed skill file.
- Rollback: revert commit `d772676`.
- The personal `bloomjoy-sprint-orchestrator` was disabled separately through local Codex configuration and was not deleted or committed. Restart Codex for that setting change to take effect.
