### PR TITLE
chore(refunds): anchor canonical retention docs

### DIFF
--- a/scripts/refunds/refund-production-release.json
+++ b/scripts/refunds/refund-production-release.json
@@ -3,7 +3,7 @@
   "environment": "production",
   "projectRef": "ygbzkgxktzqsiygjlqyg",
   "releaseId": "refund-ops-2026-08-11-production-readiness",
-  "sourceGitCommit": "d23d281ade3dcd74647256ead75f59ae7572c33d",
+  "sourceGitCommit": "f211ed50f57c80368a2db63f19d8c8a3bed8b3b8",
   "requiredMigrations": [
     "202604270001_refund_adjustment_review_matching.sql",
     "202604270002_live_refund_sheet_ingestion.sql",


### PR DESCRIPTION
Refs #805. This is the required canonical post-squash release anchor for merged docs PR #806.

## Summary
- change only the refund production manifest top-level `sourceGitCommit`
- anchor the approved refund release source to canonical main `f211ed50f57c80368a2db63f19d8c8a3bed8b3b8`
- restore the protected local release invariant after #806's squash merge

## Files changed
- `scripts/refunds/refund-production-release.json` ? one line only

## Verification
- `npm ci` ? PASS (existing audit reports 8 vulnerabilities: 3 moderate, 5 high)
- `npm run build` ? PASS
- `npm test --if-present` ? PASS
- `npm run lint --if-present` ? PASS
- `npm run auth:preflight` ? PASS using existing local environment values loaded into the process without copying or printing them
- `npm run commerce:preflight` ? BLOCKED by pre-existing missing local commerce configuration (`STRIPE_STICKS_PRICE_ID`, `STRIPE_CUSTOMER_PORTAL_CONFIGURATION_ID`, `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `STRIPE_SUGAR_NON_MEMBER_PRICE_ID`, and `STRIPE_STICKS_MEMBER_PRICE_ID`); this manifest-only PR does not touch commerce configuration
- `npm run db:validate-migrations` ? PASS (145 migrations, 32 pgTAP files, 1,204 assertions)
- `npm run refunds:validate-release-tooling` ? PASS
- `npm run refunds:release:check` ? PASS (10 functions, 49 migrations)
- `npm run agent:preflight -- --issue 805` ? PASS
- `git diff --check` ? PASS

## Risk / overlap
- Release metadata only. No function source, source digest, migration, workflow, gate, schedule, secret, database, customer-contact, refund, or production state changed.
- Recently closed stale PRs #708, #671, and #672 also touched this manifest. There is no current open-manifest overlap; any future revival must rebase from canonical main and regenerate the anchor.
- Rollback: revert this manifest-only PR to the prior canonical anchor; no operational rollback is required.

## How to test
1. Check out this branch and run `npm ci`.
2. Confirm the diff changes exactly one line in `scripts/refunds/refund-production-release.json`.
3. Confirm `sourceGitCommit` equals canonical #806 squash commit `f211ed50f57c80368a2db63f19d8c8a3bed8b3b8`.
4. Run `npm run refunds:validate-release-tooling`.
5. Run `npm run refunds:release:check`; require 10 functions and 49 migrations.
6. No localhost route or test credentials are needed for this manifest-only change.
