### PR TITLE
chore(refunds): anchor Nayax production metadata merge

### DIFF
--- a/scripts/refunds/refund-production-release.json
+++ b/scripts/refunds/refund-production-release.json
@@ -3,7 +3,7 @@
   "environment": "production",
   "projectRef": "ygbzkgxktzqsiygjlqyg",
   "releaseId": "refund-ops-2026-08-11-production-readiness",
-  "sourceGitCommit": "f77ccc0235afd93b62f4e7e31be24012d252c16e",
+  "sourceGitCommit": "fc60f4c8a89d03883b7cbdb8ee54308e50c111b4",
   "requiredMigrations": [
     "202604270001_refund_adjustment_review_matching.sql",
     "202604270002_live_refund_sheet_ingestion.sql",


### PR DESCRIPTION
## Summary
- repoint the refund release manifest to canonical metadata squash merge `fc60f4c8a89d03883b7cbdb8ee54308e50c111b4`
- preserve the exact reviewed #849 production metadata and current canonical tree
- metadata only; no production, runtime, provider, customer, Gmail, gate, Auth, or database action

Follows #849 and advances #829.

## Files changed
- `scripts/refunds/refund-production-release.json`: one top-level `sourceGitCommit` line only

## Verification
- `npm ci` - PASS
- `npm run build` - PASS
- `npm test --if-present` - PASS
- `npm run lint --if-present` - PASS
- `npm run db:validate-migrations` - PASS (34 files / 1301 tests)
- `npm run refunds:validate-release-tooling` - PASS
- `npm run refunds:release:check` - PASS (10 functions / 50 migrations)
- `npm run refunds:release:check-production -- --project-ref ygbzkgxktzqsiygjlqyg` - PASS (all 10 live production functions)

## How to test
1. Run `npm ci`.
2. Run `npm run build`, `npm test --if-present`, and `npm run lint --if-present`.
3. Run `npm run db:validate-migrations`.
4. Run `npm run refunds:validate-release-tooling` and `npm run refunds:release:check`; require 10 functions and 50 migrations.
5. From an authenticated read-only Supabase CLI session, run `npm run refunds:release:check-production -- --project-ref ygbzkgxktzqsiygjlqyg`; require all 10 functions to PASS.
6. Compare this PR with base `fc60f4c8a89d03883b7cbdb8ee54308e50c111b4`; confirm exactly one manifest line changes and points to that full canonical SHA.

No credentials are stored. No production write is authorized by this canonical metadata anchor.
