### PR TITLE
chore(refunds): anchor merged production metadata

### DIFF
--- a/scripts/refunds/refund-production-release.json
+++ b/scripts/refunds/refund-production-release.json
@@ -3,7 +3,7 @@
   "environment": "production",
   "projectRef": "ygbzkgxktzqsiygjlqyg",
   "releaseId": "refund-ops-2026-08-11-production-readiness",
-  "sourceGitCommit": "8bde6a1d5646fc889754564c5cd63e2f172642d1",
+  "sourceGitCommit": "ca53e60a2d271e134c12615fbf5d765aa8b910ad",
   "requiredMigrations": [
     "202604270001_refund_adjustment_review_matching.sql",
     "202604270002_live_refund_sheet_ingestion.sql",


### PR DESCRIPTION
## Summary

- Re-anchors the reviewed refund production release manifest to the canonical squash-merge commit from #792.
- Changes exactly one metadata value; no runtime source, migration, gate, workflow, secret, or production state changes.

## Why

This repository permits squash merges only. #792's reviewed source commit therefore no longer appears in canonical main history even though the merged tree is identical. The release tooling intentionally requires this immediate canonical re-anchor.

## Files changed

- `scripts/refunds/refund-production-release.json`

## Verification

- `npm ci` — PASS (existing audit findings unchanged: 3 moderate, 5 high)
- `npm run build` — PASS
- `npm test --if-present` — PASS
- `npm run lint --if-present` — PASS
- `npm run refunds:validate-release-tooling` — PASS
- `npm run refunds:release:check` — PASS (10 functions / 47 migrations)
- `npm run refunds:release:check-production -- --project-ref ygbzkgxktzqsiygjlqyg` — PASS (10/10 exact production match)

## How to test

1. Check out this branch and run `npm ci`.
2. Run `npm run refunds:validate-release-tooling`.
3. Run `npm run refunds:release:check`.
4. With authorized read-only production access, run `npm run refunds:release:check-production -- --project-ref ygbzkgxktzqsiygjlqyg`.
5. Confirm the diff is exactly one `sourceGitCommit` value and all ten functions / 47 migrations pass.

Refs #629, #772, #792