### PR TITLE
chore(refunds): anchor Gmail proof adapter canonical merge

### DIFF
--- a/scripts/refunds/refund-production-release.json
+++ b/scripts/refunds/refund-production-release.json
@@ -3,7 +3,7 @@
   "environment": "production",
   "projectRef": "ygbzkgxktzqsiygjlqyg",
   "releaseId": "refund-ops-2026-08-11-production-readiness",
-  "sourceGitCommit": "a40588822f1eb72a7cfe59b695b118154d808f4f",
+  "sourceGitCommit": "25e61dbaf7aba2dfdbd1f0cd6d773335d9a24d2c",
   "requiredMigrations": [
     "202604270001_refund_adjustment_review_matching.sql",
     "202604270002_live_refund_sheet_ingestion.sql",


### PR DESCRIPTION
﻿Closes #814

## Summary

- Reconcile the Refund Operations release manifest to canonical main after the reviewed Management API owner adapter merged in #815.
- Change only `sourceGitCommit` to canonical commit `25e61dbaf7aba2dfdbd1f0cd6d773335d9a24d2c`.

## Files changed

- `scripts/refunds/refund-production-release.json` — one commit-pointer line only.

## Verification

- `npm ci` — PASS
- `npm run refunds:release:check` — PASS (10 functions, 49 migrations)
- `npm run refunds:validate-release-tooling` — PASS
- `npm run build` — PASS
- `npm test --if-present` — PASS
- `npm run lint --if-present` — PASS
- `git diff --check` — PASS

No production query, deployment, gate change, email, browser action, or customer action occurred.

## How to test

1. Run `npm ci`.
2. Confirm this PR's direct parent is canonical main `25e61dbaf7aba2dfdbd1f0cd6d773335d9a24d2c`.
3. Confirm `git diff --name-only 25e61dbaf7aba2dfdbd1f0cd6d773335d9a24d2c..HEAD` contains only `scripts/refunds/refund-production-release.json`.
4. Confirm the only diff is `sourceGitCommit` changing to `25e61dbaf7aba2dfdbd1f0cd6d773335d9a24d2c`.
5. Run `npm run refunds:release:check` and `npm run refunds:validate-release-tooling`.
6. Run `npm run build`, `npm test --if-present`, and `npm run lint --if-present`.

This PR does not authorize a production dry-run or live Gmail proof; those remain separate owner-controlled operations after the anchor merges.
