### PR TITLE
Correct sitemap freshness and product structured data

### DIFF
--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -12,7 +12,7 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Direct-load public routes in browser address bar (for example `/machines`, `/supplies`, `/plus`) and confirm they do not return hosting-level 404 pages
 - [ ] View page source on a direct-loaded public route (for example `/machines`) and confirm title/description/canonical are route-specific before client-side JS executes
 - [ ] View page source on `/machines/commercial-robotic-machine` and confirm the `#root` contains rendered body HTML, the H1 text is present, and there are no `/src/assets/` image URLs
-- [ ] View page source on `/machines/commercial-robotic-machine` and confirm JSON-LD includes `Product`, `BreadcrumbList`, and `FAQPage` nodes that match visible page content
+- [ ] View page source on `/machines/commercial-robotic-machine` and confirm quote-only JSON-LD includes matching `BreadcrumbList` and `FAQPage` nodes without an ineligible `Product`, `Offer`, or public price
 - [ ] View page source on `/supplies` and confirm JSON-LD includes Product/Offer data only for direct-price supplies (`$10/kg` sugar and `$130/box` sticks)
 - [ ] View page source on a direct-loaded private route (for example `/portal`) and confirm robots is `noindex`
 - [ ] `https://www.bloomjoyusa.com/login`, `/reset-password`, `/portal*`, and `/admin*` redirect to `https://app.bloomjoyusa.com/...`
@@ -23,6 +23,9 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] Stale route chunk recovery check: simulate one route-level JS chunk load failure, confirm the app performs one automatic reload, then confirm a repeated failure shows the app-update refresh fallback instead of a blank page
 - [ ] `robots.txt` is reachable and includes a sitemap reference
 - [ ] `sitemap.xml` is reachable, lists core public routes plus public Business Playbook article routes, includes `lastmod`, and includes image sitemap entries for key machine/supplies/about/playbook URLs
+- [ ] Sitemap `lastmod` values reflect versioned route/article updates rather than one build-wide date; adding/removing a public route requires an intentional route-count regression update
+- [ ] Mini and Micro Product JSON-LD Offers match their visible USD prices and canonical page URLs; Commercial remains quote-only with no Product rich-result node, Offer, or public price in structured data
+- [ ] Machine Product/Offer JSON-LD does not add ratings, reviews, availability, inventory, shipping, returns, financing, or other unsupported commerce claims
 - [ ] Apex host (`https://bloomjoyusa.com`) redirects to canonical host (`https://www.bloomjoyusa.com/`) with permanent redirect behavior
 - [ ] Legacy paths (`/products`, `/products/mini`, `/products/micro`, `/products/commercial-robotic-machine`) return permanent redirects to `/machines*`
 - [ ] No console errors on home page load

--- a/scripts/seo-regression-check.mjs
+++ b/scripts/seo-regression-check.mjs
@@ -8,6 +8,7 @@ process.env.VITE_SUPABASE_ANON_KEY ||= "prerender-anon-key";
 const DIST_DIR = path.resolve(process.cwd(), "dist");
 const VERCEL_CONFIG_PATH = path.resolve(process.cwd(), "vercel.json");
 const SITEMAP_URL = "https://www.bloomjoyusa.com/sitemap.xml";
+const EXPECTED_PUBLIC_ROUTE_COUNT = 25;
 
 const routeToDistHtml = (routePath) => {
   if (routePath === "/") {
@@ -41,10 +42,41 @@ const assertMatches = (text, pattern, failureMessage) => {
   }
 };
 
+const readStructuredData = (html, scriptId, routePath) => {
+  const marker = `<script id="${scriptId}" type="application/ld+json">`;
+  const start = html.indexOf(marker);
+  const end = start >= 0 ? html.indexOf("</script>", start + marker.length) : -1;
+
+  if (start < 0 || end < 0) {
+    throw new Error(`Public route ${routePath} has unreadable JSON-LD`);
+  }
+
+  try {
+    return JSON.parse(html.slice(start + marker.length, end));
+  } catch {
+    throw new Error(`Public route ${routePath} has invalid JSON-LD`);
+  }
+};
+
+const expectedMachineProductByRoute = {
+  "/machines/mini": {
+    name: "Bloomjoy Sweets Mini Machine",
+    image: "https://www.bloomjoyusa.com/seo/mini-machine.jpg",
+    descriptionSnippet: "Portable robotic cotton candy machine",
+    offer: { price: "4000.00", priceCurrency: "USD" },
+  },
+  "/machines/micro": {
+    name: "Bloomjoy Sweets Micro Machine",
+    image: "https://www.bloomjoyusa.com/seo/micro-machine.jpg",
+    descriptionSnippet: "Entry-level robotic cotton candy machine",
+    offer: { price: "2200.00", priceCurrency: "USD" },
+  },
+};
+
 const expectedH1TextByRoute = {
   "/": "Robotic cotton candy",
   "/machines": "Robotic Cotton Candy Machines for Operators",
-  "/machines/commercial-robotic-machine": "Bloomjoy Sweets Commercial Machine",
+  "/machines/commercial-robotic-machine": "Bloomjoy Sweets <!-- -->Commercial Machine",
   "/machines/mini": "Bloomjoy Sweets Mini Machine",
   "/machines/micro": "Bloomjoy Sweets Micro Machine",
   "/supplies": "Cotton Candy Machine Sugar and Paper Sticks",
@@ -81,6 +113,12 @@ const validatePublicRouteHtml = async (route, seoRoutes) => {
   const html = await readFile(routeToDistHtml(route.path), "utf8");
   const canonical = seoRoutes.canonicalForPath(seoRoutes.MARKETING_ORIGIN, route.path);
   const expectedH1Text = expectedH1TextByRoute[route.path];
+  const structuredData = readStructuredData(
+    html,
+    seoRoutes.STRUCTURED_DATA_SCRIPT_ID,
+    route.path
+  );
+  const graph = Array.isArray(structuredData?.["@graph"]) ? structuredData["@graph"] : [];
 
   assertIncludes(
     html,
@@ -135,14 +173,86 @@ const validatePublicRouteHtml = async (route, seoRoutes) => {
   if (route.path.startsWith("/machines/")) {
     assertIncludes(
       html,
-      `"@type":"Product"`,
-      `Machine route ${route.path} is missing Product JSON-LD`
-    );
-    assertIncludes(
-      html,
       `"@type":"BreadcrumbList"`,
       `Machine route ${route.path} is missing BreadcrumbList JSON-LD`
     );
+
+    const expectedProduct = expectedMachineProductByRoute[route.path];
+    const product = graph.find(
+      (node) => node?.["@type"] === "Product" && node?.url === canonical
+    );
+
+    if (route.path === "/machines/commercial-robotic-machine") {
+      if (product) {
+        throw new Error(
+          `Quote-only machine route ${route.path} must not emit an ineligible Product rich-result node`
+        );
+      }
+
+      const graphText = JSON.stringify(graph);
+      assertExcludes(
+        graphText,
+        `"@type":"Offer"`,
+        `Quote-only machine route ${route.path} must not emit an Offer`
+      );
+      assertExcludes(
+        graphText,
+        `"price"`,
+        `Quote-only machine route ${route.path} must not emit a public price`
+      );
+    } else {
+      if (!expectedProduct || !product) {
+        throw new Error(`Machine route ${route.path} is missing its canonical Product node`);
+      }
+
+      if (product.name !== expectedProduct.name) {
+        throw new Error(`Machine route ${route.path} Product name does not match visible copy`);
+      }
+
+      if (product.image !== expectedProduct.image) {
+        throw new Error(`Machine route ${route.path} Product image is incorrect`);
+      }
+
+      if (!String(product.description ?? "").includes(expectedProduct.descriptionSnippet)) {
+        throw new Error(`Machine route ${route.path} Product description is incorrect`);
+      }
+
+      const productText = JSON.stringify(product);
+      for (const forbidden of [
+        '"@type":"Review"',
+        '"@type":"AggregateRating"',
+        '"aggregateRating"',
+        '"availability"',
+        '"inventoryLevel"',
+        '"shippingDetails"',
+        '"hasMerchantReturnPolicy"',
+        '"financing"',
+      ]) {
+        assertExcludes(
+          productText,
+          forbidden,
+          `Machine route ${route.path} Product JSON-LD contains unsupported ${forbidden}`
+        );
+      }
+
+      if (expectedProduct.offer) {
+        if (product.offers?.["@type"] !== "Offer") {
+          throw new Error(`Machine route ${route.path} is missing Product Offer JSON-LD`);
+        }
+        if (
+          product.offers.price !== expectedProduct.offer.price ||
+          product.offers.priceCurrency !== expectedProduct.offer.priceCurrency ||
+          product.offers.url !== canonical
+        ) {
+          throw new Error(`Machine route ${route.path} Product Offer does not match visible pricing`);
+        }
+
+        const offerKeys = Object.keys(product.offers).sort().join(",");
+        if (offerKeys !== "@type,price,priceCurrency,url") {
+          throw new Error(`Machine route ${route.path} Product Offer contains unsupported fields`);
+        }
+      }
+    }
   }
 
   if (route.path === "/machines" || route.path === "/machines/commercial-robotic-machine" || route.path === "/resources") {
@@ -306,6 +416,34 @@ const validateRobots = async () => {
 const validateSitemap = async (seoRoutes) => {
   const sitemap = await readFile(path.join(DIST_DIR, "sitemap.xml"), "utf8");
 
+  if (seoRoutes.publicRoutes.length !== EXPECTED_PUBLIC_ROUTE_COUNT) {
+    throw new Error(
+      `Public route count changed from ${EXPECTED_PUBLIC_ROUTE_COUNT}; review sitemap coverage and update the intentional baseline`
+    );
+  }
+
+  const sitemapUrlCount = (sitemap.match(/<url>/g) ?? []).length;
+  if (sitemapUrlCount !== seoRoutes.publicRoutes.length) {
+    throw new Error(
+      `sitemap.xml has ${sitemapUrlCount} URLs for ${seoRoutes.publicRoutes.length} public routes`
+    );
+  }
+
+  const versionedRoutes = seoRoutes.publicRoutes.filter(
+    (route) => route.structuredDataKind !== "business-playbook-article"
+  );
+  const configuredPaths = Object.keys(seoRoutes.publicRouteLastmods).sort();
+  const versionedPaths = versionedRoutes.map((route) => route.path).sort();
+
+  if (configuredPaths.join("\n") !== versionedPaths.join("\n")) {
+    throw new Error("Per-route sitemap freshness metadata is incomplete or contains stale paths");
+  }
+
+  const uniqueLastmods = new Set(seoRoutes.publicRoutes.map((route) => route.lastmod));
+  if (uniqueLastmods.size < 2) {
+    throw new Error("Public sitemap routes must not share one blanket lastmod date");
+  }
+
   assertIncludes(
     sitemap,
     'xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"',
@@ -314,6 +452,11 @@ const validateSitemap = async (seoRoutes) => {
 
   for (const route of seoRoutes.publicRoutes) {
     const canonical = seoRoutes.canonicalForPath(seoRoutes.MARKETING_ORIGIN, route.path);
+    assertMatches(
+      route.lastmod,
+      /^\d{4}-\d{2}-\d{2}$/,
+      `Route ${route.path} has a non-ISO lastmod`
+    );
     assertIncludes(
       sitemap,
       `<loc>${canonical}</loc>`,

--- a/src/lib/seoRoutes.ts
+++ b/src/lib/seoRoutes.ts
@@ -45,6 +45,28 @@ export const PUBLIC_ROBOTS =
   "index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1";
 export const PRIVATE_ROBOTS = "noindex,nofollow,noarchive,nosnippet";
 
+// Public sitemap freshness is versioned per route. Update only the route whose
+// visible content materially changed; Business Playbook articles use their own
+// `updatedAt` source below. Private routes are not emitted in the sitemap.
+export const publicRouteLastmods = {
+  "/": "2026-07-17",
+  "/machines": "2026-07-17",
+  "/machines/commercial-robotic-machine": "2026-07-17",
+  "/machines/mini": "2026-05-29",
+  "/machines/micro": "2026-05-11",
+  "/supplies": "2026-05-29",
+  "/plus": "2026-05-29",
+  "/resources": "2026-05-11",
+  "/resources/business-playbook": "2026-05-11",
+  "/resources/business-playbook/planner": "2026-05-01",
+  "/resources/business-playbook/payback-planner": "2026-07-17",
+  "/contact": "2026-05-11",
+  "/about": "2026-05-11",
+  "/privacy": "2026-02-23",
+  "/terms": "2026-02-23",
+  "/billing-cancellation": "2026-04-13",
+} as const;
+
 const LASTMOD = "2026-05-11";
 
 export const commercialMachineFaqs = [
@@ -168,7 +190,7 @@ const businessPlaybookSeoRoutes: RouteSeo[] = [
     ogType: "website",
     ogImagePath: DEFAULT_SHARE_IMAGE_PATH,
     ogImageAlt: "Bloomjoy Business Playbook for cotton candy machine operators",
-    lastmod: LASTMOD,
+    lastmod: publicRouteLastmods["/resources/business-playbook"],
     structuredDataKind: "business-playbook-index",
   },
   {
@@ -181,7 +203,7 @@ const businessPlaybookSeoRoutes: RouteSeo[] = [
     ogType: "website",
     ogImagePath: DEFAULT_SHARE_IMAGE_PATH,
     ogImageAlt: "Bloomjoy Business Playbook machine fit and startup budget planner",
-    lastmod: LASTMOD,
+    lastmod: publicRouteLastmods["/resources/business-playbook/planner"],
   },
   {
     path: paybackPlannerPath,
@@ -193,7 +215,7 @@ const businessPlaybookSeoRoutes: RouteSeo[] = [
     ogType: "website",
     ogImagePath: DEFAULT_SHARE_IMAGE_PATH,
     ogImageAlt: "Bloomjoy Payback Scenario Planner for cotton candy machine operators",
-    lastmod: LASTMOD,
+    lastmod: publicRouteLastmods["/resources/business-playbook/payback-planner"],
   },
   ...businessPlaybookArticles.map(
     (article): RouteSeo => ({
@@ -234,7 +256,7 @@ export const publicRoutes: RouteSeo[] = [
         title: "Bloomjoy robotic cotton candy machine",
       },
     ],
-    lastmod: LASTMOD,
+    lastmod: publicRouteLastmods["/"],
   },
   {
     path: "/machines",
@@ -251,7 +273,7 @@ export const publicRoutes: RouteSeo[] = [
         title: "Bloomjoy robotic cotton candy machines",
       },
     ],
-    lastmod: LASTMOD,
+    lastmod: publicRouteLastmods["/machines"],
     structuredDataKind: "faq",
   },
   {
@@ -269,7 +291,7 @@ export const publicRoutes: RouteSeo[] = [
         title: "Bloomjoy Commercial Machine",
       },
     ],
-    lastmod: LASTMOD,
+    lastmod: publicRouteLastmods["/machines/commercial-robotic-machine"],
     structuredDataKind: "machine-product",
   },
   {
@@ -287,7 +309,7 @@ export const publicRoutes: RouteSeo[] = [
         title: "Bloomjoy Mini Machine",
       },
     ],
-    lastmod: LASTMOD,
+    lastmod: publicRouteLastmods["/machines/mini"],
     structuredDataKind: "machine-product",
   },
   {
@@ -305,7 +327,7 @@ export const publicRoutes: RouteSeo[] = [
         title: "Bloomjoy Micro Machine",
       },
     ],
-    lastmod: LASTMOD,
+    lastmod: publicRouteLastmods["/machines/micro"],
     structuredDataKind: "machine-product",
   },
   {
@@ -323,7 +345,7 @@ export const publicRoutes: RouteSeo[] = [
         title: "Bloomjoy cotton candy machine sugar and paper sticks",
       },
     ],
-    lastmod: LASTMOD,
+    lastmod: publicRouteLastmods["/supplies"],
     structuredDataKind: "supplies",
   },
   {
@@ -335,7 +357,7 @@ export const publicRoutes: RouteSeo[] = [
     surface: "marketing",
     ogImagePath: DEFAULT_SHARE_IMAGE_PATH,
     ogImageAlt: "Bloomjoy Plus operator training and support",
-    lastmod: LASTMOD,
+    lastmod: publicRouteLastmods["/plus"],
   },
   {
     path: "/resources",
@@ -346,7 +368,7 @@ export const publicRoutes: RouteSeo[] = [
     surface: "marketing",
     ogImagePath: DEFAULT_SHARE_IMAGE_PATH,
     ogImageAlt: "Bloomjoy machine buyer resources",
-    lastmod: LASTMOD,
+    lastmod: publicRouteLastmods["/resources"],
     structuredDataKind: "faq",
   },
   ...businessPlaybookSeoRoutes,
@@ -359,7 +381,7 @@ export const publicRoutes: RouteSeo[] = [
     surface: "marketing",
     ogImagePath: DEFAULT_SHARE_IMAGE_PATH,
     ogImageAlt: "Bloomjoy quote request",
-    lastmod: LASTMOD,
+    lastmod: publicRouteLastmods["/contact"],
   },
   {
     path: "/about",
@@ -376,7 +398,7 @@ export const publicRoutes: RouteSeo[] = [
         title: "Bloomjoy operator experience",
       },
     ],
-    lastmod: LASTMOD,
+    lastmod: publicRouteLastmods["/about"],
   },
   {
     path: "/privacy",
@@ -387,7 +409,7 @@ export const publicRoutes: RouteSeo[] = [
     ogType: "article",
     ogImagePath: DEFAULT_SHARE_IMAGE_PATH,
     ogImageAlt: DEFAULT_IMAGE_ALT,
-    lastmod: LASTMOD,
+    lastmod: publicRouteLastmods["/privacy"],
   },
   {
     path: "/terms",
@@ -398,7 +420,7 @@ export const publicRoutes: RouteSeo[] = [
     ogType: "article",
     ogImagePath: DEFAULT_SHARE_IMAGE_PATH,
     ogImageAlt: DEFAULT_IMAGE_ALT,
-    lastmod: LASTMOD,
+    lastmod: publicRouteLastmods["/terms"],
   },
   {
     path: "/billing-cancellation",
@@ -410,7 +432,7 @@ export const publicRoutes: RouteSeo[] = [
     ogType: "article",
     ogImagePath: DEFAULT_SHARE_IMAGE_PATH,
     ogImageAlt: DEFAULT_IMAGE_ALT,
-    lastmod: LASTMOD,
+    lastmod: publicRouteLastmods["/billing-cancellation"],
   },
 ];
 
@@ -589,17 +611,6 @@ const getBusinessPlaybookArticleByPath = (path: string) => {
 };
 
 const machineProductDataByPath: Record<string, Record<string, unknown>> = {
-  "/machines/commercial-robotic-machine": {
-    "@type": "Product",
-    "@id": `${MARKETING_ORIGIN}/machines/commercial-robotic-machine#product`,
-    name: "Bloomjoy Sweets Commercial Machine",
-    brand: { "@type": "Brand", name: "Bloomjoy" },
-    description:
-      "Full-size commercial robotic cotton candy machine with automatic stick dispensing, 64 preset patterns, four sugar colors, and a 70-130 second candy cycle.",
-    image: `${MARKETING_ORIGIN}/seo/commercial-machine.jpg`,
-    url: `${MARKETING_ORIGIN}/machines/commercial-robotic-machine`,
-    category: "Robotic cotton candy machine",
-  },
   "/machines/mini": {
     "@type": "Product",
     "@id": `${MARKETING_ORIGIN}/machines/mini#product`,
@@ -610,6 +621,12 @@ const machineProductDataByPath: Record<string, Record<string, unknown>> = {
     image: `${MARKETING_ORIGIN}/seo/mini-machine.jpg`,
     url: `${MARKETING_ORIGIN}/machines/mini`,
     category: "Robotic cotton candy machine",
+    offers: {
+      "@type": "Offer",
+      price: "4000.00",
+      priceCurrency: "USD",
+      url: `${MARKETING_ORIGIN}/machines/mini`,
+    },
   },
   "/machines/micro": {
     "@type": "Product",
@@ -621,6 +638,12 @@ const machineProductDataByPath: Record<string, Record<string, unknown>> = {
     image: `${MARKETING_ORIGIN}/seo/micro-machine.jpg`,
     url: `${MARKETING_ORIGIN}/machines/micro`,
     category: "Robotic cotton candy machine",
+    offers: {
+      "@type": "Offer",
+      price: "2200.00",
+      priceCurrency: "USD",
+      url: `${MARKETING_ORIGIN}/machines/micro`,
+    },
   },
 };
 


### PR DESCRIPTION
## Summary
- replaces blanket public sitemap freshness with versioned per-route dates while preserving article-owned update dates
- adds price/currency/canonical Offer data for the visibly priced Mini and Micro machines only
- keeps Commercial quote-only and removes its ineligible Product rich-result node because no factual Offer, Review, or AggregateRating is available

## Files changed
- `src/lib/seoRoutes.ts` — per-route `lastmod` metadata, Mini/Micro Product Offers, and quote-only Commercial schema
- `scripts/seo-regression-check.mjs` — route-count, freshness, Product/Offer parity, Commercial, and claim-boundary assertions
- `Docs/QA_SMOKE_TEST_CHECKLIST.md` — sitemap and structured-data smoke coverage

## Verification commands + results
- `npm ci` — passed (existing audit reports 8 vulnerabilities: 3 moderate, 5 high)
- `npm run build` — passed; prerendered 25 public routes and SEO head tags for 26 private routes
- `npm test --if-present` — passed
- `npm run lint --if-present` — passed
- `npm run seo:check` — passed; 25 public and 26 private routes validated
- Google Rich Results Test, code mode — Mini: 3 valid items; Micro: 3 valid items; Commercial: 1 valid Breadcrumb item and no invalid Product item
- generated HTML check — Mini contains `4000.00` Offer, Micro contains `2200.00` Offer, Commercial has no Product/Offer/public price

## How to test
1. Check out `agent/seo-structured-data` and run `npm ci`.
2. Run `npm run build` followed by `npm run seo:check`.
3. Inspect `dist/sitemap.xml`; confirm public routes use route/article-specific ISO dates rather than one shared date.
4. Inspect JSON-LD on:
   - `/machines/mini` — USD 4000.00 Offer with canonical URL
   - `/machines/micro` — USD 2200.00 Offer with canonical URL
   - `/machines/commercial-robotic-machine` — Breadcrumb and FAQ nodes with no Product, Offer, or public price
5. Confirm no machine Product/Offer node emits review, rating, availability, inventory, shipping, returns, or financing claims.

Closes #618
Related #619
Related #722
