### PR TITLE
chore(refunds): anchor normalization closeout merge

### DIFF
--- a/scripts/refunds/refund-production-release.json
+++ b/scripts/refunds/refund-production-release.json
@@ -3,7 +3,7 @@
   "environment": "production",
   "projectRef": "ygbzkgxktzqsiygjlqyg",
   "releaseId": "refund-ops-2026-08-11-production-readiness",
-  "sourceGitCommit": "a48c935583e99540106c8edd201e350df70af5cd",
+  "sourceGitCommit": "c0dcfa5cb9780aeb4cf0e10c25972b0d35b030bc",
   "requiredMigrations": [
     "202604270001_refund_adjustment_review_matching.sql",
     "202604270002_live_refund_sheet_ingestion.sql",


### PR DESCRIPTION
## Summary

- Re-anchors the Refund Operations production release manifest to canonical squash-merged main commit `c0dcfa5cb9780aeb4cf0e10c25972b0d35b030bc`.
- Changes only the manifest's one-line `sourceGitCommit` value.
- Makes no runtime, documentation, mailbox, gate, deployment, or live-system change.

Related: #793 (already closed; this PR does not reopen or auto-close it).

## Files changed

- `scripts/refunds/refund-production-release.json`: one-line canonical `sourceGitCommit` anchor.

## Verification

- `npm ci` — passed
- `npm run build` — passed
- `npm test --if-present` — passed
- `npm run lint --if-present` — passed
- `npm run refunds:validate-release-tooling` — passed
- `npm run refunds:release:check` — passed (10 functions / 48 migrations)
- `git diff --check c0dcfa5cb9780aeb4cf0e10c25972b0d35b030bc..HEAD` — passed
- Exact diff scope — one file, one line changed

## How to test

1. From an isolated worktree, check out `agent/refund-normalization-closeout-canonical-anchor`.
2. Run `npm ci`.
3. Run `npm run build`, `npm test --if-present`, and `npm run lint --if-present`.
4. Run `npm run refunds:validate-release-tooling` and `npm run refunds:release:check`.
5. Run `git diff --name-status c0dcfa5cb9780aeb4cf0e10c25972b0d35b030bc..HEAD` and confirm the manifest is the only changed file.
6. Confirm `sourceGitCommit` equals `c0dcfa5cb9780aeb4cf0e10c25972b0d35b030bc`.

No browser route, localhost URL, credentials, production query, deployment, email, provider action, or live-system change is required.