### PR TITLE
P0: make Machine Manager UAT 404s diagnosable

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "reporting:validate-sync-diagnostics": "node scripts/sunze/validate-sync-diagnostics.mjs",
     "reporting:validate-refund-adjustments": "node scripts/validate-refund-adjustments.mjs",
     "reporting:validate-portal-uat": "node scripts/validate-reporting-uat.mjs",
-    "refunds:validate-machine-manager-uat": "node scripts/refunds/validate-machine-manager-uat.mjs",
+    "refunds:validate-machine-manager-uat": "node --test scripts/refunds/machine-manager-uat-network.test.mjs && node scripts/refunds/validate-machine-manager-uat.mjs",
     "refunds:validate-portal-uat": "node scripts/refunds/validate-refund-portal-uat.mjs",
     "refunds:validate-legacy-state-uat": "node scripts/refunds/validate-refund-portal-uat.mjs --legacy-state-only",
     "refunds:validate-customer-comms": "node scripts/refunds/validate-refund-customer-comms.mjs",

--- a/scripts/refunds/machine-manager-uat-network.mjs
+++ b/scripts/refunds/machine-manager-uat-network.mjs
@@ -1,0 +1,81 @@
+const SAFE_METHOD = /^(?:GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS)$/;
+const SAFE_RESOURCE_TYPES = new Set([
+  'document',
+  'stylesheet',
+  'image',
+  'media',
+  'font',
+  'script',
+  'texttrack',
+  'xhr',
+  'fetch',
+  'eventsource',
+  'websocket',
+  'manifest',
+  'other',
+]);
+const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f-]{27,}$/i;
+const LONG_IDENTIFIER_SHAPE = /^[A-Za-z0-9_-]{24,}$/;
+
+const redactPathSegment = (segment) => {
+  if (!segment) return segment;
+  if (UUID_SHAPE.test(segment) || LONG_IDENTIFIER_SHAPE.test(segment)) return '[id]';
+  if (segment.includes('@') || /%40/i.test(segment)) return '[identity]';
+  if (segment.length > 80 || !/^[A-Za-z0-9._~-]+$/.test(segment)) return '[redacted]';
+  return segment;
+};
+
+export const redactUatRequestTarget = (rawUrl, appUrl) => {
+  try {
+    const target = new URL(rawUrl);
+    const appOrigin = new URL(appUrl).origin;
+    const pathname = target.pathname
+      .split('/')
+      .map(redactPathSegment)
+      .join('/');
+    const safePathname = pathname || '/';
+
+    if (target.origin === appOrigin) return safePathname;
+    if (target.hostname === '127.0.0.1' || target.hostname === 'localhost') {
+      return `[loopback]${safePathname}`;
+    }
+    return `[external-origin]${safePathname}`;
+  } catch {
+    return '[invalid-url]';
+  }
+};
+
+const safeMethod = (method) => {
+  const normalized = String(method ?? '').toUpperCase();
+  return SAFE_METHOD.test(normalized) ? normalized : 'UNKNOWN';
+};
+
+const safeResourceType = (resourceType) => {
+  const normalized = String(resourceType ?? '').toLowerCase();
+  return SAFE_RESOURCE_TYPES.has(normalized) ? normalized : 'other';
+};
+
+export const describeFailedUatResponse = (response, appUrl) => {
+  const status = Number(response?.status?.());
+  if (!Number.isInteger(status) || status < 400 || status > 599) return null;
+
+  const request = response.request();
+  return [
+    `HTTP ${status}`,
+    safeMethod(request.method()),
+    safeResourceType(request.resourceType()),
+    redactUatRequestTarget(response.url(), appUrl),
+  ].join(' ');
+};
+
+export const describeFailedUatRequest = (request, appUrl) => {
+  const failure = request?.failure?.();
+  if (!failure) return null;
+
+  return [
+    'NETWORK_FAILED',
+    safeMethod(request.method()),
+    safeResourceType(request.resourceType()),
+    redactUatRequestTarget(request.url(), appUrl),
+  ].join(' ');
+};

--- a/scripts/refunds/machine-manager-uat-network.mjs
+++ b/scripts/refunds/machine-manager-uat-network.mjs
@@ -14,15 +14,46 @@ const SAFE_RESOURCE_TYPES = new Set([
   'manifest',
   'other',
 ]);
-const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f-]{27,}$/i;
-const LONG_IDENTIFIER_SHAPE = /^[A-Za-z0-9_-]{24,}$/;
+const SAFE_STATIC_PATH_SEGMENTS = new Set([
+  '.vite',
+  '.well-known',
+  '@react-refresh',
+  '@vite',
+  'admin',
+  'appspecific',
+  'assets',
+  'auth',
+  'bloomjoy-icon.png',
+  'client',
+  'com.chrome.devtools.json',
+  'deps',
+  'favicon.ico',
+  'favicon.svg',
+  'functions',
+  'index.html',
+  'login',
+  'machines',
+  'media',
+  'node_modules',
+  'pages',
+  'public',
+  'rest',
+  'robots.txt',
+  'rpc',
+  'seo',
+  'site.webmanifest',
+  'src',
+  'training-guides',
+  'v1',
+]);
+const SAFE_FILE_EXTENSION = /\.(css|gif|html|ico|jpe?g|js|json|map|mjs|mp4|png|svg|ts|tsx|ttf|webmanifest|webp|woff2?)$/i;
 
 const redactPathSegment = (segment) => {
   if (!segment) return segment;
-  if (UUID_SHAPE.test(segment) || LONG_IDENTIFIER_SHAPE.test(segment)) return '[id]';
-  if (segment.includes('@') || /%40/i.test(segment)) return '[identity]';
-  if (segment.length > 80 || !/^[A-Za-z0-9._~-]+$/.test(segment)) return '[redacted]';
-  return segment;
+  if (SAFE_STATIC_PATH_SEGMENTS.has(segment)) return segment;
+
+  const extension = segment.match(SAFE_FILE_EXTENSION)?.[0]?.toLowerCase();
+  return extension ? `[redacted${extension}]` : '[redacted]';
 };
 
 export const redactUatRequestTarget = (rawUrl, appUrl) => {

--- a/scripts/refunds/machine-manager-uat-network.mjs
+++ b/scripts/refunds/machine-manager-uat-network.mjs
@@ -14,57 +14,73 @@ const SAFE_RESOURCE_TYPES = new Set([
   'manifest',
   'other',
 ]);
-const SAFE_STATIC_PATH_SEGMENTS = new Set([
-  '.vite',
-  '.well-known',
-  '@react-refresh',
-  '@vite',
-  'admin',
-  'appspecific',
-  'assets',
-  'auth',
-  'bloomjoy-icon.png',
-  'client',
-  'com.chrome.devtools.json',
-  'deps',
-  'favicon.ico',
-  'favicon.svg',
-  'functions',
-  'index.html',
-  'login',
-  'machines',
-  'media',
-  'node_modules',
-  'pages',
-  'public',
-  'rest',
-  'robots.txt',
-  'rpc',
-  'seo',
-  'site.webmanifest',
-  'src',
-  'training-guides',
-  'v1',
+const SAFE_EXACT_PATHS = new Set([
+  '/.well-known/appspecific/com.chrome.devtools.json',
+  '/@react-refresh',
+  '/@vite/client',
+  '/bloomjoy-icon.png',
+  '/favicon.ico',
+  '/favicon.svg',
+  '/index.html',
+  '/robots.txt',
+  '/site.webmanifest',
 ]);
 const SAFE_FILE_EXTENSION = /\.(css|gif|html|ico|jpe?g|js|json|map|mjs|mp4|png|svg|ts|tsx|ttf|webmanifest|webp|woff2?)$/i;
 
-const redactPathSegment = (segment) => {
-  if (!segment) return segment;
-  if (SAFE_STATIC_PATH_SEGMENTS.has(segment)) return segment;
-
+const redactUnknownSegment = (segment) => {
   const extension = segment.match(SAFE_FILE_EXTENSION)?.[0]?.toLowerCase();
   return extension ? `[redacted${extension}]` : '[redacted]';
+};
+
+const redactUnknownPath = (pathname) =>
+  pathname
+    .split('/')
+    .map((segment) => (segment ? redactUnknownSegment(segment) : segment))
+    .join('/') || '/';
+
+const redactStaticPrefixPath = (pathname) => {
+  const twoPartStatic = pathname.match(/^\/(assets|media|seo|training-guides)\/([^/]+)$/);
+  if (twoPartStatic) {
+    return `/${twoPartStatic[1]}/${redactUnknownSegment(twoPartStatic[2])}`;
+  }
+
+  const viteDependency = pathname.match(/^\/node_modules\/\.vite\/deps\/([^/]+)$/);
+  if (viteDependency) {
+    return `/node_modules/.vite/deps/${redactUnknownSegment(viteDependency[1])}`;
+  }
+
+  const sourceModule = pathname.match(
+    /^\/src\/(pages|components|lib|data|hooks|assets|integrations|locales|i18n)\/(?:[^/]+\/)*([^/]+)$/
+  );
+  if (sourceModule) {
+    return `/src/${sourceModule[1]}/${redactUnknownSegment(sourceModule[2])}`;
+  }
+
+  const syntheticApi = pathname.match(
+    /^\/(auth|functions|rest)\/v1\/(?:rpc\/)?([^/]+)(?:\/([^/]+))?$/
+  );
+  if (syntheticApi) {
+    const rpcPrefix = pathname.includes('/v1/rpc/') ? '/rpc' : '';
+    const redactedTail = [syntheticApi[2], syntheticApi[3]]
+      .filter(Boolean)
+      .map(redactUnknownSegment)
+      .join('/');
+    return `/${syntheticApi[1]}/v1${rpcPrefix}/${redactedTail}`;
+  }
+
+  return null;
+};
+
+const redactPathname = (pathname) => {
+  if (SAFE_EXACT_PATHS.has(pathname)) return pathname;
+  return redactStaticPrefixPath(pathname) ?? redactUnknownPath(pathname);
 };
 
 export const redactUatRequestTarget = (rawUrl, appUrl) => {
   try {
     const target = new URL(rawUrl);
     const appOrigin = new URL(appUrl).origin;
-    const pathname = target.pathname
-      .split('/')
-      .map(redactPathSegment)
-      .join('/');
-    const safePathname = pathname || '/';
+    const safePathname = redactPathname(target.pathname);
 
     if (target.origin === appOrigin) return safePathname;
     if (target.hostname === '127.0.0.1' || target.hostname === 'localhost') {

--- a/scripts/refunds/machine-manager-uat-network.test.mjs
+++ b/scripts/refunds/machine-manager-uat-network.test.mjs
@@ -33,29 +33,40 @@ test('same-origin failures retain only a safe pathname', () => {
       `${APP_URL}/assets/missing.svg?email=person@example.test#private`,
       APP_URL
     ),
-    '/assets/missing.svg'
+    '/assets/[redacted.svg]'
   );
   assert.equal(
     redactUatRequestTarget(`${APP_URL}/cases/123e4567-e89b-12d3-a456-426614174000`, APP_URL),
-    '/cases/[id]'
+    '/[redacted]/[redacted]'
+  );
+  assert.equal(
+    redactUatRequestTarget(`${APP_URL}/.well-known/appspecific/com.chrome.devtools.json`, APP_URL),
+    '/.well-known/appspecific/com.chrome.devtools.json'
   );
 });
 
-test('external, identity-shaped, and invalid targets never leak', () => {
+test('external, short identity-shaped, token-shaped, and invalid targets never leak', () => {
   assert.equal(
     redactUatRequestTarget('https://private-project.example/path?token=secret', APP_URL),
-    '[external-origin]/path'
+    '[external-origin]/[redacted]'
   );
   assert.equal(
     redactUatRequestTarget(
       'http://127.0.0.1:54321/rest/v1/cases/123e4567-e89b-12d3-a456-426614174000?token=secret',
       APP_URL
     ),
-    '[loopback]/rest/v1/cases/[id]'
+    '[loopback]/rest/v1/[redacted]/[redacted]'
   );
   assert.equal(
     redactUatRequestTarget(`${APP_URL}/invite/person%40example.test`, APP_URL),
-    '/invite/[identity]'
+    '/[redacted]/[redacted]'
+  );
+  assert.equal(redactUatRequestTarget(`${APP_URL}/users/alice`, APP_URL), '/[redacted]/[redacted]');
+  assert.equal(redactUatRequestTarget(`${APP_URL}/cases/12345`, APP_URL), '/[redacted]/[redacted]');
+  assert.equal(redactUatRequestTarget(`${APP_URL}/reset/secret123`, APP_URL), '/[redacted]/[redacted]');
+  assert.equal(
+    redactUatRequestTarget('https://private-project.example/customer/jane-doe', APP_URL),
+    '[external-origin]/[redacted]/[redacted]'
   );
   assert.equal(redactUatRequestTarget('not a URL secret=unsafe', APP_URL), '[invalid-url]');
 });
@@ -63,7 +74,7 @@ test('external, identity-shaped, and invalid targets never leak', () => {
 test('an exact app 404 remains a fail-closed response with useful provenance', () => {
   assert.equal(
     describeFailedUatResponse(mockResponse(), APP_URL),
-    'HTTP 404 GET image /missing.svg'
+    'HTTP 404 GET image /[redacted.svg]'
   );
   assert.equal(describeFailedUatResponse(mockResponse({ status: 200 }), APP_URL), null);
 });
@@ -75,7 +86,7 @@ test('an unrelated 404 and a network failure are never ignored', () => {
   });
   assert.equal(
     describeFailedUatResponse(mockResponse({ request: unrelated }), APP_URL),
-    'HTTP 404 GET script /unexpected.js'
+    'HTTP 404 GET script /[redacted.js]'
   );
 
   const failed = mockRequest({
@@ -86,6 +97,6 @@ test('an unrelated 404 and a network failure are never ignored', () => {
   });
   assert.equal(
     describeFailedUatRequest(failed, APP_URL),
-    'NETWORK_FAILED POST fetch [external-origin]/rest/v1/secret'
+    'NETWORK_FAILED POST fetch [external-origin]/rest/v1/[redacted]'
   );
 });

--- a/scripts/refunds/machine-manager-uat-network.test.mjs
+++ b/scripts/refunds/machine-manager-uat-network.test.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  describeFailedUatRequest,
+  describeFailedUatResponse,
+  redactUatRequestTarget,
+} from './machine-manager-uat-network.mjs';
+
+const APP_URL = 'http://127.0.0.1:8081';
+
+const mockRequest = ({
+  url = `${APP_URL}/missing.svg`,
+  method = 'GET',
+  resourceType = 'image',
+  failure = null,
+} = {}) => ({
+  url: () => url,
+  method: () => method,
+  resourceType: () => resourceType,
+  failure: () => failure,
+});
+
+const mockResponse = ({ status = 404, request = mockRequest() } = {}) => ({
+  status: () => status,
+  url: () => request.url(),
+  request: () => request,
+});
+
+test('same-origin failures retain only a safe pathname', () => {
+  assert.equal(
+    redactUatRequestTarget(
+      `${APP_URL}/assets/missing.svg?email=person@example.test#private`,
+      APP_URL
+    ),
+    '/assets/missing.svg'
+  );
+  assert.equal(
+    redactUatRequestTarget(`${APP_URL}/cases/123e4567-e89b-12d3-a456-426614174000`, APP_URL),
+    '/cases/[id]'
+  );
+});
+
+test('external, identity-shaped, and invalid targets never leak', () => {
+  assert.equal(
+    redactUatRequestTarget('https://private-project.example/path?token=secret', APP_URL),
+    '[external-origin]/path'
+  );
+  assert.equal(
+    redactUatRequestTarget(
+      'http://127.0.0.1:54321/rest/v1/cases/123e4567-e89b-12d3-a456-426614174000?token=secret',
+      APP_URL
+    ),
+    '[loopback]/rest/v1/cases/[id]'
+  );
+  assert.equal(
+    redactUatRequestTarget(`${APP_URL}/invite/person%40example.test`, APP_URL),
+    '/invite/[identity]'
+  );
+  assert.equal(redactUatRequestTarget('not a URL secret=unsafe', APP_URL), '[invalid-url]');
+});
+
+test('an exact app 404 remains a fail-closed response with useful provenance', () => {
+  assert.equal(
+    describeFailedUatResponse(mockResponse(), APP_URL),
+    'HTTP 404 GET image /missing.svg'
+  );
+  assert.equal(describeFailedUatResponse(mockResponse({ status: 200 }), APP_URL), null);
+});
+
+test('an unrelated 404 and a network failure are never ignored', () => {
+  const unrelated = mockRequest({
+    url: `${APP_URL}/unexpected.js?credential=secret`,
+    resourceType: 'script',
+  });
+  assert.equal(
+    describeFailedUatResponse(mockResponse({ request: unrelated }), APP_URL),
+    'HTTP 404 GET script /unexpected.js'
+  );
+
+  const failed = mockRequest({
+    url: 'https://private-project.example/rest/v1/secret?token=unsafe',
+    method: 'POST',
+    resourceType: 'fetch',
+    failure: { errorText: 'net::ERR_FAILED secret=unsafe' },
+  });
+  assert.equal(
+    describeFailedUatRequest(failed, APP_URL),
+    'NETWORK_FAILED POST fetch [external-origin]/rest/v1/secret'
+  );
+});

--- a/scripts/refunds/machine-manager-uat-network.test.mjs
+++ b/scripts/refunds/machine-manager-uat-network.test.mjs
@@ -43,6 +43,10 @@ test('same-origin failures retain only a safe pathname', () => {
     redactUatRequestTarget(`${APP_URL}/.well-known/appspecific/com.chrome.devtools.json`, APP_URL),
     '/.well-known/appspecific/com.chrome.devtools.json'
   );
+  assert.equal(
+    redactUatRequestTarget(`${APP_URL}/src/pages/admin/Machines.tsx?t=secret`, APP_URL),
+    '/src/pages/[redacted.tsx]'
+  );
 });
 
 test('external, short identity-shaped, token-shaped, and invalid targets never leak', () => {
@@ -68,6 +72,12 @@ test('external, short identity-shaped, token-shaped, and invalid targets never l
     redactUatRequestTarget('https://private-project.example/customer/jane-doe', APP_URL),
     '[external-origin]/[redacted]/[redacted]'
   );
+  for (const dynamicValue of ['admin', 'login', 'machines', 'v1']) {
+    assert.equal(
+      redactUatRequestTarget(`${APP_URL}/users/${dynamicValue}`, APP_URL),
+      '/[redacted]/[redacted]'
+    );
+  }
   assert.equal(redactUatRequestTarget('not a URL secret=unsafe', APP_URL), '[invalid-url]');
 });
 

--- a/scripts/refunds/refund-production-release.json
+++ b/scripts/refunds/refund-production-release.json
@@ -3,7 +3,7 @@
   "environment": "production",
   "projectRef": "ygbzkgxktzqsiygjlqyg",
   "releaseId": "refund-ops-2026-08-11-production-readiness",
-  "sourceGitCommit": "48578b8ea515170bb79fbdf041eeb56612bb8cf3",
+  "sourceGitCommit": "69c6f784c504cdd30d81617eb4f873b69d5bfaed",
   "requiredMigrations": [
     "202604270001_refund_adjustment_review_matching.sql",
     "202604270002_live_refund_sheet_ingestion.sql",

--- a/scripts/refunds/refund-production-release.json
+++ b/scripts/refunds/refund-production-release.json
@@ -3,7 +3,7 @@
   "environment": "production",
   "projectRef": "ygbzkgxktzqsiygjlqyg",
   "releaseId": "refund-ops-2026-08-11-production-readiness",
-  "sourceGitCommit": "69c6f784c504cdd30d81617eb4f873b69d5bfaed",
+  "sourceGitCommit": "455dd79b1c8d08887062c995ddf7330550e604de",
   "requiredMigrations": [
     "202604270001_refund_adjustment_review_matching.sql",
     "202604270002_live_refund_sheet_ingestion.sql",

--- a/scripts/refunds/refund-production-release.json
+++ b/scripts/refunds/refund-production-release.json
@@ -3,7 +3,7 @@
   "environment": "production",
   "projectRef": "ygbzkgxktzqsiygjlqyg",
   "releaseId": "refund-ops-2026-08-11-production-readiness",
-  "sourceGitCommit": "787d0d90b43f211e531a633467bd4208bacab2e0",
+  "sourceGitCommit": "48578b8ea515170bb79fbdf041eeb56612bb8cf3",
   "requiredMigrations": [
     "202604270001_refund_adjustment_review_matching.sql",
     "202604270002_live_refund_sheet_ingestion.sql",

--- a/scripts/refunds/validate-machine-manager-uat.mjs
+++ b/scripts/refunds/validate-machine-manager-uat.mjs
@@ -3,6 +3,11 @@ import { mkdir } from 'node:fs/promises';
 import path from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 
+import {
+  describeFailedUatRequest,
+  describeFailedUatResponse,
+} from './machine-manager-uat-network.mjs';
+
 const DEFAULT_APP_URL = 'http://127.0.0.1:8081';
 const DEFAULT_ARTIFACT_DIR = 'output/playwright';
 
@@ -445,7 +450,17 @@ const run = async () => {
   await installMockSupabaseRoutes(context, state);
 
   const page = await context.newPage();
+  const requestFailures = [];
   const consoleErrors = [];
+
+  page.on('response', (response) => {
+    const failure = describeFailedUatResponse(response, args.appUrl);
+    if (failure) requestFailures.push(failure);
+  });
+  page.on('requestfailed', (request) => {
+    const failure = describeFailedUatRequest(request, args.appUrl);
+    if (failure) requestFailures.push(failure);
+  });
 
   page.on('console', (message) => {
     if (message.type() === 'error') {
@@ -663,8 +678,8 @@ const run = async () => {
 
     recorder.assert(
       'No browser console/page errors during mocked Machine Manager QA pass',
-      consoleErrors.length === 0,
-      consoleErrors.slice(0, 3).join(' | ')
+      requestFailures.length === 0 && consoleErrors.length === 0,
+      [...requestFailures, ...consoleErrors].slice(0, 5).join(' | ')
     );
   } finally {
     await context.close();


### PR DESCRIPTION
## Summary
- keep the Machine Manager browser UAT fail-closed while recording precise 4xx/5xx and request-failure provenance before Chromium's generic console text can obscure it
- expose only exact known public static paths or fixed route grammar; redact every dynamic segment, host, query, hash, identity, token, UUID, and ID
- add executable adversarial tests proving privacy, exact 404 visibility, and that unrelated failures are never ignored

Closes #839

The earlier anonymous hosted 404 was nondeterministic and did not recur locally or on the diagnostic head. This PR makes a future recurrence actionable; it does not claim or suppress an unobserved asset root cause.

## Files changed
- `scripts/refunds/machine-manager-uat-network.mjs`: bounded, position-scoped, redacted response/request failure descriptions
- `scripts/refunds/machine-manager-uat-network.test.mjs`: executable privacy and fail-closed regression tests, including dynamic values equal to static words
- `scripts/refunds/validate-machine-manager-uat.mjs`: capture precise request failures ahead of generic console errors
- `package.json`: run the network regression tests before the browser UAT
- `scripts/refunds/refund-production-release.json`: separate source-anchor commit only

## Verification
- `npm ci` — PASS
- network provenance tests — PASS (4/4)
- exact-head local mocked Machine Manager UAT — PASS; zero 4xx/network/console/page failures
- `npm run build` — PASS
- `npm test --if-present` — PASS
- `npm run lint --if-present` — PASS
- `npm run db:validate-migrations` — PASS (34 files / 1301 assertions)
- `npm run refunds:validate-release-tooling` — PASS
- `npm run refunds:release:check` — PASS (10 functions / 50 migrations)
- scoped local Vite listener — verified stopped and port clear

## How to test
1. Start the local synthetic app with the documented synthetic Supabase values on `127.0.0.1:8081`.
2. Run `npm run refunds:validate-machine-manager-uat -- --artifact-dir output/machine-manager-uat`.
3. Confirm all four provenance tests and the browser walkthrough pass.
4. Inject an app-origin 404 and confirm the final assertion reports `HTTP 404`, method, resource type, and only an exact safe static path or position-redacted route.
5. Confirm an unrelated 404 or request failure still fails.
6. Confirm `/users/admin`, `/users/login`, `/users/machines`, `/users/v1`, short usernames, numeric IDs, tokens, email addresses, UUIDs, query strings, hashes, hosts, and malformed raw values never appear in diagnostics.

Key URL: `/admin/machines` (synthetic local UAT only).
Test credentials: synthetic mocks embedded in the harness; no live account required.