### PR TITLE
chore(refunds): reconcile synthetic-proof version counters

### DIFF
--- a/scripts/refunds/refund-production-release.json
+++ b/scripts/refunds/refund-production-release.json
@@ -63,7 +63,7 @@
       "verifyJwt": false,
       "sourceSha256": "b7f179900f3a395457d15a64aa8ebfe609e2b284d093bf9c96b690bbb58e5c15",
       "production": {
-        "version": 40,
+        "version": 42,
         "ezbrSha256": "5f733c0b22443631b007f8418229ea36e61e95aae677148c40f755f98cca6ee1",
         "sourceSha256": "b7f179900f3a395457d15a64aa8ebfe609e2b284d093bf9c96b690bbb58e5c15"
       }
@@ -73,7 +73,7 @@
       "verifyJwt": false,
       "sourceSha256": "a2d566ce771496796ca9b4540b7a4d83043b849f76b1f19cb0b7c7f8e33ce79a",
       "production": {
-        "version": 37,
+        "version": 39,
         "ezbrSha256": "ae854beecd247f3c4b876a08843bd39cd7829d168fd737074cc09989f9ea7800",
         "sourceSha256": "a2d566ce771496796ca9b4540b7a4d83043b849f76b1f19cb0b7c7f8e33ce79a"
       }
@@ -83,7 +83,7 @@
       "verifyJwt": false,
       "sourceSha256": "51bbb90d4a6dec34365ded5e3a5992a9c6c72aa23533661452b7a13ec554cc36",
       "production": {
-        "version": 40,
+        "version": 42,
         "ezbrSha256": "151743a1d22fab9c834ecf807cb9fd09afe2627914456e90e95c54ea3ec2fe71",
         "sourceSha256": "51bbb90d4a6dec34365ded5e3a5992a9c6c72aa23533661452b7a13ec554cc36"
       }
@@ -93,7 +93,7 @@
       "verifyJwt": false,
       "sourceSha256": "e3231afff84c9c4eb47779563ed474dbee8d37842aaf86ef778bb39251d3f32b",
       "production": {
-        "version": 38,
+        "version": 40,
         "ezbrSha256": "edb6f0034e31e0e03e39b1e77311e26aadf9e15c2f7cd519a90ec298d842844e",
         "sourceSha256": "e3231afff84c9c4eb47779563ed474dbee8d37842aaf86ef778bb39251d3f32b"
       }
@@ -103,7 +103,7 @@
       "verifyJwt": false,
       "sourceSha256": "535e10f444a6ed068da3625103c59a3bdc11eb98fee17194a998ece41dcfaee2",
       "production": {
-        "version": 39,
+        "version": 41,
         "ezbrSha256": "bbd47883b4ca1f3da33af8c7da1ff13270dfba0d0367c81f8f627b5aee8b838c",
         "sourceSha256": "535e10f444a6ed068da3625103c59a3bdc11eb98fee17194a998ece41dcfaee2"
       }
@@ -113,7 +113,7 @@
       "verifyJwt": false,
       "sourceSha256": "8fd54d8195b1abbd441b6340d973956b75b01c8c48c5673b1b091a352e3ef86f",
       "production": {
-        "version": 36,
+        "version": 38,
         "ezbrSha256": "3a93a0793322581ab9083cc692c978bc25ef5cfd921716f35364d34e4c831dd5",
         "sourceSha256": "8fd54d8195b1abbd441b6340d973956b75b01c8c48c5673b1b091a352e3ef86f"
       }
@@ -123,7 +123,7 @@
       "verifyJwt": false,
       "sourceSha256": "75a9775568676551005f0ad7509dd4c51f450b8c9e8e9b4c18f521a95a5d8947",
       "production": {
-        "version": 34,
+        "version": 36,
         "ezbrSha256": "1ef839d0183516c9373b531b043d015197c365cb23785e6d16017ad9706714fd",
         "sourceSha256": "75a9775568676551005f0ad7509dd4c51f450b8c9e8e9b4c18f521a95a5d8947"
       }
@@ -133,7 +133,7 @@
       "verifyJwt": false,
       "sourceSha256": "c1d58503507f2adbdef8920fe4572b25a474a7092b83a45a821364b67d9bda40",
       "production": {
-        "version": 37,
+        "version": 39,
         "ezbrSha256": "d6f72367ee684559ccaeeeb4f8034e059759d337fba6a7a5d96dbd56c96c9e5f",
         "sourceSha256": "c1d58503507f2adbdef8920fe4572b25a474a7092b83a45a821364b67d9bda40"
       }
@@ -143,7 +143,7 @@
       "verifyJwt": false,
       "sourceSha256": "cd147f13796e0218512a281e38271ed1f1fbd2ad8aad947b10dda8d1f8336278",
       "production": {
-        "version": 28,
+        "version": 30,
         "ezbrSha256": "a87e4e43044fa1f4cfed4767345e21d012fe38b48a5dfb510123d0eca85558ba",
         "sourceSha256": "cd147f13796e0218512a281e38271ed1f1fbd2ad8aad947b10dda8d1f8336278"
       }
@@ -153,7 +153,7 @@
       "verifyJwt": false,
       "sourceSha256": "f98c1999c62b7ff51dafdcc42d42d9bebc2026da11805bb51c55e3c60c706511",
       "production": {
-        "version": 28,
+        "version": 30,
         "ezbrSha256": "2bec4ebb48cb4449262c287928f71dac004c303e9e0214f1f9e0019958cab906",
         "sourceSha256": "f98c1999c62b7ff51dafdcc42d42d9bebc2026da11805bb51c55e3c60c706511"
       }


### PR DESCRIPTION
## Summary

- Reconcile the recorded production version counters for all 10 refund Edge Functions after the controlled synthetic Gmail proof toggled the bundled functions off/on.
- Advance each recorded counter by exactly two while preserving every source hash, production bundle hash, JWT setting, release source pointer, and migration entry.
- Keep this change metadata-only; it does not deploy code, change gates, or contact a customer.

## Files changed

- `scripts/refunds/refund-production-release.json`: production version metadata only (10 counters, each `+2`).

## Verification

- `npm ci` — passed
- `npm run build` — passed
- `npm test --if-present` — passed
- `npm run lint --if-present` — passed
- `npm run db:validate-migrations` — passed, including database persona tests
- `npm run refunds:validate-release-tooling` — passed
- `npm run refunds:release:check` — passed; local alignment confirmed for 10 functions and 49 migrations
- Exact-diff assertion — passed; exactly 10 production version fields changed by `+2`, with no other JSON change

## How to test

1. Run `npm ci`.
2. Run `npm run refunds:validate-release-tooling`.
3. Run `npm run refunds:release:check` and confirm alignment passes for 10 functions and 49 migrations.
4. Run `npm run build`, `npm test --if-present`, and `npm run lint --if-present`.
5. Review the manifest diff and confirm the only changes are the 10 `functions[].production.version` counters, each advanced by exactly two.

No localhost UI route or test credentials are needed because this PR changes release metadata only and has no runtime or UI behavior.

## Risk and overlap

- Risk is limited to metadata accuracy; there is no application, database, email, provider, gate, schedule, or deployment behavior change.
- This manifest is a shared release file. Rebase and rerun release verification if another manifest PR merges first.

Merge autonomy: Lane Yellow — merge only after exact-head independent reviews and all required hosted checks are terminal green.

Fixes #823
