### PR TITLE
Anchor UTC-midnight fixture hardening to canonical main

### DIFF
--- a/scripts/refunds/refund-production-release.json
+++ b/scripts/refunds/refund-production-release.json
@@ -3,7 +3,7 @@
   "environment": "production",
   "projectRef": "ygbzkgxktzqsiygjlqyg",
   "releaseId": "refund-ops-2026-08-11-production-readiness",
-  "sourceGitCommit": "787d0d90b43f211e531a633467bd4208bacab2e0",
+  "sourceGitCommit": "5f0a43ab25d981f3e52d5861f7ddc09557cff76d",
   "requiredMigrations": [
     "202604270001_refund_adjustment_review_matching.sql",
     "202604270002_live_refund_sheet_ingestion.sql",


### PR DESCRIPTION
## Summary
- point the release manifest at canonical main after the UTC-midnight fixture hardening merge
- preserve the exact reviewed #837 tree with a one-line source pointer update only

Follow-up to #836 and #837.

## Files changed
- `scripts/refunds/refund-production-release.json`: `sourceGitCommit` only

## Verification
- `npm ci` — PASS
- `npm run refunds:validate-nayax-resolution` — PASS
- `npm run db:validate-migrations` — PASS (34 files, 1301 assertions)
- `npm run build` — PASS
- `npm test --if-present` — PASS
- `npm run lint --if-present` — PASS
- `npm run refunds:validate-release-tooling` — PASS
- `npm run refunds:release:check` — PASS (10 functions / 50 migrations)

## How to test
1. `npm ci`
2. `npm run refunds:validate-nayax-resolution`
3. `npm run db:validate-migrations`
4. `npm run refunds:validate-release-tooling`
5. `npm run refunds:release:check`
6. Confirm the PR changes exactly one manifest line and points to canonical main `5f0a43ab25d981f3e52d5861f7ddc09557cff76d`.

Key URLs: no portal or customer-facing route changes; metadata anchor only.
Test credentials: none required.