### PR TITLE
chore(refunds): anchor UAT stability merge

### DIFF
--- a/scripts/refunds/refund-production-release.json
+++ b/scripts/refunds/refund-production-release.json
@@ -3,7 +3,7 @@
   "environment": "production",
   "projectRef": "ygbzkgxktzqsiygjlqyg",
   "releaseId": "refund-ops-2026-08-11-production-readiness",
-  "sourceGitCommit": "958d2219eb4908320509a4a26ee55ccf1efe0bd5",
+  "sourceGitCommit": "f5a6a300a2867d23e3aeaee5c2618d327872e412",
   "requiredMigrations": [
     "202604270001_refund_adjustment_review_matching.sql",
     "202604270002_live_refund_sheet_ingestion.sql",


### PR DESCRIPTION
## Summary
- point the refund production release manifest at canonical squash merge `f5a6a300a2867d23e3aeaee5c2618d327872e412`
- preserve the exact reviewed #845 tree and all production metadata; this is a one-line ancestry anchor only

## Files changed
- `scripts/refunds/refund-production-release.json`: top-level `sourceGitCommit` only

## Verification
- `npm ci` — PASS
- `npm run build` — PASS
- `npm test --if-present` — PASS
- `npm run lint --if-present` — PASS
- `npm run refunds:validate-release-tooling` — PASS
- `npm run refunds:release:check` — PASS (10 functions / 50 migrations)
- direct parent, PR base, and current `origin/main` — exact `f5a6a300a2867d23e3aeaee5c2618d327872e412`
- base-to-head diff — one file / one `sourceGitCommit` line

## How to test
1. Run `npm ci`.
2. Run `npm run build`, `npm test --if-present`, and `npm run lint --if-present`.
3. Run `npm run refunds:validate-release-tooling`.
4. Run `npm run refunds:release:check`; expect local alignment for 10 functions and 50 migrations.
5. Inspect `git diff main...HEAD`; confirm only `scripts/refunds/refund-production-release.json` changes and only `sourceGitCommit` moves to `f5a6a300a2867d23e3aeaee5c2618d327872e412`.

This PR performs no deployment, gate change, provider call, customer communication, or production mutation.