### PR TITLE
chore(refunds): anchor canonical refund release

### DIFF
--- a/scripts/refunds/refund-production-release.json
+++ b/scripts/refunds/refund-production-release.json
@@ -3,7 +3,7 @@
   "environment": "production",
   "projectRef": "ygbzkgxktzqsiygjlqyg",
   "releaseId": "refund-ops-2026-08-11-production-readiness",
-  "sourceGitCommit": "5bfafbc8a999818361ddc1f6e18568bbc7073465",
+  "sourceGitCommit": "ae96bcd5abb8cedc77451270af58f87cbb57b82e",
   "requiredMigrations": [
     "202604270001_refund_adjustment_review_matching.sql",
     "202604270002_live_refund_sheet_ingestion.sql",


### PR DESCRIPTION
## Summary
- Re-anchor the protected refund production manifest to canonical main after the reviewed #796 legacy-state repair and #797 mailbox-documentation squash merges.
- Preserve all approved runtime, documentation, function, migration, version, digest, JWT, and gate content unchanged.

## Files changed
- `scripts/refunds/refund-production-release.json`: one `sourceGitCommit` value only.

## Verification
- `npm ci` — PASS
- `npm run build` — PASS
- `npm test --if-present` — PASS
- `npm run lint --if-present` — PASS
- `npm run refunds:validate-release-tooling` — PASS
- `npm run refunds:release:check` — PASS (10 functions / 48 migrations)
- `git diff --check` — PASS

## How to test
1. Check out `agent/refund-legacy-confirmation-canonical-anchor`.
2. Run `npm ci`.
3. Run `npm run refunds:validate-release-tooling`.
4. Run `npm run refunds:release:check`.
5. Confirm the PR changes exactly one manifest value and makes no runtime, migration, function, gate, workflow, secret, or documentation change.

## Safety
- Metadata only; no deploy, production query/write, email, Nayax request, refund, or customer action.
- Merge does not authorize production normalization. The separate live Auth closed-state gate and production deployment ceremony still apply.