### PR TITLE
chore(refunds): anchor historical validator to main

### DIFF
--- a/scripts/refunds/refund-production-release.json
+++ b/scripts/refunds/refund-production-release.json
@@ -3,7 +3,7 @@
   "environment": "production",
   "projectRef": "ygbzkgxktzqsiygjlqyg",
   "releaseId": "refund-ops-2026-08-11-production-readiness",
-  "sourceGitCommit": "7dfbfd605c2aa8fe60256b8424e0083b98709512",
+  "sourceGitCommit": "82266a80c7db15b3523e60b0b9af4a9b96c0e04e",
   "requiredMigrations": [
     "202604270001_refund_adjustment_review_matching.sql",
     "202604270002_live_refund_sheet_ingestion.sql",


### PR DESCRIPTION
## Summary
- anchor the merged #834 historical bridge validator to canonical main `82266a80c7db15b3523e60b0b9af4a9b96c0e04e`
- change exactly one `sourceGitCommit` line in the refund production release manifest
- preserve the reviewed #834 tree wholesale

Closes #833 after merge.

## Files changed
- `scripts/refunds/refund-production-release.json` — canonical source pointer only

## Verification
- `npm ci` — PASS
- `npm run build` — PASS (53.7s)
- `npm test --if-present` — PASS (49.1s)
- `npm run lint --if-present` — PASS (24.2s)
- `npm run refunds:validate-release-tooling` — PASS
- `npm run refunds:release:check` — PASS, 10 functions / 50 migrations
- clean exact-head worktree — PASS

## How to test
1. Check out this branch and run `npm ci`.
2. Run `npm run refunds:validate-release-tooling`.
3. Run `npm run refunds:release:check`; expect 10 functions and 50 migrations.
4. Confirm `git diff 82266a80c7db15b3523e60b0b9af4a9b96c0e04e...HEAD` contains one file and one `sourceGitCommit` line only.

No production query/write, provider call, customer message, refund, secret, gate, or deployment is part of this PR.