### PR TITLE
chore(refunds): anchor reconciled release metadata

### DIFF
--- a/scripts/refunds/refund-production-release.json
+++ b/scripts/refunds/refund-production-release.json
@@ -3,7 +3,7 @@
   "environment": "production",
   "projectRef": "ygbzkgxktzqsiygjlqyg",
   "releaseId": "refund-ops-2026-08-11-production-readiness",
-  "sourceGitCommit": "d60db6560e61b6fa16032b6476626c990244b057",
+  "sourceGitCommit": "4607354c09f718db3cec89dc2022929f18c9f6cc",
   "requiredMigrations": [
     "202604270001_refund_adjustment_review_matching.sql",
     "202604270002_live_refund_sheet_ingestion.sql",


### PR DESCRIPTION
## Summary

- Point the refund production release manifest at canonical main after the version-counter reconciliation was squash-merged in #824.
- Preserve the reviewed release tree exactly; this PR changes only the top-level `sourceGitCommit` value.
- Make no deployment, gate, email, database, provider, schedule, or customer-facing change.

## Files changed

- `scripts/refunds/refund-production-release.json`: one-line canonical source pointer update to `4607354c09f718db3cec89dc2022929f18c9f6cc`.

## Verification

- `npm ci` — passed
- `npm run agent:preflight -- --issue 823` — passed
- `npm run build` — passed
- `npm test --if-present` — passed
- `npm run lint --if-present` — passed
- `npm run db:validate-migrations` — passed, including database persona tests
- `npm run refunds:validate-release-tooling` — passed
- `npm run refunds:release:check` — passed; local alignment confirmed for 10 functions and 49 migrations
- Diff inspection — exactly one file and one `sourceGitCommit` line

## How to test

1. Run `npm ci`.
2. Run `npm run refunds:validate-release-tooling`.
3. Run `npm run refunds:release:check` and confirm alignment passes for 10 functions and 49 migrations.
4. Run `npm run build`, `npm test --if-present`, and `npm run lint --if-present`.
5. Confirm the PR changes only the top-level manifest `sourceGitCommit` to the exact #824 squash-merge SHA.

No localhost UI route or test credentials are needed because this PR is a one-line release metadata anchor with no runtime or UI behavior.

## Risk and overlap

- Risk is limited to release ancestry metadata accuracy.
- This manifest is shared release metadata; rebase if another manifest PR merges first.

Merge autonomy: Lane Yellow — merge only after exact-head independent reviews and every required hosted check is terminal green.

Relates to #823
