### PR TITLE
chore(refunds): re-anchor owner authenticator release

### DIFF
--- a/scripts/refunds/refund-production-release.json
+++ b/scripts/refunds/refund-production-release.json
@@ -3,7 +3,7 @@
   "environment": "production",
   "projectRef": "ygbzkgxktzqsiygjlqyg",
   "releaseId": "refund-ops-2026-08-11-production-readiness",
-  "sourceGitCommit": "12273229686f5e114020e4563dda3c94030e02dc",
+  "sourceGitCommit": "e3ce7863711ae28e573e71346b5b38bbd6ae821d",
   "requiredMigrations": [
     "202604270001_refund_adjustment_review_matching.sql",
     "202604270002_live_refund_sheet_ingestion.sql",


### PR DESCRIPTION
## Summary

- Re-anchors the refund release manifest to the canonical squash-merged source revision from #785.
- Changes one metadata value only; application code, database migrations, Auth configuration, operational gates, and documentation are unchanged.
- Keeps the private authenticator enrollment path default-closed and does not deploy or open any enrollment window.

Follow-up to #785 and #782.

## Files changed

- `scripts/refunds/refund-production-release.json`: updates only `sourceGitCommit` to the canonical merged source revision.

## Verification

- `npm run refunds:validate-release-tooling` — PASS
- `npm run refunds:release:check` — PASS: 10 functions, 46 migrations
- `git diff --check` — PASS
- Diff scope — PASS: one file, one insertion, one deletion

## How to test

1. Check out this branch.
2. Run `npm run refunds:validate-release-tooling`.
3. Run `npm run refunds:release:check`.
4. Confirm both commands pass.
5. Run `git diff --name-only origin/main...HEAD` and confirm the release manifest is the only changed file.
6. Inspect the diff and confirm only `sourceGitCommit` changed.

No browser testing is required because this PR changes release metadata only. Do not deploy, alter production Auth, or open an enrollment window during review.