### PR TITLE
chore(refunds): anchor browser provenance canonical merge

### DIFF
--- a/scripts/refunds/refund-production-release.json
+++ b/scripts/refunds/refund-production-release.json
@@ -3,7 +3,7 @@
   "environment": "production",
   "projectRef": "ygbzkgxktzqsiygjlqyg",
   "releaseId": "refund-ops-2026-08-11-production-readiness",
-  "sourceGitCommit": "8188efadc1696117f4573c535493719f3efd860b",
+  "sourceGitCommit": "c22c0dfbe19ac313c26ae8c410ab42e35d0091a9",
   "requiredMigrations": [
     "202604270001_refund_adjustment_review_matching.sql",
     "202604270002_live_refund_sheet_ingestion.sql",


### PR DESCRIPTION
## Summary
- repoint the refund production release manifest to canonical squash merge `c22c0dfbe19ac313c26ae8c410ab42e35d0091a9`
- preserve the exact fully reviewed #847 tree while restoring canonical release ancestry
- metadata only; no runtime, database, customer, Gmail, provider, gate, or deployment change

Follows #847 and #842.

## Files changed
- `scripts/refunds/refund-production-release.json`: one top-level `sourceGitCommit` line only

## Verification
- `npm ci` - PASS
- `npm run build` - PASS
- `npm test --if-present` - PASS
- `npm run lint --if-present` - PASS
- `npm run db:validate-migrations` - PASS (34 files / 1301 tests)
- `npm run refunds:validate-release-tooling` - PASS
- `npm run refunds:release:check` - PASS (10 functions / 50 migrations)
- base tree matches merged, exact-head-reviewed #847 tree apart from the canonical source pointer

## How to test
1. Run `npm ci`.
2. Run `npm run build`, `npm test --if-present`, and `npm run lint --if-present`.
3. Run `npm run db:validate-migrations`.
4. Run `npm run refunds:validate-release-tooling`.
5. Run `npm run refunds:release:check`; confirm local alignment passes for 10 functions and 50 migrations.
6. Compare this PR with base `c22c0dfbe19ac313c26ae8c410ab42e35d0091a9`; confirm exactly one manifest line changes and it points to that full canonical SHA.

No credentials are required. No production action is authorized by this metadata-only anchor.
