### PR TITLE
chore(refunds): anchor launch truth canonical main

### DIFF
--- a/scripts/refunds/refund-production-release.json
+++ b/scripts/refunds/refund-production-release.json
@@ -3,7 +3,7 @@
   "environment": "production",
   "projectRef": "ygbzkgxktzqsiygjlqyg",
   "releaseId": "refund-ops-2026-08-11-production-readiness",
-  "sourceGitCommit": "80a4dc0d89f9695e6b0dc2710f37a00de8d276d0",
+  "sourceGitCommit": "085eb2ac247d4da732f1d3bc1f2f6f07b101ef52",
   "requiredMigrations": [
     "202604270001_refund_adjustment_review_matching.sql",
     "202604270002_live_refund_sheet_ingestion.sql",


### PR DESCRIPTION
## Summary

- Re-anchor the Refund Operations production release manifest to canonical main after the operational-truth documentation merge.
- Preserve the reviewed #852 tree byte-for-byte; this PR changes only the top-level `sourceGitCommit` pointer.

## Files changed

- `scripts/refunds/refund-production-release.json`: one-line canonical source commit update to `085eb2ac247d4da732f1d3bc1f2f6f07b101ef52`.

## Verification

- `npm ci` ? passed
- `npm run agent:preflight -- --issue 851` ? passed
- `npm run build` ? passed
- `npm test --if-present` ? passed
- `npm run lint --if-present` ? passed
- `npm run refunds:validate-release-tooling` ? passed
- `npm run refunds:release:check` ? passed (10 functions / 50 migrations)
- `git diff --check` ? passed

## How to test

1. Run `npm ci`.
2. Run `npm run build`, `npm test --if-present`, and `npm run lint --if-present`.
3. Run `npm run refunds:validate-release-tooling`.
4. Run `npm run refunds:release:check`; confirm exact local alignment for 10 functions and 50 migrations.
5. Confirm the PR diff contains exactly one manifest line and that `sourceGitCommit` equals canonical main `085eb2ac247d4da732f1d3bc1f2f6f07b101ef52`.

No localhost UI route or credentials are required because this is a one-line metadata anchor. It performs no production, customer, provider, database, Gmail, or Auth action.

## Risk and overlap

- No runtime, migration, function, UI, customer, provider, gate, or operational behavior changes.
- If main advances before merge, rebase/recreate this anchor from the new canonical main and rerun all checks.

Relates to #851
