### PR TITLE
chore(refunds): record production release metadata

### DIFF
--- a/scripts/refunds/refund-production-release.json
+++ b/scripts/refunds/refund-production-release.json
@@ -3,7 +3,7 @@
   "environment": "production",
   "projectRef": "ygbzkgxktzqsiygjlqyg",
   "releaseId": "refund-ops-2026-08-02-portfolio-intake",
-  "sourceGitCommit": "0594a82ffc94f2aee557d5c32f3acbc916e932ab",
+  "sourceGitCommit": "500a585d06b5b4b3fd5054a2b719609451a142e2",
   "requiredMigrations": [
     "202604270001_refund_adjustment_review_matching.sql",
     "202604270002_live_refund_sheet_ingestion.sql",

--- a/scripts/refunds/refund-production-release.json
+++ b/scripts/refunds/refund-production-release.json
@@ -54,9 +54,9 @@
       "verifyJwt": false,
       "sourceSha256": "6aec865a362982f5c8ea10a1a117227e717dcdbe45ee3a782e1c2fdbfb344ae0",
       "production": {
-        "version": 7,
-        "ezbrSha256": "7484d3a4b92eae16ab7fd6e4e531e4fb73f01f58fd4f88dbbbef18be339b6abb",
-        "sourceSha256": "e409be80f17379849a1f0da6ad18ac4cf125fba410a62909774dab4f7d7b8386"
+        "version": 9,
+        "ezbrSha256": "1b29e9793a3bdf91fd4b5ba63b1b696644e50804c4f28bc45f9fc2845443d67e",
+        "sourceSha256": "6aec865a362982f5c8ea10a1a117227e717dcdbe45ee3a782e1c2fdbfb344ae0"
       }
     },
     {
@@ -64,7 +64,7 @@
       "verifyJwt": false,
       "sourceSha256": "38c54eb518d3c0905ca493d21038d4844bdc74714b22f623ed33409efc436d28",
       "production": {
-        "version": 7,
+        "version": 8,
         "ezbrSha256": "38796c4caf00459194a368321e534ede69c6b58d52512a346cd5549729e476e2",
         "sourceSha256": "38c54eb518d3c0905ca493d21038d4844bdc74714b22f623ed33409efc436d28"
       }
@@ -74,7 +74,7 @@
       "verifyJwt": false,
       "sourceSha256": "51006bc25d8424e1090b4f21afc311c89e84acdffcc47537c85d161c64248bb2",
       "production": {
-        "version": 7,
+        "version": 8,
         "ezbrSha256": "3ed34d1f8d3cea18bf4b1d022f3d49e70c1a855cf2719a6dc08846a6c04cca51",
         "sourceSha256": "51006bc25d8424e1090b4f21afc311c89e84acdffcc47537c85d161c64248bb2"
       }
@@ -84,7 +84,7 @@
       "verifyJwt": false,
       "sourceSha256": "19a5c51374c9ca17746c420c2259c29356facaf20b577183d880dce79e4a88af",
       "production": {
-        "version": 6,
+        "version": 7,
         "ezbrSha256": "b132499086bcfddb6b1243c031e4d27f33aa37065d9c5f81a5f442b3a6a437de",
         "sourceSha256": "19a5c51374c9ca17746c420c2259c29356facaf20b577183d880dce79e4a88af"
       }
@@ -94,7 +94,7 @@
       "verifyJwt": false,
       "sourceSha256": "d64362ab9fff4f302fb2e075faceb4bb4e1ae97db55e54a7dc954fd08eeea553",
       "production": {
-        "version": 7,
+        "version": 8,
         "ezbrSha256": "6d6b5ae555a308fda50504ce46329468d4425125e825bb8dd66266a7a4b1818a",
         "sourceSha256": "d64362ab9fff4f302fb2e075faceb4bb4e1ae97db55e54a7dc954fd08eeea553"
       }
@@ -104,7 +104,7 @@
       "verifyJwt": false,
       "sourceSha256": "19697ba2c49915c4d0167f4e16aa0948a0a7845d2ffa9e0f0a32c653e4eacaf9",
       "production": {
-        "version": 6,
+        "version": 7,
         "ezbrSha256": "4282c11096ba8fa4b209b11d341b791bb1208ff03e911a459b507b6f8d74f7c3",
         "sourceSha256": "19697ba2c49915c4d0167f4e16aa0948a0a7845d2ffa9e0f0a32c653e4eacaf9"
       }
@@ -114,7 +114,7 @@
       "verifyJwt": false,
       "sourceSha256": "75a9775568676551005f0ad7509dd4c51f450b8c9e8e9b4c18f521a95a5d8947",
       "production": {
-        "version": 6,
+        "version": 7,
         "ezbrSha256": "1ef839d0183516c9373b531b043d015197c365cb23785e6d16017ad9706714fd",
         "sourceSha256": "75a9775568676551005f0ad7509dd4c51f450b8c9e8e9b4c18f521a95a5d8947"
       }
@@ -124,7 +124,7 @@
       "verifyJwt": false,
       "sourceSha256": "22fd4e70c28e196761f82dc11ea9f9aa17c175cbbf49d7e3eec4681f1eb428b9",
       "production": {
-        "version": 7,
+        "version": 8,
         "ezbrSha256": "81931fe45f118a93b88c8226d2054e8fe0062d7c98b9359304a7d7079c9dc36b",
         "sourceSha256": "22fd4e70c28e196761f82dc11ea9f9aa17c175cbbf49d7e3eec4681f1eb428b9"
       }


### PR DESCRIPTION
## Summary
- record the eight verified Refund Operations function versions currently deployed in production
- pair the merged portfolio-wide intake source with production function `refund-case-intake` v9
- pin the release source to permanent merge commit `500a585`
- make the standard production drift check green after the #682 rollout

## Files changed
- `scripts/refunds/refund-production-release.json` — production version, bundle digest, and source-commit metadata only

## Verification
- `npm ci` — pass (409 packages; existing audit reports 3 moderate and 5 high vulnerabilities)
- `npm run build` — pass (30 public routes, 26 private SEO heads)
- `npm test --if-present` — pass
- `npm run lint --if-present` — pass
- `npm run refunds:release:check` — pass
- `npm run refunds:validate-release-tooling` — pass
- `npm run refunds:release:check-production -- --project-ref ygbzkgxktzqsiygjlqyg` — pass for all eight functions
- GitHub `verify`, `local-manifest`, and Vercel checks — pass on head `a761f5b`

## How to test
1. `npm ci`
2. `npm run refunds:release:check`
3. With authorized Supabase production access, run:
   `npm run refunds:release:check-production -- --project-ref ygbzkgxktzqsiygjlqyg`
4. Confirm all eight functions report `PASS`.

## Risk And Overlap
- This is a manifest-only audit update following #681/#682. It does not change application code, database schema/data, auth, customer data, email, Gmail, OpenAI, Nayax, automation, or the hosted UI.
- The P0, UI, database, and auth/payment risk context comes from the linked implementation issue. Those runtime changes were reviewed and merged in #682 before deployment; this PR only records the verified deployed versions.
- Production automation and live Nayax execution remain fail-closed.
- No overlapping source files are changed by other known refund implementation PRs; only the production release manifest is touched.

## UI / Design Evidence
- No visible UI or design changed in this PR, so new screenshots are not applicable.
- The underlying #682 UI path had required browser UAT and screenshots before merge. The post-deploy public-options smoke passed with 23 safe, non-duplicate options, and Eastridge is present exactly once after its audited label configuration.

## Independent Review / QA Evidence
- The guarded production capture independently downloaded each deployed Edge Function bundle, normalized its transitive source, and rejected any source mismatch before emitting these version/digest values.
- The standard production drift check then compared the reviewed manifest against all eight live functions and passed each version and bundle digest.
- GitHub CI re-ran release-tooling and local-manifest validation on the exact PR head and passed.
- The first CI run caught an unreachable pre-merge source SHA; the manifest was corrected to permanent merged commit `500a585`, and the full local and GitHub checks passed afterward.
- No synthetic or real case was created, no email was sent, and no provider/refund action was invoked during this metadata review.

## Merge Autonomy
Lane: Yellow

This post-deployment closeout may merge only after the exact-head GitHub checks and repository merge gate are green. Those checks are now green; the PR is reversible, contains no runtime mutation, and is required by the production runbook before the release is considered fully paired.