### PR TITLE
SEO: strengthen discovery for excluded public routes

### DIFF
--- a/Docs/INDEX_DISCOVERY_AUDIT.md
+++ b/Docs/INDEX_DISCOVERY_AUDIT.md
@@ -1,0 +1,44 @@
+# Public Route Index Discovery Audit
+
+Issue: `#731`
+
+Audit date: 2026-08-10
+
+Search Console baseline date: 2026-08-06
+
+Scope: the 12 canonical public routes excluded in the baseline. Redirects, private routes, and `/cart` are intentionally outside this audit.
+
+## Audit method
+
+The production build was inspected for sitemap membership and `lastmod`, a route-specific title, one rendered H1, exact canonical, indexable robots directive, substantive HTML inside `#root` before client execution, and crawlable incoming links from the 25 canonical public routes. Source review checked query intent, overlap, and whether links occur in decision-useful main content rather than only global navigation.
+
+A local production preview returned HTTP 200 for all 12 exact paths. Each direct response included the expected H1, exact canonical, and `data-prerendered="true"` root marker.
+
+`node scripts/validate-public-route-discovery.mjs` makes the technical and contextual-link checks repeatable after `npm run build`.
+
+## Route diagnoses
+
+| Route | 2026-08-06 status | Build evidence | Diagnosis and action |
+| --- | --- | --- | --- |
+| `/machines/commercial-robotic-machine` | Discovered, not indexed | 665 main-content words; 24 incoming routes; unique metadata/H1; exact canonical | The baseline predates the quote-only structured-data and sitemap repair in #733. Recheck after that deployment; this is a high-value manual-inspection candidate, not a content-padding candidate. |
+| `/resources/business-playbook/how-to-start-cotton-candy-vending-business` | Discovered, not indexed | 1,493 main-content words; 9 incoming routes; distinct launch intent | No current technical defect. Discovery remains unknown until recheck. A contextual About-page link now gives buyers an entity-to-launch path. |
+| `/resources/business-playbook/best-locations-for-cotton-candy-vending-machines` | Crawled, not indexed | 1,350 main-content words; 7 incoming routes; location scorecard intent | Possible selection/overlap risk with the pitch and commercial-terms guides, but each has a distinct reader job. Keep separate and inspect query matching before rewriting. |
+| `/resources/business-playbook/mini-micro-event-catering-business-guide` | Crawled, not indexed | 1,317 main-content words; 4 incoming routes including Mini and Resources | Technically sound and audience-specific. Likely lower-demand/selection uncertainty; do not invent depth or create another startup page without query evidence. |
+| `/resources/business-playbook/startup-budget-checklist-cotton-candy-machine-business` | Crawled, not indexed | 1,351 main-content words; 10 incoming routes | Technically strong with distinct cost-category intent. Recheck before changing copy; no confirmed discovery defect remains. |
+| `/resources/business-playbook/how-to-pitch-location-owners` | Discovered, not indexed | 1,477 main-content words; 6 incoming routes after this change | Weak contextual discovery was plausible. The Commercial page now links directly to the venue-owner pitch at the moment a buyer is planning a placement. |
+| `/resources/business-playbook/revenue-share-vs-rent-cotton-candy-machine-placement` | Discovered, not indexed | 1,528 main-content words; 6 incoming routes including Commercial and the indexed payback planner | Technically and contextually strong. Recheck canonical selection/query fit; avoid merging it into the broader pitch guide without evidence. |
+| `/resources/business-playbook/commercial-vending-vs-event-catering` | Crawled, not indexed | 1,115 main-content words; 7 incoming routes including the indexed machine comparison | Distinct model-choice comparison with adequate discovery. Treat as content-selection uncertainty pending query evidence. |
+| `/resources/business-playbook/business-setup-basics-llc-ein-insurance-permits` | Crawled, not indexed | 1,176 main-content words; 3 incoming routes after this change | Confirmed weakest discovery path. The indexed ROI/payback guide now links to these admin-cost and readiness basics as a related decision. |
+| `/contact` | Discovered, not indexed | 32 words in the prerendered main form introduction and 148 across the rendered page shell; 24 incoming routes; exact canonical | Expected low-priority conversion utility. Keep indexable for branded/contact queries, but do not pad the form or bulk-request indexing. Quote-form changes remain owned by #617. |
+| `/about` | Discovered, not indexed | 226 main-content words; real imagery and unique entity copy; 24 mostly navigational incoming routes | Contextual depth was weak. The page now routes readers directly to the Commercial product, operator launch guide, or contact conversation. Recheck as a branded/entity page. |
+| `/privacy` | Discovered, not indexed | 208 main-content words; 24 footer/navigation links; exact canonical | Expected low-priority legal utility. Keep crawlable and accurate; do not request indexing unless a concrete branded/legal search need appears. |
+
+## Recheck and manual-inspection policy
+
+After the link changes deploy, inspect the exact canonical URLs in Search Console in this order:
+
+1. Commercial Machine, About, launch guide, venue-owner pitch, and business-setup guide.
+2. The remaining decision guides if their exclusion persists after discovery refresh.
+3. Contact and Privacy only for technical confirmation; do not use limited manual indexing requests on utility pages.
+
+Record only the inspection date and redacted status in issue `#731`. Do not commit Search Console exports, account identifiers, or low-volume query data. A request to index is appropriate only after the inspected live response matches the canonical build and the route is high value; it is not a substitute for resolving a reported defect.

--- a/Docs/QA_SMOKE_TEST_CHECKLIST.md
+++ b/Docs/QA_SMOKE_TEST_CHECKLIST.md
@@ -24,6 +24,9 @@ Run these checks on localhost for each PR that adds a user-facing feature.
 - [ ] `robots.txt` is reachable and includes a sitemap reference
 - [ ] `sitemap.xml` is reachable, lists core public routes plus public Business Playbook article routes, includes `lastmod`, and includes image sitemap entries for key machine/supplies/about/playbook URLs
 - [ ] Sitemap `lastmod` values reflect versioned route/article updates rather than one build-wide date; adding/removing a public route requires an intentional route-count regression update
+- [ ] After `npm run build`, run `node scripts/validate-public-route-discovery.mjs`; all 12 Search Console baseline exclusions have rendered H1/body content, exact canonical/indexable robots, sitemap freshness, crawlable incoming links, and no private/noncanonical sitemap leakage
+- [ ] `/about` main content links to the Commercial Machine and launch guide; the Commercial page links to the venue-owner pitch; the indexed ROI/payback guide links to business-setup basics
+- [ ] At `320x800` and desktop widths, the revised About decision panel and Commercial planning links remain readable, keyboard reachable, and free of horizontal overflow
 - [ ] Mini and Micro Product JSON-LD Offers match their visible USD prices and canonical page URLs; Commercial remains quote-only with no Product rich-result node, Offer, or public price in structured data
 - [ ] Machine Product/Offer JSON-LD does not add ratings, reviews, availability, inventory, shipping, returns, financing, or other unsupported commerce claims
 - [ ] Apex host (`https://bloomjoyusa.com`) redirects to canonical host (`https://www.bloomjoyusa.com/`) with permanent redirect behavior

--- a/scripts/validate-public-route-discovery.mjs
+++ b/scripts/validate-public-route-discovery.mjs
@@ -1,0 +1,177 @@
+import fs from 'node:fs';
+
+const marketingOrigin = 'https://www.bloomjoyusa.com';
+const distRoot = new URL('../dist/', import.meta.url);
+const sitemapPath = new URL('sitemap.xml', distRoot);
+
+const affectedRoutes = [
+  '/machines/commercial-robotic-machine',
+  '/resources/business-playbook/how-to-start-cotton-candy-vending-business',
+  '/resources/business-playbook/best-locations-for-cotton-candy-vending-machines',
+  '/resources/business-playbook/mini-micro-event-catering-business-guide',
+  '/resources/business-playbook/startup-budget-checklist-cotton-candy-machine-business',
+  '/resources/business-playbook/how-to-pitch-location-owners',
+  '/resources/business-playbook/revenue-share-vs-rent-cotton-candy-machine-placement',
+  '/resources/business-playbook/commercial-vending-vs-event-catering',
+  '/resources/business-playbook/business-setup-basics-llc-ein-insurance-permits',
+  '/contact',
+  '/about',
+  '/privacy',
+];
+
+const articlePrefix = '/resources/business-playbook/';
+const failures = [];
+const assert = (condition, message) => {
+  if (!condition) failures.push(message);
+};
+
+if (!fs.existsSync(sitemapPath)) {
+  console.error('Missing dist/sitemap.xml. Run npm run build first.');
+  process.exit(1);
+}
+
+const sitemap = fs.readFileSync(sitemapPath, 'utf8');
+const sitemapEntries = [...sitemap.matchAll(
+  /<url>\s*<loc>https:\/\/www\.bloomjoyusa\.com([^<]*)<\/loc>\s*<lastmod>([^<]*)<\/lastmod>/g,
+)].map((match) => ({ route: match[1] || '/', lastmod: match[2] }));
+
+const routeFile = (route) =>
+  route === '/'
+    ? new URL('index.html', distRoot)
+    : new URL(`${route.slice(1)}/index.html`, distRoot);
+
+const publicPages = new Map();
+for (const entry of sitemapEntries) {
+  const file = routeFile(entry.route);
+  assert(fs.existsSync(file), `${entry.route}: prerendered HTML is missing`);
+  if (fs.existsSync(file)) {
+    publicPages.set(entry.route, {
+      ...entry,
+      html: fs.readFileSync(file, 'utf8'),
+    });
+  }
+}
+
+const extract = (html, pattern) => html.match(pattern)?.[1]?.trim() ?? '';
+const stripMarkup = (html) =>
+  html
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&[a-z#0-9]+;/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+const mainMarkup = (html) => extract(html, /<main[^>]*>([\s\S]*?)<\/main>/i);
+const normalizeHref = (href) => {
+  const decoded = href.replaceAll('&amp;', '&');
+  if (decoded.startsWith(marketingOrigin)) return new URL(decoded).pathname;
+  if (!decoded.startsWith('/') || decoded.startsWith('//')) return null;
+  return decoded.split(/[?#]/)[0] || '/';
+};
+const linkedRoutes = (html) =>
+  [...html.matchAll(/href="([^"]+)"/g)]
+    .map((match) => normalizeHref(match[1]))
+    .filter(Boolean);
+
+const report = [];
+const titles = new Set();
+const headings = new Set();
+
+for (const route of affectedRoutes) {
+  const page = publicPages.get(route);
+  assert(Boolean(page), `${route}: missing from the canonical sitemap`);
+  if (!page) continue;
+
+  const { html, lastmod } = page;
+  const title = extract(html, /<title>([^<]+)<\/title>/i);
+  const h1 = stripMarkup(extract(html, /<h1[^>]*>([\s\S]*?)<\/h1>/i));
+  const canonical = extract(
+    html,
+    /<link[^>]+rel="canonical"[^>]+href="([^"]+)"/i,
+  );
+  const robots = extract(
+    html,
+    /<meta[^>]+name="robots"[^>]+content="([^"]+)"/i,
+  );
+  const main = mainMarkup(html);
+  const wordCount = stripMarkup(main).split(/\s+/).filter(Boolean).length;
+  const incoming = [...publicPages.entries()]
+    .filter(([source]) => source !== route)
+    .filter(([, sourcePage]) => linkedRoutes(sourcePage.html).includes(route))
+    .map(([source]) => source);
+  const minimumWords = route.startsWith(articlePrefix)
+    ? 1_000
+    : route === '/machines/commercial-robotic-machine'
+      ? 600
+      : route === '/contact'
+        ? 30
+      : 100;
+
+  assert(Boolean(title), `${route}: title is missing`);
+  assert(Boolean(h1), `${route}: rendered H1 is missing`);
+  assert(
+    /<div id="root" data-prerendered="true">/.test(html),
+    `${route}: prerendered root marker is missing`,
+  );
+  assert(canonical === `${marketingOrigin}${route}`, `${route}: canonical is incorrect`);
+  assert(robots.startsWith('index,follow'), `${route}: robots is not indexable`);
+  assert(wordCount >= minimumWords, `${route}: rendered main content is too thin (${wordCount} words)`);
+  assert(/^\d{4}-\d{2}-\d{2}$/.test(lastmod), `${route}: sitemap lastmod is invalid`);
+  assert(incoming.length >= 2, `${route}: fewer than two crawlable public routes link to it`);
+  assert(!titles.has(title), `${route}: title duplicates another affected route`);
+  assert(!headings.has(h1), `${route}: H1 duplicates another affected route`);
+  titles.add(title);
+  headings.add(h1);
+  report.push({ route, wordCount, incoming: incoming.length, lastmod });
+}
+
+const contextualLinks = [
+  {
+    source: '/machines/commercial-robotic-machine',
+    target: '/resources/business-playbook/how-to-pitch-location-owners',
+  },
+  {
+    source: '/about',
+    target: '/machines/commercial-robotic-machine',
+  },
+  {
+    source: '/about',
+    target: '/resources/business-playbook/how-to-start-cotton-candy-vending-business',
+  },
+  {
+    source: '/resources/business-playbook/cotton-candy-machine-roi-sales-payback-planning',
+    target: '/resources/business-playbook/business-setup-basics-llc-ein-insurance-permits',
+  },
+];
+
+for (const { source, target } of contextualLinks) {
+  const sourcePage = publicPages.get(source);
+  assert(Boolean(sourcePage), `${source}: contextual-link source is missing`);
+  if (sourcePage) {
+    assert(
+      linkedRoutes(mainMarkup(sourcePage.html)).includes(target),
+      `${source}: rendered main content does not link to ${target}`,
+    );
+  }
+}
+
+for (const excludedRoute of [
+  '/cart',
+  '/login',
+  '/portal',
+  '/admin',
+  '/products',
+  '/products/commercial-robotic-machine',
+]) {
+  assert(!publicPages.has(excludedRoute), `${excludedRoute}: private or noncanonical route entered sitemap`);
+}
+
+if (failures.length > 0) {
+  failures.forEach((failure) => console.error(`FAIL ${failure}`));
+  process.exit(1);
+}
+
+console.log('Public route discovery validation passed.');
+for (const row of report) {
+  console.log(`${row.route} | words=${row.wordCount} | incoming=${row.incoming} | lastmod=${row.lastmod}`);
+}

--- a/src/data/businessPlaybook.ts
+++ b/src/data/businessPlaybook.ts
@@ -1387,7 +1387,7 @@ export const businessPlaybookArticles: BusinessPlaybookArticle[] = [
     relatedSlugs: [
       "startup-budget-checklist-cotton-candy-machine-business",
       "revenue-share-vs-rent-cotton-candy-machine-placement",
-      "best-locations-for-cotton-candy-vending-machines",
+      "business-setup-basics-llc-ein-insurance-permits",
     ],
   },
   {

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -158,18 +158,35 @@ export default function AboutPage() {
 
       <section className="section-padding pt-0">
         <div className="container-page">
-          <div className="card-elevated rounded-3xl p-8 text-center sm:p-10">
-            <h2 className="font-display text-3xl font-bold text-foreground">
-              Join Us on Our Sweet Journey
-            </h2>
-            <p className="mx-auto mt-4 max-w-2xl text-muted-foreground">
-              Planning a launch, scaling to multiple locations, or comparing machine options? Our
-              team can help you map the right path.
-            </p>
-            <div className="mt-6">
-              <Link to="/contact">
-                <Button size="lg">Contact Us</Button>
-              </Link>
+          <div className="card-elevated overflow-hidden rounded-3xl">
+            <div className="grid gap-8 p-8 sm:p-10 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
+              <div>
+                <p className="text-sm font-semibold uppercase tracking-[0.14em] text-primary">
+                  From our field experience to your next decision
+                </p>
+                <h2 className="mt-3 font-display text-3xl font-bold text-foreground">
+                  See the equipment. Then plan the operation around it.
+                </h2>
+                <p className="mt-4 max-w-2xl leading-relaxed text-muted-foreground">
+                  Review the full-size Commercial Machine, use our operator launch guide to map
+                  the work around a placement, or bring your open questions directly to Bloomjoy.
+                </p>
+              </div>
+              <div className="grid gap-3 sm:grid-cols-3 lg:min-w-[17rem] lg:grid-cols-1">
+                <Button asChild size="lg">
+                  <Link to="/machines/commercial-robotic-machine">
+                    Explore the Commercial Machine
+                  </Link>
+                </Button>
+                <Button asChild variant="outline" size="lg">
+                  <Link to="/resources/business-playbook/how-to-start-cotton-candy-vending-business">
+                    Read the launch guide
+                  </Link>
+                </Button>
+                <Button asChild variant="ghost" size="lg">
+                  <Link to="/contact">Contact Bloomjoy</Link>
+                </Button>
+              </div>
             </div>
           </div>
         </div>

--- a/src/pages/products/CommercialRobotic.tsx
+++ b/src/pages/products/CommercialRobotic.tsx
@@ -211,6 +211,21 @@ export default function CommercialRoboticPage() {
                         Compare revenue share and rent terms
                         <ArrowRight className="h-4 w-4" />
                       </Link>
+                      <Link
+                        to="/resources/business-playbook/how-to-pitch-location-owners"
+                        onClick={() =>
+                          trackBuyerFlowPlaybookLinkClick({
+                            surface: 'commercial_machine_page',
+                            cta: 'prepare_location_owner_pitch',
+                            href: '/resources/business-playbook/how-to-pitch-location-owners',
+                            machine: MACHINE_NAMES.commercial,
+                          })
+                        }
+                        className="inline-flex items-center gap-2 text-sm font-semibold text-primary hover:underline"
+                      >
+                        Prepare your venue-owner pitch
+                        <ArrowRight className="h-4 w-4" />
+                      </Link>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary

- Audit all 12 public routes excluded in the 2026-08-06 Search Console baseline and classify technical, discovery, selection, and utility-page cases.
- Add decision-useful contextual paths from About, Commercial, and the indexed ROI/payback guide without padding already-substantive pages.
- Add a repeatable post-build validator for rendered content, canonicals, robots, sitemap freshness, incoming discovery, and private-route exclusion.

## Linked Issue

- #731

## Files changed

- `Docs/INDEX_DISCOVERY_AUDIT.md`: route-by-route evidence, diagnosis, and prioritized reinspection policy.
- `scripts/validate-public-route-discovery.mjs`: deterministic audit for the 12 baseline routes and four contextual-link paths.
- `src/pages/About.tsx`: responsive buyer decision panel linking equipment, launch guidance, and contact.
- `src/pages/products/CommercialRobotic.tsx`: tracked venue-owner pitch link in the placement-planning section.
- `src/data/businessPlaybook.ts`: connect the indexed ROI/payback article to the weakest-discovered business-setup guide.
- `Docs/QA_SMOKE_TEST_CHECKLIST.md`: durable route-discovery and responsive checks.

## Verification

- `npm ci` — passed
- `npm run build` — passed; 25 public routes and 26 private routes prerendered/validated
- `npm test --if-present` — passed
- `npm run lint --if-present` — passed
- `npx tsc --noEmit` — passed
- `npm run seo:check` — passed; 25 public and 26 private routes validated
- `node scripts/validate-public-route-discovery.mjs` — passed for all 12 routes
- `git diff --check` — passed
- Local production preview — all 12 exact paths returned HTTP 200 with the expected H1, exact canonical, and prerender marker
- Playwright at 1440px and 320x800 — About and Commercial remained readable with zero horizontal overflow; the ROI-to-business-setup link rendered; console errors: 0

## UI / Design Evidence

- Playwright review covered `/about` at 1440px and 320x800: the new decision panel preserved hierarchy, all three native link controls appeared in the accessibility snapshot, and horizontal overflow was zero.
- `/machines/commercial-robotic-machine` at 320x800 showed the new venue-owner pitch link in context with zero horizontal overflow.
- The indexed ROI/payback article rendered its business-setup link at 320x800. Browser console review reported zero errors; only the two expected local placeholder-environment warnings appeared.
- The Vercel preview deployed successfully, and the separate GitHub synthetic screenshot workflow passed.

## How to test

1. Run `npm ci`.
2. Provide the normal local Supabase environment values described in `Docs/LOCAL_DEV.md`.
3. Run `npm run build`.
4. Run `node scripts/validate-public-route-discovery.mjs` and confirm all 12 routes pass.
5. Run `npm run dev -- --host 127.0.0.1 --port 4173`.
6. Inspect these key URLs at desktop and 320px widths:
   - `http://127.0.0.1:4173/about`
   - `http://127.0.0.1:4173/machines/commercial-robotic-machine`
   - `http://127.0.0.1:4173/resources/business-playbook/cotton-candy-machine-roi-sales-payback-planning`
7. Confirm the About panel links to the Commercial Machine and launch guide, Commercial links to the venue-owner pitch guide, and ROI/payback links to business-setup basics.

## Deployment and recheck

After deployment, inspect the exact canonical URLs in Search Console in the priority order documented in the audit. Keep #731 open until the high-value production URLs have been rechecked; do not spend limited manual indexing requests on Contact or Privacy without a concrete need.

## Risk And Overlap

- Risk is limited to crawl hierarchy and a visible About-page CTA panel; no database, authentication, checkout, payment, pricing, or schema behavior changes.
- The build validator fails if an affected route loses rendered content, its exact canonical/indexability, sitemap freshness, minimum incoming discovery, or any intended contextual link.
- `Docs/QA_SMOKE_TEST_CHECKLIST.md` is also touched by draft PRs #739 and #740. Their additions are independent; the later branch must sync from `main` and preserve each additive checklist block.

## Merge Autonomy

Lane: Yellow

P1 and `ui-change` labels require the Yellow lane. No owner or executive decision is required: scope is bounded, local and GitHub checks are green, production preview succeeded, and desktop/mobile UI evidence is documented above. The agent may merge only after the repository merge gate passes cleanly. The live Search Console recheck remains an issue follow-up after deployment, not a reason to bypass the gate.
