### PR TITLE
P0: make Nayax outcome fixture UTC-midnight safe

### DIFF
--- a/scripts/refunds/refund-production-release.json
+++ b/scripts/refunds/refund-production-release.json
@@ -3,7 +3,7 @@
   "environment": "production",
   "projectRef": "ygbzkgxktzqsiygjlqyg",
   "releaseId": "refund-ops-2026-08-11-production-readiness",
-  "sourceGitCommit": "7dfbfd605c2aa8fe60256b8424e0083b98709512",
+  "sourceGitCommit": "787d0d90b43f211e531a633467bd4208bacab2e0",
   "requiredMigrations": [
     "202604270001_refund_adjustment_review_matching.sql",
     "202604270002_live_refund_sheet_ingestion.sql",

--- a/scripts/refunds/validate-refund-nayax-resolution.mjs
+++ b/scripts/refunds/validate-refund-nayax-resolution.mjs
@@ -100,7 +100,13 @@ assert(
 );
 
 assert(
-  databaseTests.includes('select plan(81)') &&
+  databaseTests.includes('select plan(82)') &&
+    databaseTests.includes("select '2026-08-14 00:05:00+00'::timestamptz as now_at") &&
+    databaseTests.includes("occurred_at <= now_at + interval '30 seconds'") &&
+    databaseTests.includes(
+      "Previous-day UTC evidence stays in the past and crosses the LA date at 00:05 UTC"
+    ) &&
+    (databaseTests.match(/- interval '1 day' \+ interval '15 minutes'/g) ?? []).length === 3 &&
     databaseTests.includes('The default-off gate blocks preparation before any write') &&
     databaseTests.includes('PAN, phone, account, and other long digit-shaped references are rejected') &&
     databaseTests.includes('Grouped card, phone, and account digit shapes are rejected') &&

--- a/supabase/tests/refund_nayax_outcome_resolution.sql
+++ b/supabase/tests/refund_nayax_outcome_resolution.sql
@@ -3,7 +3,7 @@ begin;
 create extension if not exists pgtap with schema extensions;
 set local search_path = public, extensions;
 
-select plan(81);
+select plan(82);
 
 create function pg_temp.capture_error(statement text)
 returns text
@@ -681,20 +681,43 @@ select ok(
   and (select count(*) = 0 from public.sales_adjustment_facts where refund_case_id = 'b1600000-0000-4000-8000-000000000002'),
   'Retry-safe proves no provider call, customer message, or completion adjustment');
 
+select ok((
+  with simulated_clock as (
+    select '2026-08-14 00:05:00+00'::timestamptz as now_at
+  ), fixture_evidence as (
+    select
+      now_at,
+      (
+        date_trunc('day', now_at at time zone 'UTC')
+        - interval '1 day'
+        + interval '15 minutes'
+      ) at time zone 'UTC' as occurred_at
+    from simulated_clock
+  )
+  select
+    occurred_at <= now_at + interval '30 seconds'
+    and (occurred_at at time zone 'UTC')::date <>
+      (occurred_at at time zone 'America/Los_Angeles')::date
+  from fixture_evidence
+), 'Previous-day UTC evidence stays in the past and crosses the LA date at 00:05 UTC');
+
 update public.refund_case_nayax_refund_attempts
 set
   created_at = (
-    date_trunc('day', statement_timestamp() at time zone 'UTC') + interval '15 minutes'
+    date_trunc('day', statement_timestamp() at time zone 'UTC')
+    - interval '1 day' + interval '15 minutes'
   ) at time zone 'UTC' - interval '30 minutes',
   provider_outcome_recorded_at = (
-    date_trunc('day', statement_timestamp() at time zone 'UTC') + interval '15 minutes'
+    date_trunc('day', statement_timestamp() at time zone 'UTC')
+    - interval '1 day' + interval '15 minutes'
   ) at time zone 'UTC'
 where id = 'b1700000-0000-4000-8000-000000000003';
 set local role authenticated;
 select pg_temp.set_auth_claims('b1000000-0000-4000-8000-000000000001', 'aal1', '[]'::jsonb);
 with evidence as (
   select (
-    date_trunc('day', statement_timestamp() at time zone 'UTC') + interval '15 minutes'
+    date_trunc('day', statement_timestamp() at time zone 'UTC')
+    - interval '1 day' + interval '15 minutes'
   ) at time zone 'UTC' as occurred_at
 )
 insert into pg_temp.nayax_resolution_test_intents (intent_key, intent_id, evidence_occurred_at)


### PR DESCRIPTION
## Linked Issue
- Closes #836.

## Summary
- Move the synthetic Nayax success evidence anchor to the previous UTC day so it cannot be future-dated during the first 15 minutes after UTC midnight.
- Add an executable 00:05 UTC boundary assertion proving the fixture stays within the server guard and still crosses the America/Los_Angeles calendar date.
- Require the boundary assertion and all three corrected fixture anchors in the focused validator; production runtime is unchanged.

## Files Changed
- `supabase/tests/refund_nayax_outcome_resolution.sql`: corrected three synthetic fixture timestamps and added one pgTAP boundary assertion.
- `scripts/refunds/validate-refund-nayax-resolution.mjs`: updated the planned assertion count and required the regression evidence.
- `scripts/refunds/refund-production-release.json`: separate source-anchor commit only.

## Verification
- `npm ci` — PASS.
- `npm run refunds:validate-nayax-resolution` — PASS (7/7 focused tests plus static contract).
- `npm run db:validate-migrations` — PASS (34 files, 1,301 assertions).
- `npm run build` — PASS.
- `npm test --if-present` — PASS.
- `npm run lint --if-present` — PASS.
- `npm run refunds:validate-release-tooling` — PASS.
- `npm run refunds:release:check` — PASS (10 functions / 50 migrations).
- Hosted verify, database validate, local-manifest, screenshots attempt 2, and Vercel — PASS.

## How To Test Locally
1. Run `npm ci`.
2. Run `npm run refunds:validate-nayax-resolution` and `npm run db:validate-migrations`.
3. Confirm the pgTAP suite passes at the simulated 00:05 UTC boundary and proves the evidence is not future-dated while UTC and Los Angeles dates differ.
4. Run build, full tests, lint, release tooling, and local 10/50 alignment.

No portal, customer, provider, Gmail, refund, gate, migration, or production-runtime change is part of this PR.

## Risk And Overlap
- Test/tooling-only hardening for a deterministic midnight-UTC fixture failure; production migration and Edge function bytes are unchanged.
- Canonical release anchor #835 remains held and must be recreated from the new main after this PR and its own post-squash anchor merge.
- Held postdeployment metadata changes remain isolated and will be recreated only after both anchors are canonical.

## Independent Review / QA Evidence
- Two independent exact-SHA reviewers returned FINAL GO with P0-P3 none.
- Both verified the past-time/date-boundary semantics, unchanged runtime, full local checks, database 1,301 assertions, and terminal hosted success.
- Screenshot attempt 1 hit an unrelated anonymous 404 after functional assertions; the unchanged exact-SHA attempt 2 passed all portal, QR, Machine Manager, and evidence stages.

## UI / Design Evidence
- No UI or design source changed. Full hosted portal, QR intake, and Machine Manager evidence passed on the exact head.

## Merge Autonomy
- Lane: Yellow test-hardening correction.
- The owner explicitly authorized routine fully reviewed merge actions without another approval prompt.
- Merge only after two exact-head FINAL GO reviews and all required checks are terminal green; all conditions are satisfied.
- A separate canonical manifest-only anchor is mandatory after squash merge.