### PR TITLE
chore(refunds): re-anchor dual-role release

### DIFF
--- a/scripts/refunds/refund-production-release.json
+++ b/scripts/refunds/refund-production-release.json
@@ -3,7 +3,7 @@
   "environment": "production",
   "projectRef": "ygbzkgxktzqsiygjlqyg",
   "releaseId": "refund-ops-2026-08-11-production-readiness",
-  "sourceGitCommit": "3e3cbc7db90ba7ad8ea42d7a253d8d9a36aba932",
+  "sourceGitCommit": "450e0fd52f7c9078abef41b8d2cb2e71d6268c50",
   "requiredMigrations": [
     "202604270001_refund_adjustment_review_matching.sql",
     "202604270002_live_refund_sheet_ingestion.sql",


### PR DESCRIPTION
## Summary
- Re-anchors the Refund Operations production release manifest to the canonical squash commit from PR #778.
- Changes one metadata value only; all function versions, source/bundle hashes, migration fingerprints, JWT settings, runtime gates, secrets, and schedules are unchanged.

Closes #779.

## Files changed
- `scripts/refunds/refund-production-release.json`: top-level `sourceGitCommit` only.

## Verification
- `npm ci` — PASS
- `npm run build` — PASS
- `npm test --if-present` — PASS
- `npm run lint --if-present` — PASS
- `npm run refunds:validate-release-tooling` — PASS
- `npm run refunds:release:check` — PASS (10 functions; 45 migrations)
- `git diff --check` — PASS
- Exact diff — one insertion / one deletion in one manifest file

## How to test
1. Check out this branch and run `npm ci`.
2. Run `npm run refunds:validate-release-tooling`.
3. Run `npm run refunds:release:check`; it must report alignment for 10 functions and 45 migrations.
4. Confirm `git diff origin/main -- scripts/refunds/refund-production-release.json` changes only the top-level `sourceGitCommit` to `450e0fd52f7c9078abef41b8d2cb2e71d6268c50`.
5. No localhost UI route is affected; the hosted Refund UAT check is the authoritative unchanged-product regression.

## Safety and overlap
- Metadata-only; no deployment, database write, Gmail access, customer message, Nayax call, refund, secret, or switch change.
- Based on exact post-#778 `main`. Rebase and re-run release validation if another protected refund source change merges first.

## Rollback
Revert this one-line manifest commit. No runtime or data rollback is needed.