### PR TITLE
chore(refunds): re-anchor manager assignment release

### DIFF
--- a/scripts/refunds/refund-production-release.json
+++ b/scripts/refunds/refund-production-release.json
@@ -3,7 +3,7 @@
   "environment": "production",
   "projectRef": "ygbzkgxktzqsiygjlqyg",
   "releaseId": "refund-ops-2026-08-11-production-readiness",
-  "sourceGitCommit": "202a712499cf7750ecd39dcbae02a2e1ececc7e1",
+  "sourceGitCommit": "d7115432e4d2f274cc6333987f2cd6299d1f9d00",
   "requiredMigrations": [
     "202604270001_refund_adjustment_review_matching.sql",
     "202604270002_live_refund_sheet_ingestion.sql",


### PR DESCRIPTION
## Summary

- Re-anchor the refund production release manifest to the squash-merged source commit for #775.
- Preserve all reviewed function hashes, migration digests, versions, and default-off controls unchanged.
- Restore clean-worktree release validation before the reviewed manager-assignment migration is deployed.

## Files changed

- `scripts/refunds/refund-production-release.json` — one metadata-only `sourceGitCommit` update.

## Root cause

GitHub squash-merged PR #775. The manifest still referenced the pre-squash source commit, which contains the approved source but is not an ancestor of `main`. The release guard correctly rejected that topology.

## Verification

- `npm run refunds:validate-release-tooling` — PASS
- `npm run refunds:release:check` — PASS for 10 functions / 44 migrations
- `git diff --check` — PASS
- Source/migration/function hashes — unchanged

## Risk And Overlap

- Metadata-only: one commit pointer changes; no executable source, SQL, function bundle, migration digest, production version, or switch changes.
- Based on exact merged `main` commit `d711543`; no overlap with other source work.
- Rollback is restoring the prior pointer, though that would intentionally make the ancestry guard fail again after the squash merge.

## Merge Autonomy

- Lane: Green
- Rationale: one-line generated release metadata repair with no runtime behavior and exact local/hosted manifest validation.
- Merge after all required checks are green.

## How to test

1. Check out this branch.
2. Run `npm ci`.
3. Run `npm run refunds:validate-release-tooling`.
4. Run `npm run refunds:release:check`.
5. Confirm the diff is exactly one `sourceGitCommit` line and points to merged main commit `d7115432e4d2f274cc6333987f2cd6299d1f9d00`.

No production deployment, data write, Gmail action, Nayax action, or switch change is included in this PR.