### PR TITLE
chore(refunds): record synthetic Gmail proof production deployment

### DIFF
--- a/scripts/refunds/refund-production-release.json
+++ b/scripts/refunds/refund-production-release.json
@@ -63,9 +63,9 @@
       "verifyJwt": false,
       "sourceSha256": "b7f179900f3a395457d15a64aa8ebfe609e2b284d093bf9c96b690bbb58e5c15",
       "production": {
-        "version": 39,
-        "ezbrSha256": "392d892e11ae3695ce7fcaa6559c20901ccb14188f8a4fee4f3074026f4f7b59",
-        "sourceSha256": "23d0d2d5e4cb50e867af2fbfe61497c9cff2a6219331f53516258eda734a26a8"
+        "version": 40,
+        "ezbrSha256": "5f733c0b22443631b007f8418229ea36e61e95aae677148c40f755f98cca6ee1",
+        "sourceSha256": "b7f179900f3a395457d15a64aa8ebfe609e2b284d093bf9c96b690bbb58e5c15"
       }
     },
     {
@@ -83,9 +83,9 @@
       "verifyJwt": false,
       "sourceSha256": "51bbb90d4a6dec34365ded5e3a5992a9c6c72aa23533661452b7a13ec554cc36",
       "production": {
-        "version": 39,
-        "ezbrSha256": "068b75b7985c8cb966200dccf35224e3825965d6c00265f70f4a2ce7e7894643",
-        "sourceSha256": "134f07c877120710a2922488cc308daa568d4d7389d9c9d1db93f979a13d652d"
+        "version": 40,
+        "ezbrSha256": "151743a1d22fab9c834ecf807cb9fd09afe2627914456e90e95c54ea3ec2fe71",
+        "sourceSha256": "51bbb90d4a6dec34365ded5e3a5992a9c6c72aa23533661452b7a13ec554cc36"
       }
     },
     {
@@ -93,9 +93,9 @@
       "verifyJwt": false,
       "sourceSha256": "e3231afff84c9c4eb47779563ed474dbee8d37842aaf86ef778bb39251d3f32b",
       "production": {
-        "version": 37,
-        "ezbrSha256": "e3222f3d2e8e8ff2886f45998e9544204db7c07f761126b3725c8117ef764ab2",
-        "sourceSha256": "e9a53a755b3248f43363faceaef8f5030e226702a2c07ebae7c7ff6219ea19cf"
+        "version": 38,
+        "ezbrSha256": "edb6f0034e31e0e03e39b1e77311e26aadf9e15c2f7cd519a90ec298d842844e",
+        "sourceSha256": "e3231afff84c9c4eb47779563ed474dbee8d37842aaf86ef778bb39251d3f32b"
       }
     },
     {
@@ -103,9 +103,9 @@
       "verifyJwt": false,
       "sourceSha256": "535e10f444a6ed068da3625103c59a3bdc11eb98fee17194a998ece41dcfaee2",
       "production": {
-        "version": 38,
-        "ezbrSha256": "d6eeac897e5165f9080016423214f0b400d0e35f056b79ecd4d7492d5793903b",
-        "sourceSha256": "2f4688c1d1b718e7561ae9bdbdc2db40b44e5e515941266cd992f9547e2477ca"
+        "version": 39,
+        "ezbrSha256": "bbd47883b4ca1f3da33af8c7da1ff13270dfba0d0367c81f8f627b5aee8b838c",
+        "sourceSha256": "535e10f444a6ed068da3625103c59a3bdc11eb98fee17194a998ece41dcfaee2"
       }
     },
     {


### PR DESCRIPTION
## Summary
- record the four reviewed Edge Function production versions and fingerprints deployed for the one-case Gmail proof boundary
- preserve every repository source, migration, JWT setting, gate, schedule, and the other six production function records
- close #808 after exact-head independent review and hosted checks

Closes #808

## Files changed
- scripts/refunds/refund-production-release.json: production metadata only for refund-case-intake, refund-case-admin-update, refund-case-automation-sweep, and refund-case-message-send

## Verification
- npm ci — PASS
- npm run build — PASS
- npm test --if-present — PASS
- npm run lint --if-present — PASS
- npm run refunds:validate-release-tooling — PASS
- npm run refunds:release:check — PASS (10 functions / 49 migrations)
- npm run refunds:release:check-production -- --project-ref ygbzkgxktzqsiygjlqyg --confirm-project-ref ygbzkgxktzqsiygjlqyg — PASS (10/10 exact live functions / 49 migrations)

## How to test
1. Check out this branch and run npm ci.
2. Run npm run refunds:release:check.
3. With an authorized read-only Supabase CLI session, run npm run refunds:release:check-production -- --project-ref ygbzkgxktzqsiygjlqyg --confirm-project-ref ygbzkgxktzqsiygjlqyg.
4. Confirm the diff changes only 12 production metadata scalar values for the four named functions.

## Safety
This PR does not deploy, toggle Gmail, enable automatic contact, send mail, call Nayax, issue a refund, or change customer data. The deployment itself completed default-off, the postdeploy Auth gate passed enrollment=false/verification=true, and the temporary token was revoked.