### PR TITLE
Reconcile Gmail intake shadow production metadata

### DIFF
--- a/scripts/refunds/refund-production-release.json
+++ b/scripts/refunds/refund-production-release.json
@@ -173,9 +173,9 @@
       "verifyJwt": false,
       "sourceSha256": "730c2f0d9ea9a8cdf745b3b9d3eb8b5f9a8bcd554569b62c13d1baf1a7374378",
       "production": {
-        "version": 38,
-        "ezbrSha256": "3a93a0793322581ab9083cc692c978bc25ef5cfd921716f35364d34e4c831dd5",
-        "sourceSha256": "8fd54d8195b1abbd441b6340d973956b75b01c8c48c5673b1b091a352e3ef86f"
+        "version": 39,
+        "ezbrSha256": "d4b537e310413a95382b8f26e118284d5e7e3c2366237148fed20687907d9092",
+        "sourceSha256": "730c2f0d9ea9a8cdf745b3b9d3eb8b5f9a8bcd554569b62c13d1baf1a7374378"
       }
     },
     {

--- a/scripts/refunds/refund-production-release.json
+++ b/scripts/refunds/refund-production-release.json
@@ -3,7 +3,7 @@
   "environment": "production",
   "projectRef": "ygbzkgxktzqsiygjlqyg",
   "releaseId": "refund-ops-2026-08-11-production-readiness",
-  "sourceGitCommit": "eecd6a9263bd84883fe717e18fcf09763677e3f6",
+  "sourceGitCommit": "4c45135c7f10acedeee877f6701a94410f670cd0",
   "requiredMigrations": [
     "202604270001_refund_adjustment_review_matching.sql",
     "202604270002_live_refund_sheet_ingestion.sql",


### PR DESCRIPTION
## Summary

- Reconciles the canonical release manifest with the reviewed production deployment of `refund-gmail-sync` v39.
- Records the exact deployed bundle/source hashes, then anchors `sourceGitCommit` to the direct source commit.
- Changes no runtime, migration, function source, gate, secret, schedule, provider, customer, or Gmail behavior.

Closes the metadata-reconciliation portion of #854.

## Files changed

- `scripts/refunds/refund-production-release.json`
  - source commit `4c45135c7f10acedeee877f6701a94410f670cd0`: exactly the `refund-gmail-sync` production version/bundle/source triplet
  - anchor commit `de06f25`: exactly one top-level `sourceGitCommit` line

## Production evidence

- Exact canonical deploy source: `3e2116cb4e3cb848024acd6a2fee8ad5f29e04f0`
- Migration inventory: 51, with postdeploy dry-run zero
- `refund-gmail-sync`: v39, `verifyJwt=false`, bundle `d4b537e310413a95382b8f26e118284d5e7e3c2366237148fed20687907d9092`, source `730c2f0d9ea9a8cdf745b3b9d3eb8b5f9a8bcd554569b62c13d1baf1a7374378`
- The other nine manifest-tracked production triplets are unchanged
- Final owner DB/Auth readback passed: dispatch-control singleton 1; all new activity rows and active/unresolved safety aggregates 0; gates false; Auth enrollment false and verification true
- No initialization, lane dry-run/live invocation, Gmail access, secret mutation, retention run, schedule change, or gate activation occurred

## Verification

- `npm ci` — PASS
- `npm run build` — PASS
- `npm test --if-present` — PASS
- `npm run lint --if-present` — PASS
- `npm run refunds:validate-gmail-intake-shadow-runner` — PASS (51 Deno + 48 Node + static)
- `npm run refunds:validate-release-tooling` — PASS
- `npm run refunds:release:check` — PASS, 10 functions / 51 migrations
- `npm run refunds:release:check-production -- --project-ref ygbzkgxktzqsiygjlqyg --confirm-project-ref ygbzkgxktzqsiygjlqyg` — PASS, strict live 10/51
- `npm run db:validate-migrations` — local environment could not start because Docker Desktop is unavailable; required hosted migration validation must be terminal green before merge

## How to test

1. `npm ci`
2. `npm run refunds:validate-release-tooling`
3. `npm run refunds:release:check`
4. With the approved read-only production credential, run:
   `npm run refunds:release:check-production -- --project-ref ygbzkgxktzqsiygjlqyg --confirm-project-ref ygbzkgxktzqsiygjlqyg`
5. Run `npm run build && npm test --if-present && npm run lint --if-present`.
6. Optional UI smoke only: run `npm run dev`, open `http://localhost:8080/` and `http://localhost:8080/refunds`; no test credential or Gmail flow is required because this PR is manifest-only.
