### PR TITLE
Anchor Gmail intake shadow canonical release

### DIFF
--- a/scripts/refunds/refund-production-release.json
+++ b/scripts/refunds/refund-production-release.json
@@ -3,7 +3,7 @@
   "environment": "production",
   "projectRef": "ygbzkgxktzqsiygjlqyg",
   "releaseId": "refund-ops-2026-08-11-production-readiness",
-  "sourceGitCommit": "20fd03396f3f437c5b326b7a1758a36a836fbdfe",
+  "sourceGitCommit": "eecd6a9263bd84883fe717e18fcf09763677e3f6",
   "requiredMigrations": [
     "202604270001_refund_adjustment_review_matching.sql",
     "202604270002_live_refund_sheet_ingestion.sql",


### PR DESCRIPTION
## Summary
- anchor the reviewed Gmail intake-shadow release manifest to canonical squash main `eecd6a9263bd84883fe717e18fcf09763677e3f6`
- preserve the approved 10-function/51-migration release, canonical-50 predeployment bridge, function hashes, production metadata, and all default-off safety boundaries byte-for-byte

Follows #855 and advances #854. This PR performs no deployment, Gmail mutation, customer/manager send, refund/provider action, secret change, initialization, or DB authorization.

## Files changed
- `scripts/refunds/refund-production-release.json`: update only top-level `sourceGitCommit` from reviewed source `20fd03396f3f437c5b326b7a1758a36a836fbdfe` to canonical squash main `eecd6a9263bd84883fe717e18fcf09763677e3f6`

## Verification
- `npm ci` - PASS (existing audit findings unchanged; no dependency change)
- `npm run build` - PASS
- `npm test --if-present` - PASS
- `npm run lint --if-present` - PASS
- `npm run refunds:validate-release-tooling` - PASS
- `npm run refunds:release:check` - PASS (10 functions / 51 migrations)
- topology - PASS: direct parent/base `eecd6a9263bd84883fe717e18fcf09763677e3f6`; diff contains only the release manifest and one line changes

## How to test
1. Check out this branch in its isolated worktree and run `npm ci`.
2. Run `npm run build`, `npm test --if-present`, and `npm run lint --if-present`.
3. Run `npm run refunds:validate-release-tooling` and require the canonical-50 bridge, function source, JWT/import-map, migration order/digest, and manifest checks to pass.
4. Run `npm run refunds:release:check` and require local alignment for exactly 10 functions and 51 migrations.
5. Run `git diff --name-only eecd6a9263bd84883fe717e18fcf09763677e3f6..HEAD`; require only `scripts/refunds/refund-production-release.json`.
6. Inspect that diff; require exactly the top-level `sourceGitCommit` line to change to `eecd6a9263bd84883fe717e18fcf09763677e3f6`.
7. Do not deploy, initialize the lane, access Gmail, change secrets, or arm DB authorization while reviewing this metadata-only anchor.